### PR TITLE
fix(HorizontalScroll): update initialScrollWidth on children change

### DIFF
--- a/src/components/HorizontalScroll/Readme.md
+++ b/src/components/HorizontalScroll/Readme.md
@@ -1,28 +1,59 @@
 Компонент для отрисовки "длинного" содержимого, которое можно скроллить по горизонтали.
 
 ```jsx
-  const itemStyle = {
-    flexShrink: 0,
-    width: 80,
-    height: 94,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    fontSize: 12
-  };
+import { useEffect, useState, Fragment } from 'react';
 
-  <View activePanel="horizontal">
-    <Panel id="horizontal">
-      <PanelHeader>HorizontalScroll</PanelHeader>
-      <Group header={<Header mode="secondary">Недавние</Header>}>
-        <HorizontalScroll showArrows getScrollToLeft={i => i - 120} getScrollToRight={i => i + 120}>
-          <div style={{ display: 'flex' }}>
-            {getRandomUsers(15).map((item) => ( 
-              <HorizontalCell key={item.id} header={item.first_name}><Avatar size={56} src={item.photo_200} /></HorizontalCell>)
-            )}
-          </div>
-        </HorizontalScroll>
-      </Group>
-    </Panel>
-  </View>
+const HorizontalScrollExample = () => {
+  const [recentFriends] = useState(getRandomUsers(20));
+  const [commonFriends, setCommonFriends] = useState([]);
+
+  useEffect(() => {
+    // Эмуляция загрузки
+    setTimeout(() => {
+      setCommonFriends(getRandomUsers(20));
+    }, 500);
+  }, []);
+
+  return (
+    <View activePanel="horizontal">
+      <Panel id="horizontal">
+        <PanelHeader>HorizontalScroll</PanelHeader>
+        <Group header={<Header mode="secondary">Недавние</Header>}>
+          <HorizontalScroll showArrows getScrollToLeft={i => i - 120} getScrollToRight={i => i + 120}>
+            <div style={{ display: 'flex' }}>
+              {recentFriends.map((item) => {
+                return (
+                  <HorizontalCell key={item.id} header={item.first_name}>
+                    <Avatar size={56} src={item.photo_200} />
+                  </HorizontalCell>
+                )
+              })}
+            </div>
+          </HorizontalScroll>
+        </Group>
+
+        <Group header={<Header mode="secondary">Общие друзья</Header>}>
+          <HorizontalScroll showArrows getScrollToLeft={i => i - 120} getScrollToRight={i => i + 120}>
+            <div style={{ display: 'flex' }}>
+              {commonFriends.length === 0 && <PanelSpinner />}
+              {commonFriends.length > 0 &&
+              <Fragment>
+                {commonFriends.map((item) => {
+                  return (
+                    <HorizontalCell key={item.id} header={item.first_name}>
+                      <Avatar size={56} src={item.photo_200} />
+                    </HorizontalCell>
+                  )
+                })}
+              </Fragment>
+              }
+            </div>
+           </HorizontalScroll>
+        </Group>
+      </Panel>
+    </View>
+  );
+};
+
+<HorizontalScrollExample />
 ```

--- a/src/lib/fx.ts
+++ b/src/lib/fx.ts
@@ -1,0 +1,7 @@
+/**
+ * ease function
+ * @param x absolute progress of the animation in bounds 0 (beginning) and 1 (end)
+ */
+export function easeInOutSine(x: number) {
+  return 0.5 * (1 - Math.cos(Math.PI * x));
+}


### PR DESCRIPTION
## Исправления

* `HorizontalScroll`: исправлено обновление состояния прокрутки после изменения `children`.

До этого `initialScrollWidth` устанавливалась единожды после первоначального рендера компонента. Из-за чего после смены `children` прокрутка, зависящая от `initialScrollWidth`, ломалась.
