### PR TITLE
Fix Link component prop types

### DIFF
--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,10 +1,10 @@
-import React, { ElementType, FunctionComponent, LinkHTMLAttributes } from 'react';
+import React, { ElementType, FunctionComponent, AnchorHTMLAttributes } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { HasRootRef } from '../../types';
 
-export interface LinkProps extends LinkHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
+export interface LinkProps extends AnchorHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
   Component?: ElementType;
 }
 


### PR DESCRIPTION
Use AnchorHTMLAttributes for `<a>` tags instead of props for `<link>` tag

---

Поправил описание типов, на которые ругался тайпчекер.\
Например при передаче атрибута `_target`, которого нет у тега `<link>`