### PR TITLE
Add event as second param to Slider onChange function

### DIFF
--- a/src/components/RangeSlider/RangeSlider.js
+++ b/src/components/RangeSlider/RangeSlider.js
@@ -21,7 +21,7 @@ export default class RangeSlider extends Slider {
     const percentPosition = this.absoluteToPecent(absolutePosition);
     const percentRange = this.calcPercentRange(percentPosition);
 
-    this.onChange(this.percentToValue(percentRange), e.originalEvent);
+    this.onChange(this.percentToValue(percentRange), e);
 
     if (this.isControlledOutside) {
       this.setState({startX: absolutePosition});
@@ -46,7 +46,7 @@ export default class RangeSlider extends Slider {
     const percentPosition = this.absoluteToPecent(absolutePosition);
     const percentRange = this.calcPercentRange(percentPosition);
 
-    this.onChange(this.percentToValue(percentRange), e.originalEvent);
+    this.onChange(this.percentToValue(percentRange), e);
 
     if (!this.isControlledOutside) {
       this.setState(percentRange);

--- a/src/components/RangeSlider/RangeSlider.js
+++ b/src/components/RangeSlider/RangeSlider.js
@@ -16,12 +16,12 @@ export default class RangeSlider extends Slider {
 
   static defaultProps = Slider.defaultProps;
 
-  onStart = (e) => {
+  onStart = e => {
     const absolutePosition = this.validateAbsolute(e.startX - this.state.containerLeft);
     const percentPosition = this.absoluteToPecent(absolutePosition);
     const percentRange = this.calcPercentRange(percentPosition);
 
-    this.onChange(this.percentToValue(percentRange));
+    this.onChange(this.percentToValue(percentRange), e.originalEvent);
 
     if (this.isControlledOutside) {
       this.setState({startX: absolutePosition});
@@ -46,7 +46,7 @@ export default class RangeSlider extends Slider {
     const percentPosition = this.absoluteToPecent(absolutePosition);
     const percentRange = this.calcPercentRange(percentPosition);
 
-    this.onChange(this.percentToValue(percentRange));
+    this.onChange(this.percentToValue(percentRange), e.originalEvent);
 
     if (!this.isControlledOutside) {
       this.setState(percentRange);

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -43,7 +43,7 @@ export default class Slider extends Component {
     const absolutePosition = this.validateAbsolute(e.startX - this.state.containerLeft);
     const percentPosition = this.absoluteToPecent(absolutePosition);
 
-    this.onChange(this.percentToValue(percentPosition), e.originalEvent);
+    this.onChange(this.percentToValue(percentPosition), e);
 
     if (this.isControlledOutside) {
       this.setState({startX: absolutePosition});
@@ -61,7 +61,7 @@ export default class Slider extends Component {
     const absolutePosition = this.validateAbsolute(this.state.startX + (e.shiftX || 0));
     const percentPosition = this.absoluteToPecent(absolutePosition);
 
-    this.onChange(this.percentToValue(percentPosition), e.originalEvent);
+    this.onChange(this.percentToValue(percentPosition), e);
 
     if (!this.isControlledOutside) {
       this.setState({percentPosition});

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -39,11 +39,11 @@ export default class Slider extends Component {
     step: 0
   };
 
-  onStart = (e) => {
+  onStart = e => {
     const absolutePosition = this.validateAbsolute(e.startX - this.state.containerLeft);
     const percentPosition = this.absoluteToPecent(absolutePosition);
 
-    this.onChange(this.percentToValue(percentPosition));
+    this.onChange(this.percentToValue(percentPosition), e.originalEvent);
 
     if (this.isControlledOutside) {
       this.setState({startX: absolutePosition});
@@ -61,7 +61,7 @@ export default class Slider extends Component {
     const absolutePosition = this.validateAbsolute(this.state.startX + (e.shiftX || 0));
     const percentPosition = this.absoluteToPecent(absolutePosition);
 
-    this.onChange(this.percentToValue(percentPosition));
+    this.onChange(this.percentToValue(percentPosition), e.originalEvent);
 
     if (!this.isControlledOutside) {
       this.setState({percentPosition});
@@ -85,8 +85,8 @@ export default class Slider extends Component {
     });
   };
 
-  onChange (value) {
-    this.props.onChange && this.props.onChange(value);
+  onChange (value, e) {
+    this.props.onChange && this.props.onChange(value, e);
   }
 
   validateAbsolute (absolute) {


### PR DESCRIPTION
#244 
Передает в качестве второго параметра **event**, который можно использовать для различных кейсов, как пример кейс из issue выше
```javascript
             <Slider
                min={10}
                max={30}
                value={Number(this.state.value1)}
                onChange={(value1, e) => {
                  e.originalEvent.stopPropagation()
                  this.setState({value1})}
                }
                top="Simple [10, 30]"
              />
```