### PR TITLE
Tappable updates for devices with mouse

### DIFF
--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -99,6 +99,14 @@
   border-radius: 0;
 }
 
+.Tappable--mouse {
+  transition: opacity .15s ease-out;
+}
+
+.Tappable--mouse .Tappable__hoverShadow {
+  transition: background-color .15s ease-out;
+}
+
 /**
  * Animations
  */

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -291,7 +291,7 @@ class Tappable extends Component<TappableProps, TappableState> {
   render() {
     const { clicks, active, hovered } = this.state;
     const { children, className, Component, activeEffectDelay,
-      stopPropagation, getRootRef, platform, sizeX, hasHover, ...restProps } = this.props;
+      stopPropagation, getRootRef, platform, sizeX, hasHover, hasMouse, ...restProps } = this.props;
 
     const hoverClassModificator = this.containerHasTransparentBackground()
       ? 'shadowHovered'
@@ -304,6 +304,7 @@ class Tappable extends Component<TappableProps, TappableState> {
       {
         'Tappable--active': active,
         'Tappable--inactive': !active,
+        'Tappable--mouse': hasMouse,
         [`Tappable--${hoverClassModificator}`]: hasHover && hovered,
       });
 
@@ -352,4 +353,4 @@ class Tappable extends Component<TappableProps, TappableState> {
   }
 }
 
-export default withAdaptivity(withPlatform(Tappable), { sizeX: true });
+export default withAdaptivity(withPlatform(Tappable), { sizeX: true, hasMouse: true });

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -335,7 +335,7 @@ class Tappable extends Component<TappableProps, TappableState> {
           return (
             <RootComponent {...restProps} className={classes} {...props}>
               {children}
-              {platform === ANDROID &&
+              {platform === ANDROID && !hasMouse &&
                 <span className="Tappable__waves">
                   {Object.keys(clicks).map((k: string) => {
                     return (


### PR DESCRIPTION
- Добавлен transition .15s если определена мышка

| With mouse | No mouse (no transition) |
|-|-|
| ![Kapture 2020-12-08 at 11 38 57](https://user-images.githubusercontent.com/827338/101461382-d68fa280-394b-11eb-8c11-82f1c5f80e87.gif) | ![Kapture 2020-12-08 at 11 39 29](https://user-images.githubusercontent.com/827338/101461403-e1e2ce00-394b-11eb-84b1-24e2b5352319.gif) |

- Убран ripple effect для Android если определена мышка

![Kapture 2020-12-08 at 13 00 41](https://user-images.githubusercontent.com/827338/101469293-9f25f380-3955-11eb-8bb2-4d5238e3563a.gif)
