### PR TITLE
Fix-Alert-IOS-Scale-Transform

### DIFF
--- a/src/components/Alert/Alert.css
+++ b/src/components/Alert/Alert.css
@@ -269,12 +269,10 @@
 @keyframes animation-ios-alert-intro {
   from {
     opacity: 0;
-    transform: scale(1.05);
     }
 
   to {
     opacity: 1;
-    transform: scale(1);
     }
   }
 


### PR DESCRIPTION
При использовании **Alert** на IOS появляется неприятное смещение содержимого попапа, при завершении анимации, связанное с изменением масштаба - в нативном клиенте изменения размера нет.
https://vkcom.github.io/vkui-styleguide/#alert
![test](https://media.giphy.com/media/QWjO1DjeDfdYtYBRho/giphy.gif)
