### PR TITLE
Snackbar: ignore view transitions

### DIFF
--- a/src/components/Snackbar/Snackbar.css
+++ b/src/components/Snackbar/Snackbar.css
@@ -1,6 +1,17 @@
 .Snackbar {
   user-select: none;
   z-index: 101;
+  position: fixed;
+  bottom: 0;
+  left: auto;
+  width: 100%;
+  padding-left: var(--safe-area-inset-left);
+  padding-right: var(--safe-area-inset-right);
+  padding-bottom: var(--safe-area-inset-bottom);
+}
+
+.Epic .Snackbar {
+  padding-bottom: calc(var(--tabbar_height) + var(--safe-area-inset-bottom));
 }
 
 .Snackbar__in {

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -1,6 +1,5 @@
 import React, { HTMLAttributes, MouseEvent, PureComponent } from 'react';
 import withPlatform from '../../hoc/withPlatform';
-import FixedLayout from '../FixedLayout/FixedLayout';
 import Touch, { TouchEvent } from '../Touch/Touch';
 import classNames from '../../lib/classNames';
 import { HasPlatform } from '../../types';
@@ -209,15 +208,17 @@ class Snackbar extends PureComponent<SnackbarProps, SnackbarState> {
       before,
       after,
       viewWidth,
+      duration,
+      onActionClick,
+      onClose,
       ...restProps
     } = this.props;
     const resolvedLayout = after || this.isDesktop ? 'vertical' : layout;
 
     return (
       <AppRootPortal>
-        <FixedLayout
+        <div
           {...restProps}
-          vertical="bottom"
           className={classNames(getClassname('Snackbar', platform), className, `Snackbar--l-${resolvedLayout}`, {
             'Snackbar--closing': this.state.closing,
             'Snackbar--touched': this.state.touched,
@@ -252,7 +253,7 @@ class Snackbar extends PureComponent<SnackbarProps, SnackbarState> {
               </div>}
             </div>
           </Touch>
-        </FixedLayout>
+        </div>
       </AppRootPortal>
     );
   }


### PR DESCRIPTION
Snackbar использует FixedLayout, которые реагировал на переходы в родительском View
На многоколоночном SplitLayout, это вызывало баг: иногда снэкбар успевал отрендериться по левому краю родительской колонки, и уже затем выравнивался по левому краю: (красным выделен FixedLayout)

![telegram-cloud-photo-size-2-5224658842221130099-y](https://user-images.githubusercontent.com/827338/105828940-c9e70c80-5fd4-11eb-8591-baf5fbc13904.jpg)

## Update

- Snackbar не использует FixedLayout внутри

## Before

![Kapture 2021-01-26 at 11 33 00](https://user-images.githubusercontent.com/827338/105829048-ea16cb80-5fd4-11eb-9816-ab69f0786a38.gif)

## After

![Kapture 2021-01-26 at 12 42 56](https://user-images.githubusercontent.com/827338/105829070-f3079d00-5fd4-11eb-891b-c925225153d4.gif)


https://user-images.githubusercontent.com/827338/105853037-4b9b6200-5ff6-11eb-829d-17052f33b6be.MP4



