### PR TITLE
[TypeScript] [ModalPage] Убран некорректный тайпинг для onClose ожидавший возвращения пустого объекта.

### DIFF
--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -14,7 +14,7 @@ export interface ModalPageProps extends HTMLAttributes<HTMLDivElement>, HasInset
    * Шапка модальной страницы, `<ModalPageHeader />`
    */
   header: ReactNode;
-  onClose: () => {};
+  onClose(): void;
   /**
    * Процент, на который изначально будет открыта модальная страница
    */

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -58,7 +58,7 @@ export interface ModalsStateEntry {
 }
 
 export interface ModalRootProps extends HasChildren, HasPlatform {
-  activeModal?: string;
+  activeModal?: string | null;
 }
 
 export interface ModalRootState {


### PR DESCRIPTION
Убран некорректный тайпинг для onClose ожидавший возвращения пустого объекта.