### PR TITLE
#1314 SliderSwitch: фикс ошибок, связанных с `activeValue`

### DIFF
--- a/src/components/SliderSwitch/Readme.md
+++ b/src/components/SliderSwitch/Readme.md
@@ -1,4 +1,4 @@
-```
+```jsx
   <View activePanel="progress">
     <Panel id="progress">
       <PanelHeader>

--- a/src/components/SliderSwitch/SliderSwitch.tsx
+++ b/src/components/SliderSwitch/SliderSwitch.tsx
@@ -28,7 +28,7 @@ export default class SliderSwitch extends React.Component<SliderSwitchProps, Sli
     super(props);
 
     this.state = {
-      activeValue: props.activeValue || void 0,
+      activeValue: props.activeValue ?? '',
       hoveredOptionId: -1,
     };
 

--- a/src/components/SliderSwitch/SliderSwitch.tsx
+++ b/src/components/SliderSwitch/SliderSwitch.tsx
@@ -115,7 +115,7 @@ export default class SliderSwitch extends React.Component<SliderSwitchProps, Sli
   }
 
   public render() {
-    const { name, options, className, ...restProps } = this.props;
+    const { name, options, className, activeValue: _activeValue, ...restProps } = this.props;
     const { activeValue, hoveredOptionId } = this.state;
 
     const [firstOption, secondOption] = options;


### PR DESCRIPTION
Поправлены две ошибки реакта:
- fixes #1314: когда есть `activeValue`, больше не выскакивает "React does not recognize the `activeValue` prop on a DOM element"
- когда `activeValue` нет, при первом клике по свитчу больше не выскакивает "Warning: A component is changing an uncontrolled input of type hidden to be controlled"