### PR TITLE
Типографические компоненты

### DIFF
--- a/src/components/Cell/Cell.css
+++ b/src/components/Cell/Cell.css
@@ -2,8 +2,6 @@
   position: relative;
   margin: 0;
   padding: 0;
-  font-size: 16px;
-  line-height: 22px;
 }
 
 .List--dragging .Cell:not(.Cell--dragging) {

--- a/src/components/Checkbox/Checkbox.css
+++ b/src/components/Checkbox/Checkbox.css
@@ -18,7 +18,6 @@
       margin-right: 12px;
       border-radius: 4px;
       display: flex;
-      line-height: 24px;
       }
 
       .Checkbox__icon--on {

--- a/src/components/Chip/Chip.css
+++ b/src/components/Chip/Chip.css
@@ -19,8 +19,6 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   color: var(--text_primary);
-  font-size: 13px;
-  line-height: 16px;
   display: inline-block;
 }
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -2,6 +2,7 @@ import React, { FC, HTMLAttributes, ReactNode, useCallback, MouseEvent } from 'r
 import classNames from '../../lib/classNames';
 import { Icon16Cancel } from '@vkontakte/icons';
 import { getTitleFromChildren, hasReactNode, noop } from '../../lib/utils';
+import Caption from '../Typography/Caption/Caption';
 
 type ChipValue = string | number;
 
@@ -24,13 +25,13 @@ const Chip: FC<ChipProps> = (props: ChipProps) => {
     <div className={classNames('Chip', className)} {...restProps}>
       <div className="Chip__in">
         {hasReactNode(before) && <div className="Chip__before">{before}</div>}
-        <span className="Chip__content" title={title}>{children}</span>
+        <Caption level="1" weight="regular" className="Chip__content" title={title}>{children}</Caption>
         {hasReactNode(after) && <div className="Chip__after">{after}</div>}
-        {removable && <>
+        {removable &&
           <div className="Chip__remove" onClick={onRemoveWrapper}>
             <Icon16Cancel fill="var(--icon_secondary)" />
           </div>
-        </>}
+        }
       </div>
     </div>
   );

--- a/src/components/ChipsSelect/ChipsSelect.css
+++ b/src/components/ChipsSelect/ChipsSelect.css
@@ -12,7 +12,6 @@
 }
 
 .ChipsSelect__empty {
-  font-size: 13px;
   text-align: center;
   color: var(--text_secondary);
 }
@@ -59,7 +58,6 @@
 .ChipsSelect--sizeY-compact .CustomSelectOption {
   height: 36px;
   padding: 10px 9px;
-  font-size: 15px;
 }
 
 .ChipsSelect .CustomScrollView__box:focus {

--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -14,6 +14,7 @@ import { useChipsSelect } from './useChipsSelect';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 import { setRef, noop } from '../../lib/utils';
 import { useDOM } from '../../lib/dom';
+import Caption from '../Typography/Caption/Caption';
 
 export interface ChipsSelectProps<Option extends ChipsInputOption> extends ChipsInputProps<Option>, AdaptivityProps {
   popupDirection?: 'top' | 'bottom';
@@ -286,7 +287,7 @@ const ChipsSelect = <Option extends ChipsInputOption>(props: ChipsSelectProps<Op
                   </CustomSelectOption>
                 )}
                 {!filteredOptions?.length && !creatable && emptyText ? (
-                  <div className="ChipsSelect__empty">{emptyText}</div>
+                  <Caption level="1" weight="regular" className="ChipsSelect__empty">{emptyText}</Caption>
                 ) :
                   filteredOptions.map((option: Option, i: number) => {
                     const index = creatable ? i + 1 : i;

--- a/src/components/Counter/Counter.css
+++ b/src/components/Counter/Counter.css
@@ -5,6 +5,9 @@
   }
 
   .Counter__in {
+    width: 100%;
+    padding-left: 5px;
+    padding-right: 5px;
     text-align: center;
     box-sizing: border-box;
     }
@@ -26,39 +29,17 @@
 
 .Counter--s-m {
   height: 24px;
+  min-width: 24px;
   border-radius: 12px;
-  }
-
-  .Counter--s-m .Counter__in {
-    min-width: 24px;
-    padding: 2px 5px;
-    font-size: 15px;
-    line-height: 20px;
-    }
+}
 
 .Counter--s-s {
   height: 18px;
+  min-width: 18px;
   border-radius: 9px;
   }
-
-  .Counter--s-s .Counter__in {
-    min-width: 18px;
-    padding: 1px 5px;
-    font-size: 12px;
-    line-height: 16px;
-    }
-
-.Counter--vkcom.Counter--s-s .Counter__in {
-  font-weight: normal;
-  line-height: 14px;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  letter-spacing: .2px;
-}
 
 .Counter--vkcom.Counter--s-m .Counter__in {
   padding-left: 6px;
   padding-right: 6px;
-  font-weight: 500;
-  letter-spacing: .2px;
 }

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -2,6 +2,10 @@ import React, { HTMLAttributes } from 'react';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import usePlatform from '../../hooks/usePlatform';
+import Caption from '../Typography/Caption/Caption';
+import Text from '../Typography/Text/Text';
+import { VKCOM } from '../../lib/platform';
+import { hasReactNode } from '../../lib/utils';
 
 export interface CounterProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -15,16 +19,24 @@ const Counter: React.FunctionComponent<CounterProps> = (props: CounterProps) => 
   const { mode, size, children, className, ...restProps } = props;
 
   const platform = usePlatform();
-  const baseClassName = getClassName('Counter', platform);
+  const captionWeight = platform === VKCOM ? 'medium' : 'regular';
 
   return (
     <div
       {...restProps}
-      className={classNames(className, baseClassName, `Counter--${mode}`, `Counter--s-${size}`)}
+      className={classNames(className,
+        getClassName('Counter', platform),
+        `Counter--${mode}`,
+        `Counter--s-${size}`,
+        className,
+      )}
     >
-      <div className="Counter__in">
-        {children}
-      </div>
+      {hasReactNode(children)
+        ? size === 's'
+          ? <Caption level="2" weight={captionWeight} className="Counter__in">{children}</Caption>
+          : <Text weight="medium" className="Counter__in">{children}</Text>
+        : null
+      }
     </div>
   );
 };

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, FC } from 'react';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import usePlatform from '../../hooks/usePlatform';
@@ -6,6 +6,22 @@ import Caption from '../Typography/Caption/Caption';
 import Text from '../Typography/Text/Text';
 import { VKCOM } from '../../lib/platform';
 import { hasReactNode } from '../../lib/utils';
+
+interface CounterTypographyProps extends HTMLAttributes<HTMLDivElement> {
+  size: CounterProps['size'];
+}
+
+const CounterTypography: FC<CounterTypographyProps> = ({ size, children, ...restProps }: CounterTypographyProps) => {
+  const platform = usePlatform();
+
+  if (size === 's') {
+    const weight = platform === VKCOM ? 'medium' : 'regular';
+
+    return <Caption level="2" weight={weight} {...restProps}>{children}</Caption>;
+  }
+
+  return <Text weight="medium" {...restProps}>{children}</Text>;
+};
 
 export interface CounterProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -15,11 +31,9 @@ export interface CounterProps extends HTMLAttributes<HTMLDivElement> {
   size?: 's' | 'm';
 }
 
-const Counter: React.FunctionComponent<CounterProps> = (props: CounterProps) => {
+const Counter: FC<CounterProps> = (props: CounterProps) => {
   const { mode, size, children, className, ...restProps } = props;
-
   const platform = usePlatform();
-  const captionWeight = platform === VKCOM ? 'medium' : 'regular';
 
   return (
     <div
@@ -31,12 +45,7 @@ const Counter: React.FunctionComponent<CounterProps> = (props: CounterProps) => 
         className,
       )}
     >
-      {hasReactNode(children)
-        ? size === 's'
-          ? <Caption level="2" weight={captionWeight} className="Counter__in">{children}</Caption>
-          : <Text weight="medium" className="Counter__in">{children}</Text>
-        : null
-      }
+      {hasReactNode(children) && <CounterTypography size={size} className="Counter__in">{children}</CounterTypography>}
     </div>
   );
 };

--- a/src/components/CustomSelect/CustomSelect.css
+++ b/src/components/CustomSelect/CustomSelect.css
@@ -44,7 +44,6 @@
 .CustomSelect__options--sizeY-compact .CustomSelectOption {
   height: 36px;
   padding: 10px 9px;
-  font-size: 15px;
 }
 
 .CustomSelect__options--sizeY-compact .CustomSelectOption__selectedIcon {

--- a/src/components/CustomSelectOption/CustomSelectOption.css
+++ b/src/components/CustomSelectOption/CustomSelectOption.css
@@ -5,7 +5,6 @@
   align-items: center;
   position: relative;
   box-sizing: border-box;
-  font-size: 15px;
   padding: 10px 36px 10px 12px;
   white-space: nowrap;
   user-select: none;

--- a/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -2,6 +2,7 @@ import React, { FC, HTMLAttributes, ReactNode } from 'react';
 import { Icon16Done } from '@vkontakte/icons';
 import classNames from '../../lib/classNames';
 import { hasReactNode } from '../../lib/utils';
+import Text from '../Typography/Text/Text';
 
 export interface CustomSelectOptionProps extends HTMLAttributes<HTMLDivElement> {
   option?: any;
@@ -24,8 +25,9 @@ const CustomSelectOption: FC<CustomSelectOptionProps> = ({
   const title = typeof children === 'string' ? children : null;
 
   return (
-    <div
+    <Text
       {...restProps}
+      weight="regular"
       role="option"
       title={title}
       aria-selected={selected}
@@ -42,7 +44,7 @@ const CustomSelectOption: FC<CustomSelectOptionProps> = ({
           <Icon16Done fill="var(--accent)" />
         </div>
       )}
-    </div>
+    </Text>
   );
 };
 

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -1,13 +1,7 @@
 .Footer {
   margin: 24px 0;
-  font-size: 13px;
-  color: var(--text_secondary);
-  line-height: 16px;
-  font-weight: normal;
-  text-align: center;
-  }
-
-.Div.Footer {
   padding-top: 0;
   padding-bottom: 0;
-  }
+  text-align: center;
+  color: var(--text_secondary);
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,14 @@
 import React, { FunctionComponent } from 'react';
 import classNames from '../../lib/classNames';
-import Div, { DivProps } from '../Div/Div';
+import { DivProps } from '../Div/Div';
+import Caption from '../Typography/Caption/Caption';
 
 const Footer: FunctionComponent<DivProps> = ({ className, children, ...restProps }: DivProps) => {
-  return <Div {...restProps} className={classNames('Footer', className)}>{children}</Div>;
+  return (
+    <Caption {...restProps} level="1" weight="regular" className={classNames('Footer', className)}>
+      {children}
+    </Caption>
+  );
 };
 
 export default Footer;

--- a/src/components/HorizontalCell/HorizontalCell.tsx
+++ b/src/components/HorizontalCell/HorizontalCell.tsx
@@ -16,16 +16,21 @@ export interface HorizontalCellProps extends HTMLAttributes<HTMLDivElement>, Has
 }
 
 export const HorizontalCell: FC<HorizontalCellProps> = (props) => {
-  const platform = usePlatform();
   const { className, header, subtitle, size, style, children, getRootRef, getRef, ...restProps } = props;
+  const platform = usePlatform();
+  const weight = 'regular';
+
   return (
     <div className={classNames(getClassName('HorizontalCell', platform), `HorizontalCell--${size}`, className)} ref={getRootRef} style={style}>
       <Tappable getRootRef={getRef} {...restProps}>
         {hasReactNode(children) && <div className="HorizontalCell__image">{children}</div>}
         <div className="HorizontalCell__content">
-          {hasReactNode(header) &&
-            size === 's' ? <Caption weight="regular" level="2" className="HorizontalCell__title">{header}</Caption> :
-            <Subhead weight="regular" className="HorizontalCell__title">{header}</Subhead>}
+          {hasReactNode(header)
+            ? size === 's'
+              ? <Caption level="2" weight={weight} className="HorizontalCell__title">{header}</Caption>
+              : <Subhead weight={weight} className="HorizontalCell__title">{header}</Subhead>
+            : null
+          }
           {hasReactNode(subtitle) && <Caption weight="regular" level="1" className="HorizontalCell__subtitle">{subtitle}</Caption>}
         </div>
       </Tappable>

--- a/src/components/HorizontalCell/HorizontalCell.tsx
+++ b/src/components/HorizontalCell/HorizontalCell.tsx
@@ -18,7 +18,6 @@ export interface HorizontalCellProps extends HTMLAttributes<HTMLDivElement>, Has
 export const HorizontalCell: FC<HorizontalCellProps> = (props) => {
   const { className, header, subtitle, size, style, children, getRootRef, getRef, ...restProps } = props;
   const platform = usePlatform();
-  const weight = 'regular';
 
   return (
     <div className={classNames(getClassName('HorizontalCell', platform), `HorizontalCell--${size}`, className)} ref={getRootRef} style={style}>
@@ -27,8 +26,8 @@ export const HorizontalCell: FC<HorizontalCellProps> = (props) => {
         <div className="HorizontalCell__content">
           {hasReactNode(header)
             ? size === 's'
-              ? <Caption level="2" weight={weight} className="HorizontalCell__title">{header}</Caption>
-              : <Subhead weight={weight} className="HorizontalCell__title">{header}</Subhead>
+              ? <Caption level="2" weight="regular" className="HorizontalCell__title">{header}</Caption>
+              : <Subhead weight="regular" className="HorizontalCell__title">{header}</Subhead>
             : null
           }
           {hasReactNode(subtitle) && <Caption weight="regular" level="1" className="HorizontalCell__subtitle">{subtitle}</Caption>}

--- a/src/components/HorizontalCell/HorizontalCell.tsx
+++ b/src/components/HorizontalCell/HorizontalCell.tsx
@@ -9,6 +9,16 @@ import Subhead from '../Typography/Subhead/Subhead';
 import Avatar from '../Avatar/Avatar';
 import { HasRef, HasRootRef } from '../../types';
 
+interface CellTypographyProps extends HTMLAttributes<HTMLDivElement> {
+  size: HorizontalCellProps['size'];
+}
+
+const CellTypography: FC<CellTypographyProps> = ({ size, children, ...restProps }: CellTypographyProps) => {
+  return size === 's'
+    ? <Caption level="2" weight="regular" {...restProps}>{children}</Caption>
+    : <Subhead weight="regular" {...restProps}>{children}</Subhead>;
+};
+
 export interface HorizontalCellProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<HTMLDivElement>, HasRef<HTMLDivElement> {
   size?: 's' | 'm' | 'l';
   header?: ReactNode;
@@ -24,12 +34,9 @@ export const HorizontalCell: FC<HorizontalCellProps> = (props) => {
       <Tappable getRootRef={getRef} {...restProps}>
         {hasReactNode(children) && <div className="HorizontalCell__image">{children}</div>}
         <div className="HorizontalCell__content">
-          {hasReactNode(header)
-            ? size === 's'
-              ? <Caption level="2" weight="regular" className="HorizontalCell__title">{header}</Caption>
-              : <Subhead weight="regular" className="HorizontalCell__title">{header}</Subhead>
-            : null
-          }
+          {hasReactNode(header) && (
+            <CellTypography size={size} className="HorizontalCell__title">{header}</CellTypography>
+          )}
           {hasReactNode(subtitle) && <Caption weight="regular" level="1" className="HorizontalCell__subtitle">{subtitle}</Caption>}
         </div>
       </Tappable>

--- a/src/components/ModalPageHeader/ModalPageHeader.css
+++ b/src/components/ModalPageHeader/ModalPageHeader.css
@@ -1,5 +1,3 @@
-.ModalPageHeader {}
-
 .ModalPageHeader__in,
 .ModalPageHeader__left,
 .ModalPageHeader__right {

--- a/src/components/NativeSelect/NativeSelect.tsx
+++ b/src/components/NativeSelect/NativeSelect.tsx
@@ -7,6 +7,9 @@ import withAdaptivity, { AdaptivityProps, SizeType } from '../../hoc/withAdaptiv
 import { setRef } from '../../lib/utils';
 import { getClassName, HasPlatform } from '../..';
 import withPlatform from '../../hoc/withPlatform';
+import Headline from '../Typography/Headline/Headline';
+import Text from '../Typography/Text/Text';
+import { VKCOM } from '../../lib/platform';
 
 export interface NativeSelectProps extends
   SelectHTMLAttributes<HTMLSelectElement>,
@@ -84,6 +87,8 @@ class NativeSelect extends React.Component<NativeSelectProps, SelectState> {
     const { style, value, defaultValue, onChange, align, placeholder, children, className,
       getRef, getRootRef, disabled, sizeX, sizeY, platform, ...restProps } = this.props;
 
+    const TypographyComponent = platform === VKCOM || sizeY === SizeType.COMPACT ? Text : Headline;
+
     return (
       <FormField
         Component="label"
@@ -108,10 +113,10 @@ class NativeSelect extends React.Component<NativeSelectProps, SelectState> {
           {placeholder && <option value="">{placeholder}</option>}
           {children}
         </select>
-        <div className="Select__container">
+        <TypographyComponent weight="regular" className="Select__container">
           <div className="Select__title">{this.state.title}</div>
           {sizeY === SizeType.COMPACT ? <Icon20Dropdown /> : <Icon24Dropdown />}
-        </div>
+        </TypographyComponent>
       </FormField>
     );
   }

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -41,15 +41,18 @@
 
 .PanelHeader__content {
   overflow: hidden;
-  color: var(--header_text);
-  font-weight: 800;
-  font-family: var(--font-tt);
 }
 
 .PanelHeader__content > * {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.PanelHeader__content-in {
+  color: var(--header_text);
+  font-weight: 800;
+  font-family: var(--font-tt);
 }
 
 .PanelHeader__right {
@@ -105,11 +108,14 @@
 }
 
 .PanelHeader--ios .PanelHeader__content {
-  font-size: 21px;
-  line-height: var(--panelheader_height_ios);
   text-align: center;
   opacity: 1;
   transition: opacity .3s var(--ios-easing);
+}
+
+.PanelHeader--ios .PanelHeader__content-in {
+  font-size: 21px;
+  line-height: var(--panelheader_height_ios);
 }
 
 .PanelHeader--ios .PanelHeader__content > * {
@@ -178,10 +184,13 @@
 }
 
 .PanelHeader--android .PanelHeader__content {
-  font-size: 23px;
   align-items: center;
   flex-grow: 1;
   max-width: 100%;
+}
+
+.PanelHeader--android .PanelHeader__content-in {
+  font-size: 23px;
 }
 
 .PanelHeader--android .PanelHeader__content > * {
@@ -257,10 +266,6 @@
 
 .PanelHeader--vkcom .PanelHeader__left:not(:empty) {
   padding: 0 0 0 4px;
-}
-
-.PanelHeader--vkcom .PanelHeader__content {
-  font-family: inherit;
 }
 
 .PanelHeader--vkcom .PanelHeader__left,

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -42,7 +42,11 @@ const PanelHeaderIn: FC<PanelHeaderProps> = ({ children, left, right }) => {
         {left}
       </div>
       <div className="PanelHeader__content">
-        {isPrimitive ? platform === VKCOM ? <Text weight="medium">{children}</Text> : <span>{children}</span> : children}
+        {isPrimitive
+          ? platform === VKCOM
+            ? <Text Component="span" weight="medium">{children}</Text>
+            : <span className="PanelHeader__content-in">{children}</span>
+          : children}
       </div>
       <div className="PanelHeader__right">
         {webviewType !== WebviewType.VKAPPS && right}

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -31,10 +31,17 @@ export interface PanelHeaderProps extends
   fixed?: boolean;
 }
 
+const PanelHeaderInTypography: FC<PanelHeaderProps> = ({ children }: PanelHeaderProps) => {
+  const platform = usePlatform();
+
+  return platform === VKCOM
+    ? <Text Component="span" weight="medium">{children}</Text>
+    : <span className="PanelHeader__content-in">{children}</span>;
+};
+
 const PanelHeaderIn: FC<PanelHeaderProps> = ({ children, left, right }) => {
   const { webviewType } = useContext(ConfigProviderContext);
   const isPrimitive = isPrimitiveReactNode(children);
-  const platform = usePlatform();
 
   return (
     <div className="PanelHeader__in">
@@ -42,11 +49,7 @@ const PanelHeaderIn: FC<PanelHeaderProps> = ({ children, left, right }) => {
         {left}
       </div>
       <div className="PanelHeader__content">
-        {isPrimitive
-          ? platform === VKCOM
-            ? <Text Component="span" weight="medium">{children}</Text>
-            : <span className="PanelHeader__content-in">{children}</span>
-          : children}
+        {isPrimitive ? <PanelHeaderInTypography>{children}</PanelHeaderInTypography> : children}
       </div>
       <div className="PanelHeader__right">
         {webviewType !== WebviewType.VKAPPS && right}

--- a/src/components/PanelHeaderButton/PanelHeaderButton.css
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.css
@@ -60,6 +60,7 @@
 
 .PanelHeaderButton--android.PanelHeaderButton--primitive {
   height: 48px;
+  line-height: 48px;
   padding: 0 12px;
 }
 
@@ -100,6 +101,7 @@
 
 .PanelHeaderButton--vkcom.PanelHeaderButton--primitive {
   height: 48px;
+  line-height: 48px;
   padding: 0 10px;
 }
 

--- a/src/components/PanelHeaderButton/PanelHeaderButton.css
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.css
@@ -8,7 +8,6 @@
   color: currentColor;
   padding: 0;
   margin: 0;
-  font-size: 17px;
   position: relative;
 }
 
@@ -31,10 +30,7 @@
   position: relative;
   display: flex;
   align-items: center;
-}
-
-.PanelHeaderButton--ios.PanelHeaderButton--primary {
-  font-weight: 600;
+  font-size: 17px;
 }
 
 .PanelHeaderButton--ios.PanelHeaderButton--primitive {
@@ -60,13 +56,10 @@
 
 .PanelHeaderButton--android {
   border-radius: 50%;
-  font-weight: 500;
-  font-size: 15px;
 }
 
 .PanelHeaderButton--android.PanelHeaderButton--primitive {
   height: 48px;
-  line-height: 48px;
   padding: 0 12px;
 }
 
@@ -107,7 +100,6 @@
 
 .PanelHeaderButton--vkcom.PanelHeaderButton--primitive {
   height: 48px;
-  line-height: 48px;
   padding: 0 10px;
 }
 

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -8,6 +8,29 @@ import { IOS, VKCOM } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
 import Title from '../Typography/Title/Title';
 
+interface ButtonTypographyProps {
+  primary?: PanelHeaderButtonProps['primary'];
+  children?: ReactNode;
+}
+
+const ButtonTypography: FunctionComponent<ButtonTypographyProps> = ({ primary, children }: ButtonTypographyProps) => {
+  const platform = usePlatform();
+
+  if (platform === IOS) {
+    return (
+      <Title Component="span" level="3" weight={primary ? 'semibold' : 'regular'}>
+        {children}
+      </Title>
+    );
+  }
+
+  return (
+    <Text Component="span" weight={platform === VKCOM ? 'regular' : 'medium'}>
+      {children}
+    </Text>
+  );
+};
+
 export interface PanelHeaderButtonProps extends Omit<TappableProps, 'label'> {
   primary?: boolean;
   label?: ReactNode;
@@ -25,9 +48,6 @@ const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
   const Component = restProps.href ? 'a' : 'button';
   const platform = usePlatform();
 
-  const textWeight = platform === VKCOM ? 'regular' : 'medium';
-  const titleWeight = primary ? 'semibold' : 'regular';
-
   return (
     <Tappable
       {...restProps}
@@ -44,15 +64,11 @@ const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
       )}
     >
       {isPrimitive
-        ? platform !== IOS
-          ? <Text Component="span" weight={textWeight}>{children}</Text>
-          : <Title Component="span" level="3" weight={titleWeight}>{children}</Title>
+        ? <ButtonTypography primary={primary}>{children}</ButtonTypography>
         : children
       }
       {isPrimitiveLabel
-        ? platform !== IOS
-          ? <Text Component="span" weight={textWeight}>{label}</Text>
-          : <Title Component="span" level="3" weight={titleWeight}>{label}</Title>
+        ? <ButtonTypography primary={primary}>{label}</ButtonTypography>
         : label
       }
     </Tappable>

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, AllHTMLAttributes, ReactNode } from 'react';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
@@ -8,9 +8,8 @@ import { IOS, VKCOM } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
 import Title from '../Typography/Title/Title';
 
-interface ButtonTypographyProps {
+interface ButtonTypographyProps extends AllHTMLAttributes<HTMLElement> {
   primary?: PanelHeaderButtonProps['primary'];
-  children?: ReactNode;
 }
 
 const ButtonTypography: FunctionComponent<ButtonTypographyProps> = ({ primary, children }: ButtonTypographyProps) => {

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -4,8 +4,9 @@ import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import { isPrimitiveReactNode } from '../../lib/utils';
-import { VKCOM } from '../../lib/platform';
+import { IOS, VKCOM } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
+import Title from '../Typography/Title/Title';
 
 export interface PanelHeaderButtonProps extends Omit<TappableProps, 'label'> {
   primary?: boolean;
@@ -24,8 +25,8 @@ const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
   const Component = restProps.href ? 'a' : 'button';
   const platform = usePlatform();
 
-  const childrenComponent = isPrimitive && platform === VKCOM ? <Text weight="regular">{children}</Text> : children;
-  const labelComponent = isPrimitiveLabel && platform === VKCOM ? <Text weight="regular">{label}</Text> : label;
+  const textWeight = platform === VKCOM ? 'regular' : 'medium';
+  const titleWeight = primary ? 'semibold' : 'regular';
 
   return (
     <Tappable
@@ -42,8 +43,18 @@ const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
         },
       )}
     >
-      {childrenComponent}
-      {labelComponent}
+      {isPrimitive
+        ? platform !== IOS
+          ? <Text Component="span" weight={textWeight}>{children}</Text>
+          : <Title Component="span" level="3" weight={titleWeight}>{children}</Title>
+        : children
+      }
+      {isPrimitiveLabel
+        ? platform !== IOS
+          ? <Text Component="span" weight={textWeight}>{label}</Text>
+          : <Title Component="span" level="3" weight={titleWeight}>{label}</Title>
+        : label
+      }
     </Tappable>
   );
 };

--- a/src/components/PanelHeaderContent/PanelHeaderContent.css
+++ b/src/components/PanelHeaderContent/PanelHeaderContent.css
@@ -78,9 +78,6 @@
 /*
   iOS
  */
-.PanelHeaderContent--ios {
-  }
-
   .PanelHeaderContent--ios .PanelHeaderContent__in.Tappable--active {
     opacity: .7;
     }
@@ -96,9 +93,6 @@
 /*
   Android
  */
-.PanelHeaderContent--android {
-  }
-
   .PanelHeaderContent--android .PanelHeaderContent__in.Tappable--active,
   .PanelHeaderContent--vkcom .PanelHeaderContent__in.Tappable--active {
     background-color: rgba(255, 255, 255, .1);

--- a/src/components/PanelHeaderContent/PanelHeaderContent.css
+++ b/src/components/PanelHeaderContent/PanelHeaderContent.css
@@ -24,7 +24,8 @@
     }
 
   .PanelHeaderContent__status,
-  .PanelHeaderContent__children-in {
+  .PanelHeaderContent__children-in,
+  .PanelHeaderContent__children .Headline {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -32,20 +33,9 @@
 
     .PanelHeaderContent__status {
       order: 1;
-      font-weight: 400;
-      font-size: 13px;
-      line-height: 16px;
       margin-top: 1px;
       max-width: 100%;
-      font-family: var(--font-common);
       color: var(--header_text_secondary);
-      }
-
-    .PanelHeaderContent__status ~ .PanelHeaderContent__children .PanelHeaderContent__children-in {
-      font-weight: 500;
-      font-family: var(--font-common);
-      font-size: 16px;
-      line-height: 20px;
       }
 
     .PanelHeaderContent__children {

--- a/src/components/PanelHeaderContent/PanelHeaderContent.tsx
+++ b/src/components/PanelHeaderContent/PanelHeaderContent.tsx
@@ -4,6 +4,8 @@ import getClassName from '../../helpers/getClassName';
 import Tappable from '../Tappable/Tappable';
 import usePlatform from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
+import Caption from '../Typography/Caption/Caption';
+import Headline from '../Typography/Headline/Headline';
 
 interface PanelHeaderContentProps extends HTMLAttributes<HTMLDivElement> {
   aside?: ReactNode;
@@ -31,9 +33,18 @@ const PanelHeaderContent: FunctionComponent<PanelHeaderContentProps> = ({
     <div {...rootProps} className={classNames(baseClassNames, className)} style={style}>
       {hasReactNode(before) && <div className="PanelHeaderContent__before">{before}</div>}
       <InComponent {...inProps} className="PanelHeaderContent__in" onClick={onClick}>
-        {hasReactNode(status) && <div className="PanelHeaderContent__status">{status}</div>}
+        {hasReactNode(status) &&
+          <Caption level="1" weight="regular" className="PanelHeaderContent__status">
+            {status}
+          </Caption>
+        }
         <div className="PanelHeaderContent__children">
-          <span className="PanelHeaderContent__children-in">{children}</span>
+          {hasReactNode(status) ?
+            <Headline Component="span" weight="medium">
+              {children}
+            </Headline>
+            : <span className="PanelHeaderContent__children-in">{children}</span>
+          }
           {hasReactNode(aside) && <div className="PanelHeaderContent__aside">{aside}</div>}
         </div>
         {hasReactNode(before) && <div className="PanelHeaderContent__width" />}

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -99,8 +99,6 @@
 
 .Search__placeholder-text {
   margin-left: 8px;
-  line-height: 22px;
-  font-size: 17px;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -17,6 +17,7 @@ import Touch, { TouchEventHandler, TouchEvent } from '../Touch/Touch';
 import { VKUITouchEvent } from '../../lib/touch';
 import { setRef } from '../../lib/utils';
 import Text from '../Typography/Text/Text';
+import Title from '../Typography/Title/Title';
 import { Separator } from '../../index';
 
 let searchId = 0;
@@ -163,9 +164,10 @@ class Search extends Component<SearchProps, SearchState> {
             <div className="Search__placeholder">
               <div className="Search__placeholder-in">
                 {before}
-                <div className="Search__placeholder-text">
-                  {platform === VKCOM ? <Text weight="regular">{placeholder}</Text> : placeholder}
-                </div>
+                {platform === VKCOM
+                  ? <Text className="Search__placeholder-text" weight="regular">{placeholder}</Text>
+                  : <Title className="Search__placeholder-text" level="3" weight="regular">{placeholder}</Title>
+                }
               </div>
               {this.state.focused && platform === IOS && after && <div className="Search__after-width">{after}</div>}
             </div>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -181,10 +181,9 @@ class Search extends Component<SearchProps, SearchState> {
               }
               {!!this.value &&
                 <Touch onStart={this.onIconCancelClickStart} className="Search__icon">
-                  {platform === VKCOM ?
-                    <Icon24Cancel />
-                    :
-                    <Icon16Clear />
+                  {platform === VKCOM
+                    ? <Icon24Cancel />
+                    : <Icon16Clear />
                   }
                 </Touch>
               }

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -24,9 +24,7 @@
     }
 
   .Select__container {
-    line-height: 19px;
-    font-size: 16px;
-    padding: 12px 39px 11px 11px;
+    padding: 11px 39px 12px 11px;
     color: var(--text_primary);
     box-sizing: border-box;
     height: 42px;
@@ -95,8 +93,6 @@
   height: 34px;
   padding-top: 7px;
   padding-bottom: 7px;
-  font-size: 15px;
-  line-height: 20px;
 }
 
 .Select--sizeY--compact .Icon--h-16 {

--- a/src/components/SelectMimicry/SelectMimicry.tsx
+++ b/src/components/SelectMimicry/SelectMimicry.tsx
@@ -6,6 +6,9 @@ import { HasAlign, HasRootRef } from '../../types';
 import withAdaptivity, { AdaptivityProps, SizeType } from '../../hoc/withAdaptivity';
 import usePlatform from '../../hooks/usePlatform';
 import { getClassName } from '../..';
+import Headline from '../Typography/Headline/Headline';
+import Text from '../Typography/Text/Text';
+import { VKCOM } from '../../lib/platform';
 
 export interface SelectMimicryProps extends
   HTMLAttributes<HTMLElement>,
@@ -31,6 +34,9 @@ const SelectMimicry: FunctionComponent<SelectMimicryProps> = ({
   ...restProps
 }: SelectMimicryProps) => {
   const platform = usePlatform();
+
+  const TypographyComponent = platform === VKCOM || sizeY === SizeType.COMPACT ? Text : Headline;
+
   return (
     <FormField
       {...restProps}
@@ -46,10 +52,10 @@ const SelectMimicry: FunctionComponent<SelectMimicryProps> = ({
       getRootRef={getRootRef}
       onClick={disabled ? null : onClick}
     >
-      <div className="Select__container">
+      <TypographyComponent weight="regular" className="Select__container">
         <div className="Select__title">{children || placeholder}</div>
         {sizeY === SizeType.COMPACT ? <Icon20Dropdown /> : <Icon24Dropdown />}
-      </div>
+      </TypographyComponent>
     </FormField>
   );
 };

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -197,6 +197,12 @@
   margin-right: -14px;
 }
 
+.SimpleCell--ios.SimpleCell--sizeY-regular > .Avatar:not(.Avatar--sz-32) ~ .SimpleCell__main .SimpleCell__children,
+.SimpleCell--ios.SimpleCell--sizeY-regular > .Avatar:not(.Avatar--sz-32) ~ .SimpleCell__indicator {
+  font-size: 16px;
+  line-height: 20px;
+}
+
 /**
  * Android & VKCOM
  */

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -64,8 +64,6 @@
   color: var(--text_secondary);
   text-overflow: ellipsis;
   overflow: hidden;
-  font-size: 13px;
-  line-height: 16px;
   margin-top: 3px;
 }
 
@@ -167,8 +165,6 @@
  */
 
 .SimpleCell--ios {
-  font-size: 17px;
-  line-height: 22px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -177,12 +173,6 @@
 .SimpleCell--ios .SimpleCell__indicator {
   padding-top: 9px;
   padding-bottom: 11px;
-}
-
-.SimpleCell--ios > .Avatar:not(.Avatar--sz-32) ~ .SimpleCell__main,
-.SimpleCell--ios > .Avatar:not(.Avatar--sz-32) ~ .SimpleCell__indicator {
-  font-size: 16px;
-  line-height: 20px;
 }
 
 .SimpleCell--ios > .Icon--28,
@@ -213,8 +203,6 @@
 
 .SimpleCell--android,
 .SimpleCell--vkcom {
-  font-size: 16px;
-  line-height: 20px;
   padding-left: 16px;
   padding-right: 16px;
 }
@@ -256,13 +244,6 @@
 .SimpleCell--sizeY-compact > .Avatar--sz-28 {
   padding-top: 8px;
   padding-bottom: 8px;
-}
-
-.SimpleCell--sizeY-compact,
-.SimpleCell--sizeY-compact > .Avatar:not(.Avatar--sz-32) ~ .SimpleCell__main,
-.SimpleCell--sizeY-compact > .Avatar:not(.Avatar--sz-32) ~ .SimpleCell__indicator {
-  font-size: 15px;
-  line-height: 20px;
 }
 
 .SimpleCell--sizeY-compact .SimpleCell__description,

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, FC, ElementType } from 'react';
+import React, { ReactNode, FC, ElementType, HTMLAttributes } from 'react';
 import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
@@ -6,9 +6,22 @@ import { Icon24Chevron } from '@vkontakte/icons';
 import { IOS } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
-import withAdaptivity from '../../hoc/withAdaptivity';
+import withAdaptivity, { SizeType, AdaptivityProps } from '../../hoc/withAdaptivity';
 import Title from '../Typography/Title/Title';
+import Text from '../Typography/Text/Text';
 import Caption from '../Typography/Caption/Caption';
+
+interface SimpleCellTypographyProps extends HTMLAttributes<HTMLDivElement>, AdaptivityProps {}
+
+const SimpleCellTypography: FC<SimpleCellTypographyProps> = withAdaptivity((props: SimpleCellTypographyProps) => {
+  const { sizeY, children, ...restProps } = props;
+
+  if (sizeY === SizeType.COMPACT) {
+    return <Text weight="regular" {...restProps}>{children}</Text>;
+  }
+
+  return <Title level="3" weight="regular" {...restProps}>{children}</Title>;
+}, { sizeY: true });
 
 export interface SimpleCellOwnProps {
   /**
@@ -89,7 +102,7 @@ const SimpleCell: FC<SimpleCellProps> = ({
       {before}
       <div className="SimpleCell__main">
         <div className="SimpleCell__content">
-          <Title level="3" weight="regular" className="SimpleCell__children">{children}</Title>
+          <SimpleCellTypography className="SimpleCell__children">{children}</SimpleCellTypography>
           {hasReactNode(badge) &&
             <span className="SimpleCell__badge">
               {badge}
@@ -99,9 +112,7 @@ const SimpleCell: FC<SimpleCellProps> = ({
         {description && <Caption weight="regular" level="1" className="SimpleCell__description">{description}</Caption>}
       </div>
       {hasReactNode(indicator) &&
-        <div className="SimpleCell__indicator">
-          {indicator}
-        </div>
+        <SimpleCellTypography className="SimpleCell__indicator">{indicator}</SimpleCellTypography>
       }
       {hasAfter &&
         <div className="SimpleCell__after">

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -7,6 +7,8 @@ import { IOS } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
 import withAdaptivity from '../../hoc/withAdaptivity';
+import Title from '../Typography/Title/Title';
+import Caption from '../Typography/Caption/Caption';
 
 export interface SimpleCellOwnProps {
   /**
@@ -87,14 +89,14 @@ const SimpleCell: FC<SimpleCellProps> = ({
       {before}
       <div className="SimpleCell__main">
         <div className="SimpleCell__content">
-          <span className="SimpleCell__children">{children}</span>
+          <Title level="3" weight="regular" className="SimpleCell__children">{children}</Title>
           {hasReactNode(badge) &&
             <span className="SimpleCell__badge">
               {badge}
             </span>
           }
         </div>
-        {description && <div className="SimpleCell__description">{description}</div>}
+        {description && <Caption weight="regular" level="1" className="SimpleCell__description">{description}</Caption>}
       </div>
       {hasReactNode(indicator) &&
         <div className="SimpleCell__indicator">

--- a/src/components/SliderSwitch/SliderSwitch.css
+++ b/src/components/SliderSwitch/SliderSwitch.css
@@ -73,12 +73,13 @@
 
 .SliderSwitch__slider {
   position: absolute;
+  top: 0;
+  left: 0;
   width: calc(50% - 4px);
   height: 40px;
   margin: 2px;
   border-radius: 6px;
-  /*todo: изменить на transform*/
-  transition: margin-left 150ms;
+  transition: transform 150ms;
 }
 
 .SliderSwitch--firstActive {
@@ -87,6 +88,6 @@
 }
 
 .SliderSwitch--secondActive {
-  margin-left: calc(50% + 2px);
+  transform: translateX(100%) translateX(4px);
   background-color: var(--background_content);
 }

--- a/src/components/SliderSwitch/SliderSwitch.css
+++ b/src/components/SliderSwitch/SliderSwitch.css
@@ -84,6 +84,6 @@
 }
 
 .SliderSwitch--secondActive {
-  transform: translateX(100%) translateX(4px);
+  transform: translateX(calc(100% + 4px));
   background-color: var(--background_content);
 }

--- a/src/components/SliderSwitch/SliderSwitch.css
+++ b/src/components/SliderSwitch/SliderSwitch.css
@@ -22,10 +22,6 @@
   box-sizing: border-box;
   cursor: pointer;
   background: transparent;
-  line-height: 20px;
-  font-family: inherit;
-  font-weight: 500;
-  font-size: 15px;
   color: var(--text_subhead);
   transition: color 100ms ease-out;
   outline: none;

--- a/src/components/SliderSwitch/SliderSwitchButton.tsx
+++ b/src/components/SliderSwitch/SliderSwitchButton.tsx
@@ -4,6 +4,7 @@ import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import { HasRootRef } from '../../types';
 import usePlatform from '../../hooks/usePlatform';
+import Text from '../Typography/Text/Text';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
   active?: boolean;
@@ -39,7 +40,7 @@ const SliderSwitchButton: FunctionComponent<ButtonProps> = (props: ButtonProps) 
     onBlur={toggleFocus}
     tabIndex={0}
   >
-    {children}
+    <Text Component="span" weight="medium">{children}</Text>
   </Tappable>;
 };
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,14 +1,16 @@
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, createContext } from 'react';
 import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import { HasRootRef } from '../../types';
 import usePlatform from '../../hooks/usePlatform';
-import { ANDROID, VKCOM } from '../../lib/platform';
+import { IOS } from '../../lib/platform';
 import withAdaptivity, { AdaptivityProps } from '../../hoc/withAdaptivity';
 
 export interface TabsProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<HTMLDivElement>, AdaptivityProps {
   mode?: 'default' | 'buttons' | 'segmented';
 }
+
+export const TabsModeContext = createContext<TabsProps['mode']>('default');
 
 const Tabs: FunctionComponent<TabsProps> = ({
   className,
@@ -21,7 +23,7 @@ const Tabs: FunctionComponent<TabsProps> = ({
 }: TabsProps) => {
   const platform = usePlatform();
 
-  if ((platform === ANDROID || platform === VKCOM) && mode === 'segmented') {
+  if (platform !== IOS && mode === 'segmented') {
     mode = 'default';
   }
 
@@ -33,7 +35,9 @@ const Tabs: FunctionComponent<TabsProps> = ({
       style={style}
     >
       <div className="Tabs__in">
-        {children}
+        <TabsModeContext.Provider value={mode}>
+          {children}
+        </TabsModeContext.Provider>
       </div>
     </div>
   );

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -1,7 +1,6 @@
 .TabsItem {
   white-space: nowrap;
   text-align: center;
-  font-weight: 500;
   box-sizing: border-box;
   flex-shrink: 0;
   display: flex;
@@ -10,8 +9,6 @@
 }
 
 .Tabs--default .TabsItem {
-  font-size: 16px;
-  line-height: 20px;
   color: var(--text_secondary);
   max-width: 100%;
   min-width: 0;
@@ -57,9 +54,6 @@
   border-radius: 10px;
   box-sizing: border-box;
   padding: 0 16px;
-  font-size: 14px;
-  line-height: 18px;
-  font-weight: 500;
 }
 
 .Tabs--buttons .TabsItem__in {
@@ -104,8 +98,6 @@
  */
 .Tabs--ios.Tabs--segmented .TabsItem {
   border: 1px solid;
-  font-size: 14px;
-  line-height: 18px;
   padding: 0 12px;
   max-width: 100%;
   flex-basis: 0;
@@ -176,9 +168,6 @@
 .Tabs--vkcom .TabsItem--vkcom {
   flex-grow: 0;
   min-width: auto;
-  font-size: 15px;
-  line-height: 20px;
-  font-weight: 400;
   padding-left: 10px;
   padding-right: 10px;
 }

--- a/src/components/TabsItem/TabsItem.tsx
+++ b/src/components/TabsItem/TabsItem.tsx
@@ -1,9 +1,13 @@
-import React, { FunctionComponent, HTMLAttributes, ReactNode } from 'react';
+import React, { FunctionComponent, HTMLAttributes, ReactNode, useContext } from 'react';
 import getClassName from '../../helpers/getClassName';
 import Tappable, { ACTIVE_EFFECT_DELAY } from '../Tappable/Tappable';
 import classNames from '../../lib/classNames';
-import { IOS } from '../../lib/platform';
+import { IOS, VKCOM } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
+import { TabsModeContext } from '../Tabs/Tabs';
+import Headline from '../Typography/Headline/Headline';
+import Subhead from '../Typography/Subhead/Subhead';
+import Text from '../Typography/Text/Text';
 
 export interface TabsItemProps extends HTMLAttributes<HTMLElement> {
   after?: ReactNode;
@@ -18,6 +22,13 @@ const TabsItem: FunctionComponent<TabsItemProps> = ({
   ...restProps
 }: TabsItemProps) => {
   const platform = usePlatform();
+  const mode = useContext(TabsModeContext);
+
+  const TypographyComponent = platform === VKCOM
+    ? Text
+    : mode === 'buttons' || mode === 'segmented'
+      ? Subhead
+      : Headline;
 
   return (
     <Tappable
@@ -25,7 +36,7 @@ const TabsItem: FunctionComponent<TabsItemProps> = ({
       className={classNames(getClassName('TabsItem', platform), { 'TabsItem--selected': selected }, className)}
       activeEffectDelay={platform === IOS ? 0 : ACTIVE_EFFECT_DELAY}
     >
-      <div className="TabsItem__in">{children}</div>
+      <TypographyComponent className="TabsItem__in" weight="medium">{children}</TypographyComponent>
       {after && <div className="TabsItem__after">{after}</div>}
     </Tappable>
   );

--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -36,9 +36,7 @@
       box-shadow: 0 4px 32px 0 rgba(0, 0, 0, .16), 0 0 4px 0 rgba(0, 0, 0, .04);
       padding: 8px 12px 10px;
       border-radius: 10px;
-      font-size: 14px;
       color: #fff;
-      line-height: 1.29;
       max-width: 220px;
       }
 
@@ -46,11 +44,3 @@
       background: #fff;
       color: #2c2d2e;
     }
-
-      .Tooltip__title {
-        font-weight: 600;
-        }
-
-      .Tooltip__text {
-
-        }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -3,6 +3,7 @@ import classNames from '../../lib/classNames';
 import getClassName from '../../helpers/getClassName';
 import ReactDOM from 'react-dom';
 import { canUseDOM, DOMProps, withDOM } from '../../lib/dom';
+import Subhead from '../Typography/Subhead/Subhead';
 
 interface TooltipPortalProps extends Partial<TooltipProps> {
   target?: HTMLElement;
@@ -108,8 +109,8 @@ const TooltipPortal = withDOM<TooltipPortalProps>(
           <div className="Tooltip__container" style={{ top: this.state.y, left: this.state.x }} ref={this.getRef}>
             <div className="Tooltip__corner" style={{ [alignX]: 20 + cornerOffset }} />
             <div className="Tooltip__content">
-              {header && <div className="Tooltip__title">{header}</div>}
-              {text && <div className="Tooltip__text">{text}</div>}
+              {header && <Subhead weight="semibold" className="Tooltip__title">{header}</Subhead>}
+              {text && <Subhead weight="regular" className="Tooltip__text">{text}</Subhead>}
             </div>
           </div>
         </div>, this.portalTarget);

--- a/src/components/UsersStack/UsersStack.css
+++ b/src/components/UsersStack/UsersStack.css
@@ -19,8 +19,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
-  font-weight: 600;
   color: #fff;
   background: var(--content_placeholder_icon);
 }
@@ -73,8 +71,6 @@
   min-width: 0;
   flex: 1;
   margin: 0 0 0 8px;
-  font-size: 13px;
-  line-height: 16px;
 }
 
 /* Vertical layout */

--- a/src/components/UsersStack/UsersStack.tsx
+++ b/src/components/UsersStack/UsersStack.tsx
@@ -6,6 +6,7 @@ import { useBrowserInfo } from '../../hooks/useBrowserInfo';
 import usePlatform from '../../hooks/usePlatform';
 import { System } from '../../lib/browser';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import Caption from '../Typography/Caption/Caption';
 
 export interface UsersStackProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -63,25 +64,24 @@ const UsersStack: FC<UsersStackProps> = (props) => {
       }
     >
       <div className="UsersStack__photos">
-        {photosShown.map((photo, i) => {
-          return (
-            <div
-              key={i}
-              className="UsersStack__photo"
-              style={{ backgroundImage: `url(${photo})` }}
-            />
-          );
-        })}
+        {photosShown.map((photo, i) => (
+          <div
+            key={i}
+            className="UsersStack__photo"
+            style={{ backgroundImage: `url(${photo})` }}
+          />
+        ))}
 
         {canShowOthers &&
-        <div className={classNames('UsersStack__photo', 'UsersStack__photo--others')}>
-          {`+${othersCount}`}
-        </div>}
+          <Caption weight="medium" level="1" className="UsersStack__photo UsersStack__photo--others">
+            <span>+{othersCount}</span>
+          </Caption>
+        }
       </div>
       {children &&
-      <div className="UsersStack__text">
-        {children}
-      </div>
+        <Caption weight="regular" level="1" className="UsersStack__text">
+          {children}
+        </Caption>
       }
     </div>
   );

--- a/src/components/WriteBar/WriteBar.css
+++ b/src/components/WriteBar/WriteBar.css
@@ -54,10 +54,6 @@
  * iOS
  */
 
-.WriteBar--ios {
-
-}
-
 .WriteBar--ios .WriteBar__before,
 .WriteBar--ios .WriteBar__after {
   padding: 0 4px;
@@ -91,11 +87,6 @@
 /**
  * Android + vkcom
  */
-
-.WriteBar--android,
-.WriteBar--vkcom {
-
-}
 
 .WriteBar--android .WriteBar__before,
 .WriteBar--vkcom .WriteBar__before {


### PR DESCRIPTION
Убирает максимум возможного хардкода типографических стилей (font-size, font-weight, line-height) для компонентов, где это еще не было сделано, в пользу типографических компонентов.

В некоторых местах размер шрифта для компонентов в VKUI отличался от текущего дизайна в фигме. Тогда за истину я брала дизайн.

**Измененные компоненты:**
- [x] `<Cell/>`: убраны font-size и line-height, без них как будто ничего не поменялось
- [x] `<Checkbox/>`: убран line-height, без него как будто ничего не поменялось
- [x] `<Chip/>`
- [x] `<ChipsSelect/>`: также убран font-size для CustomSelectOption
- [x] `<Counter/>`
- [x] `<CustomSelect/>`: убран font-size для CustomSelectOption
- [x] `<CustomSelectOption/>`
- [x] `<Footer/>`
- [x] `<HorizontalCell/>`: убрано пустое правило
- [x]  `<ModalPageHeader/>`: убрано пустое правило
- [x] `<NativeSelect/>`
- [x] `<PanelHeader/>`: захардкоженные стили теперь более специфичные, чтобы не задевать содержимое `<PanelHeaderContent/>`
- [x] `<PanelHeaderButton/>`
- [x] `<PanelHeaderContent/>`
- [x] `<Search/>` (в плейсхолдере)
- [x] `<Select/>`: margin пофикшен под новый line-height
- [x] `<SelectMimicry/>`
- [x] `<SimpleCell/>`
- [x] `<SliderSwitch/>`: margin заменен на transform
- [x] `<SliderSwitchButton/>`
- [x] `<Tabs/>`: добавлен контекст, чтобы пробросить mode табов непосредственно в кнопку
- [x] `<TabsItem/>`: используется контекст TabsMode, чтобы определить правильный типографический компонент
- [x] `<Tooltip/>`
- [x] `<UsersStack/>`
- [x] `<WriteBar/>`: убраны пустые правила

**Где остается хардкод:**
-  `<Alert/>`: кнопки для iOS
-  `<Cell/>`: кнопка "Удалить" для iOS
-  `<ChipsInput/>`: для input
-  `<FormStatus/>`: хак для html, который приходит с бэка
-  `<HorizontalCell/>`: line-height остается для subtitle
-  `<Input/>`: для input
-  `<ModalPageHeader/>`: не стала трогать, т.к. есть план от него избавиться
-  `<PanelHeader/>`: кастомные стили для заголовка (23/28 Android, 21/26 iOS, VK Display Title 2)
-  `<PanelHeaderButton/>`: часть стилей для кнопок
-  `<PanelHeaderContent/>`: кастомные стили для заголовка (23/28 Android, 21/26 iOS, VK Display Title 2)
-  `<RichCell/>`: обнуления стилей
-  `<Search/>`: для input
- `<Select/>`: font-size остается для нативного select
- `<TabbarItem/>`: собственные уникальные стили
- `<Textarea/>`: для textarea
- `<WriteBar/>`: для textarea