### PR TITLE
Input: added error status styling

### DIFF
--- a/src/components/Input/Input.css
+++ b/src/components/Input/Input.css
@@ -32,6 +32,11 @@
   background: transparent;
   }
 
+.Input--s-error > .Input__border {
+  border-color: var(--field_error_border);
+  background: var(--field_error_background);
+}   
+
 .Input__el:disabled {
   opacity: .6;
   }


### PR DESCRIPTION
Added red border and red background to Input component, when its status is 'error'.