### PR TITLE
fix test command on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "tsc": "NODE_ENV=production tsc --emitDeclarationOnly --declaration",
     "tsc-es6": "NODE_ENV=production tsc --emitDeclarationOnly --declaration --outDir dist/es6/",
     "clear": "rm -rf dist/*",
-    "test": "tsc --noEmit && eslint --ext .jsx,.js,.ts,.tsx src/ && stylelint './src/**/*.css'",
+    "test": "tsc --noEmit && eslint --ext .jsx,.js,.ts,.tsx src/ && stylelint \"./src/**/*.css\"",
     "copy-default-scheme": "cp ./src/styles/bright_light.css ./dist/default_scheme.css"
   },
   "pre-commit": [


### PR DESCRIPTION
На скриншоте видно, что после смены типа кавычек stylelint перестал выдавать ошибку.
![image](https://user-images.githubusercontent.com/35631027/86591676-ae65d700-bf9a-11ea-9050-a153b04c236d.png)
