### PR TITLE
#626 Компонент Badge

### DIFF
--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -1,3 +1,21 @@
 .Badge {
-  box-sizing: border-box;
+  flex-grow: 0;
+  flex-shrink: 0;
+  display: flex;
+  flex-flow: row nowrap;
+  align-content: flex-start;
+  justify-content: flex-start;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  color: var(--dynamic_blue);
+}
+
+.Badge__default {
+  display: inline;
+  width: 6px;
+  height: 6px;
+  margin: 2px;
+  background-color: var(--dynamic_blue);
+  border-radius: 50%;
 }

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -6,26 +6,16 @@
   align-content: flex-start;
   justify-content: flex-start;
   align-items: center;
-  width: 12px;
-  height: 12px;
-}
-
-.Badge__dot {
   width: 6px;
   height: 6px;
-  margin-top: 1px;
   margin-left: 3px;
   border-radius: 50%;
 }
 
-.Badge--sizeY-compact .Badge__dot {
-  transform: translateY(.5px);
-}
-
-.Badge--primary .Badge__dot {
+.Badge.Badge--primary {
   background-color: #5c9ce6; /* blue_200 */
 }
 
-.Badge--prominent .Badge__dot {
+.Badge.Badge--prominent {
   background-color: var(--counter_prominent_background);
 }

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -8,14 +8,19 @@
   align-items: center;
   width: 16px;
   height: 16px;
-  color: var(--dynamic_blue);
+  color: #5c9ce6; /* blue_200 */
 }
 
-.Badge__default {
+.Badge__new {
   display: inline;
   width: 6px;
   height: 6px;
-  margin: 2px;
-  background-color: var(--dynamic_blue);
+  margin-top: 2px;
+  margin-left: 3px;
+  background-color: #5c9ce6; /* blue_200 */
   border-radius: 50%;
+}
+
+.Badge--sizeY-compact .Badge__new {
+  margin-top: 3px;
 }

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -12,7 +12,7 @@
   border-radius: 50%;
 }
 
-.Badge.Badge--primary {
+.Badge.Badge--new {
   background-color: #5c9ce6; /* blue_200 */
 }
 

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -12,10 +12,10 @@
   border-radius: 50%;
 }
 
-.Badge.Badge--new {
+.Badge--new {
   background-color: #5c9ce6; /* blue_200 */
 }
 
-.Badge.Badge--prominent {
+.Badge--prominent {
   background-color: var(--counter_prominent_background);
 }

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -6,21 +6,26 @@
   align-content: flex-start;
   justify-content: flex-start;
   align-items: center;
-  width: 16px;
-  height: 16px;
-  color: #5c9ce6; /* blue_200 */
+  width: 12px;
+  height: 12px;
 }
 
-.Badge__new {
-  display: inline;
+.Badge__dot {
   width: 6px;
   height: 6px;
-  margin-top: 2px;
+  margin-top: 1px;
   margin-left: 3px;
-  background-color: #5c9ce6; /* blue_200 */
   border-radius: 50%;
 }
 
-.Badge--sizeY-compact .Badge__new {
-  margin-top: 3px;
+.Badge--sizeY-compact .Badge__dot {
+  transform: translateY(.5px);
+}
+
+.Badge--primary .Badge__dot {
+  background-color: #5c9ce6; /* blue_200 */
+}
+
+.Badge--prominent .Badge__dot {
+  background-color: var(--counter_prominent_background);
 }

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -7,7 +7,7 @@
 }
 
 .Badge--new {
-  background-color: #5c9ce6; /* blue_200 */
+  background-color: var(--blue_200);
 }
 
 .Badge--prominent {

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -1,14 +1,8 @@
 .Badge {
   flex-grow: 0;
   flex-shrink: 0;
-  display: flex;
-  flex-flow: row nowrap;
-  align-content: flex-start;
-  justify-content: flex-start;
-  align-items: center;
   width: 6px;
   height: 6px;
-  margin-left: 3px;
   border-radius: 50%;
 }
 

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -1,0 +1,3 @@
+.Badge {
+  box-sizing: border-box;
+}

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -1,0 +1,6 @@
+import { baselineComponent } from '../../testing/utils';
+import Badge from './Badge';
+
+describe('Badge', () => {
+  baselineComponent(Badge);
+});

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -1,5 +1,5 @@
 import { baselineComponent } from '../../testing/utils';
-import Badge from './Badge';
+import { Badge } from './Badge';
 
 describe('Badge', () => {
   baselineComponent(Badge);

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -2,14 +2,16 @@ import React, { ReactNode, HTMLAttributes, FunctionComponent } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
+import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface BadgeProps extends HTMLAttributes<HTMLElement> {
+export interface BadgeProps extends HTMLAttributes<HTMLElement>, AdaptivityProps {
   icon: ReactNode;
 }
 
 const Badge: FunctionComponent<BadgeProps> = ({
   className,
   icon,
+  sizeY,
   ...restProps
 }: BadgeProps) => {
   const platform = usePlatform();
@@ -18,6 +20,7 @@ const Badge: FunctionComponent<BadgeProps> = ({
     <div
       className={classNames(
         getClassName('Badge', platform),
+        `Badge--sizeY-${sizeY}`,
         className,
       )}
       {...restProps}>
@@ -27,7 +30,7 @@ const Badge: FunctionComponent<BadgeProps> = ({
 };
 
 Badge.defaultProps = {
-  icon: <i className="Badge__default"></i>,
+  icon: <span className="Badge__new"></span>,
 };
 
-export default Badge;
+export default withAdaptivity(Badge, { sizeY: true });

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,29 @@
+import React, { ReactNode, HTMLAttributes, FunctionComponent } from 'react';
+import getClassName from '../../helpers/getClassName';
+import classNames from '../../lib/classNames';
+import usePlatform from '../../hooks/usePlatform';
+
+export interface BadgeProps extends HTMLAttributes<HTMLElement> {
+  icon: ReactNode;
+}
+
+const Badge: FunctionComponent<BadgeProps> = ({
+  className,
+  icon,
+  ...restProps
+}: BadgeProps) => {
+  const platform = usePlatform();
+
+  return (
+    <div
+      className={classNames(
+        getClassName('Badge', platform),
+        className,
+      )}
+      {...restProps}>
+      {icon}
+    </div>
+  );
+};
+
+export default Badge;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -2,16 +2,14 @@ import React, { HTMLAttributes, FunctionComponent } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
-import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface BadgeProps extends HTMLAttributes<HTMLElement>, AdaptivityProps {
+export interface BadgeProps extends HTMLAttributes<HTMLElement> {
   mode: 'primary' | 'prominent';
 };
 
 const Badge: FunctionComponent<BadgeProps> = ({
   className,
   mode,
-  sizeY,
   ...restProps
 }: BadgeProps) => {
   const platform = usePlatform();
@@ -21,11 +19,9 @@ const Badge: FunctionComponent<BadgeProps> = ({
       className={classNames(
         getClassName('Badge', platform),
         `Badge--${mode}`,
-        `Badge--sizeY-${sizeY}`,
         className,
       )}
       {...restProps}>
-      <span className="Badge__dot"></span>
     </div>
   );
 };
@@ -34,4 +30,4 @@ Badge.defaultProps = {
   mode: 'primary',
 };
 
-export default withAdaptivity(Badge, { sizeY: true });
+export default Badge;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -3,13 +3,14 @@ import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
-import { hasReactNode } from '../../lib/utils';
 
-export interface BadgeProps extends HTMLAttributes<HTMLElement>, AdaptivityProps {}
+export interface BadgeProps extends HTMLAttributes<HTMLElement>, AdaptivityProps {
+  mode: 'primary' | 'prominent';
+};
 
 const Badge: FunctionComponent<BadgeProps> = ({
-  children,
   className,
+  mode,
   sizeY,
   ...restProps
 }: BadgeProps) => {
@@ -19,13 +20,18 @@ const Badge: FunctionComponent<BadgeProps> = ({
     <div
       className={classNames(
         getClassName('Badge', platform),
+        `Badge--${mode}`,
         `Badge--sizeY-${sizeY}`,
         className,
       )}
       {...restProps}>
-      {hasReactNode(children) ? children : <span className="Badge__new"></span>}
+      <span className="Badge__dot"></span>
     </div>
   );
+};
+
+Badge.defaultProps = {
+  mode: 'primary',
 };
 
 export default withAdaptivity(Badge, { sizeY: true });

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -26,4 +26,8 @@ const Badge: FunctionComponent<BadgeProps> = ({
   );
 };
 
+Badge.defaultProps = {
+  icon: <i className="Badge__default"></i>,
+};
+
 export default Badge;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,16 +1,15 @@
-import React, { ReactNode, HTMLAttributes, FunctionComponent } from 'react';
+import React, { HTMLAttributes, FunctionComponent } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
+import { hasReactNode } from '../../lib/utils';
 
-export interface BadgeProps extends HTMLAttributes<HTMLElement>, AdaptivityProps {
-  icon: ReactNode;
-}
+export interface BadgeProps extends HTMLAttributes<HTMLElement>, AdaptivityProps {}
 
 const Badge: FunctionComponent<BadgeProps> = ({
+  children,
   className,
-  icon,
   sizeY,
   ...restProps
 }: BadgeProps) => {
@@ -24,13 +23,9 @@ const Badge: FunctionComponent<BadgeProps> = ({
         className,
       )}
       {...restProps}>
-      {icon}
+      {hasReactNode(children) ? children : <span className="Badge__new"></span>}
     </div>
   );
-};
-
-Badge.defaultProps = {
-  icon: <span className="Badge__new"></span>,
 };
 
 export default withAdaptivity(Badge, { sizeY: true });

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -4,7 +4,7 @@ import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 
 export interface BadgeProps extends HTMLAttributes<HTMLElement> {
-  mode: 'primary' | 'prominent';
+  mode: 'new' | 'prominent';
 };
 
 const Badge: FunctionComponent<BadgeProps> = ({
@@ -27,7 +27,7 @@ const Badge: FunctionComponent<BadgeProps> = ({
 };
 
 Badge.defaultProps = {
-  mode: 'primary',
+  mode: 'new',
 };
 
 export default Badge;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,7 +7,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLElement> {
   mode: 'new' | 'prominent';
 };
 
-const Badge: FunctionComponent<BadgeProps> = ({
+export const Badge: FunctionComponent<BadgeProps> = ({
   className,
   mode,
   ...restProps
@@ -29,5 +29,3 @@ const Badge: FunctionComponent<BadgeProps> = ({
 Badge.defaultProps = {
   mode: 'new',
 };
-
-export default Badge;

--- a/src/components/Badge/Readme.md
+++ b/src/components/Badge/Readme.md
@@ -1,21 +1,35 @@
-Используется для отображения информации рядом с именем пользователя.
+Индикатор, с помощью которого можно привлечь внимание пользователя к определенному разделу.
 
 ```jsx
 <View activePanel="badge">
   <Panel id="badge">
-    <PanelHeader>Badges</PanelHeader>
-    
-      <Group header={<Header mode="secondary">Друзья</Header>}>
-        <SimpleCell before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge><Icon12Verified/></Badge>} description="Команда ВКонтакте" after={<Icon28MessageOutline />}
-        >Артур Стамбульцян</SimpleCell>
-
-        <SimpleCell multiline before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge><Icon12Verified/></Badge>} description="Бот" after={<Icon28MessageOutline />}
-        >Константин Стамбульцян</SimpleCell>
-      </Group>
-    
-      <Group header={<Header mode="secondary">Новый пункт меню</Header>}>
+    <PanelHeader>Бейдж</PanelHeader>
+      <Group header={<Header mode="secondary">В пунктах меню</Header>}>
         <Cell expandable before={<Icon28Notifications />} badge={<Badge />}>Уведомления</Cell>
       </Group>
+
+      <Group header={<Header mode="secondary">В переключателях</Header>}>
+        <Tabs>
+          <TabsItem after={<Badge mode="prominent" />}>
+            Диалоги
+          </TabsItem>
+          <TabsItem selected after={<Badge mode="prominent" />}>
+            Сообщения
+          </TabsItem>
+        </Tabs>
+      </Group>
+
+      <Tabbar>
+        <TabbarItem text="Новости">
+          <Icon28NewsfeedOutline />
+        </TabbarItem>
+        <TabbarItem label={12} text="Сообщения">
+          <Icon28MessageOutline />
+        </TabbarItem>
+        <TabbarItem badge text="Клипы">
+          <Icon28ClipOutline />
+        </TabbarItem>
+      </Tabbar>
   </Panel>
 </View>
 ```

--- a/src/components/Badge/Readme.md
+++ b/src/components/Badge/Readme.md
@@ -23,10 +23,10 @@
         <TabbarItem text="Новости">
           <Icon28NewsfeedOutline />
         </TabbarItem>
-        <TabbarItem label={12} text="Сообщения">
+        <TabbarItem indicator={<Counter size="s" mode="prominent">12</Counter>} text="Сообщения">
           <Icon28MessageOutline />
         </TabbarItem>
-        <TabbarItem badge text="Клипы">
+        <TabbarItem indicator={<Badge mode="prominent" />} text="Клипы">
           <Icon28ClipOutline />
         </TabbarItem>
       </Tabbar>

--- a/src/components/Badge/Readme.md
+++ b/src/components/Badge/Readme.md
@@ -6,10 +6,10 @@
     <PanelHeader>Badges</PanelHeader>
     
       <Group header={<Header mode="secondary">Друзья</Header>}>
-        <SimpleCell before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge icon={<Icon12Verified/>} />} description="Команда ВКонтакте" after={<Icon28MessageOutline />}
+        <SimpleCell before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge><Icon12Verified/></Badge>} description="Команда ВКонтакте" after={<Icon28MessageOutline />}
         >Артур Стамбульцян</SimpleCell>
 
-        <SimpleCell multiline before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge icon={<Icon12Verified/>} />} description="Бот" after={<Icon28MessageOutline />}
+        <SimpleCell multiline before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge><Icon12Verified/></Badge>} description="Бот" after={<Icon28MessageOutline />}
         >Константин Стамбульцян</SimpleCell>
       </Group>
     

--- a/src/components/Badge/Readme.md
+++ b/src/components/Badge/Readme.md
@@ -4,32 +4,33 @@
 <View activePanel="badge">
   <Panel id="badge">
     <PanelHeader>Бейдж</PanelHeader>
-      <Group header={<Header mode="secondary">В пунктах меню</Header>}>
-        <Cell expandable before={<Icon28Notifications />} badge={<Badge />}>Уведомления</Cell>
-      </Group>
 
-      <Group header={<Header mode="secondary">В переключателях</Header>}>
-        <Tabs>
-          <TabsItem after={<Badge mode="prominent" />}>
-            Диалоги
-          </TabsItem>
-          <TabsItem selected after={<Badge mode="prominent" />}>
-            Сообщения
-          </TabsItem>
-        </Tabs>
-      </Group>
+    <Group header={<Header mode="secondary">В пунктах меню</Header>}>
+      <Cell expandable before={<Icon28Notifications />} badge={<Badge />}>
+        Уведомления
+      </Cell>
+    </Group>
 
-      <Tabbar>
-        <TabbarItem text="Новости">
-          <Icon28NewsfeedOutline />
-        </TabbarItem>
-        <TabbarItem indicator={<Counter size="s" mode="prominent">12</Counter>} text="Сообщения">
-          <Icon28MessageOutline />
-        </TabbarItem>
-        <TabbarItem indicator={<Badge mode="prominent" />} text="Клипы">
-          <Icon28ClipOutline />
-        </TabbarItem>
-      </Tabbar>
+    <Group header={<Header mode="secondary">В переключателях</Header>}>
+      <Tabs>
+        <TabsItem after={<Badge mode="prominent" />}>Диалоги</TabsItem>
+        <TabsItem selected after={<Badge mode="prominent" />}>
+          Сообщения
+        </TabsItem>
+      </Tabs>
+    </Group>
+
+    <Tabbar>
+      <TabbarItem text="Новости">
+        <Icon28NewsfeedOutline />
+      </TabbarItem>
+      <TabbarItem indicator={<Counter size="s" mode="prominent">12</Counter>} text="Сообщения">
+        <Icon28MessageOutline />
+      </TabbarItem>
+      <TabbarItem indicator={<Badge mode="prominent" />} text="Клипы">
+        <Icon28ClipOutline />
+      </TabbarItem>
+    </Tabbar>
   </Panel>
 </View>
 ```

--- a/src/components/Badge/Readme.md
+++ b/src/components/Badge/Readme.md
@@ -1,0 +1,13 @@
+Используется для отображения информации рядом с именем пользователя.
+
+```jsx
+<View activePanel="badge">
+  <Panel id="badge">
+    <PanelHeader>Badges</PanelHeader>
+    
+      <Group header={<Header mode="secondary">Верифицированный пользователь</Header>}>
+        <Cell before={<Avatar />}>Артур Стамбульцян</Cell>
+      </Group>
+  </Panel>
+</View>
+```

--- a/src/components/Badge/Readme.md
+++ b/src/components/Badge/Readme.md
@@ -5,8 +5,16 @@
   <Panel id="badge">
     <PanelHeader>Badges</PanelHeader>
     
-      <Group header={<Header mode="secondary">Верифицированный пользователь</Header>}>
-        <Cell before={<Avatar />}>Артур Стамбульцян</Cell>
+      <Group header={<Header mode="secondary">Друзья</Header>}>
+        <SimpleCell before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge icon={<Icon12Verified/>} />} description="Команда ВКонтакте" after={<Icon28MessageOutline />}
+        >Артур Стамбульцян</SimpleCell>
+
+        <SimpleCell multiline before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} badge={<Badge icon={<Icon12Verified/>} />} description="Бот" after={<Icon28MessageOutline />}
+        >Константин Стамбульцян</SimpleCell>
+      </Group>
+    
+      <Group header={<Header mode="secondary">Новый пункт меню</Header>}>
+        <Cell expandable before={<Icon28Notifications />} badge={<Badge />}>Уведомления</Cell>
       </Group>
   </Panel>
 </View>

--- a/src/components/SimpleCell/Readme.md
+++ b/src/components/SimpleCell/Readme.md
@@ -37,7 +37,7 @@
             </Group>
             <Group>
               <Header mode="secondary">Список друзей</Header>
-              <SimpleCell before={<Avatar size={48} src={getAvatarUrl('user_xyz')} />} after={<IconButton icon={<Icon28MessageOutline />} />} description="Команда ВКонтакте">Игорь Фёдоров</SimpleCell>
+              <SimpleCell before={<Avatar size={48} src={getAvatarUrl('user_xyz')} />} badge={<Icon12Verified />} after={<IconButton icon={<Icon28MessageOutline />} />} description="Команда ВКонтакте">Игорь Фёдоров</SimpleCell>
               <SimpleCell before={<Avatar size={48} src={getAvatarUrl('user_arthurstam')} />} after={<IconButton icon={<Icon28MessageOutline />} />} description="Бот">Artur Stambultsian</SimpleCell>
             </Group>
           </Panel>

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -74,10 +74,30 @@
   margin-top: 2px;
 }
 
+.SimpleCell:not(.SimpleCell--mult) .SimpleCell__content {
+  display: inline-flex;
+  flex-flow: row nowrap;
+  align-content: flex-start;
+  align-items: center;
+  justify-content: flex-start;
+  max-width: 100%;
+}
+
 .SimpleCell__children {
   color: inherit;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+.SimpleCell__badge {
+  flex-grow: 0;
+  flex-shrink: 0;
+  display: inline-flex;
+  flex-flow: row nowrap;
+  align-content: center;
+  align-items: center;
+  justify-content: center;
+  padding-left: 4px;
 }
 
 .SimpleCell__indicator {

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -97,7 +97,8 @@
   align-content: center;
   align-items: center;
   justify-content: center;
-  padding-left: 4px;
+  margin-left: 4px;
+  color: #5c9ce6; /* blue_200 */
 }
 
 .SimpleCell__indicator {

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -94,7 +94,7 @@
   flex-grow: 0;
   flex-shrink: 0;
   margin-left: 4px;
-  color: #5c9ce6; /* blue_200 */
+  color: var(--blue_200);
 }
 
 .SimpleCell__badge .Badge {

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -75,7 +75,7 @@
 }
 
 .SimpleCell:not(.SimpleCell--mult) .SimpleCell__content {
-  display: inline-flex;
+  display: flex;
   flex-flow: row nowrap;
   align-content: flex-start;
   align-items: center;

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -74,6 +74,10 @@
   margin-top: 2px;
 }
 
+.SimpleCell__content {
+  display: inline-block;
+}
+
 .SimpleCell:not(.SimpleCell--mult) .SimpleCell__content {
   display: inline-flex;
   flex-flow: row nowrap;
@@ -90,19 +94,27 @@
 }
 
 .SimpleCell__badge {
+  display: inline-block;
   flex-grow: 0;
   flex-shrink: 0;
-  display: inline-flex;
-  flex-flow: row nowrap;
-  align-content: center;
-  align-items: center;
-  justify-content: center;
   margin-left: 4px;
   color: #5c9ce6; /* blue_200 */
 }
 
 .SimpleCell__badge .Badge {
-  margin-top: 2px;
+  margin-top: 3px;
+}
+
+.SimpleCell--mult .SimpleCell__badge {
+  vertical-align: top;
+}
+
+.SimpleCell--mult .SimpleCell__badge .Icon {
+  transform: translateY(2px);
+}
+
+.SimpleCell--mult .SimpleCell__badge .Badge {
+  margin-top: 8px;
 }
 
 .SimpleCell__indicator {
@@ -283,5 +295,9 @@
 }
 
 .SimpleCell--sizeY-compact .SimpleCell__badge .Badge {
+  transform: translateY(-.5px);
+}
+
+.SimpleCell--sizeY-compact.SimpleCell--mult .SimpleCell__badge .Badge {
   transform: translateY(.5px);
 }

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -102,7 +102,7 @@
 }
 
 .SimpleCell__badge .Badge {
-  margin-top: 3px;
+  margin-top: 2px;
 }
 
 .SimpleCell--mult .SimpleCell__badge {
@@ -295,9 +295,5 @@
 }
 
 .SimpleCell--sizeY-compact .SimpleCell__badge .Badge {
-  transform: translateY(-.5px);
-}
-
-.SimpleCell--sizeY-compact.SimpleCell--mult .SimpleCell__badge .Badge {
   transform: translateY(.5px);
 }

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -74,10 +74,6 @@
   margin-top: 2px;
 }
 
-.SimpleCell__content {
-  display: inline-block;
-}
-
 .SimpleCell:not(.SimpleCell--mult) .SimpleCell__content {
   display: inline-flex;
   flex-flow: row nowrap;

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -99,6 +99,7 @@
 
 .SimpleCell__badge .Badge {
   margin-top: 2px;
+  margin-left: 3px;
 }
 
 .SimpleCell--mult .SimpleCell__badge {

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -101,6 +101,10 @@
   color: #5c9ce6; /* blue_200 */
 }
 
+.SimpleCell__badge .Badge {
+  margin-top: 2px;
+}
+
 .SimpleCell__indicator {
   color: var(--text_secondary);
   min-width: 0;
@@ -276,4 +280,8 @@
 .SimpleCell--sizeY-compact .SimpleCell__after .IconButton .Icon--w-8,
 .SimpleCell--sizeY-compact .SimpleCell__after .IconButton .Icon--w-8 ~ * {
   margin-right: -10px;
+}
+
+.SimpleCell--sizeY-compact .SimpleCell__badge .Badge {
+  transform: translateY(.5px);
 }

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -14,6 +14,7 @@ export interface SimpleCellOwnProps extends HasLinkProps {
    * Иконка 28 или `<Avatar size={28|32|40|48|72} />`
    */
   before?: ReactNode;
+  badge?: ReactNode;
   /**
    * Контейнер для текста справа от `children`.
    */
@@ -41,6 +42,7 @@ export interface SimpleCellOwnProps extends HasLinkProps {
 export interface SimpleCellProps extends SimpleCellOwnProps, HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, AdaptivityProps {}
 
 const SimpleCell: FC<SimpleCellProps> = ({
+  badge,
   before,
   indicator,
   children,
@@ -82,7 +84,14 @@ const SimpleCell: FC<SimpleCellProps> = ({
     >
       {before}
       <div className="SimpleCell__main">
-        <div className="SimpleCell__children">{children}</div>
+        <div className="SimpleCell__content">
+          <span className="SimpleCell__children">{children}</span>
+          {hasReactNode(badge) &&
+            <span className="SimpleCell__badge">
+              {badge}
+            </span>
+          }
+        </div>
         {description && <div className="SimpleCell__description">{description}</div>}
       </div>
       {hasReactNode(indicator) &&

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -14,6 +14,9 @@ export interface SimpleCellOwnProps extends HasLinkProps {
    * Иконка 28 или `<Avatar size={28|32|40|48|72} />`
    */
   before?: ReactNode;
+  /**
+   * Иконка 12 или `<Badge />`. Добавится справа от текста `children`.
+   */
   badge?: ReactNode;
   /**
    * Контейнер для текста справа от `children`.

--- a/src/components/TabbarItem/TabbarItem.css
+++ b/src/components/TabbarItem/TabbarItem.css
@@ -42,13 +42,13 @@
 .TabbarItem__label {
   position: absolute;
   top: -2px;
-  left: calc(100% - 9px);
+  right: -9px;
 }
 
 .TabbarItem__badge {
   position: absolute;
-  top: -6px;
-  right: -7px;
+  top: -2px;
+  right: -4px;
 }
 
 .Tabbar--l-vertical .TabbarItem__text {

--- a/src/components/TabbarItem/TabbarItem.css
+++ b/src/components/TabbarItem/TabbarItem.css
@@ -39,13 +39,13 @@
   position: relative;
 }
 
-.TabbarItem__label {
+.TabbarItem__label .Counter {
   position: absolute;
   top: -2px;
   right: -9px;
 }
 
-.TabbarItem__badge {
+.TabbarItem__label .Badge {
   position: absolute;
   top: -2px;
   right: -4px;

--- a/src/components/TabbarItem/TabbarItem.css
+++ b/src/components/TabbarItem/TabbarItem.css
@@ -45,6 +45,12 @@
       left: calc(100% - 9px);
       }
 
+      .TabbarItem__badge {
+        position: absolute;
+        top: -6px;
+        right: -7px;
+      }
+
     .Tabbar--l-vertical .TabbarItem__text {
       font-size: 10px;
       line-height: 12px;

--- a/src/components/TabbarItem/TabbarItem.css
+++ b/src/components/TabbarItem/TabbarItem.css
@@ -8,58 +8,58 @@
   justify-content: center;
   color: var(--tabbar_inactive_icon);
   text-decoration: none;
-  }
+}
 
 .Tabbar--l-vertical .TabbarItem.TabbarItem--text {
   position: relative;
   top: 2px;
-  }
+}
 
 .TabbarItem--selected {
   color: var(--tabbar_active_icon);
-  }
+}
 
-  .TabbarItem__in {
-    align-self: center;
-    display: flex;
-    }
+.TabbarItem__in {
+  align-self: center;
+  display: flex;
+}
 
-  .Tabbar--l-vertical .TabbarItem__in {
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    }
+.Tabbar--l-vertical .TabbarItem__in {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
 
-  .Tabbar--l-horizontal .TabbarItem__in {
-    flex-direction: row;
-    align-items: center;
-    }
+.Tabbar--l-horizontal .TabbarItem__in {
+  flex-direction: row;
+  align-items: center;
+}
 
-    .TabbarItem__icon {
-      position: relative;
-      }
+.TabbarItem__icon {
+  position: relative;
+}
 
-    .TabbarItem__label {
-      position: absolute;
-      top: -2px;
-      left: calc(100% - 9px);
-      }
+.TabbarItem__label {
+  position: absolute;
+  top: -2px;
+  left: calc(100% - 9px);
+}
 
-      .TabbarItem__badge {
-        position: absolute;
-        top: -6px;
-        right: -7px;
-      }
+.TabbarItem__badge {
+  position: absolute;
+  top: -6px;
+  right: -7px;
+}
 
-    .Tabbar--l-vertical .TabbarItem__text {
-      font-size: 10px;
-      line-height: 12px;
-      font-weight: 500;
-      margin-top: 2px;
-      }
+.Tabbar--l-vertical .TabbarItem__text {
+  font-size: 10px;
+  line-height: 12px;
+  font-weight: 500;
+  margin-top: 2px;
+}
 
-    .Tabbar--l-horizontal .TabbarItem__text {
-      font-size: 13px;
-      font-weight: 500;
-      margin-left: 8px;
-      }
+.Tabbar--l-horizontal .TabbarItem__text {
+  font-size: 13px;
+  font-weight: 500;
+  margin-left: 8px;
+}

--- a/src/components/TabbarItem/TabbarItem.tsx
+++ b/src/components/TabbarItem/TabbarItem.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, ReactNode, HTMLAttributes, ElementType } from 'react';
 import getClassName from '../../helpers/getClassName';
 import Counter from '../Counter/Counter';
-import Badge from '../Badge/Badge';
+import { Badge } from '../Badge/Badge';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { HasLinkProps } from '../../types';

--- a/src/components/TabbarItem/TabbarItem.tsx
+++ b/src/components/TabbarItem/TabbarItem.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent, ReactNode, HTMLAttributes, ElementType, AnchorHTMLAttributes } from 'react';
 import getClassName from '../../helpers/getClassName';
 import Counter from '../Counter/Counter';
-import { Badge } from '../Badge/Badge';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
+import { hasReactNode } from '../../lib/utils';
 
 export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, AnchorHTMLAttributes<HTMLElement> {
   selected?: boolean;
@@ -12,17 +12,17 @@ export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, AnchorHTML
    */
   text?: ReactNode;
   /**
-   * `<Counter />` рядом с иконкой
+   * Индикатор над иконкой. Принимает `<Badge mode="prominent" />` или `<Counter size="s" mode="prominent" />`
    */
-  label?: number;
+  indicator?: ReactNode;
   /**
-   * `<Badge />` рядом с иконкой
+   * @deprecated будет удалено в 5.0.0. Используйте `indicator`
    */
-  badge?: boolean;
+  label?: ReactNode;
 }
 
 const TabbarItem: FunctionComponent<TabbarItemProps> = (props: TabbarItemProps) => {
-  const { className, children, selected, label, text, badge, ...restProps } = props;
+  const { className, children, selected, label, indicator, text, ...restProps } = props;
   const platform = usePlatform();
   const Component: ElementType = restProps.href ? 'a' : 'div';
 
@@ -37,8 +37,10 @@ const TabbarItem: FunctionComponent<TabbarItemProps> = (props: TabbarItemProps) 
       <div className="TabbarItem__in">
         <div className="TabbarItem__icon">
           {children}
-          {badge && <Badge className="TabbarItem__badge" mode="prominent" />}
-          {label && <Counter className="TabbarItem__label" size="s" mode="prominent">{label}</Counter>}
+          <div className="TabbarItem__label">
+            {hasReactNode(indicator) && indicator}
+            {!indicator && label && <Counter size="s" mode="prominent">{label}</Counter>}
+          </div>
         </div>
         {text && <div className="TabbarItem__text">{text}</div>}
       </div>

--- a/src/components/TabbarItem/TabbarItem.tsx
+++ b/src/components/TabbarItem/TabbarItem.tsx
@@ -13,11 +13,11 @@ export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, HasLinkPro
    */
   text?: ReactNode;
   /**
-   * Счетчик рядом с иконкой
+   * `<Counter />` рядом с иконкой
    */
-  label?: ReactNode;
+  label?: number;
   /**
-   * Индикатор рядом с иконкой
+   * `<Badge />` рядом с иконкой
    */
   badge?: boolean;
 }

--- a/src/components/TabbarItem/TabbarItem.tsx
+++ b/src/components/TabbarItem/TabbarItem.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, ReactNode, HTMLAttributes, ElementType } from 'react';
 import getClassName from '../../helpers/getClassName';
 import Counter from '../Counter/Counter';
+import Badge from '../Badge/Badge';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { HasLinkProps } from '../../types';
@@ -15,10 +16,14 @@ export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, HasLinkPro
    * Счетчик рядом с иконкой
    */
   label?: ReactNode;
+  /**
+   * Индикатор рядом с иконкой
+   */
+  badge?: boolean;
 }
 
 const TabbarItem: FunctionComponent<TabbarItemProps> = (props: TabbarItemProps) => {
-  const { className, children, selected, label, text, ...restProps } = props;
+  const { className, children, selected, label, text, badge, ...restProps } = props;
   const platform = usePlatform();
   const Component: ElementType = restProps.href ? 'a' : 'div';
 
@@ -33,6 +38,7 @@ const TabbarItem: FunctionComponent<TabbarItemProps> = (props: TabbarItemProps) 
       <div className="TabbarItem__in">
         <div className="TabbarItem__icon">
           {children}
+          {badge && <Badge className="TabbarItem__badge" mode="prominent" />}
           {label && <Counter className="TabbarItem__label" size="s" mode="prominent">{label}</Counter>}
         </div>
         {text && <div className="TabbarItem__text">{text}</div>}

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: baseline;
   justify-content: center;
-  }
+}
 
 .Tabs--default .TabsItem {
   font-size: 16px;
@@ -21,13 +21,13 @@
   position: relative;
   padding-left: 16px;
   padding-right: 16px;
-  }
+}
 
-  .Tabs--default .TabsItem__in {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding: 14px 0;
-    }
+.Tabs--default .TabsItem__in {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 14px 0;
+}
 
 .Tabs--default .TabsItem::after {
   content: '';
@@ -38,15 +38,15 @@
   width: calc(100% - 32px);
   height: 2px;
   border-radius: 2px;
-  }
+}
 
 .Tabs--default .TabsItem--selected {
   color: var(--text_primary);
-  }
+}
 
 .Tabs--default .TabsItem--selected::after {
   background: var(--accent);
-  }
+}
 
 .HorizontalScroll .TabsItem {
   min-width: 64px;
@@ -60,39 +60,39 @@
   font-size: 14px;
   line-height: 18px;
   font-weight: 500;
-  }
+}
 
-  .Tabs--buttons .TabsItem__in {
-    padding: 6px 0;
-    }
+.Tabs--buttons .TabsItem__in {
+  padding: 6px 0;
+}
 
 /* Для случая, когда внутри Tabs нет HorizontalScroll */
 .Tabs--buttons .Tabs__in > .TabsItem:first-child {
   margin-left: 8px;
-  }
+}
 
 .Tabs--buttons .TabsItem:not(:last-child) {
   margin-right: 8px;
-  }
+}
 
 .Tabs--buttons .TabsItem {
   background-color: var(--header_background);
   color: var(--header_tab_inactive_text);
-  }
+}
 
 .Tabs--buttons .TabsItem--selected {
   background-color: var(--header_tab_active_background);
   color: var(--header_tab_active_text);
-  }
+}
 
 .Tabs--buttons .TabsItem {
   color: var(--panel_tab_inactive_text);
-  }
+}
 
 .Tabs--buttons .TabsItem--selected {
   background-color: var(--panel_tab_active_background);
   color: var(--panel_tab_active_text);
-  }
+}
 
 /*
   iOS
@@ -106,54 +106,54 @@
   flex-basis: 0;
   flex-shrink: 0;
   flex-grow: 1;
-  }
+}
 
-  .Tabs--ios.Tabs--segmented .TabsItem__in {
-    padding: 7px 0;
-    }
+.Tabs--ios.Tabs--segmented .TabsItem__in {
+  padding: 7px 0;
+}
 
 .Tabs--ios.Tabs--segmented .TabsItem:not(:first-child) {
   border-left: none;
-  }
+}
 
 .Tabs--ios.Tabs--segmented .TabsItem:last-child {
   border-radius: 0 10px 10px 0;
-  }
+}
 
 .Tabs--ios.Tabs--segmented .TabsItem:first-child {
   border-radius: 10px 0 0 10px;
-  }
+}
 
 .Tabs--ios.Tabs--segmented .TabsItem {
   border-color: var(--segmented_control_tint);
   color: var(--segmented_control_tint);
-  }
+}
 
 .Tabs--ios.Tabs--segmented .TabsItem--selected {
   background-color: var(--segmented_control_tint);
-  }
+}
 
 .Tabs--ios.Tabs--segmented .TabsItem--selected {
   color: var(--background_content);
-  }
+}
 
 .Tabs--ios.Tabs--segmented .TabsItem:not(.TabsItem--selected).Tappable--active {
   background: var(--separator_common);
-  }
+}
 
 .PanelHeader--ios .Tabs--segmented.TabsItem:not(.TabsItem--selected).Tappable--active .TabsItem__in {
   opacity: .7;
-  }
+}
 
 .PanelHeader--ios .Tabs--segmented .TabsItem {
   border-color: var(--header_tint);
   color: var(--header_tint);
-  }
+}
 
 .Tabs--ios.Tabs--segmented.Tabs--header .TabsItem--selected {
   background-color: var(--header_tint);
   color: var(--header_background);
-  }
+}
 
 /*
   Android
@@ -162,24 +162,24 @@
 .TabsItem--android .Tappable__waves,
 .TabsItem--vkcom .Tappable__waves {
   display: none;
-  }
+}
 
-  /*
+/*
   VKCOM
   */
 
-  .Tabs--vkcom .TabsItem--vkcom {
-    flex-grow: 0;
-    min-width: auto;
-    font-size: 15px;
-    line-height: 20px;
-    font-weight: 400;
-    padding-left: 10px;
-    padding-right: 10px;
-  }
+.Tabs--vkcom .TabsItem--vkcom {
+  flex-grow: 0;
+  min-width: auto;
+  font-size: 15px;
+  line-height: 20px;
+  font-weight: 400;
+  padding-left: 10px;
+  padding-right: 10px;
+}
 
-  .Tabs--vkcom .TabsItem--vkcom::after {
-    left: 2px;
-    bottom: 0;
-    width: calc(100% - 4px);
-  }
+.Tabs--vkcom .TabsItem--vkcom::after {
+  left: 2px;
+  bottom: 0;
+  width: calc(100% - 4px);
+}

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -94,6 +94,11 @@
   color: var(--panel_tab_active_text);
 }
 
+.TabsItem__after .Badge {
+  transform: translateY(-2px);
+  margin-left: 6px;
+}
+
 /*
   iOS
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export { default as ModalDismissButton } from './components/ModalDismissButton/M
 /**
  * Blocks
  */
+export { default as Badge } from './components/Badge/Badge';
 export { default as Button } from './components/Button/Button';
 export { default as IconButton } from './components/IconButton/IconButton';
 export { default as Card } from './components/Card/Card';

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export { default as ModalDismissButton } from './components/ModalDismissButton/M
 /**
  * Blocks
  */
-export { default as Badge } from './components/Badge/Badge';
+export { Badge } from './components/Badge/Badge';
 export { default as Button } from './components/Button/Button';
 export { default as IconButton } from './components/IconButton/IconButton';
 export { default as Card } from './components/Card/Card';

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -19,6 +19,7 @@
 
   /* colors */
   --white: #fff;
+  --blue_200: #5c9ce6;
 
   /* iOS insets */
   --safe-area-inset-top: 20px;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -56,6 +56,7 @@
 @import '../components/ModalPageHeader/ModalPageHeader.css';
 
 /* Blocks */
+@import '../components/Badge/Badge.css';
 @import '../components/IconButton/IconButton.css';
 @import '../components/Card/Card.css';
 @import '../components/CardGrid/CardGrid.css';

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -102,6 +102,7 @@ module.exports = {
       }, {
         name: 'Blocks',
         components: () => [
+          "../src/components/Badge/Badge.tsx",
           '../src/components/Button/Button.tsx',
           '../src/components/CellButton/CellButton.tsx',
           '../src/components/IconButton/IconButton.tsx',


### PR DESCRIPTION
resolves #626: добавить возможность вставлять иконку или бейдж справа от заголовка.

- добавляет компонент `<Badge/>` с двумя модами - `new` и `prominent`
- добавляет в `<SimpleCell/>` возможность вставить бейджик справа от текста заголовка (иконку размером 12|16 или `<Badge/>`)
- добавляет `<Badge/>` в `<TabsItem/>`
- в `<TabbarItem/>`:
  - добавляется новое свойство `indicator` (на замену текущему `label`), которое принимает в себя `ReactNode`. Ему можно передавать `<Badge mode="prominent" />` или `<Counter size="s" mode="prominent" />`
  - `label` становится deprecated и будет удален в 5.0.0