### PR TITLE
Added missing style for PanelHeader 

### DIFF
--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -222,6 +222,7 @@
           font-family: var(--font-tt);
           display: flex;
           align-items: center;
+          color: var(--header_text);
         }
 
         .PanelHeader--android .PanelHeader-content > *:not(.Search):not(.PanelHeaderContent) {


### PR DESCRIPTION
Исправляет #491 и даёт возможность изменять цвет заголовка так же, как и на iOS. 