### PR TITLE
Simplify React map children in ActionSheet

### DIFF
--- a/src/components/ActionSheet/ActionSheet.js
+++ b/src/components/ActionSheet/ActionSheet.js
@@ -89,10 +89,10 @@ export default class ActionSheet extends React.Component {
             {text && <div className="ActionSheet__text">{text}</div>}
           </header>
           }
-          {Children.toArray(children).map((Child, index, arr) => (
+          {Children.map(children, (Child, index) => (
             Child && React.cloneElement(Child, {
               onClick: this.onItemClick(Child.props.onClick, Child.props.autoclose),
-              style: index === arr.length - 1 && this.context.insets ? { marginBottom: this.context.insets.bottom } : null
+              style: index === children.length - 1 && this.context.insets ? { marginBottom: this.context.insets.bottom } : null
             })
           ))}
         </div>


### PR DESCRIPTION
Заменил **Children.toArray(children).map** на **Children.map**:
Получилась идентичная логика, но вариант с использованием **Children.map** более производителен, так как **Children.toArray(children)** тот же **Children.map** в котором в качестве callback функции используется **child => child**.
В итоге, вместо двух проходов получается один.
https://github.com/facebook/react/blob/master/packages/react/src/ReactChildren.js
