### PR TITLE
Fix ModalPage/ModalCard adaptivity behavior on small screens

### DIFF
--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -61,10 +61,11 @@ const ModalCard: FC<ModalCardProps> = (props) => {
     className,
     viewWidth,
     viewHeight,
+    hasMouse,
     ...restProps
   } = props;
 
-  const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && viewHeight >= ViewHeight.MEDIUM;
+  const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
   const canShowCloseBtn = viewWidth >= ViewWidth.SMALL_TABLET;
   const canShowCloseBtnIos = platform === IOS && !canShowCloseBtn;
 
@@ -110,4 +111,5 @@ ModalCard.defaultProps = {
 export default withAdaptivity(withPlatform(ModalCard), {
   viewWidth: true,
   viewHeight: true,
+  hasMouse: true,
 });

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -32,6 +32,7 @@ const ModalPage: FC<ModalPageProps> = (props) => {
     header,
     viewWidth,
     viewHeight,
+    hasMouse,
     onClose,
     id,
     settlingHeight,
@@ -43,7 +44,7 @@ const ModalPage: FC<ModalPageProps> = (props) => {
     updateModalHeight();
   }, [children]);
 
-  const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && viewHeight >= ViewHeight.MEDIUM;
+  const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
   const canShowCloseBtn = viewWidth >= ViewWidth.SMALL_TABLET;
 
   return (
@@ -80,4 +81,5 @@ ModalPage.defaultProps = {
 export default withAdaptivity(ModalPage, {
   viewWidth: true,
   viewHeight: true,
+  hasMouse: true,
 });

--- a/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -14,8 +14,8 @@ export interface ModalRootProps extends HasChildren, AdaptivityProps {
 }
 
 const ModalRootComponent: FC<ModalRootProps> = (props) => {
-  const { viewWidth, viewHeight } = props;
-  const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && viewHeight >= ViewHeight.MEDIUM;
+  const { viewWidth, viewHeight, hasMouse } = props;
+  const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
 
   const RootComponent = isDesktop ? ModalRootDesktop : ModalRootTouch;
 
@@ -29,4 +29,5 @@ ModalRootComponent.displayName = 'ModalRoot';
 export const ModalRoot = withAdaptivity(ModalRootComponent, {
   viewWidth: true,
   viewHeight: true,
+  hasMouse: true,
 });


### PR DESCRIPTION
При наличии мышки, модалки будут открываться в десктопной режиме, независимо от высоты экрана

## Before (height = 667px, with mouse)

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/827338/104152255-0c62f380-53f0-11eb-972f-cd499cce3486.png">


## After (height = 667px, with mouse)

<img width="1335" alt="image" src="https://user-images.githubusercontent.com/827338/104152237-03722200-53f0-11eb-9410-efbd0749c55c.png">
