### PR TITLE
Select fixes

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -228,19 +228,9 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   handleOptionHover: MouseEventHandler = (e: MouseEvent<HTMLElement>) => {
-    const { options } = this.props;
-    const label = e.currentTarget.title;
-
-    if (!label) {
-      return;
-    }
-
-    const index = options.findIndex(
-      (option) => option.label === label);
-
-    this.setState(() => ({
-      focusedOptionIndex: index,
-    }));
+    this.setState({
+      focusedOptionIndex: Array.prototype.indexOf.call(e.currentTarget.parentNode.children, e.currentTarget),
+    });
   };
 
   handleOptionDown: MouseEventHandler = (e: MouseEvent<HTMLElement>) => {
@@ -326,7 +316,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     const selected = index === selectedOptionIndex;
 
     return (
-      <React.Fragment key={index}>
+      <React.Fragment key={`${option.value}`}>
         {renderOption({
           option,
           hovered,
@@ -402,7 +392,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
           value={value}
           className="CustomSelect__control"
         >
-          {options.map((item) => <option key={item.label} value={item.value} />)}
+          {options.map((item) => <option key={`${item.value}`} value={item.value} />)}
         </select>
         {opened &&
         <div

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -366,6 +366,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       onBlur,
       onFocus,
       renderOption,
+      children,
       ...restProps
     } = this.props;
     const selected = this.getSelectedItem();

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -1,38 +1,22 @@
 Делает из [SelectMimicry](#!/SelectMimicry) селект с выпадающим списком
 
 ```jsx
-class Example extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      value: '0',
-      options: new Array(20).fill({}).map((item, index) => ({ label: String(index), value: String(index) }))
-    }
-  }
-
-  render() {
-    return (
-      <View activePanel="сustomSelect">
-        <Panel id="сustomSelect">
-          <PanelHeader>
-            CustomSelect
-          </PanelHeader>
-          <Group>
-            <FormItem>
-              <CustomSelect
-                placeholder="Не выбрано"
-                options={this.state.options}
-                value={this.state.value}
-                onChange={(e) => this.setState({ value: e.target.value })}
-              />
-            </FormItem>
-          </Group>
-        </Panel>
-      </View>
-    )
-  }
-}
-
-<Example />
+<View activePanel="select">
+  <Panel id="select">
+    <PanelHeader>
+      CustomSelect
+    </PanelHeader>
+    <Group>
+      <FormItem top="Администратор">
+        <Select
+          placeholder="Не выбран" 
+          options={getRandomUsers(10).map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+          renderOption={({ option, ...restProps }) => (
+            <CustomSelectOption {...restProps} before={<Avatar size={24} src={option.avatar} />} />
+          )}
+        />
+      </FormItem>
+    </Group>
+  </Panel>
+</View>
 ```

--- a/src/components/FormItem/Readme.md
+++ b/src/components/FormItem/Readme.md
@@ -64,10 +64,13 @@ class Example extends React.Component {
               </FormItem>
             </FormLayoutGroup>
             <FormItem top="Пол">
-              <Select placeholder="Выберите пол">
-                <option value="m">Мужской</option>
-                <option value="f">Женский</option>
-              </Select>
+              <Select 
+                placeholder="Выберите пол"
+                options={[{
+                  value: '0', label: 'Мужской' }, { 
+                  value: '1', label: 'Женский' }
+                ]}
+              />
             </FormItem>
 
             <FormItem top="Тип документа">
@@ -86,11 +89,12 @@ class Example extends React.Component {
                 onChange={this.onChange}
                 value={purpose}
                 name="purpose"
-              >
-                <option value="0">Бизнес или работа</option>
-                <option value="1">Индивидуальный туризм</option>
-                <option value="2">Посещение близких родственников</option>
-              </Select>
+                options={[{
+                  value: '0', label: 'Бизнес или работа' }, { 
+                  value: '1', label: 'Индивидуальный туризм' }, {
+                  value: '2', label: 'Посещение близких родственников' }
+                ]}
+              />
             </FormItem>
             <FormItem top="О себе">
               <Textarea />

--- a/src/components/Select/Readme.md
+++ b/src/components/Select/Readme.md
@@ -1,14 +1,5 @@
 Отрисовывает [CustomSelect](#!/CustomSelect), если есть мышка, либо [NativeSelect](#!/NativeSelect)
 
-```jsx static
-import { Select } from '@vkontakte/vkui';
-
-<Select placeholder="Выберите пол">
-  <option value="m">Мужской</option>
-  <option value="f">Женский</option>
-</Select>
-```
-
 ```jsx
 <View activePanel="select">
   <Panel id="select">
@@ -16,27 +7,14 @@ import { Select } from '@vkontakte/vkui';
       Select
     </PanelHeader>
     <Group>
-      <FormItem top="Обычный Select">
-        <Select placeholder="Выберите пол">
-          <option value="m">Мужской</option>
-          <option value="f">Женский</option>
-        </Select>
-      </FormItem>
-      <FormItem top="Обычный Select с скроллом">
-        <Select placeholder="Выберите месяц">
-          <option value="1">Январь</option>
-          <option value="2">Февраль</option>
-          <option value="3">Март</option>
-          <option value="4">Апрель</option>
-          <option value="5">Май</option>
-          <option value="6">Июнь</option>
-          <option value="7">Июль</option>
-          <option value="8">Август</option>
-          <option value="9">Сентябрь</option>
-          <option value="10">Октябрь</option>
-          <option value="11">Ноябрь</option>
-          <option value="12">Декабрь</option>
-        </Select>
+      <FormItem top="Администратор">
+        <Select
+          placeholder="Не выбран" 
+          options={getRandomUsers(10).map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+          renderOption={({ option, ...restProps }) => (
+            <CustomSelectOption {...restProps} before={<Avatar size={24} src={option.avatar} />} />
+          )}
+        />
       </FormItem>
     </Group>
   </Panel>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,25 +1,12 @@
-import React, { FunctionComponent, ReactElement } from 'react';
-import NativeSelect, { NativeSelectProps } from '../NativeSelect/NativeSelect';
-import CustomSelect, { SelectOption } from '../CustomSelect/CustomSelect';
+import React, { FunctionComponent } from 'react';
+import NativeSelect from '../NativeSelect/NativeSelect';
+import CustomSelect, { CustomSelectProps } from '../CustomSelect/CustomSelect';
 import { hasMouse } from '@vkontakte/vkjs/lib/InputUtils';
 
-const Select: FunctionComponent<NativeSelectProps> = (props) => {
+const Select: FunctionComponent<CustomSelectProps> = (props) => {
   // Use custom select if device has connected a mouse
   if (hasMouse) {
     const { children, ...restProps } = props;
-
-    let options: SelectOption[] = [];
-
-    if (Array.isArray(children)) {
-      // filter <option> elements from children root and ignore others
-      options = children
-        .filter((node) => React.isValidElement(node) && node.type === 'option')
-        .map((element: ReactElement) => {
-          const value = element.props?.value?.toString() ?? '';
-          const label = element.props?.children?.toString() ?? '';
-          return { value, label };
-        });
-    }
 
     const value = restProps.hasOwnProperty('value')
       ? restProps.value
@@ -27,18 +14,17 @@ const Select: FunctionComponent<NativeSelectProps> = (props) => {
 
     return (
       <CustomSelect
-        options={options}
         value={value}
         {...restProps}
       />
     );
   }
 
-  const { children, ...restProps } = props;
+  const { options, popupDirection, renderOption, ...restProps } = props;
 
   return (
     <NativeSelect {...restProps}>
-      {children}
+      {options.map(({ label, value }) => <option value={value} key={`${value}`}>{label}</option>)}
     </NativeSelect>
   );
 };

--- a/src/components/Slider/Readme.md
+++ b/src/components/Slider/Readme.md
@@ -15,7 +15,7 @@
     options () {
       let options = [];
       for (let i = 0; i <= 10; i += 2) {
-        options.push(<option value={`${i / 10}`} key={`${i}`}>{i / 10}</option>)
+        options.push({ value: `${i / 10}`, label: `${i / 10}` });
       }
       return options;
     }
@@ -47,9 +47,11 @@
                 />
               </FormItem>
               <FormItem>
-                <Select onChange={e => this.setState({ value2: e.target.value })} value={String(this.state.value2)}>
-                  {this.options()}
-                </Select>
+                <Select
+                  onChange={e => this.setState({ value2: e.target.value })} 
+                  value={String(this.state.value2)}
+                  options={this.options()} 
+                />
               </FormItem>
               <FormItem top="Uncontrolled">
                 <Slider


### PR DESCRIPTION
## Фиксы и улучшения
* Вернули возможность передавать свойcтва CustomSelect, типа `popupDirection`
* Поправлен баг с опциями с одинаковыми `label`  (fixes #1137)
## Обратно несовместимые изменения
* Опции больше нельзя передавать как `children`. Теперь доступен только валидный массив `options`.  (fixes #1139)
