### PR TITLE
V4 fix

### DIFF
--- a/src/components/CustomSelect/CustomSelect.css
+++ b/src/components/CustomSelect/CustomSelect.css
@@ -5,6 +5,10 @@
   display: block;
 }
 
+.CustomSelect__control {
+  display: none;
+}
+
 .CustomSelect__options {
   width: 100%;
   overflow: hidden;

--- a/src/components/CustomSelect/CustomSelect.css
+++ b/src/components/CustomSelect/CustomSelect.css
@@ -2,7 +2,7 @@
   width: 100%;
   position: relative;
   cursor: pointer;
-  user-select: none;
+  display: block;
 }
 
 .CustomSelect__options {

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -398,7 +398,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
           onBlur={onBlur}
           onFocus={onFocus}
           value={value}
-          style={{ display: 'none' }}
+          className="CustomSelect__control"
         >
           {options.map((item) => <option key={item.label} value={item.value} />)}
         </select>

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -20,6 +20,7 @@ type SelectValue = SelectHTMLAttributes<HTMLSelectElement>['value'];
 export interface SelectOption {
   value: SelectValue;
   label: string;
+  [index: string]: any;
 }
 
 interface CustomSelectState {
@@ -144,7 +145,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       focused: true,
     }));
 
-    const event = new Event('focus', { bubbles: true });
+    const event = new Event('focus');
     this.selectEl.dispatchEvent(event);
   };
 
@@ -156,7 +157,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       focused: false,
     }));
 
-    const event = new Event('blur', { bubbles: true });
+    const event = new Event('blur');
     this.selectEl.dispatchEvent(event);
   };
 

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -24,7 +24,7 @@ class Example extends React.Component {
                 placeholder="Не выбрано"
                 options={this.state.options}
                 value={this.state.value}
-                onChange={(option) => this.setState({ value: option.value })}
+                onChange={(e) => this.setState({ value: e.target.value })}
               />
             </FormItem>
           </Group>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,6 +1,5 @@
 import React, {
   Component,
-  ChangeEvent,
   ChangeEventHandler,
   HTMLAttributes,
 } from 'react';
@@ -9,7 +8,7 @@ import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 import { hasMouse } from '@vkontakte/vkjs/lib/InputUtils';
 import { HasPlatform } from '../../types';
 import { leadingZero } from '../../lib/utils';
-import Select from '../Select/Select';
+import CustomSelect from '../CustomSelect/CustomSelect';
 
 const DefaultMonths: string[] = [
   'Января', 'Февраля', 'Марта', 'Апреля', 'Мая', 'Июня', 'Июля', 'Августа', 'Сентября', 'Октября', 'Ноября', 'Декабря',
@@ -136,21 +135,19 @@ class DatePicker extends Component<Props, Partial<State>> {
     return yearOptions;
   };
 
-  onSelectChange: ChangeEventHandler = (e: ChangeEvent) => {
+  onSelectChange: ChangeEventHandler<HTMLSelectElement> = (e) => {
     const { onDateChange } = this.props;
-    const target = e.target as HTMLSelectElement;
 
-    this.setState(() => ({
-      [target.name]: Number(target.value),
-    }), () => {
+    this.setState({
+      [e.target.name]: Number(e.target.value),
+    }, () => {
       onDateChange && onDateChange(this.state as State);
     });
   };
 
-  onStringChange: ChangeEventHandler = (e: ChangeEvent<HTMLSelectElement>) => {
+  onStringChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { onDateChange } = this.props;
-    const { value } = e.currentTarget;
-    const date = this.parseInputDate(value);
+    const date = this.parseInputDate(e.currentTarget.value);
 
     this.setState(() => ({
       ...date,
@@ -167,7 +164,7 @@ class DatePicker extends Component<Props, Partial<State>> {
       <div className="DatePicker">
         <div className="DatePicker__container">
           <div className="DatePicker__day">
-            <Select
+            <CustomSelect
               name="day"
               value={day}
               options={this.getDayOptions()}
@@ -177,7 +174,7 @@ class DatePicker extends Component<Props, Partial<State>> {
             />
           </div>
           <div className="DatePicker__month">
-            <Select
+            <CustomSelect
               name="month"
               value={month}
               options={this.getMonthOptions()}
@@ -187,7 +184,7 @@ class DatePicker extends Component<Props, Partial<State>> {
             />
           </div>
           <div className="DatePicker__year">
-            <Select
+            <CustomSelect
               name="year"
               value={year}
               options={this.getYearOptions()}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -4,7 +4,6 @@ import React, {
   ChangeEventHandler,
   HTMLAttributes,
 } from 'react';
-import { SelectChangeResult } from '../CustomSelect/CustomSelect';
 import Input from '../Input/Input';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 import { hasMouse } from '@vkontakte/vkjs/lib/InputUtils';
@@ -44,7 +43,6 @@ interface Props extends Attrs, HasPlatform, AdaptivityProps {
 }
 
 type GetOptions = () => SelectOption[];
-type SelectChangeHandler = (result: SelectChangeResult) => void;
 
 class DatePicker extends Component<Props, Partial<State>> {
   constructor(props: Props) {
@@ -138,11 +136,12 @@ class DatePicker extends Component<Props, Partial<State>> {
     return yearOptions;
   };
 
-  onSelectChange: SelectChangeHandler = ({ value, name }) => {
+  onSelectChange: ChangeEventHandler = (e: ChangeEvent) => {
     const { onDateChange } = this.props;
+    const target = e.target as HTMLSelectElement;
 
     this.setState(() => ({
-      [name]: value,
+      [name]: target.value,
     }), () => {
       onDateChange && onDateChange(this.state as State);
     });

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -141,7 +141,7 @@ class DatePicker extends Component<Props, Partial<State>> {
     const target = e.target as HTMLSelectElement;
 
     this.setState(() => ({
-      [name]: target.value,
+      [target.name]: Number(target.value),
     }), () => {
       onDateChange && onDateChange(this.state as State);
     });

--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -74,20 +74,9 @@
 .FormField.Textarea .Textarea__el:focus ~ .FormField__border,
 .FormField.Select .Select__el:focus ~ .FormField__border,
 .FormField.Select--mimicry:focus .FormField__border,
-.FormField.ChipsInput.ChipsInput--focused .ChipsInput__container ~ .FormField__border {
+.FormField.ChipsInput--focused .ChipsInput__container ~ .FormField__border {
   border-color: var(--accent);
   background: var(--field_background);
-}
-
-.FormField--ios.Input .Input__el:focus ~ .FormField__border,
-.FormField--ios.Textarea .Textarea__el:focus ~ .FormField__border,
-.FormField--ios.Select .Select__el:focus ~ .FormField__border,
-.FormField--ios.Select--mimicry:focus .FormField__border,
-.FormField--ios.ChipsInput.ChipsInput--focused .ChipsInput__container ~ .FormField__border {
-  border-radius: 10px;
-  transform: scale(1);
-  width: 100%;
-  height: 100%;
 }
 
 .CustomSelect__open.Select--mimicry:focus .FormField__border {

--- a/src/components/FormItem/Readme.md
+++ b/src/components/FormItem/Readme.md
@@ -19,15 +19,10 @@ class Example extends React.Component {
     ];
 
     this.onChange = this.onChange.bind(this);
-    this.onSelectChange = this.onSelectChange.bind(this);
   }
 
   onChange(e) {
     const { name, value } = e.currentTarget;
-    this.setState({ [name]: value });
-  }
-
-  onSelectChange({ name, value }) {
     this.setState({ [name]: value });
   }
 
@@ -88,7 +83,7 @@ class Example extends React.Component {
             <FormItem top="Цель поездки" bottom={purpose ? '' : 'Пожалуйста, укажите цель поездки'} status={purpose ? 'valid' : 'error'}>
               <Select
                 placeholder="Выберите цель поездки"
-                onChange={this.onSelectChange}
+                onChange={this.onChange}
                 value={purpose}
                 name="purpose"
               >

--- a/src/components/ModalCard/ModalCard.css
+++ b/src/components/ModalCard/ModalCard.css
@@ -68,7 +68,7 @@
 }
 
 .ModalCard .UsersStack {
-  margin-top: 12px;
+  margin-top: 20px;
 }
 
 .ModalCard__icon {
@@ -84,7 +84,7 @@
 }
 
 .ModalCard .UsersStack + .ModalCard__actions {
-  margin-top: 24px;
+  margin-top: 32px;
 }
 
 .ModalCard__header + .ModalCard__actions,

--- a/src/components/NativeSelect/NativeSelect.tsx
+++ b/src/components/NativeSelect/NativeSelect.tsx
@@ -9,7 +9,7 @@ import { setRef } from '../../lib/utils';
 import { getClassName, HasPlatform } from '../..';
 import withPlatform from '../../hoc/withPlatform';
 
-export interface SelectProps extends
+export interface NativeSelectProps extends
   SelectHTMLAttributes<HTMLSelectElement>,
   HasRef<HTMLSelectElement>,
   HasRootRef<HTMLLabelElement>,
@@ -26,8 +26,8 @@ export interface SelectState {
   notSelected?: boolean;
 }
 
-class NativeSelect extends React.Component<SelectProps, SelectState> {
-  constructor(props: SelectProps) {
+class NativeSelect extends React.Component<NativeSelectProps, SelectState> {
+  constructor(props: NativeSelectProps) {
     super(props);
     const state: SelectState = {
       title: '',
@@ -62,7 +62,7 @@ class NativeSelect extends React.Component<SelectProps, SelectState> {
     });
   };
 
-  componentDidUpdate(prevProps: SelectProps) {
+  componentDidUpdate(prevProps: NativeSelectProps) {
     if (prevProps.value !== this.props.value || prevProps.children !== this.props.children) {
       this.setTitle();
     }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent, ReactElement } from 'react';
-import NativeSelect from '../NativeSelect/NativeSelect';
-import CustomSelect, { CustomSelectProps, SelectOption } from '../CustomSelect/CustomSelect';
+import NativeSelect, { NativeSelectProps } from '../NativeSelect/NativeSelect';
+import CustomSelect, { SelectOption } from '../CustomSelect/CustomSelect';
 import { hasMouse } from '@vkontakte/vkjs/lib/InputUtils';
 
-const Select: FunctionComponent<CustomSelectProps> = (props) => {
+const Select: FunctionComponent<NativeSelectProps> = (props) => {
   // Use custom select if device has connected a mouse
   if (hasMouse) {
     const { children, ...restProps } = props;
@@ -17,7 +17,6 @@ const Select: FunctionComponent<CustomSelectProps> = (props) => {
         .map((element: ReactElement) => {
           const value = element.props?.value?.toString() ?? '';
           const label = element.props?.children?.toString() ?? '';
-
           return { value, label };
         });
     }
@@ -35,14 +34,11 @@ const Select: FunctionComponent<CustomSelectProps> = (props) => {
     );
   }
 
-  const { options, children, ...restProps } = props;
+  const { children, ...restProps } = props;
 
   return (
-    <NativeSelect
-      {...restProps}>
-      {!!children ? children : options.map(({ label, value }, key) => {
-        return <option value={`${value}`} key={key}>{label}</option>;
-      })}
+    <NativeSelect {...restProps}>
+      {children}
     </NativeSelect>
   );
 };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,24 +1,12 @@
-import React, { FunctionComponent, ReactElement, ChangeEvent, useRef } from 'react';
-import NativeSelect, { SelectProps } from '../NativeSelect/NativeSelect';
-import CustomSelect, { SelectOption, SelectChangeResult } from '../CustomSelect/CustomSelect';
+import React, { FunctionComponent, ReactElement } from 'react';
+import NativeSelect from '../NativeSelect/NativeSelect';
+import CustomSelect, { CustomSelectProps, SelectOption } from '../CustomSelect/CustomSelect';
 import { hasMouse } from '@vkontakte/vkjs/lib/InputUtils';
-import { HasRef, Ref } from '../../types';
-import { setRef } from '../../lib/utils';
 
-interface Props extends Omit<SelectProps, 'onChange' | 'getRef'>, HasRef<HTMLSelectElement | HTMLInputElement> {
-  options?: SelectOption[];
-  popupDirection?: 'top' | 'bottom';
-  onChange?: (result: SelectChangeResult) => void;
-  onFocus?: () => void;
-  onBlur?: () => void;
-}
-
-const Select: FunctionComponent<Props> = (props) => {
-  const nativeSelectRef = useRef<HTMLSelectElement>();
-
+const Select: FunctionComponent<CustomSelectProps> = (props) => {
   // Use custom select if device has connected a mouse
   if (hasMouse) {
-    const { children, getRef, getRootRef, ...restProps } = props;
+    const { children, ...restProps } = props;
 
     let options: SelectOption[] = [];
 
@@ -41,51 +29,16 @@ const Select: FunctionComponent<Props> = (props) => {
     return (
       <CustomSelect
         options={options}
-        getRef={getRef as Ref<HTMLInputElement>}
-        getRootRef={getRootRef}
         value={value}
         {...restProps}
       />
     );
   }
 
-  const { options, children, onChange, onFocus, onBlur, getRef, getRootRef, ...restProps } = props;
-
-  const handleFocus = () => {
-    onFocus && onFocus();
-  };
-
-  const handleBlur = () => {
-    onBlur && onBlur();
-  };
-
-  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    // values from DOM api is always strings
-    // search for value from input options if present
-    const selectedIndex = nativeSelectRef.current?.selectedIndex ?? -1;
-
-    const value = Array.isArray(options)
-      ? options[selectedIndex]?.value
-      : e.target.value;
-
-    onChange && onChange({
-      value,
-      name: e.target.name,
-    });
-  };
-
-  const getRefWrapper = (element: HTMLSelectElement) => {
-    nativeSelectRef.current = element;
-    setRef(element, getRef);
-  };
+  const { options, children, ...restProps } = props;
 
   return (
     <NativeSelect
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onChange={handleChange}
-      getRef={getRefWrapper}
-      getRootRef={getRootRef}
       {...restProps}>
       {!!children ? children : options.map(({ label, value }, key) => {
         return <option value={`${value}`} key={key}>{label}</option>;

--- a/src/components/UsersStack/Readme.md
+++ b/src/components/UsersStack/Readme.md
@@ -8,47 +8,55 @@
     <PanelHeader>Аватарки пользователей</PanelHeader>
 
     <Group>
-      <UsersStack
-        photos={[
-          getAvatarUrl('user_lihachyov'),
-        ]}
-      >Понравилось Муртолу Левзачеву</UsersStack>
+      <Div>
+        <UsersStack
+          photos={[
+            getAvatarUrl('user_lihachyov'),
+          ]}
+        >Понравилось Муртолу Левзачеву</UsersStack>
+      </Div>
     </Group>
 
     <Group>
-      <UsersStack
-        photos={[
-          getAvatarUrl('user_manzuk'),
-          getAvatarUrl('user_ji'),
-        ]}
-        size="m"
-      >Настя и Jean пойдут на это мероприятие</UsersStack>
+      <Div>
+        <UsersStack
+          photos={[
+            getAvatarUrl('user_manzuk'),
+            getAvatarUrl('user_ji'),
+          ]}
+          size="m"
+        >Настя и Jean пойдут на это мероприятие</UsersStack>
+      </Div>
     </Group>
 
     <Group>
-      <UsersStack
-        photos={[
-          getAvatarUrl('user_ox'),
-          getAvatarUrl('user_vitalyavolyn'),
-          getAvatarUrl('user_eee'),
-        ]}
-      >Иван и ещё 2 ваших друга подписаны</UsersStack>
+      <Div>
+        <UsersStack
+          photos={[
+            getAvatarUrl('user_ox'),
+            getAvatarUrl('user_vitalyavolyn'),
+            getAvatarUrl('user_eee'),
+          ]}
+        >Иван и ещё 2 ваших друга подписаны</UsersStack>
+      </Div>
     </Group>
 
     <Group header={<Header mode="secondary">Вертикальный режим</Header>}>
-      <UsersStack
-        photos={[
-          getAvatarUrl('user_mm'),
-          getAvatarUrl('user_ilyagrshn'),
-          getAvatarUrl('user_lihachyov'),
-          getAvatarUrl('user_wayshev'),
-          getAvatarUrl('user_arthurstam'),
-          getAvatarUrl('user_xyz'),
-        ]}
-        size="m"
-        count={3}
-        layout="vertical"
-      >Алексей, Илья, Михаил<br />и ещё 3 человека</UsersStack>
+      <Div>
+        <UsersStack
+          photos={[
+            getAvatarUrl('user_mm'),
+            getAvatarUrl('user_ilyagrshn'),
+            getAvatarUrl('user_lihachyov'),
+            getAvatarUrl('user_wayshev'),
+            getAvatarUrl('user_arthurstam'),
+            getAvatarUrl('user_xyz'),
+          ]}
+          size="m"
+          count={3}
+          layout="vertical"
+        >Алексей, Илья, Михаил<br />и ещё 3 человека</UsersStack>
+      </Div>
     </Group>
 
     <Group>
@@ -68,7 +76,7 @@
               getAvatarUrl('user_va'),
               getAvatarUrl('user_tc'),
             ]}
-            style={{ color: "#fff" }}
+            style={{ color: "#fff", padding: '8px 0' }}
           >Проголосовали 2 176 человек</UsersStack>
         </div>
       </Div>

--- a/src/components/UsersStack/UsersStack.css
+++ b/src/components/UsersStack/UsersStack.css
@@ -78,16 +78,3 @@
   margin: 8px 0 0;
   text-align: center;
 }
-
-/* iOS */
-
-.UsersStack--ios {
-  padding: 8px 12px;
-}
-
-/* Android */
-
-.UsersStack--android,
-.UsersStack--vkcom {
-  padding: 8px 16px;
-}


### PR DESCRIPTION
## Фиксы и улучшения
* Поправлены `border-radius` у `CustomSelect` и `ChipsSelect` на `ios`
* `Select`: поправлены `getRef` и `getRootRef`
* `Select`: `onBlur` и `onFocus` стали возвращать объекты событий

## Обратно несовместимые изменения
* `Select`: `onChange` теперь возвращает корректный объект события `change`. Это изменение делает компонент более предсказуемым
* `CustomSelect`: `CustomOptionValue` теперь идентичен типам `SelectHTMLAttributes<HTMLSelectElement>['value']`, то есть `boolean` туда уже не положешь. `CustomSelect` — это надстройка над нативным `select`, которая расширяет его возможности, но не меняет базовых принципов
* `UsersStack`: компонент лишился внешних отступов. Теперь их нужно устанавливать в месте использования. Мы стараемся избегать предустановленных внешних отступов, чтобы улучшить компоновку