### PR TITLE
VKUI-129: label in checkbox now doesn't overlap paddings

### DIFF
--- a/src/components/Checkbox/Checkbox.css
+++ b/src/components/Checkbox/Checkbox.css
@@ -33,6 +33,7 @@
     .Checkbox__content {
       flex-grow: 1;
       color: var(--text_primary);
+      word-break: break-word;
       }
 
     .Checkbox__input:checked ~ .Checkbox__container .Checkbox__icon--on {

--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -118,17 +118,6 @@ const App = withAdaptivity(class App extends React.Component {
               <Textarea placeholder="Описание"/>
             </FormItem>
           </Group>
-          <Group header={<Header>Чеклист</Header>}>
-            <Checkbox>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            </Checkbox>
-            <Checkbox>
-              Изучить восстановление сервиса из кеша: https://vk.com/dev/vk_bridge_events_14?f=Восстановление%20сервиса%20из%20кэша
-            </Checkbox>
-            <Checkbox>
-              Выпустить мини-аппу
-            </Checkbox>
-          </Group>
           <Group header={<Header aside={<Link>Показать все</Link>}>Мини-приложения</Header>}>
             <HorizontalScroll>
               <div style={{display: "flex"}}>

--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -118,6 +118,17 @@ const App = withAdaptivity(class App extends React.Component {
               <Textarea placeholder="Описание"/>
             </FormItem>
           </Group>
+          <Group header={<Header>Чеклист</Header>}>
+            <Checkbox>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </Checkbox>
+            <Checkbox>
+              Изучить восстановление сервиса из кеша: https://vk.com/dev/vk_bridge_events_14?f=Восстановление%20сервиса%20из%20кэша
+            </Checkbox>
+            <Checkbox>
+              Выпустить мини-аппу
+            </Checkbox>
+          </Group>
           <Group header={<Header aside={<Link>Показать все</Link>}>Мини-приложения</Header>}>
             <HorizontalScroll>
               <div style={{display: "flex"}}>


### PR DESCRIPTION
Текст перекрывал паддинги чекбокса.

<img width="509" alt="image" src="https://user-images.githubusercontent.com/36237725/105742332-6e713c00-5f4c-11eb-93ff-616b236db2a2.png">
<img width="488" alt="image" src="https://user-images.githubusercontent.com/36237725/105742476-9bbdea00-5f4c-11eb-9115-14da2fcc4f05.png">
