### PR TITLE
ModalRoot: prevent modal calculations while scrolling inside horizontal scroll

### DIFF
--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -430,6 +430,11 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
     originalEvent.stopPropagation();
 
+    // запрещаем дальнейшие вычисления, если внутри скролла
+    if (target.closest('.HorizontalScroll__in') || target.closest('textarea')) {
+      return;
+    }
+
     const { expandable, contentScrolled, collapsed, expanded } = modalState;
 
     if (contentScrolled) {


### PR DESCRIPTION
При скроле внутри HorisontalScroll или Textarea, скролл работал, но ModalRoot продолжал обрабатывать и проверять event.shiftY: если тач во время скрола смещался хоть немного вниз, это вызывало закрывание модалки

## Before:

![Kapture 2021-01-23 at 22 22 34](https://user-images.githubusercontent.com/827338/105612088-9e90d180-5dca-11eb-94c5-9b00246f3336.gif)

## After:

![Kapture 2021-01-23 at 22 29 26](https://user-images.githubusercontent.com/827338/105612089-a05a9500-5dca-11eb-918a-3184752ace97.gif)

