### PR TITLE
Legacy context

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -6,14 +6,14 @@ import {
   Scheme,
   defaultConfigProviderProps,
 } from './ConfigProviderContext';
-import { HasChildren } from '../../types';
+import { HasChildren, DOMProps } from '../../types';
 import { AppearanceSchemeType } from '@vkontakte/vk-bridge';
 import PropTypes from 'prop-types';
 
 export interface ConfigProviderProps extends ConfigProviderContextInterface, HasChildren {}
 
 export default class ConfigProvider extends React.Component<ConfigProviderProps> {
-  constructor(props: ConfigProviderProps, context: any) {
+  constructor(props: ConfigProviderProps, context: DOMProps) {
     super(props);
     if (canUseDOM) {
       this.setScheme(this.mapOldScheme(props.scheme), context);
@@ -24,7 +24,9 @@ export default class ConfigProvider extends React.Component<ConfigProviderProps>
     document: PropTypes.any,
   };
 
-  static defaultProps: ConfigProviderProps = defaultConfigProviderProps;
+  // Деструктуризация нужна из бага в react-docgen-typescript
+  // https://github.com/styleguidist/react-docgen-typescript/issues/195
+  public static defaultProps = { ...defaultConfigProviderProps };
 
   mapOldScheme(scheme: AppearanceSchemeType): AppearanceSchemeType {
     switch (scheme) {
@@ -37,7 +39,7 @@ export default class ConfigProvider extends React.Component<ConfigProviderProps>
     }
   }
 
-  setScheme = (scheme: AppearanceSchemeType, context: any): void => {
+  setScheme = (scheme: AppearanceSchemeType, context: DOMProps): void => {
     (context.document || document).body.setAttribute('scheme', scheme);
   };
 

--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -27,8 +27,6 @@ export interface FixedLayoutProps extends
   /**
    * @ignore
    */
-  separator?: boolean;
-
   splitCol?: SplitContextProps;
 }
 
@@ -114,7 +112,7 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
   };
 
   render() {
-    const { className, children, style, vertical, getRootRef, platform, filled, separator, splitCol, ...restProps } = this.props;
+    const { className, children, style, vertical, getRootRef, platform, filled, splitCol, panel, ...restProps } = this.props;
 
     return (
       <div

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -5,14 +5,23 @@ import { isFunction } from '../../lib/utils';
 import { transitionEvent } from '../../lib/supportEvents';
 import { HasChildren, HasPlatform } from '../../types';
 import withPlatform from '../../hoc/withPlatform';
+import withContext from '../../hoc/withContext';
 import ModalRootContext, { ModalRootContextInterface } from './ModalRootContext';
-import { WebviewType } from '../ConfigProvider/ConfigProviderContext';
+import {
+  ConfigProviderContext,
+  ConfigProviderContextInterface,
+  WebviewType,
+} from '../ConfigProvider/ConfigProviderContext';
 import { ModalsStateEntry, ModalType } from './types';
 import { ANDROID } from '../../lib/platform';
 import getClassName from '../../helpers/getClassName';
 
 export interface ModalRootProps extends HasChildren, HasPlatform {
   activeModal?: string | null;
+  /**
+   * @ignore
+   */
+  configProvider?: ConfigProviderContextInterface;
 
   /**
    * Будет вызвано при закрытии активной модалки с её id
@@ -70,7 +79,6 @@ class ModalRootDesktop extends Component<ModalRootProps, ModalRootState> {
   static contextTypes = {
     window: PropTypes.any,
     document: PropTypes.any,
-    webviewType: PropTypes.oneOf([WebviewType.VKAPPS, WebviewType.INTERNAL]),
   };
 
   get document(): Document {
@@ -79,10 +87,6 @@ class ModalRootDesktop extends Component<ModalRootProps, ModalRootState> {
 
   get window(): Window {
     return this.context.window || window;
-  }
-
-  get webviewType(): WebviewType {
-    return this.context.webviewType || WebviewType.VKAPPS;
   }
 
   get modals() {
@@ -418,7 +422,7 @@ class ModalRootDesktop extends Component<ModalRootProps, ModalRootState> {
       <ModalRootContext.Provider value={this.modalRootContext}>
         <div
           className={classNames(getClassName('ModalRoot', this.props.platform), {
-            'ModalRoot--vkapps': this.webviewType === 'vkapps',
+            'ModalRoot--vkapps': this.props.configProvider.webviewType === WebviewType.VKAPPS,
           })}
         >
           <div
@@ -454,4 +458,4 @@ class ModalRootDesktop extends Component<ModalRootProps, ModalRootState> {
   }
 }
 
-export default withPlatform(ModalRootDesktop);
+export default withContext(withPlatform(ModalRootDesktop), ConfigProviderContext, 'configProvider');

--- a/src/components/ModalRoot/ModalRootTouch.tsx
+++ b/src/components/ModalRoot/ModalRootTouch.tsx
@@ -11,8 +11,13 @@ import { ANDROID } from '../../lib/platform';
 import { transitionEvent } from '../../lib/supportEvents';
 import { HasChildren, HasPlatform } from '../../types';
 import withPlatform from '../../hoc/withPlatform';
+import withContext from '../../hoc/withContext';
 import ModalRootContext, { ModalRootContextInterface } from './ModalRootContext';
-import { WebviewType } from '../ConfigProvider/ConfigProviderContext';
+import {
+  ConfigProviderContext,
+  ConfigProviderContextInterface,
+  WebviewType,
+} from '../ConfigProvider/ConfigProviderContext';
 import { ModalsStateEntry, ModalType, TranslateRange } from './types';
 
 function numberInRange(number: number, range: TranslateRange) {
@@ -30,6 +35,10 @@ export interface ModalRootProps extends HasChildren, HasPlatform {
    * Будет вызвано при закрытии активной модалки с её id
    */
   onClose?(modalId: string): void;
+  /**
+   * @ignore
+   */
+  configProvider?: ConfigProviderContextInterface;
 }
 
 interface ModalRootState {
@@ -91,7 +100,6 @@ class ModalRootTouch extends Component<ModalRootProps, ModalRootState> {
   static contextTypes = {
     window: PropTypes.any,
     document: PropTypes.any,
-    webviewType: PropTypes.oneOf([WebviewType.VKAPPS, WebviewType.INTERNAL]),
   };
 
   get document(): Document {
@@ -100,10 +108,6 @@ class ModalRootTouch extends Component<ModalRootProps, ModalRootState> {
 
   get window(): Window {
     return this.context.window || window;
-  }
-
-  get webviewType(): WebviewType {
-    return this.context.webviewType || WebviewType.VKAPPS;
   }
 
   get modals() {
@@ -792,7 +796,7 @@ class ModalRootTouch extends Component<ModalRootProps, ModalRootState> {
         <ModalRootContext.Provider value={this.modalRootContext}>
           <Touch
             className={classNames(getClassName('ModalRoot', this.props.platform), {
-              'ModalRoot--vkapps': this.webviewType === WebviewType.VKAPPS,
+              'ModalRoot--vkapps': this.props.configProvider.webviewType === WebviewType.VKAPPS,
               'ModalRoot--touched': touchDown,
               'ModalRoot--switching': switching,
             })}
@@ -842,4 +846,4 @@ class ModalRootTouch extends Component<ModalRootProps, ModalRootState> {
   }
 }
 
-export default withPlatform(ModalRootTouch);
+export default withContext(withPlatform(ModalRootTouch), ConfigProviderContext, 'configProvider');

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -11,26 +11,23 @@ import { setRef } from '../../lib/utils';
 
 export interface PanelProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, HasRootRef<HTMLDivElement>, AdaptivityProps {
   id: string;
-  separator?: boolean;
   centered?: boolean;
 }
 
 class Panel extends Component<PanelProps> {
+  constructor(props: PanelProps) {
+    super(props);
+    this.childContext = {
+      panel: props.id,
+    };
+  }
+
+  private readonly childContext: PanelContextProps;
+
   static defaultProps: Partial<PanelProps> = {
     children: '',
     centered: false,
-    /**
-     * @deprecated будет удалено в 4-й версии. Сепаратор теперь устанавливается в PanelHeader
-     */
-    separator: true,
   };
-
-  getContext(): PanelContextProps {
-    return {
-      panel: this.props.id,
-      separator: this.props.separator,
-    };
-  }
 
   container: HTMLDivElement;
 
@@ -40,10 +37,10 @@ class Panel extends Component<PanelProps> {
   };
 
   render() {
-    const { className, centered, children, platform, separator, getRootRef, sizeX, ...restProps } = this.props;
+    const { className, centered, children, platform, getRootRef, sizeX, ...restProps } = this.props;
 
     return (
-      <PanelContext.Provider value={this.getContext()}>
+      <PanelContext.Provider value={this.childContext}>
         <div
           {...restProps}
           ref={this.getRef}

--- a/src/components/Panel/PanelContext.tsx
+++ b/src/components/Panel/PanelContext.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 export interface PanelContextProps {
-  separator?: boolean;
   panel?: string;
 }
 

--- a/src/components/Panel/withPanelContext.tsx
+++ b/src/components/Panel/withPanelContext.tsx
@@ -3,9 +3,9 @@ import { PanelContext } from './PanelContext';
 
 export default function withPanelContext<T>(Component: T): T {
   function WithPanelContext(props: {}) {
-    const { panel, separator } = useContext(PanelContext);
+    const { panel } = useContext(PanelContext);
     // @ts-ignore
-    return <Component {...props} panel={panel} separator={separator} />;
+    return <Component {...props} panel={panel} />;
   }
   return WithPanelContext as unknown as T;
 }

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -7,7 +7,6 @@ import Separator from '../Separator/Separator';
 import { ANDROID } from '../../lib/platform';
 import { HasRef, HasRootRef } from '../../types';
 import { ConfigProviderContext, WebviewType } from '../ConfigProvider/ConfigProviderContext';
-import { PanelContext } from '../Panel/PanelContext';
 import withAdaptivity, { AdaptivityProps, SizeType } from '../../hoc/withAdaptivity';
 
 export interface PanelHeaderProps extends HTMLAttributes<HTMLDivElement>, HasRef<HTMLDivElement>, HasRootRef<HTMLDivElement>, AdaptivityProps {
@@ -43,13 +42,7 @@ const PanelHeader = ({
 }: PanelHeaderProps) => {
   const platform = usePlatform();
   const { webviewType } = useContext(ConfigProviderContext);
-  const panelContext = useContext(PanelContext);
   const needShadow = shadow && sizeX === SizeType.REGULAR;
-  let needSeparator = separator;
-
-  if (typeof separator !== 'boolean') {
-    needSeparator = panelContext.separator;
-  }
 
   const isPrimitive = typeof children === 'string' || typeof children === 'number';
 
@@ -63,7 +56,7 @@ const PanelHeader = ({
             'PanelHeader--trnsp': transparent,
             'PanelHeader--shadow': needShadow,
             'PanelHeader--vis': visor,
-            'PanelHeader--sep': needSeparator && visor,
+            'PanelHeader--sep': separator && visor,
             'PanelHeader--vkapps': webviewType === WebviewType.VKAPPS,
             'PanelHeader--no-left': left === undefined,
             'PanelHeader--no-right': right === undefined,
@@ -98,7 +91,7 @@ const PanelHeader = ({
           </div>
         </div>
       </FixedLayout>
-      {needSeparator && visor && <Separator
+      {separator && visor && <Separator
         className={sizeX === SizeType.COMPACT ? 'PanelHeader__separator' : ''}
         expanded={sizeX === SizeType.REGULAR}
       />}

--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Component, HTMLAttributes, ReactElement, ReactNode } from 'react';
-import PropTypes, { Requireable, Validator } from 'prop-types';
+import PropTypes, { Requireable } from 'prop-types';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import { animationEvent } from '../../lib/supportEvents';
@@ -8,13 +8,21 @@ import { SplitContext, SplitContextProps } from '../../components/SplitLayout/Sp
 import withPlatform from '../../hoc/withPlatform';
 import withContext from '../../hoc/withContext';
 import { HasPlatform } from '../../types';
+import { ConfigProviderContext, ConfigProviderContextInterface } from '../ConfigProvider/ConfigProviderContext';
 
 export interface RootProps extends HTMLAttributes<HTMLDivElement>, HasPlatform {
   activeView: string;
   onTransition?(params: { isBack: boolean; from: string; to: string }): void;
   popout?: ReactNode;
   modal?: ReactNode;
+  /**
+   * @ignore
+   */
   splitCol?: SplitContextProps;
+  /**
+   * @ignore
+   */
+  configProvider?: ConfigProviderContextInterface;
 }
 
 export type AnimationEndCallback = (e?: AnimationEvent) => void;
@@ -34,7 +42,6 @@ export interface RootState {
 export interface RootContext {
   document: Requireable<object>;
   window: Requireable<object>;
-  transitionMotionEnabled: Validator<boolean>;
 }
 
 class Root extends Component<RootProps, RootState> {
@@ -59,7 +66,6 @@ class Root extends Component<RootProps, RootState> {
   static contextTypes: RootContext = {
     window: PropTypes.any,
     document: PropTypes.any,
-    transitionMotionEnabled: PropTypes.bool,
   };
 
   private animationFinishTimeout: ReturnType<typeof setTimeout>;
@@ -123,7 +129,7 @@ class Root extends Component<RootProps, RootState> {
   }
 
   shouldDisableTransitionMotion(): boolean {
-    return this.context.transitionMotionEnabled === false ||
+    return this.props.configProvider.transitionMotionEnabled === false ||
       !this.props.splitCol.animate;
   }
 
@@ -207,8 +213,8 @@ class Root extends Component<RootProps, RootState> {
   }
 }
 
-export default withContext(
+export default withContext(withContext(
   withPlatform(Root),
   SplitContext,
   'splitCol',
-);
+), ConfigProviderContext, 'configProvider');

--- a/src/components/Tooltip/Readme.md
+++ b/src/components/Tooltip/Readme.md
@@ -70,7 +70,7 @@ import { Tooltip, Button } from '@vkontakte/vkui';
             <PanelHeader
               left={
                 <PanelHeaderButton onClick={() => this.setState({ activePanel: 'tooltip' })}>
-                  {osname === ANDROID ? <Icon24Back/> : <Icon28ChevronBack/>}
+                  {this.props.platform === ANDROID ? <Icon24Back/> : <Icon28ChevronBack/>}
                 </PanelHeaderButton>
               }
               right={
@@ -115,5 +115,7 @@ import { Tooltip, Button } from '@vkontakte/vkui';
     }
   }
 
-  <Example />
+  const ExampleWithPlatform = withPlatform(Example);
+
+  <ExampleWithPlatform /> 
 ```

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -16,7 +16,6 @@ interface TooltipPortalState {
 
 interface TooltipPortalContextType {
   document: Requireable<{}>;
-  panel: Requireable<string>;
 }
 
 type GetBoundingTargetRect = () => {
@@ -57,7 +56,6 @@ class TooltipPortal extends Component<TooltipPortalProps, TooltipPortalState> {
 
   static contextTypes: TooltipPortalContextType = {
     document: PropTypes.object,
-    panel: PropTypes.string,
   };
 
   get document() {

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -11,6 +11,7 @@ import { HasChildren, HasPlatform } from '../../types';
 import { SplitContext, SplitContextProps } from '../../components/SplitLayout/SplitLayout';
 import withPlatform from '../../hoc/withPlatform';
 import withContext from '../../hoc/withContext';
+import { ConfigProviderContext, ConfigProviderContextInterface } from '../ConfigProvider/ConfigProviderContext';
 
 export const transitionStartEventName = 'VKUI:View:transition-start';
 export const transitionEndEventName = 'VKUI:View:transition-end';
@@ -46,7 +47,14 @@ export interface ViewProps extends HTMLAttributes<HTMLElement>, HasChildren, Has
   onSwipeBackStart?(): void;
   history?: string[];
   id?: string;
+  /**
+   * @ignore
+   */
   splitCol?: SplitContextProps;
+  /**
+   * @ignore
+   */
+  configProvider?: ConfigProviderContextInterface;
 }
 
 export interface ViewState {
@@ -100,10 +108,8 @@ class View extends Component<ViewProps, ViewState> {
   };
 
   static contextTypes = {
-    isWebView: PropTypes.bool,
     window: PropTypes.any,
     document: PropTypes.any,
-    transitionMotionEnabled: PropTypes.bool,
   };
 
   private transitionFinishTimeout: ReturnType<typeof setTimeout>;
@@ -226,7 +232,7 @@ class View extends Component<ViewProps, ViewState> {
   }
 
   shouldDisableTransitionMotion(): boolean {
-    return this.context.transitionMotionEnabled === false ||
+    return this.props.configProvider.transitionMotionEnabled === false ||
       !this.props.splitCol.animate;
   }
 
@@ -356,13 +362,13 @@ class View extends Component<ViewProps, ViewState> {
       return;
     }
 
-    const { platform } = this.props;
+    const { platform, configProvider } = this.props;
 
-    if (platform === IOS && !this.context.isWebView && (e.startX <= 70 || e.startX >= this.window.innerWidth - 70) && !this.state.browserSwipe) {
+    if (platform === IOS && !configProvider.isWebView && (e.startX <= 70 || e.startX >= this.window.innerWidth - 70) && !this.state.browserSwipe) {
       this.setState({ browserSwipe: true });
     }
 
-    if (platform === IOS && this.context.isWebView && this.props.onSwipeBack) {
+    if (platform === IOS && configProvider.isWebView && this.props.onSwipeBack) {
       if (this.state.animated && e.startX <= 70) {
         return;
       }
@@ -503,8 +509,8 @@ class View extends Component<ViewProps, ViewState> {
   }
 }
 
-export default withContext(
+export default withContext(withContext(
   withPlatform(View),
   SplitContext,
   'splitCol',
-);
+), ConfigProviderContext, 'configProvider');

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,3 +68,8 @@ export interface Version {
   minor?: number;
   patch?: number;
 }
+
+export interface DOMProps {
+  document?: Document;
+  window?: Window;
+}

--- a/styleguide/Components/PathlineRenderer.js
+++ b/styleguide/Components/PathlineRenderer.js
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-styleguidist/lib/client/rsg-components/Link';
 import pkg from '../../package.json';
 import Styled from 'react-styleguidist/lib/client/rsg-components/Styled';
-import { schemeOptions } from '../utils';
+import { StyleGuideContext } from './StyleGuideRenderer';
+import { PlatformSelect } from './PlatformSelect';
+import { SchemeSelect } from './SchemeSelect';
+import { WebviewTypeSelect } from './WebviewTypeSelect';
 
 export const styles = ({ fontFamily, fontSize }) => ({
   pathline: {
@@ -17,31 +20,38 @@ export const styles = ({ fontFamily, fontSize }) => ({
 
 export function PathlineRenderer({ classes, children }) {
   return (
-    <div className={classes.pathline}>
-      <span>
-        Платформа:&nbsp;
-        <select onChange={ (e) => {
-          window.localStorage.setItem('vkui-styleguide:ua', e.target.value);
-          window.location.reload();
-        } } value={window.navigator.userAgent}>
-          <option value={window.uaList.ios}>ios</option>
-          <option value={window.uaList.android}>android</option>
-        </select>
-      </span>&nbsp;|&nbsp;<span>
-        Тема:&nbsp;
-        <select onChange={ (e) => {
-          window.localStorage.setItem('vkui-styleguide:schemeId', e.target.value);
-          window.location.reload();
-        } } value={window.schemeId}>
-          {schemeOptions}
-        </select>
-      </span>&nbsp;|&nbsp;<span className={classes.link}>
-        Исходники:&nbsp;
-        <Link target="_blank" href={`${pkg.repository}/tree/v${pkg.version}/${children.replace('../', '')}`}>
-          GitHub
-        </Link>
-      </span>
-    </div>
+    <StyleGuideContext.Consumer>
+      {(styleGuideContext) => {
+        return (
+          <div className={classes.pathline}>
+            <PlatformSelect
+              onChange={(e) => styleGuideContext.setContext({ platform: e.target.value })}
+              value={styleGuideContext.platform}
+            />
+            &nbsp;|&nbsp;
+            <SchemeSelect
+              onChange={(e) => styleGuideContext.setContext({ scheme: e.target.value })}
+              value={styleGuideContext.scheme}
+            />
+            &nbsp;|&nbsp;
+            <WebviewTypeSelect
+              onChange={(e) => styleGuideContext.setContext({ webviewType: e.target.value })}
+              value={styleGuideContext.webviewType}
+            />
+            &nbsp;|&nbsp;
+            <span className={classes.link}>
+              Исходники:&nbsp;
+                <Link
+                  target="_blank"
+                  href={`${pkg.repository}/tree/v${pkg.version}/${children.replace('../', '')}`}
+                >
+                  GitHub
+                </Link>
+            </span>
+          </div>
+        )
+      }}
+    </StyleGuideContext.Consumer>
   );
 }
 

--- a/styleguide/Components/PlatformSelect.js
+++ b/styleguide/Components/PlatformSelect.js
@@ -1,0 +1,12 @@
+import React, { Fragment } from 'react';
+import { OS } from '../../src/lib/platform';
+
+export const PlatformSelect = ({ onChange, value }) => (
+  <Fragment>
+    platform:&nbsp;
+    <select onChange={onChange} value={value}>
+      <option value={OS.IOS}>{OS.IOS}</option>
+      <option value={OS.ANDROID}>{OS.ANDROID}</option>
+    </select>
+  </Fragment>
+)

--- a/styleguide/Components/SchemeSelect.js
+++ b/styleguide/Components/SchemeSelect.js
@@ -1,0 +1,15 @@
+import React, { Fragment } from 'react';
+import { Scheme } from '../../src/components/ConfigProvider/ConfigProviderContext';
+
+const schemeOptions = [Scheme.BRIGHT_LIGHT, Scheme.SPACE_GRAY].map((schemeId) => (
+  <option value={schemeId} key={schemeId}>{schemeId}</option>
+))
+
+export const SchemeSelect = ({ onChange, value }) => (
+  <Fragment>
+    scheme:&nbsp;
+    <select onChange={onChange} value={value}>
+      {schemeOptions}
+    </select>
+  </Fragment>
+)

--- a/styleguide/Components/WebviewTypeSelect.js
+++ b/styleguide/Components/WebviewTypeSelect.js
@@ -1,0 +1,12 @@
+import React, { Fragment } from 'react';
+import { WebviewType } from '../../src/components/ConfigProvider/ConfigProviderContext';
+
+export const WebviewTypeSelect = ({ onChange, value }) => (
+  <Fragment>
+    webviewType:&nbsp;
+    <select onChange={onChange} value={value}>
+      <option value={WebviewType.VKAPPS}>{WebviewType.VKAPPS}</option>
+      <option value={WebviewType.INTERNAL}>{WebviewType.INTERNAL}</option>
+    </select>
+  </Fragment>
+)

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -224,7 +224,7 @@ module.exports = {
     ],
     resolve: {
       alias: {
-        'rsg-components/Preview': path.join(__dirname, './Components/Preview')
+        'rsg-components/Preview': path.join(__dirname, './components/Preview')
       }
     }
   })

--- a/styleguide/setup.js
+++ b/styleguide/setup.js
@@ -1,6 +1,5 @@
 import '../src/styles/styles.css';
 
-import pkg from '../package';
 import { getRandomInt, getRandomUser, getRandomUsers, importantCountries, getAvatarUrl } from './utils';
 import * as VKUI from '../src';
 
@@ -80,10 +79,6 @@ import Icon56UsersOutline from '@vkontakte/icons/dist/56/users_outline';
 for (let i in VKUI) {
   window[i] = VKUI[i];
 }
-
-window.osname = VKUI.platform();
-
-window.schemeId = window.localStorage.getItem('vkui-styleguide:schemeId') || pkg.defaultSchemeId;
 
 window.getRandomInt = getRandomInt;
 window.getRandomUser = getRandomUser;

--- a/styleguide/utils.js
+++ b/styleguide/utils.js
@@ -1,24 +1,9 @@
 import React from 'react';
 import { users } from './demo_dataset';
 
-window.uaList = {
-  ios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1',
-  android: 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Mobile Safari/537.36',
-};
-
-Object.defineProperty(navigator, 'userAgent', {
-  get: function() {
-    return window.localStorage.getItem('vkui-styleguide:ua') || window.uaList.ios;
-  },
-});
-
 export function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
-
-export const schemeOptions = ['bright_light', 'space_gray'].map((schemeId) => (
-  <option value={schemeId} key={schemeId}>{schemeId}</option>
-));
 
 function getRandomArrayElement(items) {
   return items[Math.floor(Math.random() * items.length)];
@@ -28,24 +13,6 @@ function getRandomObjectKey(object) {
   const keys = Object.keys(object);
   return keys[keys.length * Math.random() << 0];
 }
-
-export const testStrings = [
-  'Далеко-далеко за словесными горами в стране, гласных и согласных живут рыбные тексты.',
-  'Переписали правилами по всей свой буквенных единственное жизни пустился!',
-  'Которой реторический, текстами речью маленький обеспечивает пор они знаках свой текстов но!',
-  'Семантика по всей ведущими несколько за, выйти эта, lorem свой рукописи на берегу свое обеспечивает, злых коварный?',
-  'Путь не сих переулка сбить моей, напоивший, над продолжил необходимыми, снова журчит за грамматики злых.',
-  'По всей подпоясал, безопасную рыбного деревни послушавшись свое маленький текстов.',
-  'Сбить свою несколько маленький взобравшись.',
-  'Подпоясал осталось своего, до это свой реторический всеми агенство.',
-  'Назад океана, коварных они моей дороге но рукописи которое заманивший власти проектах текст себя текста то великий решила взобравшись большой приставка?',
-  'Свой там, переписывается семь, напоивший буквенных необходимыми если первую предложения своих?',
-  'Живет взобравшись лучше безорфографичный текстов пояс заманивший родного не она одна он дороге дал алфавит заголовок мир последний',
-  'Напоивший продолжил сих свой буквенных власти диких составитель, правилами lorem.',
-  'Что образ прямо ipsum от всех назад предупреждал наш точках.',
-  'Живет всеми но текстов рекламных грамматики залетают все вершину последний. Запятой его там, великий она это?',
-  'Рот языкового скатился, злых, жаренные вопрос снова он единственное журчит меня одна дорогу залетают повстречался толку страна вершину.',
-];
 
 const photos = {
   'app_shorm_online': {


### PR DESCRIPTION
## Исходники
* `ConfigProvider`: избавился от legacy context API
* `Panel`: убрал устаревшее свойство `separator`

## Документация
* Теперь каждый пример обернут в ConfigProvider
* Добавил возможность менять webviewType
* Избавился от перезагрузки при смене параметров ConfigProvider
* Избавился от ненужного ReactDOM.render внутри каждого примера
* Удалил лишний код из setup.js и config.js
