### PR TITLE
disable linebreak-style eslint rule and fix stylelint command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,6 @@
     "@typescript-eslint/no-magic-numbers": "off",
     "@typescript-eslint/no-unused-vars": ["error", {
       "ignoreRestSiblings": true
-    }],
-    "linebreak-style": "off"
+    }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/no-magic-numbers": "off",
     "@typescript-eslint/no-unused-vars": ["error", {
       "ignoreRestSiblings": true
-    }]
+    }],
+    "linebreak-style": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "tsc": "NODE_ENV=production tsc --emitDeclarationOnly --declaration",
     "tsc-es6": "NODE_ENV=production tsc --emitDeclarationOnly --declaration --outDir dist/es6/",
     "clear": "rm -rf dist/*",
-    "test": "tsc --noEmit && eslint --ext .jsx,.js,.ts,.tsx src/ && stylelint './src/**/*.css'",
+    "test": "tsc --noEmit && eslint --ext .jsx,.js,.ts,.tsx src/ && stylelint ./src/**/*.css",
     "copy-default-scheme": "cp ./src/styles/bright_light.css ./dist/default_scheme.css"
   },
   "pre-commit": [

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -135,7 +135,7 @@ class View extends Component<ViewProps, ViewState> {
     // Нужен переход
     if (prevProps.activePanel !== this.props.activePanel && !prevState.swipingBack && !prevState.browserSwipe) {
       const firstLayer = this.panels.find(
-        (panel: React.ReactElement) => panel.props.id === prevProps.activePanel || panel.props.id === this.props.activePanel
+        (panel: React.ReactElement) => panel.props.id === prevProps.activePanel || panel.props.id === this.props.activePanel,
       );
 
       const isBack = firstLayer && firstLayer.props.id === this.props.activePanel;


### PR DESCRIPTION
При запуске yarn test или при создании коммита запускается eslint, который на Windows (хотя может и у вас тоже) выдает ошибку для каждой строки во всех файлах о том, что символ для переноса строки отличается от рекомендуемого.

Я решил отключить это правило, потому что:
- Оно никак не влияет на работу кода и не отображается в редакторах;
- Некоторые редакторы при создании или изменении кода могут самостоятельно изменить тип переноса строки;
- Из-за причины выше я не вижу смысла постоянно подправлять эти окончания строк.

Также я исправил одно предупреждение eslint и подправил запуск stylelint внутри команды test. Насчет последнего я думаю стоит проверить на ваших устройствах отдельно работу команды без кавычек, потому что проблема могла быть опять же только на Windows.

![image](https://user-images.githubusercontent.com/35631027/78135115-ff10e580-7429-11ea-8324-7d8b102c9b96.png)
