### PR TITLE
 Calculate sizeX/sizeY from viewWidth/viewHeight

### DIFF
--- a/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -80,10 +80,8 @@ function calculateAdaptivity(windowWidth: number, windowHeight: number, props: A
     viewWidth = ViewWidth.SMALL_TABLET;
   } else if (windowWidth >= MOBILE_SIZE) {
     viewWidth = ViewWidth.MOBILE;
-    sizeX = SizeType.COMPACT;
   } else {
     viewWidth = ViewWidth.SMALL_MOBILE;
-    sizeX = SizeType.COMPACT;
   }
 
   if (windowHeight >= MEDIUM_HEIGHT) {
@@ -92,15 +90,19 @@ function calculateAdaptivity(windowWidth: number, windowHeight: number, props: A
     viewHeight = ViewHeight.SMALL;
   } else {
     viewHeight = ViewHeight.EXTRA_SMALL;
-    sizeY = SizeType.COMPACT;
-  }
-
-  if (windowWidth >= SMALL_TABLET_SIZE && hasMouse) {
-    sizeY = SizeType.COMPACT;
   }
 
   props.viewWidth && (viewWidth = props.viewWidth);
   props.viewHeight && (viewHeight = props.viewHeight);
+
+  if (viewWidth <= ViewWidth.MOBILE) {
+    sizeX = SizeType.COMPACT;
+  }
+
+  if (viewWidth >= ViewWidth.SMALL_TABLET && hasMouse || viewHeight <= ViewHeight.EXTRA_SMALL) {
+    sizeY = SizeType.COMPACT;
+  }
+
   props.sizeX && (sizeX = props.sizeX);
   props.sizeY && (sizeY = props.sizeY);
 

--- a/styleguide/Components/PathlineRenderer.js
+++ b/styleguide/Components/PathlineRenderer.js
@@ -59,7 +59,6 @@ export function PathlineRenderer({ classes, children }) {
             <HasMouseCheckbox 
               onChange={(e) => styleGuideContext.setContext({ hasMouse: e.target.checked })}
               value={styleGuideContext.hasMouse}
-              disabled={styleGuideContext.platform === VKCOM}
             />
             &nbsp;|&nbsp;
             <span className={classes.link}>

--- a/styleguide/Components/StyleGuideRenderer.js
+++ b/styleguide/Components/StyleGuideRenderer.js
@@ -174,7 +174,6 @@ function StyleGuideRenderer({ classes, title, homepageUrl, children, toc, hasSid
               <HasMouseCheckbox
                 onChange={ (e) => setContext({ hasMouse: e.target.checked })}
                 value={hasMouse}
-                disabled={platform === VKCOM}
               />
             </div>
             <div style={{ marginTop: 4 }}>


### PR DESCRIPTION
Исправляет баг: если задать `viewWidth`/`viewWidthHeight` в `AdaptivityProvider`, то `sizeX`/`sizeY` все равно вычисляются в зависимости от ширины экрана