### PR TITLE
#1108: [Bug] [ChipsInput] вертикальное выравнивание плэйсхолдера

### DIFF
--- a/src/components/Chip/Chip.css
+++ b/src/components/Chip/Chip.css
@@ -4,6 +4,7 @@
   background: var(--background_content);
   border-radius: 4px;
   height: 28px;
+  box-sizing: border-box;
 }
 
 .Chip__in {

--- a/src/components/ChipsInput/ChipsInput.css
+++ b/src/components/ChipsInput/ChipsInput.css
@@ -2,8 +2,12 @@
   display: flex;
   position: relative;
   /* 2px горизонтального отступа ушли в chip и input-container для 2+2=4px отступа между строками при многострочном инпуте */
-  padding: 2px 12px 2px 0;
+  padding: 4px 14px;
   box-sizing: border-box;
+}
+
+.ChipsInput.ChipsInput--sizeY-compact {
+  padding: 2px 12px;
 }
 
 .ChipsInput__container {
@@ -15,7 +19,7 @@
 }
 
 .ChipsInput__chip {
-  margin: 2px 0 2px 4px;
+  margin: 2px 12px 2px -8px;
   max-width: calc(100% - 8px);
 }
 
@@ -23,7 +27,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  margin: 2px 0 2px 12px;
+  margin: 2px 0;
 }
 
 .ChipsInput__el {

--- a/src/components/ChipsInput/ChipsInput.css
+++ b/src/components/ChipsInput/ChipsInput.css
@@ -1,7 +1,8 @@
 .ChipsInput {
   display: flex;
   position: relative;
-  padding: 10px 12px;
+  /* 2px горизонтального отступа ушли в chip и input-container для 2+2=4px отступа между строками при многострочном инпуте */
+  padding: 2px 12px 2px 0;
   box-sizing: border-box;
 }
 
@@ -11,11 +12,10 @@
   flex-wrap: wrap;
   position: relative;
   z-index: 2;
-  margin: -7px -4px;
 }
 
 .ChipsInput__chip {
-  margin: 2px;
+  margin: 2px 0 2px 4px;
   max-width: calc(100% - 8px);
 }
 
@@ -23,16 +23,17 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  margin: 3px 0 3px;
+  margin: 2px 0 2px 12px;
 }
 
 .ChipsInput__el {
-  line-height: 20px;
+  /* Визуальная компенсация - центрируем строчные буквы */
+  line-height: 26px;
+  margin-bottom: 2px;
   font-size: 15px;
   color: var(--text_primary);
   border: none;
   outline: none;
-  height: 28px;
   width: 100%;
   box-sizing: border-box;
   box-shadow: none;
@@ -41,12 +42,10 @@
   z-index: 2;
   background: transparent;
   padding: 0;
-  margin-left: 4px;
 }
 
 .ChipsInput__el:focus {
   min-width: 64px;
-  margin-left: 4px;
 }
 
 .ChipsInput:focus {
@@ -62,23 +61,9 @@
 }
 
 .ChipsInput__el::placeholder {
-  line-height: 20px;
-  font-size: 15px;
   color: var(--field_text_placeholder);
 }
 
 .ChipsInput__el:disabled::placeholder {
   color: var(--text_secondary);
-}
-
-.ChipsInput--withChips .ChipsInput__container {
-  margin-left: -7px;
-}
-
-.ChipsInput--withChips .ChipsInput__el {
-  margin-left: 0;
-}
-
-.ChipsInput--withChips .ChipsInput__el:focus {
-  margin-left: 7px;
 }

--- a/src/components/ChipsInput/ChipsInput.tsx
+++ b/src/components/ChipsInput/ChipsInput.tsx
@@ -13,6 +13,7 @@ import classNames from '../../lib/classNames';
 import Chip, { ChipProps } from '../Chip/Chip';
 import { noop } from '../../lib/utils';
 import { useChipsInput } from './useChipsInput';
+import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
 export type ChipsInputValue = string | number;
 
@@ -32,7 +33,8 @@ export interface ChipsInputProps<Option extends ChipsInputOption> extends
   Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>,
   HasRef<HTMLInputElement>,
   HasRootRef<HTMLDivElement>,
-  HasAlign {
+  HasAlign,
+  AdaptivityProps {
   value: Option[];
   inputValue?: string;
   onChange?: (o: Option[]) => void;
@@ -45,7 +47,8 @@ export interface ChipsInputProps<Option extends ChipsInputOption> extends
 
 const ChipsInput = <Option extends ChipsInputOption>(props: ChipsInputProps<Option>) => {
   const { style, value, onChange, onInputChange, onKeyDown, onBlur, onFocus, children, className, inputValue,
-    getRef, getRootRef, disabled, placeholder, tabIndex, getOptionValue, getOptionLabel, getNewOptionData, renderChip, ...restProps } = props;
+    getRef, getRootRef, disabled, placeholder, tabIndex, getOptionValue, getOptionLabel, getNewOptionData, renderChip,
+    sizeY, ...restProps } = props;
   const [focused, setFocused] = useState(false);
   const { fieldValue, addOptionFromInput, removeOption, selectedOptions, handleInputChange } = useChipsInput(props);
 
@@ -85,7 +88,7 @@ const ChipsInput = <Option extends ChipsInputOption>(props: ChipsInputProps<Opti
     <FormField
       Component="label"
       getRootRef={getRootRef}
-      className={classNames('ChipsInput', {
+      className={classNames('ChipsInput', `ChipsInput--sizeY-${sizeY}`, {
         'ChipsInput--focused': focused,
         'ChipsInput--disabled': disabled,
         'ChipsInput--withChips': !!selectedOptions.length,
@@ -126,7 +129,7 @@ const ChipsInput = <Option extends ChipsInputOption>(props: ChipsInputProps<Opti
   );
 };
 
-ChipsInput.defaultProps = {
+export const chipsInputDefaultProps: ChipsInputProps<any> = {
   type: 'text',
   onChange: noop,
   onInputChange: noop,
@@ -146,5 +149,6 @@ ChipsInput.defaultProps = {
     >{label}</Chip>;
   },
 };
+ChipsInput.defaultProps = chipsInputDefaultProps;
 
-export default ChipsInput;
+export default withAdaptivity(ChipsInput, { sizeY: true });

--- a/src/components/ChipsSelect/ChipsSelect.css
+++ b/src/components/ChipsSelect/ChipsSelect.css
@@ -19,8 +19,8 @@
 
 .ChipsSelect__toggle {
   position: absolute;
-  right: 10px;
-  top: 12px;
+  right: 8px;
+  top: 10px;
   z-index: 1;
   color: var(--icon_secondary);
 }

--- a/src/components/ChipsSelect/ChipsSelect.css
+++ b/src/components/ChipsSelect/ChipsSelect.css
@@ -19,10 +19,15 @@
 
 .ChipsSelect__toggle {
   position: absolute;
-  right: 8px;
-  top: 10px;
+  right: 10px;
+  top: 12px;
   z-index: 1;
   color: var(--icon_secondary);
+}
+
+.ChipsSelect--sizeY-compact .ChipsSelect__toggle {
+  right: 8px;
+  top: 10px;
 }
 
 .ChipsSelect__options {
@@ -51,8 +56,8 @@
   box-shadow: 0 -2px 2px rgba(0, 0, 0, .06), 0 0 2px rgba(0, 0, 0, .03);
 }
 
-.ChipsSelect__options--sizeY-compact .CustomSelectOption {
-  height: 40px;
-  padding: 10px 11px;
+.ChipsSelect--sizeY-compact .CustomSelectOption {
+  height: 36px;
+  padding: 10px 9px;
   font-size: 15px;
 }

--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -9,7 +9,7 @@ import Icon20Dropdown from '@vkontakte/icons/dist/20/dropdown';
 import classNames from '../../lib/classNames';
 import Spinner from '../Spinner/Spinner';
 import CustomScrollView from '../CustomScrollView/CustomScrollView';
-import ChipsInput, { ChipsInputOption, ChipsInputProps, ChipsInputValue, RenderChip } from '../ChipsInput/ChipsInput';
+import ChipsInput, { ChipsInputOption, ChipsInputProps, ChipsInputValue, RenderChip, chipsInputDefaultProps } from '../ChipsInput/ChipsInput';
 import CustomSelectOption, { CustomSelectOptionProps } from '../CustomSelectOption/CustomSelectOption';
 import { useChipsSelect } from './useChipsSelect';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
@@ -198,7 +198,7 @@ const ChipsSelect: FC<ChipsSelectProps<ChipsInputOption>> = <Option extends Chip
 
   return (
     <div
-      className={classNames('ChipsSelect', className)}
+      className={classNames('ChipsSelect', `ChipsSelect--sizeY-${sizeY}`, className)}
       ref={getRootRef}
       style={style}
     >
@@ -228,8 +228,7 @@ const ChipsSelect: FC<ChipsSelectProps<ChipsInputOption>> = <Option extends Chip
       </div>
       {opened &&
         <div
-          className={classNames(`ChipsSelect__options--sizeY-${sizeY}`, {
-            ['ChipsSelect__options']: opened,
+          className={classNames('ChipsSelect__options', {
             ['ChipsSelect__options--popupDirectionTop']: popupDirection === 'top',
           })}
           onMouseLeave={() => setFocusedOptionIndex(null)}
@@ -288,7 +287,7 @@ const ChipsSelect: FC<ChipsSelectProps<ChipsInputOption>> = <Option extends Chip
 };
 
 ChipsSelect.defaultProps = {
-  ...ChipsInput.defaultProps,
+  ...chipsInputDefaultProps,
   creatable: false,
   fetching: false,
   showSelected: true,


### PR DESCRIPTION
- fixes #1108 
- Привел отступы в ChipsInput / ChipsSelect в соответствие с [макетом](https://www.figma.com/file/TDK0ARSsxCXRAX8VLIFMS6/VKUI-Web-Library-%C2%B7-Beta?node-id=3269%3A1) после https://github.com/VKCOM/VKUI/pull/983
- Добавил sizeY-compact