### PR TITLE
Typing fixes

### DIFF
--- a/src/components/ActionSheet/ActionSheetDropdown.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdown.tsx
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import withPlatform from '../../hoc/withPlatform';
-import { HasChildren, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 
-interface Props extends HasPlatform, HasChildren {
+interface Props extends HasPlatform {
   closing: boolean;
   onClose(): void;
   toggleRef: Element;

--- a/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
@@ -1,13 +1,13 @@
-import React, { Component } from 'react';
+import React, { Component, HTMLAttributes } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import withPlatform from '../../hoc/withPlatform';
-import { HasChildren, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 import { PointerEventsProperty } from 'csstype';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 import { DOMProps, withDOM } from '../../lib/dom';
 
-interface Props extends HasPlatform, AdaptivityProps, HasChildren {
+interface Props extends HTMLAttributes<HTMLDivElement>, HasPlatform, AdaptivityProps {
   closing: boolean;
   onClose(): void;
   toggleRef: Element;

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, HTMLAttributes, InputHTMLAttributes, useContext } from 'react';
+import React, { AnchorHTMLAttributes, ElementType, HTMLAttributes, InputHTMLAttributes, useContext } from 'react';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import Tappable from '../Tappable/Tappable';
@@ -8,7 +8,6 @@ import Subhead from '../Typography/Subhead/Subhead';
 import Title from '../Typography/Title/Title';
 import Text from '../Typography/Text/Text';
 import { ANDROID, VKCOM } from '../../lib/platform';
-import { HasLinkProps } from '../../types';
 import { Icon16Done, Icon24Done } from '@vkontakte/icons';
 import { ActionSheetContext } from '../ActionSheet/ActionSheetContext';
 import Caption from '../Typography/Caption/Caption';
@@ -16,7 +15,7 @@ import withAdaptivity, { AdaptivityProps, SizeType } from '../../hoc/withAdaptiv
 
 export interface ActionSheetItemProps extends
   HTMLAttributes<HTMLElement>,
-  HasLinkProps,
+  AnchorHTMLAttributes<HTMLElement>,
   Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'checked' | 'value'>,
   AdaptivityProps {
   mode?: 'default' | 'destructive' | 'cancel';

--- a/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { HasChildren } from '../../types';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { hasMouse as _hasMouse } from '@vkontakte/vkjs/lib/InputUtils';
 import { AdaptivityContext, AdaptivityContextInterface, SizeType, ViewHeight, ViewWidth } from './AdaptivityContext';
 import { canUseDOM, useDOM } from '../../lib/dom';
 
-export interface AdaptivityProviderProps extends AdaptivityContextInterface, HasChildren {}
+export interface AdaptivityProviderProps extends AdaptivityContextInterface {
+  children?: ReactNode;
+}
 
 export const DESKTOP_SIZE = 1280;
 export const TABLET_SIZE = 1024;

--- a/src/components/AppRoot/AppRoot.tsx
+++ b/src/components/AppRoot/AppRoot.tsx
@@ -1,12 +1,11 @@
-import React, { FC, useRef, useState } from 'react';
+import React, { FC, HTMLAttributes, useRef, useState } from 'react';
 import { useDOM } from '../../lib/dom';
-import { HasChildren } from '../../types';
 import classNames from '../../lib/classNames';
 import { AppRootContext } from './AppRootContext';
 import withAdaptivity, { SizeType, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 
-export interface AppRootProps extends HasChildren, AdaptivityProps {
+export interface AppRootProps extends HTMLAttributes<HTMLDivElement>, AdaptivityProps {
   embedded?: boolean;
   window?: Window;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
@@ -19,11 +19,7 @@ export interface VKUIButtonProps extends HasAlign {
   after?: ReactNode;
 }
 
-export interface ButtonProps extends TappableProps, ButtonHTMLAttributes<HTMLElement>, VKUIButtonProps {
-  href?: string;
-  target?: string;
-  rel?: string;
-}
+export interface ButtonProps extends Omit<TappableProps, 'size'>, VKUIButtonProps {}
 
 const getContent = (size: ButtonProps['size'], children: ButtonProps['children'], hasIcons: boolean, sizeY: AdaptivityProps['sizeY'], platform: Platform) => {
   switch (size) {

--- a/src/components/CellButton/CellButton.tsx
+++ b/src/components/CellButton/CellButton.tsx
@@ -1,10 +1,10 @@
-import React, { ButtonHTMLAttributes } from 'react';
+import React from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import SimpleCell, { SimpleCellProps } from '../SimpleCell/SimpleCell';
 
-export interface CellButtonProps extends ButtonHTMLAttributes<HTMLElement>, SimpleCellProps {
+export interface CellButtonProps extends SimpleCellProps {
   mode?: 'primary' | 'danger';
   stopPropagation?: boolean;
   centered?: boolean;

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { canUseDOM, withDOM, DOMProps } from '../../lib/dom';
 import {
   ConfigProviderContext,
@@ -7,10 +7,11 @@ import {
   AppearanceScheme,
   defaultConfigProviderProps,
 } from './ConfigProviderContext';
-import { HasChildren } from '../../types';
 import { Platform, VKCOM } from '../../lib/platform';
 
-export interface ConfigProviderProps extends ConfigProviderContextInterface, HasChildren {}
+export interface ConfigProviderProps extends ConfigProviderContextInterface {
+  children?: ReactNode;
+}
 
 class ConfigProvider extends React.Component<ConfigProviderProps & DOMProps> {
   constructor(props: ConfigProviderProps) {

--- a/src/components/Epic/Epic.tsx
+++ b/src/components/Epic/Epic.tsx
@@ -1,12 +1,11 @@
 import React, { HTMLAttributes, ReactNode, ReactElement, FC, useEffect, useRef } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
-import { HasChildren } from '../../types';
 import usePlatform from '../../hooks/usePlatform';
 import withAdaptivity, { ViewWidth, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { ScrollSaver } from './ScrollSaver';
 
-export interface EpicProps extends HTMLAttributes<HTMLDivElement>, HasChildren, AdaptivityProps {
+export interface EpicProps extends HTMLAttributes<HTMLDivElement>, AdaptivityProps {
   tabbar?: ReactNode;
   activeStory: string;
 }

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -1,11 +1,11 @@
-import React, { ElementType, HTMLAttributes, useState } from 'react';
+import React, { AllHTMLAttributes, ElementType, useState } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { HasRootRef } from '../../types';
 
 export interface FormFieldProps extends
-  HTMLAttributes<HTMLElement>,
+  AllHTMLAttributes<HTMLElement>,
   HasRootRef<HTMLElement> {
   Component?: ElementType;
 }

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, FC, LabelHTMLAttributes, ReactNode } from 'react';
+import React, { AllHTMLAttributes, ElementType, FC, ReactNode } from 'react';
 import { classNames } from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { getClassName } from '../../helpers/getClassName';
@@ -7,7 +7,7 @@ import Subhead from '../Typography/Subhead/Subhead';
 import Caption from '../Typography/Caption/Caption';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface FormItemProps extends LabelHTMLAttributes<HTMLElement> {
+export interface FormItemProps extends AllHTMLAttributes<HTMLElement> {
   top?: ReactNode;
   bottom?: ReactNode;
   status?: 'default' | 'error' | 'valid';

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -33,5 +33,5 @@ export const FormItem: FC<FormItemProps> = withAdaptivity(({ className, children
 
 FormItem.defaultProps = {
   status: 'default',
-  Component: 'label',
+  Component: 'div',
 };

--- a/src/components/FormLayout/FormLayout.tsx
+++ b/src/components/FormLayout/FormLayout.tsx
@@ -1,6 +1,6 @@
 import React, {
   FunctionComponent,
-  HTMLAttributes,
+  AllHTMLAttributes,
   FormEvent,
   ElementType,
 } from 'react';
@@ -11,7 +11,7 @@ import { HasRef } from '../../types';
 
 const preventDefault = (e: FormEvent) => e.preventDefault();
 
-export interface FormLayoutProps extends HTMLAttributes<HTMLElement>, HasRef<HTMLElement> {
+export interface FormLayoutProps extends AllHTMLAttributes<HTMLElement>, HasRef<HTMLElement> {
   Component?: ElementType;
 }
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,18 +1,15 @@
-import React, { ReactNode, ButtonHTMLAttributes, FunctionComponent } from 'react';
-import Tappable from '../Tappable/Tappable';
+import React, { ReactNode, FunctionComponent } from 'react';
+import Tappable, { TappableProps } from '../Tappable/Tappable';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
-import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
-import { HasLinkProps } from '../../types';
+import withAdaptivity from '../../hoc/withAdaptivity';
 
-export interface IconButtonProps extends ButtonHTMLAttributes<HTMLElement>, HasLinkProps {
+export interface IconButtonProps extends TappableProps {
   /**
    * @deprecated будет удалено в 5.0.0. Используйте `children`
    */
   icon: ReactNode;
-  href?: string;
-  sizeY?: AdaptivityProps['sizeY'];
 }
 
 const IconButton: FunctionComponent<IconButtonProps> = ({

--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -6,14 +6,14 @@ import { Icon24Dismiss } from '@vkontakte/icons';
 import { IOS } from '../../lib/platform';
 import { hasReactNode } from '../../lib/utils';
 import withPlatform from '../../hoc/withPlatform';
-import { HasChildren, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 import withAdaptivity, { AdaptivityProps, ViewHeight, ViewWidth } from '../../hoc/withAdaptivity';
 import Subhead from '../Typography/Subhead/Subhead';
 import Title from '../Typography/Title/Title';
 import ModalDismissButton from '../ModalDismissButton/ModalDismissButton';
 import ModalRootContext from '../ModalRoot/ModalRootContext';
 
-export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform, HasChildren, AdaptivityProps {
+export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform, AdaptivityProps {
   /**
    * Иконка.
    *

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -8,7 +8,7 @@ import { rubber } from '../../lib/touch';
 import { isFunction } from '../../lib/utils';
 import { ANDROID, VKCOM } from '../../lib/platform';
 import { transitionEvent } from '../../lib/supportEvents';
-import { HasChildren, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 import withPlatform from '../../hoc/withPlatform';
 import withContext from '../../hoc/withContext';
 import ModalRootContext, { ModalRootContextInterface } from './ModalRootContext';
@@ -29,7 +29,7 @@ function rangeTranslate(number: number) {
   return Math.max(0, Math.min(98, number));
 }
 
-export interface ModalRootProps extends HasChildren, HasPlatform {
+export interface ModalRootProps extends HasPlatform {
   activeModal?: string | null;
 
   /**

--- a/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -1,10 +1,9 @@
 import React, { FC } from 'react';
-import { HasChildren } from '../../types';
 import withAdaptivity, { AdaptivityProps, ViewHeight, ViewWidth } from '../../hoc/withAdaptivity';
 import { ModalRootTouch } from './ModalRoot';
 import { ModalRootDesktop } from './ModalRootDesktop';
 
-export interface ModalRootProps extends HasChildren, AdaptivityProps {
+export interface ModalRootProps extends AdaptivityProps {
   activeModal?: string | null;
 
   /**

--- a/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -9,10 +9,10 @@ export interface ModalRootProps extends AdaptivityProps {
   /**
    * Будет вызвано при закрытии активной модалки с её id
    */
-  onClose?(modalId: string): void;
+  onClose?: (modalId: string) => void;
 }
 
-const ModalRootComponent: FC<ModalRootProps> = (props) => {
+const ModalRootComponent: FC<ModalRootProps> = (props: ModalRootProps) => {
   const { viewWidth, viewHeight, hasMouse } = props;
   const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
 

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -2,7 +2,7 @@ import React, { Component, ReactElement } from 'react';
 import classNames from '../../lib/classNames';
 import { isFunction } from '../../lib/utils';
 import { transitionEvent } from '../../lib/supportEvents';
-import { HasChildren, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 import withPlatform from '../../hoc/withPlatform';
 import withContext from '../../hoc/withContext';
 import ModalRootContext, { ModalRootContextInterface } from './ModalRootContext';
@@ -16,7 +16,7 @@ import { ANDROID, VKCOM } from '../../lib/platform';
 import getClassName from '../../helpers/getClassName';
 import { DOMProps, withDOM } from '../../lib/dom';
 
-export interface ModalRootProps extends HasChildren, HasPlatform {
+export interface ModalRootProps extends HasPlatform {
   activeModal?: string | null;
   /**
    * @ignore

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -1,5 +1,5 @@
-import React, { ButtonHTMLAttributes, FunctionComponent, ReactNode } from 'react';
-import Tappable from '../Tappable/Tappable';
+import React, { FunctionComponent, ReactNode } from 'react';
+import Tappable, { TappableProps } from '../Tappable/Tappable';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
@@ -7,10 +7,8 @@ import { isPrimitiveReactNode } from '../../lib/utils';
 import { VKCOM } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
 
-export interface PanelHeaderButtonProps extends ButtonHTMLAttributes<HTMLElement> {
+export interface PanelHeaderButtonProps extends Omit<TappableProps, 'label'> {
   primary?: boolean;
-  href?: string;
-  target?: string;
   label?: ReactNode;
 }
 

--- a/src/components/RichCell/RichCell.tsx
+++ b/src/components/RichCell/RichCell.tsx
@@ -1,15 +1,14 @@
-import React, { ElementType, FunctionComponent, HTMLAttributes, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import getClassName from '../../helpers/getClassName';
-import { HasLinkProps, HasRootRef } from '../../types';
-import Tappable from '../Tappable/Tappable';
+import Tappable, { TappableProps } from '../Tappable/Tappable';
 import { hasReactNode } from '../../lib/utils';
 import Text from '../Typography/Text/Text';
 import Caption from '../Typography/Caption/Caption';
-import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
+import withAdaptivity from '../../hoc/withAdaptivity';
 
-export interface RichCellProps extends HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, HasLinkProps, AdaptivityProps {
+export interface RichCellProps extends TappableProps {
   /**
    * Контейнер для текста под `children`.
    */
@@ -39,7 +38,6 @@ export interface RichCellProps extends HTMLAttributes<HTMLElement>, HasRootRef<H
    */
   disabled?: boolean;
   multiline?: boolean;
-  Component?: ElementType;
 }
 
 const RichCell: FunctionComponent<RichCellProps> = ({

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -1,15 +1,14 @@
-import React, { HTMLAttributes, ReactNode, FC, ElementType } from 'react';
+import React, { ReactNode, FC, ElementType } from 'react';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
-import Tappable from '../Tappable/Tappable';
+import Tappable, { TappableProps } from '../Tappable/Tappable';
 import { Icon24Chevron } from '@vkontakte/icons';
-import { HasLinkProps, HasRootRef } from '../../types';
 import { IOS } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
-import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
+import withAdaptivity from '../../hoc/withAdaptivity';
 
-export interface SimpleCellOwnProps extends HasLinkProps {
+export interface SimpleCellOwnProps {
   /**
    * Иконка 28 или `<Avatar size={28|32|40|48|72} />`
    */
@@ -38,7 +37,7 @@ export interface SimpleCellOwnProps extends HasLinkProps {
   Component?: ElementType;
 }
 
-export interface SimpleCellProps extends SimpleCellOwnProps, HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, AdaptivityProps {}
+export interface SimpleCellProps extends SimpleCellOwnProps, TappableProps {}
 
 const SimpleCell: FC<SimpleCellProps> = ({
   before,

--- a/src/components/SplitLayout/SplitLayout.tsx
+++ b/src/components/SplitLayout/SplitLayout.tsx
@@ -1,13 +1,12 @@
 import React, { HTMLAttributes, ReactNode, FC } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
-import { HasChildren, HasRef, HasRootRef } from '../../types';
+import { HasRef, HasRootRef } from '../../types';
 import PopoutRoot from '../PopoutRoot/PopoutRoot';
 import usePlatform from '../../hooks/usePlatform';
 
 export interface SplitLayoutProps extends
   HTMLAttributes<HTMLDivElement>,
-  HasChildren,
   HasRootRef<HTMLDivElement>,
   HasRef<HTMLDivElement> {
   popout?: ReactNode;

--- a/src/components/TabbarItem/TabbarItem.tsx
+++ b/src/components/TabbarItem/TabbarItem.tsx
@@ -1,11 +1,10 @@
-import React, { FunctionComponent, ReactNode, HTMLAttributes, ElementType } from 'react';
+import React, { FunctionComponent, ReactNode, HTMLAttributes, ElementType, AnchorHTMLAttributes } from 'react';
 import getClassName from '../../helpers/getClassName';
 import Counter from '../Counter/Counter';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
-import { HasLinkProps } from '../../types';
 
-export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, HasLinkProps {
+export interface TabbarItemProps extends HTMLAttributes<HTMLElement>, AnchorHTMLAttributes<HTMLElement> {
   selected?: boolean;
   /**
    * Тест рядом с иконкой

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ElementType, HTMLAttributes, RefCallback } from 'react';
+import React, { AllHTMLAttributes, Component, ElementType, RefCallback } from 'react';
 import Touch, { TouchEvent, TouchEventHandler, TouchProps } from '../Touch/Touch';
 import TouchRootContext from '../Touch/TouchContext';
 import classNames from '../../lib/classNames';
@@ -12,13 +12,10 @@ import { hasHover } from '@vkontakte/vkjs/lib/InputUtils';
 import { setRef } from '../../lib/utils';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
-export interface TappableProps extends HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, HasPlatform, AdaptivityProps {
+export interface TappableProps extends AllHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, HasPlatform, AdaptivityProps {
   Component?: ElementType;
   activeEffectDelay?: number;
-  disabled?: boolean;
   stopPropagation?: boolean;
-  href?: string;
-  target?: string;
   hasHover?: boolean;
   hasActive?: boolean;
 }

--- a/src/components/Touch/Touch.tsx
+++ b/src/components/Touch/Touch.tsx
@@ -1,4 +1,11 @@
-import React, { Component, HTMLAttributes, DragEvent, ElementType, MouseEvent as ReactMouseEvent, RefCallback } from 'react';
+import React, {
+  Component,
+  DragEvent,
+  ElementType,
+  MouseEvent as ReactMouseEvent,
+  RefCallback,
+  AllHTMLAttributes,
+} from 'react';
 import {
   getSupportedEvents,
   coordX,
@@ -11,7 +18,7 @@ import { HasRootRef } from '../../types';
 import { canUseDOM, DOMProps, withDOM } from '../../lib/dom';
 import { setRef } from '../../lib/utils';
 
-export interface TouchProps extends HTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
+export interface TouchProps extends AllHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
   onEnter?(outputEvent: MouseEvent): void;
   onLeave?(outputEvent: MouseEvent): void;
   onStart?(outputEvent: TouchEvent): void;

--- a/src/components/Typography/Caption/Caption.tsx
+++ b/src/components/Typography/Caption/Caption.tsx
@@ -1,13 +1,14 @@
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
 import usePlatform from '../../../hooks/usePlatform';
 import classNames from '../../../lib/classNames';
 import getClassName from '../../../helpers/getClassName';
 import { ANDROID } from '../../../lib/platform';
 
-export interface CaptionProps extends HTMLAttributes<HTMLElement> {
+export interface CaptionProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'regular' | 'medium' | 'semibold' | 'bold';
   level: '1' | '2' | '3' | '4';
   caps?: boolean;
+  Component?: ElementType;
 }
 
 const Caption: FunctionComponent<CaptionProps> = ({
@@ -16,6 +17,7 @@ const Caption: FunctionComponent<CaptionProps> = ({
   weight,
   level,
   caps,
+  Component,
   ...restProps
 }: CaptionProps) => {
   const platform = usePlatform();
@@ -29,7 +31,7 @@ const Caption: FunctionComponent<CaptionProps> = ({
   }
 
   return (
-    <div
+    <Component
       {...restProps}
       className={
         classNames(
@@ -44,8 +46,12 @@ const Caption: FunctionComponent<CaptionProps> = ({
       }
     >
       {children}
-    </div>
+    </Component>
   );
+};
+
+Caption.defaultProps = {
+  Component: 'div',
 };
 
 export default Caption;

--- a/src/components/Typography/Headline/Headline.tsx
+++ b/src/components/Typography/Headline/Headline.tsx
@@ -1,10 +1,10 @@
-import React, { ElementType, FunctionComponent, HTMLAttributes } from 'react';
+import React, { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
 import usePlatform from '../../../hooks/usePlatform';
 import classNames from '../../../lib/classNames';
 import getClassName from '../../../helpers/getClassName';
 import { ANDROID } from '../../../lib/platform';
 
-export interface HeadlineProps extends HTMLAttributes<HTMLElement> {
+export interface HeadlineProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'regular' | 'medium' | 'semibold';
   Component?: ElementType;
 }

--- a/src/components/Typography/Subhead/Subhead.tsx
+++ b/src/components/Typography/Subhead/Subhead.tsx
@@ -1,10 +1,10 @@
-import React, { ElementType, FunctionComponent, HTMLAttributes } from 'react';
+import React, { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
 import usePlatform from '../../../hooks/usePlatform';
 import classNames from '../../../lib/classNames';
 import getClassName from '../../../helpers/getClassName';
 import { ANDROID } from '../../../lib/platform';
 
-export interface SubheadProps extends HTMLAttributes<HTMLElement> {
+export interface SubheadProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'regular' | 'medium' | 'semibold' | 'bold';
   Component?: ElementType;
 }

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -1,17 +1,19 @@
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
 import usePlatform from '../../../hooks/usePlatform';
 import classNames from '../../../lib/classNames';
 import getClassName from '../../../helpers/getClassName';
 import { ANDROID } from '../../../lib/platform';
 
-export interface TextProps extends HTMLAttributes<HTMLElement> {
+export interface TextProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'regular' | 'medium' | 'semibold';
+  Component?: ElementType;
 }
 
 const Text: FunctionComponent<TextProps> = ({
   children,
   className,
   weight,
+  Component,
   ...restProps
 }: TextProps) => {
   const platform = usePlatform();
@@ -25,13 +27,17 @@ const Text: FunctionComponent<TextProps> = ({
   }
 
   return (
-    <div
+    <Component
       {...restProps}
       className={classNames(getClassName('Text', platform), `Text--w-${textWeight}`, className)}
     >
       {children}
-    </div>
+    </Component>
   );
+};
+
+Text.defaultProps = {
+  Component: 'div',
 };
 
 export default Text;

--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -1,11 +1,11 @@
-import React, { ElementType, FunctionComponent, HTMLAttributes } from 'react';
+import React, { ElementType, FunctionComponent, AllHTMLAttributes } from 'react';
 import usePlatform from '../../../hooks/usePlatform';
 import classNames from '../../../lib/classNames';
 import getClassName from '../../../helpers/getClassName';
 import { ANDROID } from '../../../lib/platform';
 import Headline, { HeadlineProps } from '../Headline/Headline';
 
-export interface TitleProps extends HTMLAttributes<HTMLElement> {
+export interface TitleProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'heavy' | 'bold' | 'semibold' | 'medium' | 'regular';
   level: '1' | '2' | '3';
   Component?: ElementType;

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -5,7 +5,7 @@ import getClassName from '../../helpers/getClassName';
 import { IOS, ANDROID, VKCOM } from '../../lib/platform';
 import Touch, { TouchEvent } from '../Touch/Touch';
 import removeObjectKeys from '../../lib/removeObjectKeys';
-import { HasChildren, HasPlatform } from '../../types';
+import { HasPlatform } from '../../types';
 import withPlatform from '../../hoc/withPlatform';
 import withContext from '../../hoc/withContext';
 import { ConfigProviderContext, ConfigProviderContextInterface } from '../ConfigProvider/ConfigProviderContext';
@@ -41,7 +41,7 @@ let scrollsCache: ViewsScrolls = {};
 
 const swipeBackExcludedTags = ['input', 'textarea'];
 
-export interface ViewProps extends HTMLAttributes<HTMLElement>, HasChildren, HasPlatform {
+export interface ViewProps extends HTMLAttributes<HTMLElement>, HasPlatform {
   activePanel: string;
   popout?: ReactNode;
   modal?: ReactNode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import React, { RefCallback } from 'react';
+import { RefCallback } from 'react';
 import { PlatformType } from './lib/platform';
 import { Insets } from '@vkontakte/vk-bridge';
 
@@ -36,16 +36,6 @@ export interface HasInsets {
    * @ignore
    */
   insets?: Partial<Insets>;
-}
-
-export interface HasChildren {
-  children?: React.ReactNode;
-}
-
-export interface HasLinkProps {
-  href?: string;
-  target?: string;
-  rel?: string;
 }
 
 export interface Version {


### PR DESCRIPTION
- Убран `HasChildren`. Практически везде он дублировал свойство из интерфейса `HTMLAttributes`.
- Вместо `HasLinkProps` теперь `AnchorHTMLAttributes`.
- `FormItem` по-умолчанию теперь `div` (fixes #1302 ).
- Все компоненты, в которых можно переопределить корневой элемент (свойство `Component`), наследуются от `AllHTMLAttributes`, чтобы дать возможность навешивать специфические для конкретной ноды свойства (типа `htmlFor`, `target` и т.д.)
- `Text`, `Caption`: добавлено свойство `Component`
- `ModalRoot`: поправлен вывод props & methods