### PR TITLE
Switch: обновление дизайна в соответствии с макетами

### DIFF
--- a/src/components/Switch/Switch.css
+++ b/src/components/Switch/Switch.css
@@ -25,8 +25,6 @@
 /**
  * iOS
  */
-.Switch--ios {
-}
 
 .Switch--ios .Switch__pseudo {
   width: 51px;
@@ -62,7 +60,10 @@
   height: 27px;
   border-radius: 13px;
   background: var(--white);
-  box-shadow: 0 3px 8px rgba(0, 0, 0, .15), 0 3px 1px rgba(0, 0, 0, .06), inset 0 0 0 .5px rgba(0, 0, 0, .04);
+  box-shadow:
+    0 3px 8px rgba(0, 0, 0, .15),
+    0 3px 1px rgba(0, 0, 0, .06),
+    inset 0 0 0 .5px rgba(0, 0, 0, .04);
   transition: transform .2s cubic-bezier(.36, -.24, .26, 1.32);
 }
 

--- a/src/components/Switch/Switch.css
+++ b/src/components/Switch/Switch.css
@@ -22,6 +22,10 @@
   transform: translateX(20px);
 }
 
+.Switch__self[disabled] + .Switch__pseudo {
+  opacity: .4;
+}
+
 /**
  * iOS
  */
@@ -47,10 +51,6 @@
 .Switch--ios .Switch__self:checked + .Switch__pseudo {
   border-color: var(--accent);
   background: var(--accent);
-}
-
-.Switch--ios .Switch__self[disabled] + .Switch__pseudo {
-  opacity: .4;
 }
 
 .Switch--ios .Switch__pseudo::before {
@@ -99,11 +99,6 @@
 .Switch--vkcom .Switch__self:checked + .Switch__pseudo::after {
   background: var(--accent);
   opacity: .48;
-}
-
-.Switch--android .Switch__self[disabled] + .Switch__pseudo,
-.Switch--vkcom .Switch__self[disabled] + .Switch__pseudo {
-  opacity: .4;
 }
 
 /**

--- a/src/components/Switch/Switch.css
+++ b/src/components/Switch/Switch.css
@@ -78,7 +78,7 @@
 }
 
 /**
- * Android
+ * Android & VKCOM
  */
 
 .Switch--android,
@@ -86,26 +86,47 @@
   padding: 3px;
 }
 
+.Switch--android .Switch__pseudo::after,
+.Switch--vkcom .Switch__pseudo::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  transition: background-color .1s ease;
+}
+
+.Switch--android .Switch__self:checked + .Switch__pseudo::after,
+.Switch--vkcom .Switch__self:checked + .Switch__pseudo::after {
+  background: var(--accent);
+  opacity: .48;
+}
+
+.Switch--android .Switch__self[disabled] + .Switch__pseudo,
+.Switch--vkcom .Switch__self[disabled] + .Switch__pseudo {
+  opacity: .4;
+}
+
+/**
+ * Android
+ */
+
 .Switch--android .Switch__pseudo {
   width: 34px;
   height: 14px;
+}
+
+.Switch--android .Switch__pseudo::after {
   background: #c6c5c5;
   border-radius: 7px;
-  transition: background-color .1s ease;
 }
 
 .Switch--android.Switch--sizeY-compact .Switch__pseudo {
   width: 32px;
   height: 12px;
+}
+
+.Switch--android.Switch--sizeY-compact .Switch__pseudo::after {
   border-radius: 6px;
-}
-
-.Switch--android .Switch__self:checked + .Switch__pseudo {
-  background: #a8bfdb;
-}
-
-.Switch--android .Switch__self[disabled] + .Switch__pseudo {
-  opacity: .4;
 }
 
 .Switch--android .Switch__pseudo::before {
@@ -143,23 +164,9 @@
 }
 
 .Switch--vkcom .Switch__pseudo::after {
-  content: '';
-  display: block;
   border-radius: 45px;
-  transition: background-color .1s ease;
-  width: 100%;
-  height: 100%;
   background: var(--icon_tertiary);
   opacity: .48;
-}
-
-.Switch--vkcom .Switch__self:checked + .Switch__pseudo::after {
-  background: var(--accent);
-  opacity: .48;
-}
-
-.Switch--vkcom .Switch__self[disabled] + .Switch__pseudo {
-  opacity: .4;
 }
 
 .Switch--vkcom .Switch__pseudo::before {

--- a/src/components/Switch/Switch.css
+++ b/src/components/Switch/Switch.css
@@ -9,6 +9,7 @@
 .Switch__pseudo {
   position: relative;
   display: block;
+  box-sizing: border-box;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-tap-highlight-color: transparent;
 }
@@ -16,6 +17,8 @@
 .Switch__pseudo::before {
   position: absolute;
   content: '';
+  border-radius: 50%;
+  box-sizing: border-box;
 }
 
 .Switch__self:checked + .Switch__pseudo::before {
@@ -29,14 +32,12 @@
 /**
  * iOS
  */
-
 .Switch--ios .Switch__pseudo {
   width: 51px;
   height: 31px;
-  border: 2px solid var(--switch_ios_off_border);
-  background: transparent;
+  border: 2px solid transparent;
+  background: var(--placeholder_icon_background);
   border-radius: 15px;
-  box-sizing: border-box;
   transition:
     background-color .2s ease,
     border-color .2s ease;
@@ -49,7 +50,6 @@
 }
 
 .Switch--ios .Switch__self:checked + .Switch__pseudo {
-  border-color: var(--accent);
   background: var(--accent);
 }
 
@@ -58,7 +58,6 @@
   left: 0;
   width: 27px;
   height: 27px;
-  border-radius: 13px;
   background: var(--white);
   box-shadow:
     0 3px 8px rgba(0, 0, 0, .15),
@@ -70,7 +69,6 @@
 .Switch--ios.Switch--sizeY-compact .Switch__pseudo::before {
   width: 23px;
   height: 23px;
-  border-radius: 11px;
 }
 
 .Switch--ios .Switch__self:checked + .Switch__pseudo::before {
@@ -80,7 +78,6 @@
 /**
  * Android & VKCOM
  */
-
 .Switch--android,
 .Switch--vkcom {
   padding: 3px;
@@ -104,14 +101,13 @@
 /**
  * Android
  */
-
 .Switch--android .Switch__pseudo {
   width: 34px;
   height: 14px;
 }
 
 .Switch--android .Switch__pseudo::after {
-  background: #c6c5c5;
+  background: #c6c5c5; /* todo: 1077 replace w/ a variable */
   border-radius: 7px;
 }
 
@@ -129,8 +125,7 @@
   left: -3px;
   width: 20px;
   height: 20px;
-  background: #f1f1f1;
-  border-radius: 10px;
+  background: #f1f1f1; /* todo: 1077 replace w/ a proper variable */
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, .12), 0 2px 2px 0 rgba(0, 0, 0, .24);
   transition: transform .1s ease;
 }
@@ -138,7 +133,6 @@
 .Switch--android.Switch--sizeY-compact .Switch__pseudo::before {
   width: 18px;
   height: 18px;
-  border-radius: 9px;
 }
 
 .Switch--android .Switch__self:checked + .Switch__pseudo::before {
@@ -152,7 +146,6 @@
 /**
  * VKCOM
  */
-
 .Switch--vkcom .Switch__pseudo {
   width: 28px;
   height: 10px;
@@ -171,8 +164,6 @@
   height: 16px;
   background: var(--background_light);
   border: 1px solid var(--icon_tertiary);
-  border-radius: 8px;
-  box-sizing: border-box;
   transition: transform .1s ease;
   z-index: 1;
 }

--- a/src/components/Switch/Switch.e2e.tsx
+++ b/src/components/Switch/Switch.e2e.tsx
@@ -1,0 +1,12 @@
+import { Switch } from './Switch';
+import { describeScreenshotFuzz } from '../../testing/e2e/utils';
+
+describe('Switch', () => {
+  describeScreenshotFuzz(Switch, [{
+    checked: [true, false],
+    disabled: [true, false],
+  },
+  {
+    $adaptivity: 'y',
+  }]);
+});

--- a/src/components/Switch/Switch.test.tsx
+++ b/src/components/Switch/Switch.test.tsx
@@ -1,5 +1,5 @@
 import { baselineComponent } from '../../testing/utils';
-import Switch from './Switch';
+import { Switch } from './Switch';
 
 describe('Switch', () => {
   baselineComponent(Switch);

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -12,7 +12,7 @@ export interface SwitchProps extends
   HasRef<HTMLInputElement>,
   AdaptivityProps { }
 
-const Switch: FunctionComponent<SwitchProps> = ({
+export const Switch: FunctionComponent<SwitchProps> = withAdaptivity(({
   style,
   className,
   getRef,
@@ -29,6 +29,4 @@ const Switch: FunctionComponent<SwitchProps> = ({
       <span vkuiClass="Switch__pseudo" />
     </label>
   );
-};
-
-export default withAdaptivity(Switch, { sizeY: true });
+}, { sizeY: true });

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -4,6 +4,7 @@ import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
 import { HasRef, HasRootRef } from '../../types';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
+import { useExternRef } from '../../hooks/useExternRef';
 
 export interface SwitchProps extends
   InputHTMLAttributes<HTMLInputElement>,
@@ -20,12 +21,11 @@ const Switch: FunctionComponent<SwitchProps> = ({
   ...restProps
 }: SwitchProps) => {
   const platform = usePlatform();
+  const inputRef = useExternRef(getRef);
 
   return (
-    <label vkuiClass={classNames(
-      getClassName('Switch', platform),
-      `Switch--sizeY-${sizeY}`)} className={className} style={style} ref={getRootRef}>
-      <input {...restProps} type="checkbox" vkuiClass="Switch__self" ref={getRef} />
+    <label vkuiClass={classNames(getClassName('Switch', platform), `Switch--sizeY-${sizeY}`)} className={className} style={style} ref={getRootRef}>
+      <input {...restProps} type="checkbox" vkuiClass="Switch__self" ref={inputRef} />
       <span vkuiClass="Switch__pseudo" />
     </label>
   );

--- a/src/components/Switch/__image_snapshots__/switch-android-bright_light-1-snap.png
+++ b/src/components/Switch/__image_snapshots__/switch-android-bright_light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c35985364e23ec818f05eeed378ff7e63a51378b120315b5f20520b6a351f57c
+size 17169

--- a/src/components/Switch/__image_snapshots__/switch-android-space_gray-1-snap.png
+++ b/src/components/Switch/__image_snapshots__/switch-android-space_gray-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:470d72c18a272aa4a1d59be764eecbfcf8011346c1813a67f070cda33b6c9096
+size 17431

--- a/src/components/Switch/__image_snapshots__/switch-ios-bright_light-1-snap.png
+++ b/src/components/Switch/__image_snapshots__/switch-ios-bright_light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c051447a0222b64ed10f66e16226bc6ac93bcfd2b9464e63395f5575fe29ef19
+size 21739

--- a/src/components/Switch/__image_snapshots__/switch-ios-space_gray-1-snap.png
+++ b/src/components/Switch/__image_snapshots__/switch-ios-space_gray-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9707817c49c2b7727ada39cbd5b89e938b9036d4bc55522f17fa3ebd7db4687
+size 21217

--- a/src/components/Switch/__image_snapshots__/switch-vkcom-vkcom-1-snap.png
+++ b/src/components/Switch/__image_snapshots__/switch-vkcom-vkcom-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a22687bdbfabdf1e2ee6411a8d2d2cad73bf70baa9754a3eca49918efb0f048
+size 4879

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,7 +156,7 @@ export { default as FormLayoutGroup } from './components/FormLayoutGroup/FormLay
 export type { FormLayoutGroupProps } from './components/FormLayoutGroup/FormLayoutGroup';
 export { FormStatus } from './components/FormStatus/FormStatus';
 export type { FormStatusProps } from './components/FormStatus/FormStatus';
-export { default as Switch } from './components/Switch/Switch';
+export { Switch } from './components/Switch/Switch';
 export type { SwitchProps } from './components/Switch/Switch';
 export { default as File } from './components/File/File';
 export type { FileProps } from './components/File/File';


### PR DESCRIPTION
Привела в порядок дизайн компонента Switch:
- Android: цвет подложки теперь — `accent` с прозрачностью в соответствии с [макетом для Android](https://www.figma.com/file/lLXmjJhnJa4OhgZXzcNJD9/VKUI-Android-Library?node-id=69%3A5521) (fixes #1077);
- iOS: вместо границы в `disabled`-состоянии теперь подложка в соответствии с [макетом для iOS](https://www.figma.com/file/kvjzdHwTDO7Vcrh1VglGQ5/VKUI-iOS-Library?node-id=12785%3A0) (fixes #1560);

Также добавила скриншотные тесты для компонента и подчистила css.