### PR TITLE
Modals: pass onClose from ModalRoot to Page/Card

### DIFF
--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactNode, FC } from 'react';
+import React, { HTMLAttributes, ReactNode, FC, useContext } from 'react';
 import PanelHeaderButton from '../PanelHeaderButton/PanelHeaderButton';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
@@ -11,6 +11,7 @@ import withAdaptivity, { AdaptivityProps, ViewHeight, ViewWidth } from '../../ho
 import Subhead from '../Typography/Subhead/Subhead';
 import Title from '../Typography/Title/Title';
 import ModalDismissButton from '../ModalDismissButton/ModalDismissButton';
+import ModalRootContext from '../ModalRoot/ModalRootContext';
 
 export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform, HasChildren, AdaptivityProps {
   /**
@@ -69,6 +70,8 @@ const ModalCard: FC<ModalCardProps> = (props) => {
   const canShowCloseBtn = viewWidth >= ViewWidth.SMALL_TABLET;
   const canShowCloseBtnIos = platform === IOS && !canShowCloseBtn;
 
+  const modalContext = useContext(ModalRootContext);
+
   return (
     <div
       {...restProps}
@@ -92,9 +95,9 @@ const ModalCard: FC<ModalCardProps> = (props) => {
           </div>
           }
 
-          {canShowCloseBtn && <ModalDismissButton onClick={onClose} />}
+          {canShowCloseBtn && <ModalDismissButton onClick={onClose || modalContext.onClose} />}
           {canShowCloseBtnIos &&
-          <PanelHeaderButton className="ModalCard__dismiss" onClick={onClose}>
+          <PanelHeaderButton className="ModalCard__dismiss" onClick={onClose || modalContext.onClose}>
             <Icon24Dismiss />
           </PanelHeaderButton>
           }

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -47,6 +47,8 @@ const ModalPage: FC<ModalPageProps> = (props) => {
   const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
   const canShowCloseBtn = viewWidth >= ViewWidth.SMALL_TABLET;
 
+  const modalContext = useContext(ModalRootContext);
+
   return (
     <div
       {...restProps}
@@ -67,7 +69,7 @@ const ModalPage: FC<ModalPageProps> = (props) => {
               </div>
             </div>
           </div>
-          {canShowCloseBtn && <ModalDismissButton onClick={onClose} />}
+          {canShowCloseBtn && <ModalDismissButton onClick={onClose || modalContext.onClose} />}
         </div>
       </div>
     </div>

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -83,6 +83,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
     this.modalRootContext = {
       updateModalHeight: this.updateModalHeight,
+      onClose: this.triggerClose,
       isInsideModal: true,
     };
 
@@ -750,7 +751,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
   /**
    * По клику на полупрозрачный черный фон нужно закрыть текущую модалку
    */
-  onMaskClick = () => {
+  triggerClose = () => {
     this.triggerActiveModalClose();
   };
 
@@ -776,7 +777,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
           >
             <div
               className="ModalRoot__mask"
-              onClick={this.onMaskClick}
+              onClick={this.triggerClose}
               ref={this.maskElementRef}
             />
             <div className="ModalRoot__viewport">

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -83,7 +83,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
     this.modalRootContext = {
       updateModalHeight: this.updateModalHeight,
-      onClose: this.triggerClose,
+      onClose: this.triggerActiveModalClose,
       isInsideModal: true,
     };
 
@@ -731,12 +731,12 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
   /**
    * Закрывает текущую модалку
    */
-  triggerActiveModalClose() {
+  triggerActiveModalClose = () => {
     const activeModalState = this.modalsState[this.state.activeModal];
     if (activeModalState) {
       this.doCloseModal(activeModalState);
     }
-  }
+  };
 
   private readonly doCloseModal = (modalState: ModalsStateEntry) => {
     if (isFunction(modalState.onClose)) {
@@ -746,13 +746,6 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     } else {
       console.error('[ModalRoot] onClose is undefined');
     }
-  };
-
-  /**
-   * По клику на полупрозрачный черный фон нужно закрыть текущую модалку
-   */
-  triggerClose = () => {
-    this.triggerActiveModalClose();
   };
 
   render() {
@@ -777,7 +770,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
           >
             <div
               className="ModalRoot__mask"
-              onClick={this.triggerClose}
+              onClick={this.triggerActiveModalClose}
               ref={this.maskElementRef}
             />
             <div className="ModalRoot__viewport">

--- a/src/components/ModalRoot/ModalRootContext.tsx
+++ b/src/components/ModalRoot/ModalRootContext.tsx
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 
 export interface ModalRootContextInterface {
   updateModalHeight: () => void;
+  onClose?: () => void;
   isInsideModal: boolean;
 }
 

--- a/src/components/ModalRoot/ModalRootContext.tsx
+++ b/src/components/ModalRoot/ModalRootContext.tsx
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
 
 export interface ModalRootContextInterface {
-  updateModalHeight: () => void;
-  onClose?: () => void;
+  updateModalHeight: VoidFunction;
+  onClose?: VoidFunction;
   isInsideModal: boolean;
 }
 

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -66,7 +66,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
 
     this.modalRootContext = {
       updateModalHeight: this.updateModalHeight,
-      onClose: this.triggerClose,
+      onClose: this.triggerActiveModalClose,
       isInsideModal: true,
     };
   }
@@ -369,12 +369,12 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
   /**
    * Закрывает текущую модалку
    */
-  triggerActiveModalClose() {
+  triggerActiveModalClose = () => {
     const activeModalState = this.modalsState[this.state.activeModal];
     if (activeModalState) {
       this.doCloseModal(activeModalState);
     }
-  }
+  };
 
   private readonly doCloseModal = (modalState: ModalsStateEntry) => {
     if (isFunction(modalState.onClose)) {
@@ -384,13 +384,6 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
     } else {
       console.error('[ModalRoot] onClose is undefined');
     }
-  };
-
-  /**
-   * По клику на полупрозрачный черный фон нужно закрыть текущую модалку
-   */
-  triggerClose = () => {
-    this.triggerActiveModalClose();
   };
 
   render() {
@@ -409,7 +402,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
         >
           <div
             className="ModalRoot__mask"
-            onClick={this.triggerClose}
+            onClick={this.triggerActiveModalClose}
             ref={this.maskElementRef}
           />
           <div className="ModalRoot__viewport">

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -66,6 +66,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
 
     this.modalRootContext = {
       updateModalHeight: this.updateModalHeight,
+      onClose: this.triggerClose,
       isInsideModal: true,
     };
   }
@@ -388,7 +389,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
   /**
    * По клику на полупрозрачный черный фон нужно закрыть текущую модалку
    */
-  onMaskClick = () => {
+  triggerClose = () => {
     this.triggerActiveModalClose();
   };
 
@@ -408,7 +409,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
         >
           <div
             className="ModalRoot__mask"
-            onClick={this.onMaskClick}
+            onClick={this.triggerClose}
             ref={this.maskElementRef}
           />
           <div className="ModalRoot__viewport">


### PR DESCRIPTION
Если `onClose` не задан у ModalPage/ModalCard, будет использован onClose из родительского ModalRoot