### PR TITLE
moved yarn build to prepare script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,9 @@ jobs:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
 
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
 
       - run: yarn test
-
-      - run: yarn build
 
       - uses: oleksiyrudenko/gha-git-credentials@v1
         with:

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-dom": "^16.8.6"
   },
   "scripts": {
+    "prepare": "yarn build",
     "styleguide": "NODE_ENV=development styleguidist server --config=styleguide/config.js",
     "styleguide:build": "NODE_ENV=production styleguidist build --config=styleguide/config.js",
     "dev": "yarn clear && yarn copy-default-scheme && concurrently \"yarn:tsc-dev\" \"yarn:babel-dev\" \"yarn:postcss-dev\"",


### PR DESCRIPTION
Теперь `yarn build` будет запускать перед публикацией пакета с помощью скрипта `prepare`. Этот скрипт так же будет запускаться во время установки в проект зависимости `@vkontakte/vkui` через git+ssh. Таким образом, можно будет тестировать код из pr, собирая либу на стороне проекта.