### PR TITLE
Root: hide overflow content during View change transition

### DIFF
--- a/src/components/Root/Root.css
+++ b/src/components/Root/Root.css
@@ -6,6 +6,7 @@
 
 .Root--transition {
   pointer-events: none;
+  overflow: hidden;
   }
 
   .Root__view {


### PR DESCRIPTION
## Before

![before](https://user-images.githubusercontent.com/827338/104853185-406a7700-5910-11eb-8646-076782f477dd.gif)

## After

![after](https://user-images.githubusercontent.com/827338/104853192-452f2b00-5910-11eb-8f89-3c69fe96ddda.gif)
