### PR TITLE
ModalDismissButton: fixed icon misplacement and typo in readme.md

### DIFF
--- a/src/components/ModalDismissButton/ModalDismissButton.css
+++ b/src/components/ModalDismissButton/ModalDismissButton.css
@@ -1,16 +1,20 @@
 .ModalDismissButton {
   position: absolute;
+  justify-content: center;
   width: 28px;
   height: 28px;
   top: 14px;
+  padding: 4px;
   box-sizing: border-box;
   background-color: rgba(0, 0, 0, .35);
   color: var(--white);
   border-radius: 50%;
   right: -42px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  transition: opacity .15s ease-out;
+}
+
+.ModalDismissButton .Icon {
+  -webkit-transform: translateX(0);
 }
 
 .ModalDismissButton--ios {
@@ -18,9 +22,9 @@
 }
 
 .ModalDismissButton.Tappable--shadowHovered {
-  filter: opacity(.6);
+  opacity: .6;
 }
 
 .ModalDismissButton.Tappable--shadowHovered.Tappable--active {
-  filter: opacity(1);
+  opacity: 1;
 }

--- a/src/components/ModalDismissButton/ModalDismissButton.css
+++ b/src/components/ModalDismissButton/ModalDismissButton.css
@@ -13,6 +13,7 @@
   transition: opacity .15s ease-out;
 }
 
+/* fixes icon misplacement on Safari in some cases */
 .ModalDismissButton .Icon {
   -webkit-transform: translateX(0);
 }

--- a/src/components/ModalDismissButton/ModalDismissButton.css
+++ b/src/components/ModalDismissButton/ModalDismissButton.css
@@ -1,16 +1,16 @@
 .ModalDismissButton {
   position: absolute;
-  justify-content: center;
   width: 28px;
   height: 28px;
   top: 14px;
-  padding: 4px;
   box-sizing: border-box;
   background-color: rgba(0, 0, 0, .35);
   color: var(--white);
   border-radius: 50%;
   right: -42px;
-  transition: opacity .15s ease-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .ModalDismissButton--ios {
@@ -18,9 +18,9 @@
 }
 
 .ModalDismissButton.Tappable--shadowHovered {
-  opacity: .6;
+  filter: opacity(.6);
 }
 
 .ModalDismissButton.Tappable--shadowHovered.Tappable--active {
-  opacity: 1;
+  filter: opacity(1);
 }

--- a/src/components/ModalDismissButton/ModalDismissButton.tsx
+++ b/src/components/ModalDismissButton/ModalDismissButton.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes, FC } from 'react';
-import { Icon28CancelOutline } from '@vkontakte/icons';
+import { Icon20Cancel } from '@vkontakte/icons';
 import Tappable from '../Tappable/Tappable';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
@@ -11,7 +11,7 @@ const ModalDismissButton: FC<ModalDismissButtonProps> = ({ className, ...props }
   const platform = usePlatform();
   return (
     <Tappable className={classNames(getClassName('ModalDismissButton', platform), className)} {...props}>
-      <Icon28CancelOutline width={20} height={20} />
+      <Icon20Cancel />
     </Tappable>
   );
 };

--- a/src/components/ModalDismissButton/Readme.md
+++ b/src/components/ModalDismissButton/Readme.md
@@ -5,12 +5,12 @@
 
 const CustomPopout = withAdaptivity(({ onClose, viewWidth }) => {
   return (
-    <PopoutWrapper>
+    <PopoutWrapper onClick={onClose}>
       <div style={{
         backgroundColor: "var(--background_content)",
-        padding: 16,
         borderRadius: 8,
-        position: "relative"
+        position: "relative",
+        padding: "12px"
       }}>
         <h4>Кастомное модальное окно</h4>
         {viewWidth >= ViewWidth.SMALL_TABLET && <ModalDismissButton onClick={onClose} />}

--- a/src/components/ModalDismissButton/Readme.md
+++ b/src/components/ModalDismissButton/Readme.md
@@ -3,11 +3,11 @@
 
 ```jsx
 
-const CustomPoput = withAdaptivity(({ onClose, viewWidth }) => {
+const CustomPopout = withAdaptivity(({ onClose, viewWidth }) => {
   return (
     <PopoutWrapper>
       <div style={{
-        backgroundColor: "#fff",
+        backgroundColor: "var(--background_content)",
         padding: 16,
         borderRadius: 8,
         position: "relative"
@@ -22,10 +22,10 @@ const CustomPoput = withAdaptivity(({ onClose, viewWidth }) => {
 })
 
 const Example = () => {
-  const [popout, setPoput] = React.useState(null);
+  const [popout, setPopout] = React.useState(null);
   
-  const onClick = () => setPoput(
-    <CustomPoput onClose={() => setPoput(null)} />
+  const onClick = () => setPopout(
+    <CustomPopout onClose={() => setPopout(null)} />
   );
 
   return (


### PR DESCRIPTION
Слева текущий вид иконки, справа после 
`.ModalDismissButton .Icon {
  -webkit-transform: translateX(0);
}`

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/36237725/105525186-c829fa00-5cf1-11eb-853f-1218cdb3c5b1.png">

fixes #1300
