### PR TITLE
ActionSheet: proper breakpoint and mouse check for adaptivity

### DIFF
--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -2,7 +2,7 @@ import React, { Component, HTMLAttributes } from 'react';
 import PopoutWrapper from '../PopoutWrapper/PopoutWrapper';
 import { transitionEvent } from '../../lib/supportEvents';
 import withPlatform from '../../hoc/withPlatform';
-import withAdaptivity, { AdaptivityProps, ViewWidth } from '../../hoc/withAdaptivity';
+import withAdaptivity, { AdaptivityProps, ViewWidth, ViewHeight } from '../../hoc/withAdaptivity';
 import { HasPlatform } from '../../types';
 import { ANDROID, IOS, VKCOM } from '../../lib/platform';
 import ActionSheetDropdownDesktop from './ActionSheetDropdownDesktop';
@@ -63,8 +63,13 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
     }
   };
 
+  get isDesktop() {
+    const { viewWidth, viewHeight, hasMouse } = this.props;
+    return viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
+  }
+
   waitTransitionFinish(eventHandler: AnimationEndCallback) {
-    if (this.props.viewWidth >= ViewWidth.TABLET) {
+    if (this.isDesktop) {
       eventHandler();
     }
 
@@ -86,12 +91,13 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
       style,
       platform,
       viewWidth,
+      viewHeight,
       hasMouse,
       iosCloseItem,
       ...restProps
     } = this.props;
 
-    const isDesktop = hasMouse || viewWidth >= ViewWidth.SMALL_TABLET;
+    const isDesktop = this.isDesktop;
 
     const DropdownComponent = isDesktop
       ? ActionSheetDropdownDesktop
@@ -139,5 +145,6 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
 
 export default withAdaptivity(withPlatform(ActionSheet), {
   viewWidth: true,
+  viewHeight: true,
   hasMouse: true,
 });

--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -86,11 +86,12 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
       style,
       platform,
       viewWidth,
+      hasMouse,
       iosCloseItem,
       ...restProps
     } = this.props;
 
-    const isDesktop = viewWidth >= ViewWidth.TABLET;
+    const isDesktop = hasMouse || viewWidth >= ViewWidth.SMALL_TABLET;
 
     const DropdownComponent = isDesktop
       ? ActionSheetDropdownDesktop
@@ -138,4 +139,5 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
 
 export default withAdaptivity(withPlatform(ActionSheet), {
   viewWidth: true,
+  hasMouse: true,
 });


### PR DESCRIPTION
- добавлена проверка на наличие мышки и высоту экрана
- исправлен desktop брейкпоинт в соотвествии с дизайном

<img width="765" alt="image" src="https://user-images.githubusercontent.com/827338/104153948-acbb1700-53f4-11eb-8ea7-0eef146897ac.png">

## Demo

| | has mouse | no mouse |
|-|-|-|
| 768 x 667 | <img width="786" alt="image" src="https://user-images.githubusercontent.com/827338/104154488-1687f080-53f6-11eb-885c-c50e9a3fe8e6.png"> | <img width="779" alt="image" src="https://user-images.githubusercontent.com/827338/104154508-23a4df80-53f6-11eb-96cf-1f8a522bd51d.png"> |
| 768 x 414 (horizontal mobile) | <img width="786" alt="image" src="https://user-images.githubusercontent.com/827338/104154607-5cdd4f80-53f6-11eb-8fd3-b25d529bf277.png"> | <img width="780" alt="image" src="https://user-images.githubusercontent.com/827338/104154620-649cf400-53f6-11eb-9b8c-02c03f35cee9.png"> |
| 1024 x 667 | <img width="1038" alt="image" src="https://user-images.githubusercontent.com/827338/104155069-6e732700-53f7-11eb-8ebe-6208fb777bea.png"> | <img width="1036" alt="image" src="https://user-images.githubusercontent.com/827338/104155087-79c65280-53f7-11eb-8e92-6efc21842b54.png"> |
| 768 x 720 (small tablet and larger) | <img width="772" alt="image" src="https://user-images.githubusercontent.com/827338/104154680-8eeeb180-53f6-11eb-8f79-af3356de86f0.png"> | <img width="782" alt="image" src="https://user-images.githubusercontent.com/827338/104154698-9ada7380-53f6-11eb-9b4c-467645ee7913.png"> |






