### PR TITLE
Fix Tooltip padding

### DIFF
--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -34,7 +34,7 @@
     .Tooltip__content {
       background-color: #47a3ff;
       box-shadow: 0 4px 32px 0 rgba(0, 0, 0, .16), 0 0 4px 0 rgba(0, 0, 0, .04);
-      padding: 6px 16px;
+      padding: 8.5px 12px 9.5px;
       border-radius: 10px;
       font-size: 14px;
       color: #fff;

--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -34,7 +34,7 @@
     .Tooltip__content {
       background-color: #47a3ff;
       box-shadow: 0 4px 32px 0 rgba(0, 0, 0, .16), 0 0 4px 0 rgba(0, 0, 0, .04);
-      padding: 8.5px 12px 9.5px;
+      padding: 8px 12px 10px;
       border-radius: 10px;
       font-size: 14px;
       color: #fff;


### PR DESCRIPTION
resolves #1261 

Before

<img width="310" alt="Снимок экрана 2020-12-22 в 13 21 57" src="https://user-images.githubusercontent.com/827338/102878477-60b22d80-4459-11eb-9293-de5ad60f81db.png">

After

![image](https://user-images.githubusercontent.com/827338/102884942-98be6e00-4463-11eb-843b-57ee6f5a0ce3.png)

