### PR TITLE
Prevent overscroll propagation

### DIFF
--- a/src/components/CustomScrollView/CustomScrollView.css
+++ b/src/components/CustomScrollView/CustomScrollView.css
@@ -11,7 +11,7 @@
   overflow-y: scroll;
   overflow-x: hidden;
   padding-right: 100px;
-  scrollbar-width: noneж
+  scrollbar-width: none;
 }
 
 .CustomScrollView__box::-webkit-scrollbar {

--- a/src/components/CustomScrollView/CustomScrollView.css
+++ b/src/components/CustomScrollView/CustomScrollView.css
@@ -12,6 +12,9 @@
   overflow-x: hidden;
   padding-right: 100px;
   scrollbar-width: none;
+  -ms-scroll-chaining: none;
+  -ms-overflow-style: none;
+  overscroll-behavior: contain;
 }
 
 .CustomScrollView__box::-webkit-scrollbar {

--- a/src/components/CustomScrollView/CustomScrollView.css
+++ b/src/components/CustomScrollView/CustomScrollView.css
@@ -11,10 +11,7 @@
   overflow-y: scroll;
   overflow-x: hidden;
   padding-right: 100px;
-  scrollbar-width: none;
-  -ms-scroll-chaining: none;
-  -ms-overflow-style: none;
-  overscroll-behavior: contain;
+  scrollbar-width: noneж
 }
 
 .CustomScrollView__box::-webkit-scrollbar {

--- a/src/components/CustomSelect/CustomSelect.css
+++ b/src/components/CustomSelect/CustomSelect.css
@@ -28,6 +28,7 @@
 
 .CustomSelect__options .CustomScrollView__box {
   max-height: 160px;
+  overscroll-behavior: contain;
 }
 
 .CustomSelect__option {


### PR DESCRIPTION
Сейчас при достижении конца прокрутки CustomScrollView, скролл передается родительским элементам.
Исправляем это на поддерживающих предотвращение оверскролла браузерах.