### PR TITLE
PanelHeaderSimple

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,19 +84,21 @@
     "prepublishOnly": "yarn clear && yarn build",
     "styleguide": "NODE_ENV=development styleguidist server --config=styleguide/config.js",
     "styleguide:build": "NODE_ENV=production styleguidist build --config=styleguide/config.js",
-    "dev": "yarn clear && concurrently \"yarn:tsc-dev\" \"yarn:babel-dev\" \"yarn:postcss-dev\"",
+    "dev": "yarn clear && yarn copy-default-scheme && concurrently \"yarn:tsc-dev\" \"yarn:babel-dev\" \"yarn:postcss-dev\"",
+    "dev-es6": "yarn clear && yarn copy-default-scheme && concurrently \"yarn:tsc-dev\" \"yarn:babel-es6-dev\" \"yarn:postcss-dev\"",
     "postcss-dev": "postcss src/styles/styles.css --output dist/vkui.css --watch --verbose --no-map",
     "babel-dev": "babel src/ --out-dir dist/ --extensions .tsx,.jsx,.ts,.js --watch",
-    "babel:es6-dev": "babel --config-file ./babel.es6.config.js src/ --out-dir dist/es6/ --extensions .tsx,.jsx,.ts,.js --watch",
+    "babel-es6-dev": "babel --config-file ./babel.es6.config.js src/ --out-dir dist/es6/ --extensions .tsx,.jsx,.ts,.js --watch",
     "tsc-dev": "tsc --noEmit --watch --preserveWatchOutput",
-    "build": "yarn tsc && yarn babel && yarn tsc:es6 && yarn babel:es6 && yarn postcss && cp ./src/styles/bright_light.css ./dist/default_scheme.css",
+    "build": "yarn tsc && yarn babel && yarn tsc-es6 && yarn babel-es6 && yarn postcss && yarn copy-default-scheme",
     "postcss": "NODE_ENV=production postcss src/styles/styles.css --output dist/vkui.css --verbose",
     "babel": "NODE_ENV=production babel src/ --out-dir dist/ --source-maps --extensions .tsx,.jsx,.ts,.js",
-    "babel:es6": "NODE_ENV=production babel --config-file ./babel.es6.config.js src/ --out-dir dist/es6/ --source-maps --extensions .tsx,.jsx,.ts,.js",
+    "babel-es6": "NODE_ENV=production babel --config-file ./babel.es6.config.js src/ --out-dir dist/es6/ --source-maps --extensions .tsx,.jsx,.ts,.js",
     "tsc": "NODE_ENV=production tsc --emitDeclarationOnly --declaration",
-    "tsc:es6": "NODE_ENV=production tsc --emitDeclarationOnly --declaration --outDir dist/es6/",
+    "tsc-es6": "NODE_ENV=production tsc --emitDeclarationOnly --declaration --outDir dist/es6/",
     "clear": "rm -rf dist/*",
-    "test": "tsc --noEmit && eslint --ext .jsx,.js,.ts,.tsx src/ && stylelint './src/**/*.css'"
+    "test": "tsc --noEmit && eslint --ext .jsx,.js,.ts,.tsx src/ && stylelint './src/**/*.css'",
+    "copy-default-scheme": "cp ./src/styles/bright_light.css ./dist/default_scheme.css"
   },
   "pre-commit": [
     "test"

--- a/src/components/PanelHeaderSimple/PanelHeaderSimple.css
+++ b/src/components/PanelHeaderSimple/PanelHeaderSimple.css
@@ -1,5 +1,6 @@
 .PanelHeaderSimple {
-
+  position: relative;
+  z-index: 10;
 }
 
 .PanelHeaderSimple__in {
@@ -45,9 +46,14 @@
  * iOS
  */
 
+.PanelHeaderSimple--ios ~ .FixedLayout--top {
+  top: calc(var(--panelheader_height_ios) + var(--safe-area-inset-top));
+}
+
 .PanelHeaderSimple--ios .PanelHeaderSimple__height,
 .PanelHeaderSimple--ios .PanelHeaderSimple__in {
   height: var(--panelheader_height_ios);
+  padding-top: var(--safe-area-inset-top);
 }
 
 .PanelHeaderSimple--ios .PanelHeaderSimple__left {
@@ -112,9 +118,14 @@
  * Android
  */
 
+.PanelHeaderSimple--android ~ .FixedLayout--top {
+  top: calc(var(--panelheader_height_android) + var(--safe-area-inset-top));
+}
+
 .PanelHeaderSimple--android .PanelHeaderSimple__height,
 .PanelHeaderSimple--android .PanelHeaderSimple__in {
   height: var(--panelheader_height_android);
+  padding-top: var(--safe-area-inset-top);
 }
 
 .PanelHeaderSimple--android .PanelHeaderSimple__left-in:not(:empty) {

--- a/src/components/PanelHeaderSimple/PanelHeaderSimple.css
+++ b/src/components/PanelHeaderSimple/PanelHeaderSimple.css
@@ -12,6 +12,10 @@
   background: var(--header_background);
 }
 
+.PanelHeaderSimple--transparent .PanelHeaderSimple__in {
+  background: transparent;
+}
+
 .PanelHeaderSimple__left {
   box-sizing: border-box;
   color: var(--header_tint);
@@ -64,6 +68,8 @@
   flex-basis: 0;
   padding-right: 12px;
   font-size: 17px;
+  opacity: 1;
+  transition: opacity .3s var(--ios-easing);
 }
 
 .PanelHeaderSimple--ios .PanelHeaderSimple__left .PanelHeaderButton .Icon--24 {
@@ -84,8 +90,9 @@
   font-size: 21px;
   line-height: var(--panelheader_height_ios);
   text-align: center;
-  transition: color .6s var(--ios-easing);
   color: var(--header_text);
+  opacity: 1;
+  transition: opacity .3s var(--ios-easing);
 }
 
 .PanelHeaderSimple--ios .PanelHeaderSimple__right {
@@ -96,6 +103,8 @@
   flex-basis: 0;
   padding-left: 12px;
   font-size: 17px;
+  opacity: 1;
+  transition: opacity .3s var(--ios-easing);
 }
 
 .PanelHeaderSimple--ios .PanelHeaderSimple__right .PanelHeaderButton:not(:first-child) {
@@ -112,6 +121,12 @@
 
 .PanelHeaderSimple--ios .PanelHeaderSimple__right .PanelHeaderButton > *:not(.Icon) {
   padding-right: 16px;
+}
+
+.View--ios .View__panel--prev .PanelHeaderSimple__left,
+.View--ios .View__panel--prev .PanelHeaderSimple__right,
+.View--ios .View__panel--prev .PanelHeaderSimple__content {
+  opacity: 0;
 }
 
 /**

--- a/src/components/PanelHeaderSimple/PanelHeaderSimple.css
+++ b/src/components/PanelHeaderSimple/PanelHeaderSimple.css
@@ -1,0 +1,146 @@
+.PanelHeaderSimple {
+
+}
+
+.PanelHeaderSimple__in {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  white-space: nowrap;
+  position: relative;
+  background: var(--header_background);
+}
+
+.PanelHeaderSimple__left {
+  box-sizing: border-box;
+  color: var(--header_tint);
+  display: flex;
+}
+
+.PanelHeaderSimple__left-in {
+  flex-shrink: 0;
+  color: var(--header_tint);
+}
+
+.PanelHeaderSimple__addon {
+  flex-shrink: 0;
+  color: var(--header_tint);
+}
+
+.PanelHeaderSimple__content {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.PanelHeaderSimple__right {
+  box-sizing: border-box;
+  color: var(--header_tint);
+}
+
+.PanelHeaderSimple__separator {
+  padding-top: 4px;
+}
+
+/**
+ * iOS
+ */
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__height,
+.PanelHeaderSimple--ios .PanelHeaderSimple__in {
+  height: var(--panelheader_height_ios);
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__left {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  flex-grow: 1;
+  flex-basis: 0;
+  padding-right: 12px;
+  font-size: 17px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__left .PanelHeaderButton .Icon--24 {
+  padding-left: 12px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__left .PanelHeaderButton .Icon--28 {
+  padding-left: 10px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__left .PanelHeaderButton > *:not(.Icon) {
+  padding-left: 16px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__content {
+  font-weight: 800;
+  font-family: var(--font-tt);
+  font-size: 21px;
+  line-height: var(--panelheader_height_ios);
+  text-align: center;
+  transition: color .6s var(--ios-easing);
+  color: var(--header_text);
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__right {
+  display: flex;
+  justify-content: flex-end;
+  flex-shrink: 0;
+  flex-grow: 1;
+  flex-basis: 0;
+  padding-left: 12px;
+  font-size: 17px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__right .PanelHeaderButton:not(:first-child) {
+  padding-left: 12px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__right .PanelHeaderButton .Icon--24 {
+  padding-right: 12px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__right .PanelHeaderButton .Icon--28 {
+  padding-right: 10px;
+}
+
+.PanelHeaderSimple--ios .PanelHeaderSimple__right .PanelHeaderButton > *:not(.Icon) {
+  padding-right: 16px;
+}
+
+/**
+ * Android
+ */
+
+.PanelHeaderSimple--android .PanelHeaderSimple__height,
+.PanelHeaderSimple--android .PanelHeaderSimple__in {
+  height: var(--panelheader_height_android);
+}
+
+.PanelHeaderSimple--android .PanelHeaderSimple__left-in:not(:empty) {
+  padding-right: 8px;
+  padding-left: 4px;
+}
+
+.PanelHeaderSimple--android .PanelHeaderSimple__left-in:empty {
+  width: 16px;
+}
+
+.PanelHeaderSimple--android .PanelHeaderSimple__content {
+  font-size: 20px;
+  font-weight: 800;
+  font-family: var(--font-tt);
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  max-width: 100%;
+}
+
+.PanelHeaderSimple--android .PanelHeaderSimple__right:not(:empty) {
+  padding-left: 8px;
+  padding-right: 4px;
+}
+
+.PanelHeaderSimple--android .PanelHeaderSimple__right:empty {
+  width: 16px;
+}

--- a/src/components/PanelHeaderSimple/PanelHeaderSimple.tsx
+++ b/src/components/PanelHeaderSimple/PanelHeaderSimple.tsx
@@ -21,12 +21,22 @@ const PanelHeaderSimple = ({
   children,
   right,
   separator,
+  transparent,
   ...restProps
 }: PanelHeaderSimpleProps) => {
   const platform = usePlatform();
 
   return (
-    <div {...restProps} className={classNames(getClassname('PanelHeaderSimple', platform), className)}>
+    <div
+      {...restProps}
+      className={
+        classNames(
+          getClassname('PanelHeaderSimple', platform),
+          { 'PanelHeaderSimple--transparent': transparent },
+          className,
+        )
+      }
+    >
       <div className="PanelHeaderSimple__height" />
       <FixedLayout vertical="top">
         <div className="PanelHeaderSimple__in">

--- a/src/components/PanelHeaderSimple/PanelHeaderSimple.tsx
+++ b/src/components/PanelHeaderSimple/PanelHeaderSimple.tsx
@@ -1,0 +1,61 @@
+import React, { HTMLAttributes, ReactNode } from 'react';
+import usePlatform from '../../hooks/usePlatform';
+import getClassname from '../../helpers/getClassName';
+import classNames from '../../lib/classNames';
+import FixedLayout from '../FixedLayout/FixedLayout';
+import Separator from '../Separator/Separator';
+import { ANDROID } from '../../lib/platform';
+
+export interface PanelHeaderSimpleProps extends HTMLAttributes<HTMLDivElement> {
+  left?: ReactNode;
+  addon?: ReactNode;
+  right?: ReactNode;
+  separator?: boolean;
+  transparent?: boolean;
+}
+
+const PanelHeaderSimple = ({
+  className,
+  left,
+  addon,
+  children,
+  right,
+  separator,
+  ...restProps
+}: PanelHeaderSimpleProps) => {
+  const platform = usePlatform();
+
+  return (
+    <div {...restProps} className={classNames(getClassname('PanelHeaderSimple', platform), className)}>
+      <div className="PanelHeaderSimple__height" />
+      <FixedLayout vertical="top">
+        <div className="PanelHeaderSimple__in">
+          <div className="PanelHeaderSimple__left">
+            <div className="PanelHeaderSimple__left-in">
+              {left}
+            </div>
+            {platform === ANDROID &&
+            <div className="PanelHeaderSimple__addon">
+              {addon}
+            </div>
+            }
+          </div>
+          <div className="PanelHeaderSimple__content">
+            {children}
+          </div>
+          <div className="PanelHeaderSimple__right">
+            {right}
+          </div>
+        </div>
+      </FixedLayout>
+      {separator && <Separator className="PanelHeaderSimple__separator" />}
+    </div>
+  );
+};
+
+PanelHeaderSimple.defaultProps = {
+  separator: true,
+  transparent: false,
+};
+
+export default PanelHeaderSimple;

--- a/src/components/PanelHeaderSimple/Readme.md
+++ b/src/components/PanelHeaderSimple/Readme.md
@@ -1,0 +1,33 @@
+`PanelHeaderSimple` — это то, что в 4-й версии заменит `PanelHeader`. У `PanelHeader` есть ряд проблем:
+
+1. Части этого компонента рендерятся с помощью порталов в ближайший `View`, что делает невозможным SSR и замедляет
+отрисовку и перерисовку компонента.
+2. Невозможно было в пределах одного `View` мешать панели с шапкой и без шапки.
+3. Большая вложенность вёрстки.
+4. Наличием или отсутствием разделителя управляет `Panel`, было бы удобнее, если бы это делал `PanelHeader`
+
+У `PanelHeaderSimple` этих проблем нет. Он рендерится как обычный компонент, имеет простую структуру, быстро рисуется и
+поддерживает SSR.
+
+### Переход от PanelHeader к PanelHeaderSimple
+
+1. Во `<View />` добавляем `header={false}`
+2. В `<Panel />` добавляем `separator={false}`. Это свойство теперь есть у `PanelHeaderSimple`
+3. Заменяем `<PanelHeader />` на `<PanelHeaderSimple />`
+4. Вы крутой :)
+
+В 4-й версии библиотеки первых двух шагов не будет, PanelHeaderSimple переименуется в PanelHeader, а текущий PanelHeader
+будет удален.
+
+```jsx
+<View activePanel="panelheader" header={false}>
+  <Panel id="panelheader" separator={false}>
+    <PanelHeaderSimple
+      left={<PanelHeaderBack />}
+      right={<PanelHeaderButton><Icon24MoreHorizontal /></PanelHeaderButton>}
+    >
+      Запись
+    </PanelHeaderSimple>
+  </Panel>
+</View>
+```

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -181,38 +181,46 @@
 /*
   header
  */
-.PanelHeader .Search {
+.PanelHeader .Search,
+.PanelHeaderSimple .Search {
   background: var(--header_background);
   padding: 0;
   }
 
-  .PanelHeader .Search__control {
+  .PanelHeader .Search__control,
+  .PanelHeaderSimple .Search__control {
     background-color: var(--header_search_field_background);
     }
 
-    .PanelHeader .Search__input {
+    .PanelHeader .Search__input,
+    .PanelHeaderSimple .Search__input {
       color: var(--text_primary);
       }
 
-    .PanelHeader .Search__placeholder {
+    .PanelHeader .Search__placeholder,
+    .PanelHeaderSimple .Search__placeholder {
       color: var(--header_search_field_tint);
       }
 
-    .PanelHeader .Search__after-width {
+    .PanelHeader .Search__after-width,
+    .PanelHeaderSimple .Search__after-width {
       background: var(--header_search_field_background);
       color: var(--header_search_field_background);
       }
 
-  .PanelHeader .Search__after {
+  .PanelHeader .Search__after,
+  .PanelHeaderSimple .Search__after {
     background: var(--header_background);
     color: var(--header_tint);
     }
 
-    .PanelHeader .Search__after::after {
+    .PanelHeader .Search__after::after,
+    .PanelHeaderSimple .Search__after::after {
       background-color: var(--header_search_field_background);
       }
 
-    .PanelHeader .Search__after::before {
+    .PanelHeader .Search__after::before,
+    .PanelHeaderSimple .Search__after::before {
       background-color: var(--header_background);
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { default as View } from './components/View/View';
 export { default as Panel } from './components/Panel/Panel';
 export { default as PanelHeaderButton } from './components/PanelHeaderButton/PanelHeaderButton';
 export { default as PanelHeader } from './components/PanelHeader/PanelHeader';
+export { default as PanelHeaderSimple } from './components/PanelHeaderSimple/PanelHeaderSimple';
 export { default as PanelHeaderContent } from './components/PanelHeaderContent/PanelHeaderContent';
 export { default as PanelHeaderContext } from './components/PanelHeaderContext/PanelHeaderContext';
 export { default as Epic } from './components/Epic/Epic';

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -11,6 +11,7 @@
 @import '../components/View/View.css';
 @import '../components/Panel/Panel.css';
 @import '../components/PanelHeader/PanelHeader.css';
+@import '../components/PanelHeaderSimple/PanelHeaderSimple.css';
 @import '../components/PanelHeaderButton/PanelHeaderButton.css';
 @import '../components/PanelHeaderContent/PanelHeaderContent.css';
 @import '../components/PanelHeaderContext/PanelHeaderContext.css';

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -38,6 +38,7 @@ module.exports = {
           '../src/components/View/View.tsx',
           '../src/components/Panel/Panel.tsx',
           '../src/components/PanelHeader/PanelHeader.tsx',
+          '../src/components/PanelHeaderSimple/PanelHeaderSimple.tsx',
           '../src/components/PanelHeaderButton/PanelHeaderButton.tsx',
           '../src/components/PanelHeaderContent/PanelHeaderContent.tsx',
           '../src/components/PanelHeaderContext/PanelHeaderContext.tsx',


### PR DESCRIPTION
`PanelHeaderSimple` — это то, что в 4-й версии заменит `PanelHeader`. У `PanelHeader` есть ряд проблем:

1. Части этого компонента рендерятся с помощью порталов в ближайший `View`, что делает невозможным SSR и замедляет
отрисовку и перерисовку компонента.
2. Невозможно было в пределах одного `View` мешать панели с шапкой и без шапки.
3. Большая вложенность вёрстки.
4. Наличием или отсутствием разделителя управляет `Panel`, было бы удобнее, если бы это делал `PanelHeader`

У `PanelHeaderSimple` этих проблем нет. Он рендерится как обычный компонент, имеет простую структуру, быстро рисуется и
поддерживает SSR.

### Переход от PanelHeader к PanelHeaderSimple

1. Во `<View />` добавляем `header={false}`
2. В `<Panel />` добавляем `separator={false}`. Это свойство теперь есть у `PanelHeaderSimple`
3. Заменяем `<PanelHeader />` на `<PanelHeaderSimple />`
4. Вы крутой :)

В 4-й версии библиотеки первых двух шагов не будет, PanelHeaderSimple переименуется в PanelHeader, а текущий PanelHeader
будет удален.