### PR TITLE
remove border, sizeY=compact для ActionSheetDropdownDesktop

### DIFF
--- a/src/components/ActionSheet/ActionSheet.css
+++ b/src/components/ActionSheet/ActionSheet.css
@@ -123,7 +123,6 @@
 
 .ActionSheet--desktop.ActionSheet--vkcom {
   border-radius: 12px;
-  border: 1px solid var(--modal_card_border);
   box-shadow: 0 0 2px rgba(0, 0, 0, .08), 0 8px 24px rgba(0, 0, 0, .08);
 }
 
@@ -146,17 +145,5 @@
 
   to {
     transform: translateY(0);
-  }
-}
-
-@media (min-resolution: 2dppx) {
-  .ActionSheet--desktop.ActionSheet--vkcom {
-    border-width: .5px;
-  }
-}
-
-@media (min-resolution: 3dppx) {
-  .ActionSheet--desktop.ActionSheet--vkcom {
-    border-width: .33px;
   }
 }

--- a/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
@@ -5,8 +5,9 @@ import withPlatform from '../../hoc/withPlatform';
 import { HasPlatform } from '../../types';
 import { PointerEventsProperty } from 'csstype';
 import PropTypes from 'prop-types';
+import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-interface Props extends HasPlatform {
+interface Props extends HasPlatform, AdaptivityProps {
   closing: boolean;
   onClose(): void;
   toggleRef: Element;
@@ -75,7 +76,7 @@ class ActionSheetDropdownDesktop extends Component<Props> {
   stopPropagation: ClickHandler = (e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation();
 
   render() {
-    const { children, platform, elementRef, toggleRef, closing, ...restProps } = this.props;
+    const { children, platform, elementRef, toggleRef, closing, sizeY, ...restProps } = this.props;
     const baseClaseName = getClassName('ActionSheet', platform);
 
     return (
@@ -86,7 +87,7 @@ class ActionSheetDropdownDesktop extends Component<Props> {
         style={this.state.dropdownStyles}
         className={classNames(baseClaseName, 'ActionSheet--desktop', {
           'ActionSheet--closing': this.props.closing,
-        })}
+        }, `ActionSheet--sizeY-${sizeY}`)}
       >
         {children}
       </div>
@@ -94,4 +95,6 @@ class ActionSheetDropdownDesktop extends Component<Props> {
   }
 }
 
-export default withPlatform(ActionSheetDropdownDesktop);
+export default withAdaptivity(withPlatform(ActionSheetDropdownDesktop), {
+  sizeY: true,
+});


### PR DESCRIPTION
После дизайн-ревью, решили убрать бордер у ActionSheet для vkcom, пока непонятно с цветами
Проброс `sizeY` в ActionSheetDropdownDesktop, для выставления корректных отступов