### PR TITLE
Wrong optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui",
-  "version": "2.18.2",
+  "version": "2.18.3-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui",
-  "version": "2.18.2",
+  "version": "2.18.3-rc.0",
   "main": "dist/vkui.js",
   "license": "MIT",
   "description": "VKUI library",

--- a/src/components/Panel/Panel.js
+++ b/src/components/Panel/Panel.js
@@ -16,24 +16,14 @@ export default class Panel extends Component {
     className: PropTypes.string,
     theme: PropTypes.oneOf(['white', 'gray']),
     id: PropTypes.string.isRequired,
-    optimized: PropTypes.bool,
     centered: PropTypes.bool,
-    style: PropTypes.object,
-    /**
-     * @ignore
-     */
-    isPrev: PropTypes.bool,
-    /**
-     * @ignore
-     */
-    isNext: PropTypes.bool
+    style: PropTypes.object
   };
 
   static defaultProps = {
     children: '',
     theme: 'gray',
-    centered: false,
-    optimized: true
+    centered: false
   };
 
   static contextTypes = {
@@ -56,12 +46,8 @@ export default class Panel extends Component {
     return this.context.insets || {};
   }
 
-  shouldComponentUpdate ({ optimized, isNext, isPrev }) {
-    return optimized ? !isNext && !isPrev : true;
-  }
-
   render () {
-    const { className, centered, children, isPrev, isNext, theme, optimized, ...restProps } = this.props;
+    const { className, centered, children, theme, ...restProps } = this.props;
     const tabbarPadding = this.context.hasTabbar ? tabbarHeight : 0;
 
     return (

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -154,11 +154,7 @@ export default class Root extends React.Component {
             'Root__view--show-forward': View.props.id === nextView && !isBack,
             'Root__view--active': View.props.id === activeView
           })}>
-            {React.cloneElement(View, {
-              inRoot: true,
-              isNext: View.props.id === nextView,
-              isPrev: View.props.id === prevView
-            })}
+            {View}
           </div>
         ))}
         {this.props.popout && <div className="Root__popout">{this.props.popout}</div>}

--- a/src/components/View/View.js
+++ b/src/components/View/View.js
@@ -57,20 +57,7 @@ export default class View extends Component {
     /**
      * @ignore
      */
-    history: PropTypes.arrayOf(PropTypes.string),
-
-    /**
-     * @ignore
-     */
-    isNext: PropTypes.bool,
-    /**
-     * @ignore
-     */
-    isPrev: PropTypes.bool,
-    /**
-     * @ignore
-     */
-    inRoot: PropTypes.bool
+    history: PropTypes.arrayOf(PropTypes.string)
   };
 
   static defaultProps = {
@@ -241,8 +228,6 @@ export default class View extends Component {
   transitionEndHandler = (e = { manual: true }) => {
     if ([
       'animation-ios-next-forward',
-      'animation-ios-next-back',
-      'animation-ios-prev-forward',
       'animation-ios-prev-back',
       'animation-android-next-forward',
       'animation-android-prev-back'
@@ -455,10 +440,6 @@ export default class View extends Component {
     }
   }
 
-  shouldComponentUpdate ({ inRoot, isNext, isPrev }) {
-    return inRoot ? !isNext && !isPrev : true;
-  }
-
   render () {
     const { style, popout, header } = this.props;
     const { prevPanel, nextPanel, activePanel, swipeBackPrevPanel, swipeBackNextPanel, swipingBackFinish } = this.state;
@@ -564,10 +545,7 @@ export default class View extends Component {
                 key={panelId}
               >
                 <div className="View__panel-in">
-                  {React.cloneElement(panel, {
-                    isNext: panelId === nextPanel || panelId === swipeBackNextPanel,
-                    isPrev: panelId === prevPanel || panelId === swipeBackPrevPanel
-                  })}
+                  {panel}
                 </div>
               </div>
             );


### PR DESCRIPTION
Убрали оптимизации, написанные на основе React.cloneElement и shouldComponentUpdate во View, Root и Panel. Их лучше описывать в компонентах уровня приложения, не прибегая к клонированию.