### PR TITLE
Fix mouse detection on Android devices

### DIFF
--- a/src/helpers/inputUtils.ts
+++ b/src/helpers/inputUtils.ts
@@ -17,8 +17,8 @@ if (IS_PLATFORM_IOS) {
     && navigator.maxTouchPoints > 0;
 
   if (hasTouchEvents) {
-    hasMouse = window.matchMedia && matchMedia('(any-pointer)').matches
-      ? matchMedia('(any-pointer: fine)').matches
+    hasMouse = window.matchMedia && matchMedia('(pointer)').matches
+      ? matchMedia('(pointer: fine)').matches
       : /android|mobile|tablet/i.test(navigator.userAgent);
 
     hasHover = hasMouse && (


### PR DESCRIPTION
Сейчас на Android применяются стили для мышки, даже если её нет.
Правильнее будет указать `pointer: fine`, вместо `any-pointer: fine`.