### PR TITLE
insets: setting vk bridge insets only if more than 0

### DIFF
--- a/src/hooks/useInsets.ts
+++ b/src/hooks/useInsets.ts
@@ -38,7 +38,7 @@ vkBridge.subscribe((e: BridgeEvent) => {
   if (insets) {
     const htmlElement = window.document.documentElement;
     for (let key in insets) {
-      if (insets.hasOwnProperty(key) && insets[key as keyof Insets] >= 0) {
+      if (insets.hasOwnProperty(key) && insets[key as keyof Insets] > 0) {
         htmlElement.style.setProperty(`--safe-area-inset-${key}`, `${insets[key as keyof Insets]}px`);
       }
     }


### PR DESCRIPTION
iOS присылает нулевой инсет сверху. Поэтому нули от VK Bridge учитывать не будем.