### PR TITLE
Root, View: do not apply transition classes, if animation disabled

### DIFF
--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -179,11 +179,12 @@ class Root extends Component<RootProps & DOMProps, RootState> {
     });
 
     const baseClassName = getClassName('Root', platform);
+    const disableAnimation = this.shouldDisableTransitionMotion();
 
     return (
       <div className={classNames(baseClassName, this.props.className, {
-        'Root--transition': transition,
-        'Root--no-motion': this.shouldDisableTransitionMotion(),
+        'Root--transition': !disableAnimation && transition,
+        'Root--no-motion': disableAnimation,
       })} {...restProps}>
         {Views.map((view: ReactElement) => {
           return (

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -478,10 +478,12 @@ class View extends Component<ViewProps & DOMProps, ViewState> {
         panelId === swipeBackNextPanel;
     });
 
+    const disableAnimation = this.shouldDisableTransitionMotion();
+
     const modifiers = {
-      'View--animated': this.state.animated,
-      'View--swiping-back': this.state.swipingBack,
-      'View--no-motion': this.shouldDisableTransitionMotion(),
+      'View--animated': !disableAnimation && this.state.animated,
+      'View--swiping-back': !disableAnimation && this.state.swipingBack,
+      'View--no-motion': disableAnimation,
     };
 
     return (


### PR DESCRIPTION
## Проблема

`SplitCol`, `ConfigProvider` могут выключать анимацию переходов внутри компонентов Root и View, но даже в выключенном состоянии они применяют некоторые классы анимации
-> View, Panel во время перехода разворачиваются на весь экран
-> Компоненты, зависящие от ширины контейнера неправильно высчитывают ширину (Gallery, #1315)

## Before

![before](https://user-images.githubusercontent.com/827338/105839087-05d49e80-5fe2-11eb-9592-1eacadd1d7df.gif)

## After

![after](https://user-images.githubusercontent.com/827338/105839098-09682580-5fe2-11eb-9dc7-b2abf5a966b0.gif)

