### PR TITLE
Pkorchevskiy/bugfix/header jump/sak 1918

### DIFF
--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -83,11 +83,19 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
 
   onViewTransitionStart: EventListener = (e: CustomEvent<TransitionStartEventDetail>) => {
     let panelScroll = e.detail.scrolls[this.props.panel] || 0;
-    this.setState({
-      position: 'absolute',
-      top: this.el.offsetTop + panelScroll,
-      width: '',
-    });
+    const fromPannelHasScroll = this.props.panel === e.detail.from && panelScroll > 0;
+    const toPannelHasScroll = this.props.panel === e.detail.to && panelScroll > 0;
+    const document = this.document;
+
+    // Для панелей, с которых уходим всегда выставляется скролл
+    // Для панелей на которые приходим надо смотреть, есть ли браузерный скролл
+    if (fromPannelHasScroll ||
+      (toPannelHasScroll && !document || document?.documentElement?.scrollTop > 0)) {
+      this.setState({
+        position: 'absolute',
+        top: this.el.offsetTop + panelScroll,
+      });
+    }
   };
 
   onViewTransitionEnd: VoidFunction = () => {

--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -65,6 +65,25 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
     return this.context.window || window;
   }
 
+  get currentPanel(): HTMLElement {
+    const { panel: id } = this.props;
+    const elem = this.document.getElementById(id);
+
+    if (!elem) {
+      console.warn(`Element #${id} not found`);
+    }
+
+    return elem;
+  }
+
+  get canTargetPanelScroll() {
+    const panelEl = this.currentPanel;
+    if (!panelEl) {
+      return true; // Всегда предпологаем, что может быть скролл в случае, если нет document
+    }
+    return panelEl.scrollHeight > panelEl.clientHeight;
+  }
+
   componentDidMount() {
     this.onMountResizeTimeout = setTimeout(() => this.doResize());
     this.window.addEventListener('resize', this.doResize);
@@ -85,15 +104,14 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
     let panelScroll = e.detail.scrolls[this.props.panel] || 0;
     const fromPannelHasScroll = this.props.panel === e.detail.from && panelScroll > 0;
     const toPannelHasScroll = this.props.panel === e.detail.to && panelScroll > 0;
-    const document = this.document;
 
     // Для панелей, с которых уходим всегда выставляется скролл
     // Для панелей на которые приходим надо смотреть, есть ли браузерный скролл
-    if (fromPannelHasScroll ||
-      (toPannelHasScroll && !document || document?.documentElement?.scrollTop > 0)) {
+    if (fromPannelHasScroll || toPannelHasScroll && this.canTargetPanelScroll) {
       this.setState({
         position: 'absolute',
         top: this.el.offsetTop + panelScroll,
+        width: '',
       });
     }
   };

--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -102,12 +102,12 @@ class FixedLayout extends React.Component<FixedLayoutProps, FixedLayoutState> {
 
   onViewTransitionStart: EventListener = (e: CustomEvent<TransitionStartEventDetail>) => {
     let panelScroll = e.detail.scrolls[this.props.panel] || 0;
-    const fromPannelHasScroll = this.props.panel === e.detail.from && panelScroll > 0;
-    const toPannelHasScroll = this.props.panel === e.detail.to && panelScroll > 0;
+    const fromPanelHasScroll = this.props.panel === e.detail.from && panelScroll > 0;
+    const toPanelHasScroll = this.props.panel === e.detail.to && panelScroll > 0;
 
     // Для панелей, с которых уходим всегда выставляется скролл
     // Для панелей на которые приходим надо смотреть, есть ли браузерный скролл
-    if (fromPannelHasScroll || toPannelHasScroll && this.canTargetPanelScroll) {
+    if (fromPanelHasScroll || toPanelHasScroll && this.canTargetPanelScroll) {
       this.setState({
         position: 'absolute',
         top: this.el.offsetTop + panelScroll,

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -25,6 +25,8 @@ interface Scrolls {
 
 export type TransitionStartEventDetail = {
   scrolls: Scrolls;
+  from: string;
+  to: string;
 };
 
 interface ViewsScrolls {
@@ -197,7 +199,14 @@ class View extends Component<ViewProps, ViewState> {
 
     // Начался переход
     if (!prevState.animated && this.state.animated) {
-      this.document.dispatchEvent(createCustomEvent(this.window, transitionStartEventName, { detail: { scrolls } }));
+      const transitionStartEventData = {
+        detail: {
+          from: this.state.prevPanel,
+          to: this.state.nextPanel,
+          scrolls,
+        },
+      };
+      this.document.dispatchEvent(new this.window.CustomEvent(transitionStartEventName, transitionStartEventData));
       const nextPanelElement = this.pickPanel(this.state.nextPanel);
       const prevPanelElement = this.pickPanel(this.state.prevPanel);
 
@@ -210,7 +219,14 @@ class View extends Component<ViewProps, ViewState> {
 
     // Начался свайп назад
     if (!prevState.swipingBack && this.state.swipingBack) {
-      this.document.dispatchEvent(createCustomEvent(this.window, transitionStartEventName, { detail: { scrolls } }));
+      const transitionStartEventData = {
+        detail: {
+          from: this.state.swipeBackPrevPanel,
+          to: this.state.swipeBackNextPanel,
+          scrolls,
+        },
+      };
+      this.document.dispatchEvent(new this.window.CustomEvent(transitionStartEventName, transitionStartEventData));
       this.props.onSwipeBackStart && this.props.onSwipeBackStart();
       const nextPanelElement = this.pickPanel(this.state.swipeBackNextPanel);
       const prevPanelElement = this.pickPanel(this.state.swipeBackPrevPanel);


### PR DESCRIPTION
Фикс бага, который правит следующую проблему: если панель скроллится и динамически подгружает на себя данные каждый раз, когда пользователь переходит на неё, то FixedLayout в шапке панели позиционируется учитывая предыдущий скролл. А т.к. сама панель не скроллируемая, то скролл не восстанавливается и шапка отображается посередине окна.