### PR TITLE
Fix Panel background on desktop

### DIFF
--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -91,7 +91,7 @@
   background-color: var(--background_content);
 }
 
-.Panel.Panel--regular .Panel__in,
-.Panel.Panel--regular::after {
+.SplitLayout .Panel.Panel--regular .Panel__in,
+.SplitLayout .Panel.Panel--regular::after {
   background-color: transparent;
 }


### PR DESCRIPTION
Если не используется SplitLayout, анимации перехода происходят с прозрачным фоном.
Исправляем это - только внутри SplitLayout фон у Panel должен быть прозрачным.