### PR TITLE
[Header] fix baseline-aligning firefox bug

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -71,11 +71,13 @@
   .Header--ios.Header--mode-primary .Header__content {
     font-size: 17px;
     line-height: 22px;
-    padding: 13px 0 9px;
+    /* https://github.com/VKCOM/VKUI/issues/738 */
+    margin: 13px 0 9px;
     }
 
   .Header--ios.Header--mode-secondary .Header__content {
-    padding: 14px 0 10px;
+    /* https://github.com/VKCOM/VKUI/issues/738 */
+    margin: 14px 0 10px;
     font-size: 13px;
     line-height: 16px;
     }
@@ -87,14 +89,16 @@
 
   .Header--android.Header--mode-primary .Header__content,
   .Header--vkcom.Header--mode-primary .Header__content {
-    padding: 15px 0 9px;
+    /* https://github.com/VKCOM/VKUI/issues/738 */
+    margin: 15px 0 9px;
     font-size: 16px;
     line-height: 20px;
     }
 
   .Header--android.Header--mode-secondary .Header__content,
   .Header--vkcom.Header--mode-secondary .Header__content {
-    padding: 15px 0 9px;
+    /* https://github.com/VKCOM/VKUI/issues/738 */
+    margin: 15px 0 9px;
     font-size: 13px;
     line-height: 16px;
     }


### PR DESCRIPTION
Решение проблемы #738.
В Firefox есть проблема с выравниванием по baseline при задании элементу вертикальных пэддингов.

В багтрекере нашел несколько похожих багов, но не идентичных этому. Инфы практически нет, и единственное что сработало без создания дополнительных элементов разметки - это изменение padding на margin.

Наиболее близкое из того что нашел:
https://github.com/webcompat/web-bugs/issues/12629