### PR TITLE
Fix ActionSheet direction in scrollable container

### DIFF
--- a/src/components/ActionSheet/Readme.md
+++ b/src/components/ActionSheet/Readme.md
@@ -20,6 +20,7 @@ class Example extends React.Component {
     }
 
     this.openBase = this.openBase.bind(this);
+    this.openScrollable = this.openScrollable.bind(this);
     this.openIcons = this.openIcons.bind(this);
     this.openSubtitle = this.openSubtitle.bind(this);
     this.openSelectable = this.openSelectable.bind(this);
@@ -27,6 +28,7 @@ class Example extends React.Component {
     this.onChange = this.onChange.bind(this);
 
     this.baseTargetRef = React.createRef();
+    this.scrollableTargetRef = React.createRef();
     this.iconsTargetRef = React.createRef();
     this.subtitleTargetRef = React.createRef();
     this.selectableTargetRef = React.createRef();
@@ -35,6 +37,8 @@ class Example extends React.Component {
 
   componentDidMount() {
     this.openBase();
+
+    this.scrollableTargetRef.current.parentNode.parentNode.scrollTop = this.scrollableTargetRef.current.offsetTop / 2;
   }
 
   openBase () {
@@ -43,6 +47,32 @@ class Example extends React.Component {
         onClose={() => this.setState({ popout: null })}
         iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
         toggleRef={this.baseTargetRef.current}
+      >
+        <ActionSheetItem autoclose>
+          Сохранить в закладках
+        </ActionSheetItem>
+        <ActionSheetItem autoclose>
+          Закрепить запись
+        </ActionSheetItem>
+        <ActionSheetItem autoclose>
+          Выключить комментирование
+        </ActionSheetItem>
+        <ActionSheetItem autoclose>
+          Закрепить запись
+        </ActionSheetItem>
+        <ActionSheetItem autoclose mode="destructive">
+          Удалить запись
+        </ActionSheetItem>
+      </ActionSheet>
+    });
+  }
+  
+  openScrollable () {
+    this.setState({ popout:
+      <ActionSheet 
+        onClose={() => this.setState({ popout: null })}
+        iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
+        toggleRef={this.scrollableTargetRef.current}
       >
         <ActionSheetItem autoclose>
           Сохранить в закладках
@@ -193,7 +223,7 @@ class Example extends React.Component {
     this.setState({ filter: e.target.value });
   }
 
-  render() {
+  render() {    
     return (
       <View popout={this.state.popout} activePanel="panel">
         <Panel id="panel">
@@ -204,6 +234,15 @@ class Example extends React.Component {
             <CellButton getRootRef={this.subtitleTargetRef} onClick={this.openSubtitle}>С подзаголовком</CellButton>
             <CellButton getRootRef={this.selectableTargetRef} onClick={this.openSelectable}>Выделяемые</CellButton>
             <CellButton getRootRef={this.titleTargetRef} onClick={this.openTitle}>C заголовком</CellButton>
+          </Group>
+          <Group>
+            <Header mode="secondary">Внутри scrollable элемента</Header>
+            <div style={{ height: '90vh', overflow: 'scroll' }}>
+              <div style={{ height: 1500 }}>
+                
+                <CellButton style={{ marginTop: 700 }} getRootRef={this.scrollableTargetRef} onClick={this.openScrollable}>Базовый список</CellButton>
+              </div>
+            </div>
           </Group>
         </Panel>
       </View>

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -14,6 +14,8 @@ export interface PanelProps extends HTMLAttributes<HTMLDivElement>, HasPlatform,
   centered?: boolean;
 }
 
+export const PANEL_CLASS = 'Panel';
+
 class Panel extends Component<PanelProps> {
   constructor(props: PanelProps) {
     super(props);
@@ -44,7 +46,7 @@ class Panel extends Component<PanelProps> {
         <div
           {...restProps}
           ref={this.getRef}
-          className={classNames(getClassName('Panel', platform), className, `Panel--${sizeX}`, {
+          className={classNames(getClassName(PANEL_CLASS, platform), className, `Panel--${sizeX}`, {
             'Panel--centered': centered,
             [`Panel--sizeX-${sizeX}`]: true,
           })}

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -1,1 +1,15 @@
 export { canUseDOM, canUseEventListeners, onDOMLoaded } from '@vkontakte/vkjs/lib/dom';
+
+const isScrollable = function(el: Element) {
+  const hasScrollableContent = el.scrollHeight > el.clientHeight;
+  const overflowYStyle = getComputedStyle(el).overflowY;
+  const isOverflowHidden = overflowYStyle === 'hidden';
+
+  return hasScrollableContent && !isOverflowHidden;
+};
+
+export const getScrollableParent = function(el: Element): Element {
+  return !el || el === document.body
+    ? document.body
+    : isScrollable(el) ? el : getScrollableParent(el.parentNode as Element);
+};


### PR DESCRIPTION
Добавил определение направления для ActionSheet, открытого внутри контейнера со скроллом. Внутри есть проверка элемента на PANEL_CLASS, но я уверен в этом решении и как вы относитесь к завязке на классы.