### PR TITLE
Fix popout backdrop height on desktop

### DIFF
--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -104,6 +104,7 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
         style={style}
         onClick={this.onClose}
         hasMask={!isDesktop}
+        fixed={!isDesktop}
       >
         <ActionSheetContext.Provider
           value={{

--- a/src/components/PopoutWrapper/PopoutWrapper.css
+++ b/src/components/PopoutWrapper/PopoutWrapper.css
@@ -15,26 +15,29 @@
   pointer-events: none;
 }
 
-  .PopoutWrapper--fixed {
-    position: fixed;
-  }
+.PopoutWrapper--fixed {
+  position: fixed;
+}
 
-  .PopoutWrapper--closing .PopoutWrapper__overlay--mask {
-    opacity: 0;
-    }
+.PopoutWrapper:not(.PopoutWrapper--fixed) .PopoutWrapper__overlay {
+  position: fixed;
+}
+
+.PopoutWrapper--masked .PopoutWrapper__overlay {
+  background: rgba(0, 0, 0, .4);
+}
+
+.PopoutWrapper--closing .PopoutWrapper__overlay {
+  opacity: 0;
+}
 
 .PopoutWrapper__overlay {
-  position: fixed;
+  position: absolute;
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
   opacity: 1;
-}
-
-.PopoutWrapper__overlay--mask {
-  position: absolute;
-  background: rgba(0, 0, 0, .4);
 }
 
   .PopoutWrapper__container {
@@ -74,11 +77,11 @@
  * iOS version
  */
 
-.PopoutWrapper--ios .PopoutWrapper__overlay--mask {
+.PopoutWrapper--ios .PopoutWrapper__overlay {
   animation: animation-full-fade-in .3s ease;
   }
 
-.PopoutWrapper--ios.PopoutWrapper--closing .PopoutWrapper__overlay--mask {
+.PopoutWrapper--ios.PopoutWrapper--closing .PopoutWrapper__overlay {
   transition: opacity .3s var(--ios-easing);
   }
 
@@ -86,13 +89,13 @@
  * Android version
  */
 
-.PopoutWrapper--android .PopoutWrapper__overlay--mask,
-.PopoutWrapper--vkcom .PopoutWrapper__overlay--mask {
+.PopoutWrapper--android .PopoutWrapper__overlay,
+.PopoutWrapper--vkcom .PopoutWrapper__overlay {
   animation: animation-full-fade-in .2s ease;
   }
 
-.PopoutWrapper--android.PopoutWrapper--closing .PopoutWrapper__overlay--mask,
-.PopoutWrapper--vkcom.PopoutWrapper--closing .PopoutWrapper__overlay--mask {
+.PopoutWrapper--android.PopoutWrapper--closing .PopoutWrapper__overlay,
+.PopoutWrapper--vkcom.PopoutWrapper--closing .PopoutWrapper__overlay {
   transition: opacity .2s var(--android-easing);
   }
 

--- a/src/components/PopoutWrapper/PopoutWrapper.css
+++ b/src/components/PopoutWrapper/PopoutWrapper.css
@@ -19,10 +19,6 @@
   position: fixed;
 }
 
-.PopoutWrapper:not(.PopoutWrapper--fixed) .PopoutWrapper__overlay {
-  position: fixed;
-}
-
 .PopoutWrapper--masked .PopoutWrapper__overlay {
   background: rgba(0, 0, 0, .4);
 }
@@ -32,7 +28,7 @@
 }
 
 .PopoutWrapper__overlay {
-  position: absolute;
+  position: fixed;
   left: 0;
   top: 0;
   width: 100%;
@@ -40,7 +36,11 @@
   opacity: 1;
 }
 
-  .PopoutWrapper__container {
+.PopoutWrapper--fixed .PopoutWrapper__overlay {
+  position: absolute;
+}
+
+.PopoutWrapper__container {
     width: 100%;
     height: 100%;
     position: relative;

--- a/src/components/PopoutWrapper/PopoutWrapper.css
+++ b/src/components/PopoutWrapper/PopoutWrapper.css
@@ -23,6 +23,14 @@
     opacity: 0;
     }
 
+  .PopoutWrapper__overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
   .PopoutWrapper__mask {
     opacity: 1;
     width: 100%;

--- a/src/components/PopoutWrapper/PopoutWrapper.css
+++ b/src/components/PopoutWrapper/PopoutWrapper.css
@@ -5,7 +5,7 @@
   left: 0;
   top: 0;
   pointer-events: none;
-  }
+}
 
 .PopoutWrapper--opened {
   pointer-events: initial;
@@ -41,37 +41,43 @@
 }
 
 .PopoutWrapper__container {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    display: flex;
-    box-sizing: border-box;
-    z-index: 2;
-    }
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  box-sizing: border-box;
+}
 
-  .PopoutWrapper--v-center .PopoutWrapper__container {
-    align-items: center;
-    }
+.PopoutWrapper__content {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  z-index: 2;
+}
 
-  .PopoutWrapper--v-bottom .PopoutWrapper__container {
-    align-items: flex-end;
-    }
+.PopoutWrapper--v-center .PopoutWrapper__container {
+  align-items: center;
+}
 
-  .PopoutWrapper--v-top .PopoutWrapper__container {
-    align-items: flex-start;
-    }
+.PopoutWrapper--v-bottom .PopoutWrapper__container {
+  align-items: flex-end;
+}
 
-  .PopoutWrapper--h-center .PopoutWrapper__container {
-    justify-content: center;
-    }
+.PopoutWrapper--v-top .PopoutWrapper__container {
+  align-items: flex-start;
+}
 
-  .PopoutWrapper--h-left .PopoutWrapper__container {
-    justify-content: flex-start;
-    }
+.PopoutWrapper--h-center .PopoutWrapper__container {
+  justify-content: center;
+}
 
-  .PopoutWrapper--h-right .PopoutWrapper__container {
-    justify-content: flex-end;
-    }
+.PopoutWrapper--h-left .PopoutWrapper__container {
+  justify-content: flex-start;
+}
+
+.PopoutWrapper--h-right .PopoutWrapper__container {
+  justify-content: flex-end;
+}
 
 /**
  * iOS version
@@ -79,11 +85,11 @@
 
 .PopoutWrapper--ios .PopoutWrapper__overlay {
   animation: animation-full-fade-in .3s ease;
-  }
+}
 
 .PopoutWrapper--ios.PopoutWrapper--closing .PopoutWrapper__overlay {
   transition: opacity .3s var(--ios-easing);
-  }
+}
 
 /**
  * Android version
@@ -92,12 +98,12 @@
 .PopoutWrapper--android .PopoutWrapper__overlay,
 .PopoutWrapper--vkcom .PopoutWrapper__overlay {
   animation: animation-full-fade-in .2s ease;
-  }
+}
 
 .PopoutWrapper--android.PopoutWrapper--closing .PopoutWrapper__overlay,
 .PopoutWrapper--vkcom.PopoutWrapper--closing .PopoutWrapper__overlay {
   transition: opacity .2s var(--android-easing);
-  }
+}
 
 @keyframes animation-full-fade-in {
   from {

--- a/src/components/PopoutWrapper/PopoutWrapper.css
+++ b/src/components/PopoutWrapper/PopoutWrapper.css
@@ -19,27 +19,23 @@
     position: fixed;
   }
 
-  .PopoutWrapper--closing .PopoutWrapper__mask {
+  .PopoutWrapper--closing .PopoutWrapper__overlay--mask {
     opacity: 0;
     }
 
-  .PopoutWrapper__overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
+.PopoutWrapper__overlay {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 1;
+}
 
-  .PopoutWrapper__mask {
-    opacity: 1;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    left: 0;
-    top: 0;
-    background: rgba(0, 0, 0, .4);
-    }
+.PopoutWrapper__overlay--mask {
+  position: absolute;
+  background: rgba(0, 0, 0, .4);
+}
 
   .PopoutWrapper__container {
     width: 100%;
@@ -78,11 +74,11 @@
  * iOS version
  */
 
-.PopoutWrapper--ios .PopoutWrapper__mask {
+.PopoutWrapper--ios .PopoutWrapper__overlay--mask {
   animation: animation-full-fade-in .3s ease;
   }
 
-.PopoutWrapper--ios.PopoutWrapper--closing .PopoutWrapper__mask {
+.PopoutWrapper--ios.PopoutWrapper--closing .PopoutWrapper__overlay--mask {
   transition: opacity .3s var(--ios-easing);
   }
 
@@ -90,13 +86,13 @@
  * Android version
  */
 
-.PopoutWrapper--android .PopoutWrapper__mask,
-.PopoutWrapper--vkcom .PopoutWrapper__mask {
+.PopoutWrapper--android .PopoutWrapper__overlay--mask,
+.PopoutWrapper--vkcom .PopoutWrapper__overlay--mask {
   animation: animation-full-fade-in .2s ease;
   }
 
-.PopoutWrapper--android.PopoutWrapper--closing .PopoutWrapper__mask,
-.PopoutWrapper--vkcom.PopoutWrapper--closing .PopoutWrapper__mask {
+.PopoutWrapper--android.PopoutWrapper--closing .PopoutWrapper__overlay--mask,
+.PopoutWrapper--vkcom.PopoutWrapper--closing .PopoutWrapper__overlay--mask {
   transition: opacity .2s var(--android-easing);
   }
 

--- a/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -81,11 +81,12 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
   preventTouch: WindowTouchListener = (e: Event) => e.preventDefault();
 
   render() {
-    const { alignY, alignX, closing, children, hasMask, className, platform, ...restProps } = this.props;
+    const { alignY, alignX, closing, children, hasMask, className, platform, onClick, ...restProps } = this.props;
     const baseClassNames = getClassName('PopoutWrapper', platform);
 
     return (
       <div
+        onClick={onClick}
         {...restProps}
         className={classNames(baseClassNames, `PopoutWrapper--v-${alignY}`, `PopoutWrapper--h-${alignX}`, {
           'PopoutWrapper--closing': closing,
@@ -94,7 +95,12 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
         }, className)}
         ref={this.elRef}
       >
-        {hasMask && <div className="PopoutWrapper__mask" />}
+        <div
+          className={classNames({
+            'PopoutWrapper__mask': hasMask,
+            'PopoutWrapper__overlay': !hasMask,
+          })}
+          onClick={onClick} />
         <div className="PopoutWrapper__container">{children}</div>
       </div>
     );

--- a/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -9,6 +9,7 @@ import { canUseDOM } from '../../lib/dom';
 
 export interface PopoutWrapperProps extends HTMLAttributes<HTMLDivElement>, HasPlatform {
   hasMask?: boolean;
+  fixed?: boolean;
   alignY?: 'top' | 'center' | 'bottom';
   alignX?: 'left' | 'center' | 'right';
   closing?: boolean;
@@ -35,6 +36,7 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
 
   static defaultProps: PopoutWrapperProps = {
     hasMask: true,
+    fixed: true,
     alignY: 'center',
     alignX: 'center',
     closing: false,
@@ -81,7 +83,7 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
   preventTouch: WindowTouchListener = (e: Event) => e.preventDefault();
 
   render() {
-    const { alignY, alignX, closing, children, hasMask, className, platform, onClick, ...restProps } = this.props;
+    const { alignY, alignX, closing, children, hasMask, fixed, className, platform, onClick, ...restProps } = this.props;
     const baseClassNames = getClassName('PopoutWrapper', platform);
 
     return (
@@ -91,12 +93,13 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
         className={classNames(baseClassNames, `PopoutWrapper--v-${alignY}`, `PopoutWrapper--h-${alignX}`, {
           'PopoutWrapper--closing': closing,
           'PopoutWrapper--opened': this.state.opened,
-          'PopoutWrapper--fixed': hasMask,
+          'PopoutWrapper--fixed': fixed,
+          'PopoutWrapper--masked': hasMask,
         }, className)}
         ref={this.elRef}
       >
         <div
-          className={classNames('PopoutWrapper__overlay', { 'PopoutWrapper__overlay--mask': hasMask })}
+          className="PopoutWrapper__overlay"
           onClick={onClick} />
         <div className="PopoutWrapper__container">{children}</div>
       </div>

--- a/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -88,7 +88,6 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
 
     return (
       <div
-        onClick={onClick}
         {...restProps}
         className={classNames(baseClassNames, `PopoutWrapper--v-${alignY}`, `PopoutWrapper--h-${alignX}`, {
           'PopoutWrapper--closing': closing,
@@ -98,10 +97,14 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
         }, className)}
         ref={this.elRef}
       >
-        <div
-          className="PopoutWrapper__overlay"
-          onClick={onClick} />
-        <div className="PopoutWrapper__container">{children}</div>
+        <div className="PopoutWrapper__container">
+          <div
+            className="PopoutWrapper__overlay"
+            onClick={onClick} />
+          <div className="PopoutWrapper__content">
+            {children}
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -96,10 +96,7 @@ class PopoutWrapper extends Component<PopoutWrapperProps, PopoutWrapperState> {
         ref={this.elRef}
       >
         <div
-          className={classNames({
-            'PopoutWrapper__mask': hasMask,
-            'PopoutWrapper__overlay': !hasMask,
-          })}
+          className={classNames('PopoutWrapper__overlay', { 'PopoutWrapper__overlay--mask': hasMask })}
           onClick={onClick} />
         <div className="PopoutWrapper__container">{children}</div>
       </div>

--- a/src/components/ScreenSpinner/ScreenSpinner.css
+++ b/src/components/ScreenSpinner/ScreenSpinner.css
@@ -1,4 +1,4 @@
-.ScreenSpinner .PopoutWrapper__mask {
+.ScreenSpinner .PopoutWrapper__overlay--mask {
   background: none;
   }
 

--- a/src/components/ScreenSpinner/ScreenSpinner.css
+++ b/src/components/ScreenSpinner/ScreenSpinner.css
@@ -1,4 +1,4 @@
-.ScreenSpinner .PopoutWrapper__overlay--mask {
+.ScreenSpinner .PopoutWrapper__overlay {
   background: none;
   }
 


### PR DESCRIPTION
Пролема исходит вот от сюда:

https://github.com/VKCOM/VKUI/blob/85d3ba3e107c382ded673015dff3d49893d4a757/src/styles/styles.css#L109-L114

Высота `<body>` и  `#root` всегда равна высоте viewport.
И все абсолютно-спозиционированные внутри body блоки с `width: 100%; height: 100%` (как например PopoutRoot--absolute), по высоте будут равны высоте `<body />`. То есть высоте и ширине вьюпорта.

Выглядит это вот так:

![image](https://user-images.githubusercontent.com/5102818/97853189-3671a880-1d11-11eb-9987-715d687e542a.png)

`.PopoutRoot--absolute`, который должен ловить `click` и закрывать `<ActionSheet />`, не тянется вниз и из-за этого появляется возможность клинуть на нижестоящие элементы. 

Изначально пытался решить проблему с высотой `<body>`, но решение предусматривает использование `min-height: 100vh` что сломает мобильную Safari. Возможно можно поправить при помощи https://github.com/postcss/postcss-100vh-fix. Однако проще рендерить `PopoutRoot__popout`  всегда через `position: fixed`.

Может кто-нибудь помнит, для чего использовалось абсолютное позиционирование в popout на десктопе?

**Демо**
Воспроизводится здесь: https://j00ou.csb.app/