### PR TITLE
PopoutWrapper: fix close from overlay click

### DIFF
--- a/src/components/PopoutWrapper/PopoutWrapper.css
+++ b/src/components/PopoutWrapper/PopoutWrapper.css
@@ -53,6 +53,11 @@
   justify-content: center;
   width: 100%;
   z-index: 2;
+  pointer-events: none;
+}
+
+.PopoutWrapper__content > * {
+  pointer-events: auto;
 }
 
 .PopoutWrapper--v-center .PopoutWrapper__container {


### PR DESCRIPTION
## Исправления:

### Нажатия по бокам от блока внутри PopoutWrapper не вызывали onClose (перехватывались растянутым PopoutWrapper__content)

Before:

![Kapture 2020-12-25 at 11 12 12](https://user-images.githubusercontent.com/827338/103127701-cabe1300-46a3-11eb-8739-7ff15979f323.gif)

After:

![Kapture 2020-12-25 at 11 24 11](https://user-images.githubusercontent.com/827338/103127704-cd206d00-46a3-11eb-8eaf-cd4af5dbe646.gif)

