### PR TITLE
Fix-Main-Fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vkontakte/vkui",
   "version": "2.21.7",
-  "main": "dist/vkui.js",
+  "main": "dist/index.js",
   "license": "MIT",
   "description": "VKUI library",
   "repository": "https://github.com/VKCOM/VKUI",


### PR DESCRIPTION
Есть ли какие-то причины почему в качестве **main** файла используется **vkui**?
Доставляет неудобство, что приходится импортировать компоненты таким образом:
```javascript
import { Panel, List, } from '@vkontakte/vkui/dist';
```
Иначе:
![webstorm](http://joxi.ru/KAgq7Y5fE9PpBm.jpg)