### PR TITLE
Add falsy types to classNames args types

### DIFF
--- a/src/lib/classNames.ts
+++ b/src/lib/classNames.ts
@@ -1,9 +1,11 @@
 import { ObjectClassNames } from '../types/props';
 
-export default function classNames(...classnames: Array<number | string | ObjectClassNames | false | null | undefined>) {
+type ClassName = number | string | ObjectClassNames | false | null | undefined;
+
+export default function classNames(...classnames: ClassName[]) {
   let result: string[] = [];
 
-  classnames.forEach((item: number | string | ObjectClassNames): void => {
+  classnames.forEach((item: ClassName): void => {
     if (!item) {
       return;
     }

--- a/src/lib/classNames.ts
+++ b/src/lib/classNames.ts
@@ -1,6 +1,6 @@
 import { ObjectClassNames } from '../types/props';
 
-export default function classNames(...classnames: Array<number | string | ObjectClassNames>) {
+export default function classNames(...classnames: Array<number | string | ObjectClassNames | false | null | undefined>) {
   let result: string[] = [];
 
   classnames.forEach((item: number | string | ObjectClassNames): void => {


### PR DESCRIPTION
Теперь в `classNames(...)` можно передавать `false`, `null` и `undefined`, что позволяет удобно включать и выключать классы по условию и добавлять юзерский `className` к своим:

```jsx
const Radio = ({ isSelected, className, ...restProps }) => {
  return (
    <input
      className={classNames(
        'Radio',
        isSelected && 'Radio--selected',
        className
      )}
      type="radio"
      checked={isSelected}
      {...restProps}
    />
  );
};
```

resolves #459 