### PR TITLE
Fix Switch props types to include <input> attributes

### DIFF
--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, InputHTMLAttributes } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { HasRef, HasRootRef } from '../../types/props';
 
 export interface SwitchProps extends
-  HTMLAttributes<HTMLInputElement>,
+  InputHTMLAttributes<HTMLInputElement>,
   HasRootRef<HTMLLabelElement>,
   HasRef<HTMLInputElement> {}
 


### PR DESCRIPTION
Этот пулл-реквест заменяет `React.HTMLAttributes<InputHTMLElement>` на более полный `React.InputHTMLAttributes<InputHTMLElement>`, который включает в себя свойства `<input>`, а не только свойства обработчиков событий, в том числе и `checked`.

fixes #460 
