### PR TITLE
fix position icon for windows

### DIFF
--- a/src/components/Radio/Radio.css
+++ b/src/components/Radio/Radio.css
@@ -177,7 +177,7 @@
         border: 1px solid var(--icon_secondary);
         border-radius: 50%;
         transition: border-color .5s var(--ios-easing);
-        position: relative;
+        position: absolute;
         top: 2px;
         left: 2px;
       }


### PR DESCRIPTION
На windows положение элемента с кругом, по умолчанию не в 0,0 родителя, поэтому и при смещении выглядело неверно