### PR TITLE
Замена селекторов тегов на селекторы классов

### DIFF
--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -8,7 +8,7 @@
   outline: none;
   }
 
-  .Select select {
+  .Select__el {
     display: block;
     position: absolute;
     appearance: none;

--- a/src/components/Textarea/Textarea.css
+++ b/src/components/Textarea/Textarea.css
@@ -2,7 +2,7 @@
   position: relative;
   }
 
-  .Textarea textarea {
+  .Textarea__el {
     margin: 0;
     width: 100%;
     display: block;
@@ -22,7 +22,7 @@
     background: transparent;
     }
 
-  .Textarea--sizeY-compact textarea {
+  .Textarea--sizeY-compact .Textarea__el {
     padding-top: 10px;
     padding-bottom: 10px;
     font-size: 15px;
@@ -30,14 +30,14 @@
     min-height: 60px;
   }
 
-  .Textarea textarea::placeholder {
+  .Textarea__el::placeholder {
     color: var(--field_text_placeholder);
   }
 
-  .Textarea textarea:disabled {
+  .Textarea__el:disabled {
     opacity: .4;
   }
 
-  .Textarea textarea:disabled::placeholder {
+  .Textarea__el:disabled::placeholder {
     color: var(--text_secondary);
   }


### PR DESCRIPTION
Приветствую!

Заменил селекторы тегов на селекторы классов в компонентах `Select` и `Textarea`.

Мотивация — более полноценное следование методологии БЭМ, которая не позволяет использовать селекторы тегов.

> В БЭМ не используют селекторы тегов и идентификаторов. Стили блоков и элементов описываются через селекторы классов. - https://ru.bem.info/methodology/css/#%D1%81%D0%B5%D0%BB%D0%B5%D0%BA%D1%82%D0%BE%D1%80%D1%8B

Следовать этому правило помогает правило линтера Stylelint `selector-max-type` со значением `0`.

В текущем состоянии проекта правило также находит ошибки в следующих компонентах:
- src/styles/styles.css
```
  95:1  ✖  Expected "html" to have no more than 0 type selectors       selector-max-type
  96:1  ✖  Expected "body" to have no more than 0 type selectors       selector-max-type
  97:1  ✖  Expected "div#root" to have no more than 0 type selectors   selector-max-type
 109:1  ✖  Expected "body" to have no more than 0 type selectors       selector-max-type
 113:1  ✖  Expected "input" to have no more than 0 type selectors      selector-max-type
 114:1  ✖  Expected "textarea" to have no more than 0 type selectors   selector-max-type
 115:1  ✖  Expected "select" to have no more than 0 type selectors     selector-max-type
 116:1  ✖  Expected "button" to have no more than 0 type selectors     selector-max-type
 124:1  ✖  Expected "a:focus" to have no more than 0 type selectors    selector-max-type
```
Возможное решение — не использовать глобальные стили и селекторы тегов. На уровне библиотеки определить текущие правила во всех нужных компонентах точечно. К примеру, правило `button { font-family: inherit; }`, кажется, нужно определить только для элемента `Snackbar__action`, и, конечно, для компонента `Tappable`.

- src/components/Alert/Alert.css
```
  72:5  ✖  Expected ".Alert--ios .Alert__content h2" to have no more than 0 type selectors          selector-max-type
  79:5  ✖  Expected ".Alert--ios .Alert__content p" to have no more than 0 type selectors           selector-max-type
 216:5  ✖  Expected ".Alert--android .Alert__content h2" to have no more than 0 type selectors      selector-max-type
 223:5  ✖  Expected ".Alert--android .Alert__content p" to have no more than 0 type selectors       selector-max-type
 227:5  ✖  Expected ".Alert--android .Alert__content p + p" to have no more than 0 type selectors   selector-max-type
```
Возможное решение — создать компонент `AlertContent` и именно на его уровне определить текущие CSS-правила, отключив для него правило линтера `selector-max-type`. Таким образом получится разделить ответственность между компонентами, следуя [принципу единственной ответственности](https://ru.wikipedia.org/wiki/%D0%9F%D1%80%D0%B8%D0%BD%D1%86%D0%B8%D0%BF_%D0%B5%D0%B4%D0%B8%D0%BD%D1%81%D1%82%D0%B2%D0%B5%D0%BD%D0%BD%D0%BE%D0%B9_%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D1%81%D1%82%D0%B2%D0%B5%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8)

- src/components/FormStatus/FormStatus.css
```
 29:5  ✖  Expected ".FormStatus__content b" to have no more than 0 type selectors   selector-max-type
```
Возможное решение — определить дополнительный Реакт-компонент для сущности БЭМ-элемента `<FormStatus__HighlightedPhrase>`, вызывая при этом компонент `FormStatus` в рабочем проекте следующим образом:

```
<FormStatus header="Некорректный мобильный номер" mode="error">
  <FormStatus__HighlightedPhrase>
    Необходимо корректно ввести номер в международном формате
  </FormStatus__HighlightedPhrase>
</FormStatus>
```

Несмотря на то, что вызов получится чуть более многословным, API компонента станет более выразительным. При этом пропс `dangerouslySetInnerHTML` в API компонента вероятно получится упразднить (возможно, я ошибаюсь).

- src/components/Gradient/Gradient.css
```
  1:1  ✖  Expected "body[scheme='bright_light'] .Gradient--md-tint.Gradient--to-top" to have no more than 0 type selectors      selector-max-type
  5:1  ✖  Expected "body[scheme='bright_light'] .Gradient--md-tint.Gradient--to-bottom" to have no more than 0 type selectors   selector-max-type
  9:1  ✖  Expected "body[scheme='space_gray'] .Gradient--md-tint.Gradient--to-top" to have no more than 0 type selectors        selector-max-type
 13:1  ✖  Expected "body[scheme='space_gray'] .Gradient--md-tint.Gradient--to-bottom" to have no more than 0 type selectors     selector-max-type
```
Возможное решение — определить стили в классах модификаторов компонента.

- src/components/Spinner/Spinner.css
```
 30:3  ✖  Expected ".Spinner__self svg" to have no more than 0 type selectors   selector-max-type
```

Возможное решение — перенести CSS-правило (transform: scale(1)) в библиотеку `@vkontakte/icons`, добавив возможность при этом использовать его через вызов компонентов пиктограмм с соответствующим пропсом.

Если какое-то из предложенных решений покажется справедливым и привлекательным, я могу внести эти правки в этом или следующих ПР.

Буду рад предложениям, замечаниям и комментариям.