### PR TITLE
Fix FormLayoutGroup overflow

### DIFF
--- a/src/components/FormLayoutGroup/FormLayoutGroup.css
+++ b/src/components/FormLayoutGroup/FormLayoutGroup.css
@@ -10,6 +10,7 @@
   flex-basis: 0;
   padding-left: 0;
   padding-right: 0;
+  min-width: 0;
 }
 
 .FormLayoutGroup--horizontal > .FormItem + .FormItem {


### PR DESCRIPTION
Если `white-space: nowrap` относится не напрямую к flex child, а к вложенным в него элементам, блок будет переполняться до бесконечности. Это известная особенность (https://css-tricks.com/flexbox-truncated-text/).

Фиксится добавлением `min-width: 0` флекс-элементу.

**Сломано:**

![image](https://user-images.githubusercontent.com/5102818/98641087-a18c3200-2344-11eb-95f9-0a567ddc0f28.png)

**Пофикшено:**

![image](https://user-images.githubusercontent.com/5102818/98641406-21b29780-2345-11eb-9ddf-d9fd998d537b.png)

