### PR TITLE
[Search] Fix unclickable zone on IOS 

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -157,7 +157,7 @@ class Search extends Component<SearchProps, SearchState> {
               onChange={this.onChange}
               value={this.value}
             />
-            {platform === IOS && after && <div className="Search__after-width">{after}</div>}
+            {platform === IOS && after && this.state.focused && <div className="Search__after-width">{after}</div>}
             <div className="Search__placeholder">
               <div className="Search__placeholder-in">
                 <Icon16SearchOutline />
@@ -178,7 +178,7 @@ class Search extends Component<SearchProps, SearchState> {
                 </Touch>
               }
             </div>
-            {platform === IOS && after &&
+            {platform === IOS && after && this.state.focused &&
               <div className="Search__after-in">{after}</div>
             }
           </div>


### PR DESCRIPTION
Из-за того, что Search__after-width рисовался даже без фокуса, выделенная на скриншоте область строки поиска была некликабельной на IOS
![image](https://user-images.githubusercontent.com/58112106/92299502-3309ad00-ef6c-11ea-8233-086f56934c40.png)
