### PR TITLE
Removed JS insets style logic

### DIFF
--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -1,16 +1,14 @@
 import React, { Children, Component, HTMLAttributes } from 'react';
 import PopoutWrapper from '../PopoutWrapper/PopoutWrapper';
 import transitionEvents from '../../lib/transitionEvents';
-import withInsets from '../../hoc/withInsets';
 import withPlatform from '../../hoc/withPlatform';
 import withAdaptivity, { AdaptivityProps, ViewMode } from '../../hoc/withAdaptivity';
-import { isNumeric } from '../../lib/utils';
-import { HasInsets, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 import { ANDROID, IOS } from '../../lib/platform';
 import ActionSheetDropdownDesktop from './ActionSheetDropdownDesktop';
 import ActionSheetDropdown from './ActionSheetDropdown';
 
-export interface ActionSheetProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, HasInsets, AdaptivityProps {
+export interface ActionSheetProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, AdaptivityProps {
   /**
    * iOS only
    */
@@ -102,7 +100,6 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
       header,
       text,
       style,
-      insets,
       platform,
       viewMode,
       iosCloseItem,
@@ -139,9 +136,6 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
           {Children.toArray(children).map((child: React.ReactElement, index: number) =>
             child && React.cloneElement(child, {
               onClick: this.onItemClick(child.props.onClick, child.props.autoclose),
-              style: this.isItemLast(index) && isNumeric(insets.bottom)
-                ? { marginBottom: insets.bottom }
-                : null,
               isLast: this.isItemLast(index),
             }),
           )}
@@ -152,6 +146,6 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
   }
 }
 
-export default withAdaptivity(withPlatform(withInsets(ActionSheet)), {
+export default withAdaptivity(withPlatform(ActionSheet), {
   viewMode: true,
 });

--- a/src/components/Epic/Epic.tsx
+++ b/src/components/Epic/Epic.tsx
@@ -1,5 +1,4 @@
 import React, { HTMLAttributes, ReactNode, Component } from 'react';
-import PropTypes from 'prop-types';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import { HasChildren, HasPlatform } from '../../types';
@@ -10,21 +9,7 @@ export interface EpicProps extends HTMLAttributes<HTMLDivElement>, HasChildren, 
   activeStory: string;
 }
 
-export interface EpicContext {
-  hasTabbar: boolean;
-}
-
 class Epic extends Component<EpicProps> {
-  getChildContext(): EpicContext {
-    return {
-      hasTabbar: this.props.hasOwnProperty('tabbar'),
-    };
-  }
-
-  static childContextTypes: {} = {
-    hasTabbar: PropTypes.bool,
-  };
-
   render() {
     const { className, activeStory, tabbar, children, platform, ...restProps } = this.props;
 

--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -4,18 +4,14 @@ import PropTypes, { Requireable } from 'prop-types';
 import classNames from '../../lib/classNames';
 import { transitionEndEventName, TransitionStartEventDetail, transitionStartEventName } from '../View/View';
 import { SplitContext, SplitContextProps } from '../../components/SplitLayout/SplitLayout';
-import { tabbarHeight } from '../../appearance/constants';
-import withInsets from '../../hoc/withInsets';
 import withContext from '../../hoc/withContext';
-import { isNumeric } from '../../lib/utils';
-import { HasInsets, HasPlatform, HasRootRef, OldRef } from '../../types';
+import { HasPlatform, HasRootRef, OldRef } from '../../types';
 import withPlatform from '../../hoc/withPlatform';
 import withPanelContext from '../Panel/withPanelContext';
 
 export interface FixedLayoutProps extends
   HTMLAttributes<HTMLDivElement>,
   HasRootRef<HTMLDivElement>,
-  HasInsets,
   HasPlatform {
   vertical?: 'top' | 'bottom';
   /**
@@ -43,7 +39,6 @@ export interface FixedLayoutState {
 
 export interface FixedLayoutContext {
   document: Requireable<{}>;
-  hasTabbar: Requireable<boolean>;
 }
 
 class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
@@ -57,7 +52,6 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
 
   static contextTypes: FixedLayoutContext = {
     document: PropTypes.any,
-    hasTabbar: PropTypes.bool,
   };
 
   private onMountResizeTimeout: number;
@@ -127,9 +121,7 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
   };
 
   render() {
-    const { className, children, style, vertical, getRootRef, insets, platform, filled, separator, splitCol, ...restProps } = this.props;
-    const tabbarPadding = this.context.hasTabbar ? tabbarHeight : 0;
-    const paddingBottom = vertical === 'bottom' && isNumeric(insets.bottom) ? insets.bottom + tabbarPadding : null;
+    const { className, children, style, vertical, getRootRef, platform, filled, separator, splitCol, ...restProps } = this.props;
 
     return (
       <div
@@ -138,7 +130,7 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
         className={classNames(getClassName('FixedLayout', platform), {
           'FixedLayout--filled': filled,
         }, `FixedLayout--${vertical}`, className)}
-        style={{ ...style, ...this.state, paddingBottom }}
+        style={{ ...style, ...this.state }}
       >
         <div className="FixedLayout__in">{children}</div>
       </div>
@@ -147,7 +139,7 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
 }
 
 export default withContext(
-  withPlatform(withInsets(withPanelContext(FixedLayout))),
+  withPlatform(withPanelContext(FixedLayout)),
   SplitContext,
   'splitCol',
 );

--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -3,12 +3,10 @@ import Button from '../Button/Button';
 import PanelHeaderButton from '../PanelHeaderButton/PanelHeaderButton';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
-import withInsets from '../../hoc/withInsets';
 import Icon24Dismiss from '@vkontakte/icons/dist/24/dismiss';
 import { IOS } from '../../lib/platform';
-import { isNumeric } from '../../lib/utils';
 import withPlatform from '../../hoc/withPlatform';
-import { HasChildren, HasInsets, HasPlatform } from '../../types';
+import { HasChildren, HasPlatform } from '../../types';
 import withAdaptivity, { AdaptivityProps, ViewMode } from '../../hoc/withAdaptivity';
 
 export interface ModalCardActionInterface {
@@ -17,7 +15,7 @@ export interface ModalCardActionInterface {
   mode?: 'secondary' | 'primary';
 }
 
-export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform, HasChildren, HasInsets, AdaptivityProps {
+export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform, HasChildren, AdaptivityProps {
   /**
    * Иконка.
    *
@@ -55,7 +53,6 @@ class ModalCard extends Component<ModalCardProps> {
   static defaultProps: ModalCardProps = {
     actions: [],
     actionsLayout: 'horizontal',
-    insets: {},
   };
 
   onButtonClick: MouseEventHandler = (event: MouseEvent) => {
@@ -71,7 +68,6 @@ class ModalCard extends Component<ModalCardProps> {
 
   render() {
     const {
-      insets,
       icon,
       header,
       caption,
@@ -91,7 +87,7 @@ class ModalCard extends Component<ModalCardProps> {
         'ModalCard--desktop': isDesktop,
       })}>
         <div className="ModalCard__in">
-          <div className="ModalCard__container" style={isNumeric(insets.bottom) ? { marginBottom: insets.bottom } : null}>
+          <div className="ModalCard__container">
             {icon && <div className="ModalCard__icon">{icon}</div>}
             {header && <div className="ModalCard__title">{header}</div>}
             {caption && <div className="ModalCard__caption">{caption}</div>}
@@ -130,6 +126,6 @@ class ModalCard extends Component<ModalCardProps> {
   }
 }
 
-export default withAdaptivity(withPlatform(withInsets(ModalCard)), {
+export default withAdaptivity(withPlatform(ModalCard), {
   viewMode: true,
 });

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -1,15 +1,13 @@
 import React, { Component, HTMLAttributes, ReactNode } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
-import withInsets from '../../hoc/withInsets';
-import { isNumeric } from '../../lib/utils';
-import { HasInsets, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 import { ModalRootContextInterface } from '../ModalRoot/ModalRootContext';
 import withModalRootContext from '../ModalRoot/withModalRootContext';
 import withPlatform from '../../hoc/withPlatform';
 import withAdaptivity, { AdaptivityProps, ViewMode } from '../../hoc/withAdaptivity';
 
-export interface ModalPageProps extends HTMLAttributes<HTMLDivElement>, HasInsets, HasPlatform, AdaptivityProps {
+export interface ModalPageProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, AdaptivityProps {
   id: string;
   /**
    * Шапка модальной страницы, `<ModalPageHeader />`
@@ -39,11 +37,10 @@ class ModalPage extends Component<ModalPageProps> {
 
   static defaultProps: Partial<ModalPageProps> = {
     settlingHeight: 75,
-    insets: {},
   };
 
   render() {
-    const { children, className, header, insets, platform, viewMode } = this.props;
+    const { children, className, header, platform, viewMode } = this.props;
     const isDesktop = viewMode >= ViewMode.TABLET;
 
     return (
@@ -57,7 +54,7 @@ class ModalPage extends Component<ModalPageProps> {
             </div>
 
             <div className="ModalPage__content">
-              <div className="ModalPage__content-in" style={isNumeric(insets.bottom) ? { paddingBottom: insets.bottom } : null}>
+              <div className="ModalPage__content-in">
                 {children}
               </div>
             </div>
@@ -68,6 +65,6 @@ class ModalPage extends Component<ModalPageProps> {
   }
 }
 
-export default withAdaptivity(withInsets(withPlatform(withModalRootContext(ModalPage))), {
+export default withAdaptivity(withPlatform(withModalRootContext(ModalPage)), {
   viewMode: true,
 });

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -1,24 +1,16 @@
 import React, { Component, HTMLAttributes } from 'react';
-import PropTypes, { Requireable } from 'prop-types';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import Touch from '../Touch/Touch';
-import { tabbarHeight } from '../../appearance/constants';
-import withInsets from '../../hoc/withInsets';
 import withPlatform from '../../hoc/withPlatform';
-import { isNumeric } from '../../lib/utils';
-import { HasInsets, HasPlatform, HasRootRef, OldRef } from '../../types';
+import { HasPlatform, HasRootRef, OldRef } from '../../types';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 import { PanelContext, PanelContextProps } from './PanelContext';
 
-export interface PanelProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, HasInsets, HasRootRef<HTMLDivElement>, AdaptivityProps {
+export interface PanelProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, HasRootRef<HTMLDivElement>, AdaptivityProps {
   id: string;
   separator?: boolean;
   centered?: boolean;
-}
-
-export interface PanelContext {
-  hasTabbar: Requireable<boolean>;
 }
 
 class Panel extends Component<PanelProps> {
@@ -29,10 +21,6 @@ class Panel extends Component<PanelProps> {
      * @deprecated будет удалено в 4-й версии. Сепаратор теперь устанавливается в PanelHeader
      */
     separator: true,
-  };
-
-  static contextTypes: PanelContext = {
-    hasTabbar: PropTypes.bool,
   };
 
   getContext(): PanelContextProps {
@@ -58,8 +46,7 @@ class Panel extends Component<PanelProps> {
   };
 
   render() {
-    const { className, centered, children, insets, platform, separator, getRootRef, sizeX, ...restProps } = this.props;
-    const tabbarPadding = this.context.hasTabbar ? tabbarHeight : 0;
+    const { className, centered, children, platform, separator, getRootRef, sizeX, ...restProps } = this.props;
 
     return (
       <PanelContext.Provider value={this.getContext()}>
@@ -71,9 +58,7 @@ class Panel extends Component<PanelProps> {
             [`Panel--sizeX-${sizeX}`]: true,
           })}
         >
-          <Touch className="Panel__in" style={{
-            paddingBottom: isNumeric(insets.bottom) ? insets.bottom + tabbarPadding : null,
-          }}>
+          <Touch className="Panel__in">
             <div className="Panel__in-before" />
             {centered ? <div className="Panel__centered">{children}</div> : children}
             <div className="Panel__in-after" />
@@ -84,6 +69,6 @@ class Panel extends Component<PanelProps> {
   }
 }
 
-export default withAdaptivity(withPlatform(withInsets(Panel)), {
+export default withAdaptivity(withPlatform(Panel), {
   sizeX: true,
 });

--- a/src/components/Tabbar/Tabbar.tsx
+++ b/src/components/Tabbar/Tabbar.tsx
@@ -1,9 +1,7 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
-import { isNumeric } from '../../lib/utils';
 import usePlatform from '../../hooks/usePlatform';
-import useInsets from '../../hooks/useInsets';
 
 export interface TabbarProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -16,7 +14,6 @@ export interface TabbarProps extends HTMLAttributes<HTMLDivElement> {
 const Tabbar: FunctionComponent<TabbarProps> = (props: TabbarProps) => {
   const { className, children, shadow, itemsLayout } = props;
   const platform = usePlatform();
-  const insets = useInsets();
 
   const getItemsLayout = () => {
     switch (itemsLayout) {
@@ -33,7 +30,6 @@ const Tabbar: FunctionComponent<TabbarProps> = (props: TabbarProps) => {
       className={classNames(getClassName('Tabbar', platform), className, `Tabbar--l-${getItemsLayout()}`, {
         'Tabbar--shadow': shadow,
       })}
-      style={{ paddingBottom: isNumeric(insets.bottom) ? insets.bottom : null }}
     >
       {children}
     </div>


### PR DESCRIPTION
Инсеты из JS теперь меняют css-перменные. Поэтому JS-логику можно выпилить.