### PR TITLE
Fix modal blurring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ PUBLISHING.md
 .idea/markdown-navigator-enh.xml
 .idea/markdown-navigator.xml
 docs/
+.vscode/

--- a/src/components/ModalPage/ModalPage.css
+++ b/src/components/ModalPage/ModalPage.css
@@ -8,6 +8,12 @@
   pointer-events: none;
 }
 
+.ModalPage--desktop {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .ModalPage__in-wrap {
   width: 100%;
   height: 100%;
@@ -38,9 +44,8 @@
   transition: opacity 340ms var(--android-easing);
   width: auto;
   height: auto;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  position: relative;
+  transform: none;
 }
 
 .ModalRoot--touched .ModalPage__in-wrap {


### PR DESCRIPTION
Fixed blur of modal page due to using `transform` to center modals in desktop when devicePixelRatio < 2