### PR TITLE
css build error fix

### DIFF
--- a/src/components/SplitLayout/SplitLayout.css
+++ b/src/components/SplitLayout/SplitLayout.css
@@ -19,12 +19,12 @@
 }
 
 .SplitLayout--ios .SplitLayout__inner--header {
-  margin-top: calc(var(--panelheader_height_ios) * -1);
+  margin-top: calc(-1 * var(--panelheader_height_ios));
 }
 
 .SplitLayout--android .SplitLayout__inner--header,
 .SplitLayout--vkcom .SplitLayout__inner--header {
-  margin-top: calc(var(--panelheader_height_android) * -1);
+  margin-top: calc(-1 * var(--panelheader_height_android));
 }
 
 .SplitLayout__popout {


### PR DESCRIPTION
Выражение `calc(var(--panelheader_height_ios) * -1)` после минификации `postcss-csso` оставалось без пробелов, что ломало некоторым сборщикам мозг.

fixes #1057
fixes #1083