### PR TITLE
Cell hover fixes

### DIFF
--- a/src/components/CellButton/CellButton.css
+++ b/src/components/CellButton/CellButton.css
@@ -12,6 +12,10 @@
   position: relative;
   }
 
+.CellButton--sizeX-compact {
+  border-radius: 0;
+}
+
 .CellButton[disabled] {
   opacity: .4;
   }

--- a/src/components/CellButton/CellButton.tsx
+++ b/src/components/CellButton/CellButton.tsx
@@ -4,8 +4,9 @@ import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { HasAlign } from '../../types';
+import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface CellButtonProps extends ButtonHTMLAttributes<HTMLElement>, HasAlign {
+export interface CellButtonProps extends ButtonHTMLAttributes<HTMLElement>, HasAlign, AdaptivityProps {
   mode?: 'primary' | 'danger';
   before?: React.ReactNode;
   Component?: ElementType;
@@ -22,6 +23,7 @@ const CellButton: React.FunctionComponent<CellButtonProps> = ({
   children,
   stopPropagation,
   Component,
+  sizeX,
   ...restProps
 }: CellButtonProps) => {
   const platform = usePlatform();
@@ -32,6 +34,7 @@ const CellButton: React.FunctionComponent<CellButtonProps> = ({
       className={classNames(
         getClassName('CellButton', platform),
         className,
+        `CellButton--sizeX-${sizeX}`,
         `CellButton--lvl-${mode}`,
         `CellButton--aln-${align}`,
       )}
@@ -52,4 +55,4 @@ CellButton.defaultProps = {
   stopPropagation: true,
 };
 
-export default CellButton;
+export default withAdaptivity(CellButton, { sizeX: true });

--- a/src/components/IconButton/IconButton.css
+++ b/src/components/IconButton/IconButton.css
@@ -55,10 +55,6 @@
   padding: 10px;
 }
 
-.IconButton--android .Tappable__waves {
-  border-radius: 50%;
-}
-
 .IconButton--android.Tappable--active {
   background-color: var(--background_highlighted);
 }

--- a/src/components/PanelHeaderButton/PanelHeaderButton.css
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.css
@@ -78,10 +78,6 @@
   padding: 10px;
 }
 
-.PanelHeaderButton--android .Tappable__waves {
-  border-radius: 50%;
-}
-
 .PanelHeaderButton--android.Tappable--active {
   background-color: var(--background_highlighted);
 }

--- a/src/components/RichCell/RichCell.css
+++ b/src/components/RichCell/RichCell.css
@@ -35,6 +35,8 @@
 }
 
 .RichCell__top {
+  font-size: 0;
+  line-height: 0;
 }
 
 .RichCell__top > :first-child:not(.RichCell__content) {

--- a/src/components/RichCell/RichCell.css
+++ b/src/components/RichCell/RichCell.css
@@ -8,6 +8,10 @@
   color: var(--text_primary);
 }
 
+.RichCell--sizeX-compact {
+  border-radius: 0;
+}
+
 .RichCell--mult {
   white-space: normal;
 }

--- a/src/components/RichCell/RichCell.tsx
+++ b/src/components/RichCell/RichCell.tsx
@@ -43,7 +43,6 @@ const RichCell: FunctionComponent<RichCellProps> = ({
   ...restProps
 }) => {
   const platform = usePlatform();
-  const isAfterPrimitive = typeof after === 'string' || typeof after === 'number';
 
   return (
     <Tappable
@@ -63,7 +62,7 @@ const RichCell: FunctionComponent<RichCellProps> = ({
       <div className="RichCell__in">
         <div className="RichCell__top">
           {/* Этот after будет скрыт из верстки. Он нужен для CSS */}
-          {isAfterPrimitive ? <span>{after}</span> : after}
+          {after}
           <div className="RichCell__content">
             <div className="RichCell__children">{children}</div>
             {after && <div className="RichCell__after">{after}</div>}

--- a/src/components/RichCell/RichCell.tsx
+++ b/src/components/RichCell/RichCell.tsx
@@ -4,8 +4,9 @@ import usePlatform from '../../hooks/usePlatform';
 import getClassName from '../../helpers/getClassName';
 import { HasRootRef } from '../../types';
 import Tappable from '../Tappable/Tappable';
+import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface RichCellProps extends HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
+export interface RichCellProps extends HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, AdaptivityProps {
   text?: ReactNode;
   caption?: ReactNode;
   /**
@@ -40,6 +41,7 @@ const RichCell: FunctionComponent<RichCellProps> = ({
   actions,
   multiline,
   className,
+  sizeX,
   ...restProps
 }) => {
   const platform = usePlatform();
@@ -52,6 +54,7 @@ const RichCell: FunctionComponent<RichCellProps> = ({
         classNames(
           className,
           getClassName('RichCell', platform),
+          `RichCell--sizeX-${sizeX}`,
           {
             'RichCell--mult': multiline,
           },
@@ -81,4 +84,4 @@ const RichCell: FunctionComponent<RichCellProps> = ({
   );
 };
 
-export default RichCell;
+export default withAdaptivity(RichCell, { sizeX: true });

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -7,6 +7,10 @@
   color: var(--text_primary);
 }
 
+.SimpleCell--sizeX-compact {
+  border-radius: 0;
+}
+
 .SimpleCell--mult {
   white-space: normal;
 }

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -6,8 +6,9 @@ import Icon24Chevron from '@vkontakte/icons/dist/24/chevron';
 import { HasRootRef } from '../../types';
 import { IOS } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
+import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface SimpleCellOwnProps {
+export interface SimpleCellOwnProps extends AdaptivityProps {
   /**
    * Иконка 28 или `<Avatar size={28|32|40|48|72} />`
    */
@@ -38,6 +39,7 @@ const SimpleCell: FC<SimpleCellProps> = ({
   expandable,
   multiline,
   Component,
+  sizeX,
   ...restProps
 }) => {
   const platform = usePlatform();
@@ -51,6 +53,7 @@ const SimpleCell: FC<SimpleCellProps> = ({
         classNames(
           className,
           getClassName('SimpleCell', platform),
+          `SimpleCell--sizeX-${sizeX}`,
           {
             'SimpleCell--exp': expandable,
             'SimpleCell--mult': multiline,
@@ -82,4 +85,4 @@ SimpleCell.defaultProps = {
   Component: 'div',
 };
 
-export default SimpleCell;
+export default withAdaptivity(SimpleCell, { sizeX: true });

--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -22,11 +22,8 @@
 .Tappable--android {
   position: relative;
   transition: background-color .15s ease-out;
-  }
-
-.Tappable--android:not(.PanelHeaderButton):not(.IconButton) {
   border-radius: 8px;
-}
+  }
 
 .Tappable--android.Tappable--active:not([disabled]):not(.TabsItem):not(.PanelHeaderButton):not(.IconButton):not(.Button):not(.SliderSwitch__button):not(.PanelHeaderContent__in) {
   background: var(--background_highlighted) !important;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -6,6 +6,10 @@
 /* Файлы с CSS компонентов подключаются здесь неслучайно. Пока не удалось делать импорты через JS так,
  * чтобы в каждом файле были доступны CSS переменные без их дублирования.
  */
+
+/* Service */
+@import '../components/Tappable/Tappable.css';
+
 /* Layout */
 @import '../components/Root/Root.css';
 @import '../components/View/View.css';
@@ -36,7 +40,6 @@
 @import '../components/ModalPageHeader/ModalPageHeader.css';
 
 /* Blocks */
-@import '../components/Tappable/Tappable.css';
 @import '../components/Button/Button.css';
 @import '../components/IconButton/IconButton.css';
 @import '../components/Card/Card.css';


### PR DESCRIPTION
* Убрал закругления у Cell, SimpleCell, RichCell и CellButton для ховеров/тапов в компактной версии
* Починил баг, когда в RichCell всплывал невидимый after
* Облегчил селекторы в Tappable.css, поместив его выше в styles.css, вынеся стили для PanelHeaderButton и IconButton в соответствующие файлы.