### PR TITLE
Fix HasLinkProps typings

### DIFF
--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, HTMLAttributes, InputHTMLAttributes, useContext } from 'react';
+import React, { ElementType, InputHTMLAttributes, useContext } from 'react';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import Tappable from '../Tappable/Tappable';
@@ -8,7 +8,7 @@ import Subhead from '../Typography/Subhead/Subhead';
 import Title from '../Typography/Title/Title';
 import Text from '../Typography/Text/Text';
 import { ANDROID, VKCOM } from '../../lib/platform';
-import { HasLinkProps } from '../../types';
+import { MorphButtonLink } from '../../types';
 import Icon16Done from '@vkontakte/icons/dist/16/done';
 import Icon24Done from '@vkontakte/icons/dist/24/done';
 import { ActionSheetContext } from '../ActionSheet/ActionSheetContext';
@@ -17,8 +17,7 @@ import { SizeType } from '../../hoc/withAdaptivity';
 import Caption from '../Typography/Caption/Caption';
 
 export interface ActionSheetItemProps extends
-  HTMLAttributes<HTMLElement>,
-  HasLinkProps,
+  MorphButtonLink,
   Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'checked' | 'value'> {
   mode?: 'default' | 'destructive' | 'cancel';
   before?: React.ReactNode;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -19,10 +19,12 @@ export interface VKUIButtonProps extends HasAlign {
   after?: ReactNode;
 }
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, AnchorHTMLAttributes<HTMLAnchorElement>, HasRootRef<HTMLElement>, VKUIButtonProps, AdaptivityProps {
+type MorphButtonLink = ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement>;
+
+export interface ButtonProps extends MorphButtonLink, HasRootRef<HTMLElement>, VKUIButtonProps, AdaptivityProps {
   Component?: ElementType;
   stopPropagation?: boolean;
-}
+};
 
 const getContent = (size: ButtonProps['size'], children: ButtonProps['children'], hasIcons: boolean, sizeY: AdaptivityProps['sizeY'], platform: Platform) => {
   switch (size) {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode, ElementType, ButtonHTMLAttributes } from 'react';
+import React, { FunctionComponent, ReactNode, ElementType, ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import Tappable from '../Tappable/Tappable';
@@ -19,11 +19,9 @@ export interface VKUIButtonProps extends HasAlign {
   after?: ReactNode;
 }
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, VKUIButtonProps, AdaptivityProps {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, AnchorHTMLAttributes<HTMLAnchorElement>, HasRootRef<HTMLElement>, VKUIButtonProps, AdaptivityProps {
   Component?: ElementType;
   stopPropagation?: boolean;
-  href?: string;
-  target?: string;
 }
 
 const getContent = (size: ButtonProps['size'], children: ButtonProps['children'], hasIcons: boolean, sizeY: AdaptivityProps['sizeY'], platform: Platform) => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode, ElementType, ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
+import React, { FunctionComponent, ReactNode, ElementType } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import Tappable from '../Tappable/Tappable';
@@ -6,7 +6,7 @@ import Title from '../Typography/Title/Title';
 import Text from '../Typography/Text/Text';
 import Subhead from '../Typography/Subhead/Subhead';
 import Caption from '../Typography/Caption/Caption';
-import { HasAlign, HasRootRef } from '../../types';
+import { MorphButtonLink, HasAlign, HasRootRef } from '../../types';
 import usePlatform from '../../hooks/usePlatform';
 import withAdaptivity, { AdaptivityProps, SizeType } from '../../hoc/withAdaptivity';
 import { Platform, VKCOM } from '../../lib/platform';
@@ -18,8 +18,6 @@ export interface VKUIButtonProps extends HasAlign {
   before?: ReactNode;
   after?: ReactNode;
 }
-
-type MorphButtonLink = ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export interface ButtonProps extends MorphButtonLink, HasRootRef<HTMLElement>, VKUIButtonProps, AdaptivityProps {
   Component?: ElementType;

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,12 +1,12 @@
-import React, { ReactNode, ButtonHTMLAttributes, FunctionComponent } from 'react';
+import React, { ReactNode, FunctionComponent } from 'react';
+import { MorphButtonLink } from '../../types';
 import Tappable from '../Tappable/Tappable';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 
-export interface IconButtonProps extends ButtonHTMLAttributes<HTMLElement> {
+export interface IconButtonProps extends MorphButtonLink {
   icon: ReactNode;
-  href?: string;
 }
 
 const IconButton: FunctionComponent<IconButtonProps> = ({

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -1,4 +1,5 @@
-import React, { ButtonHTMLAttributes, FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
+import { MorphButtonLink } from '../../types';
 import Tappable from '../Tappable/Tappable';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
@@ -7,10 +8,8 @@ import { isPrimitiveReactNode } from '../../lib/utils';
 import { VKCOM } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
 
-export interface PanelHeaderButtonProps extends ButtonHTMLAttributes<HTMLElement> {
+export interface PanelHeaderButtonProps extends MorphButtonLink {
   primary?: boolean;
-  href?: string;
-  target?: string;
   label?: ReactNode;
 }
 

--- a/src/components/RichCell/RichCell.tsx
+++ b/src/components/RichCell/RichCell.tsx
@@ -1,15 +1,15 @@
-import React, { ElementType, FunctionComponent, HTMLAttributes, ReactNode } from 'react';
+import React, { ElementType, FunctionComponent, ReactNode } from 'react';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import getClassName from '../../helpers/getClassName';
-import { HasLinkProps, HasRootRef } from '../../types';
+import { MorphButtonLink, HasRootRef } from '../../types';
 import Tappable from '../Tappable/Tappable';
 import { hasReactNode } from '../../lib/utils';
 import Text from '../Typography/Text/Text';
 import Caption from '../Typography/Caption/Caption';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface RichCellProps extends HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, HasLinkProps, AdaptivityProps {
+export interface RichCellProps extends MorphButtonLink, HasRootRef<HTMLElement>, AdaptivityProps {
   /**
    * Контейнер для текста под `children`.
    */

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -1,15 +1,15 @@
-import React, { HTMLAttributes, ReactNode, FC, ElementType } from 'react';
+import React, { ReactNode, FC, ElementType } from 'react';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import Tappable from '../Tappable/Tappable';
 import Icon24Chevron from '@vkontakte/icons/dist/24/chevron';
-import { HasLinkProps, HasRootRef } from '../../types';
+import { MorphButtonLink, HasRootRef } from '../../types';
 import { IOS } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface SimpleCellOwnProps extends HasLinkProps {
+export interface SimpleCellOwnProps extends MorphButtonLink {
   /**
    * Иконка 28 или `<Avatar size={28|32|40|48|72} />`
    */
@@ -38,7 +38,7 @@ export interface SimpleCellOwnProps extends HasLinkProps {
   Component?: ElementType;
 }
 
-export interface SimpleCellProps extends SimpleCellOwnProps, HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, AdaptivityProps {}
+export interface SimpleCellProps extends SimpleCellOwnProps, HasRootRef<HTMLElement>, AdaptivityProps {}
 
 const SimpleCell: FC<SimpleCellProps> = ({
   before,

--- a/src/components/TabbarItem/TabbarItem.tsx
+++ b/src/components/TabbarItem/TabbarItem.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent, ReactNode, HTMLAttributes, ElementType } from 'react';
+import React, { FunctionComponent, ReactNode, ElementType } from 'react';
 import getClassName from '../../helpers/getClassName';
 import Counter from '../Counter/Counter';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
-import { HasLinkProps } from '../../types';
+import { MorphButtonLink } from '../../types';
 
-export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, HasLinkProps {
+export interface TabbarItemProps extends MorphButtonLink {
   selected?: boolean;
   /**
    * Тест рядом с иконкой
@@ -20,7 +20,7 @@ export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, HasLinkPro
 const TabbarItem: FunctionComponent<TabbarItemProps> = (props: TabbarItemProps) => {
   const { className, children, selected, label, text, ...restProps } = props;
   const platform = usePlatform();
-  const Component: ElementType = restProps.href ? 'a' : 'div';
+  const Component: ElementType = restProps.href ? 'a' : 'button';
 
   return (
     <Component

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -17,8 +17,6 @@ export interface TappableProps extends HTMLAttributes<HTMLElement>, HasRootRef<H
   activeEffectDelay?: number;
   disabled?: boolean;
   stopPropagation?: boolean;
-  href?: string;
-  target?: string;
 }
 
 export interface TappableState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import React, { RefCallback } from 'react';
+import React, { RefCallback, ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
 import { PlatformType } from './lib/platform';
 import { Insets } from '@vkontakte/vk-bridge';
 
@@ -48,12 +48,6 @@ export interface HasChildren {
   children?: React.ReactNode;
 }
 
-export interface HasLinkProps {
-  href?: string;
-  target?: string;
-  rel?: string;
-}
-
 export interface Version {
   major: number;
   minor?: number;
@@ -64,3 +58,10 @@ export interface DOMProps {
   document?: Document;
   window?: Window;
 }
+
+export type MorphButtonLink = Omit<ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
+  /**
+   * Превращает компонент в `<a>`
+   */
+  href?: string;
+};


### PR DESCRIPTION
Side effects:
1. `TabbarItem`
    - Root component is `div` => `button`