### PR TITLE
DatePicker: added min-width properties for date & year to avoid jumps

### DIFF
--- a/src/components/DatePicker/DatePicker.css
+++ b/src/components/DatePicker/DatePicker.css
@@ -10,10 +10,18 @@
   flex-direction: row;
 }
 
+.DatePicker__day {
+  min-width: 68px;
+}
+
 .DatePicker__month {
   display: flex;
   flex: 1 0 auto;
   padding: 0 8px;
+}
+
+.DatePicker__year {
+  min-width: 85px;
 }
 
 .DatePicker__month .Select {

--- a/src/components/DatePicker/DatePicker.css
+++ b/src/components/DatePicker/DatePicker.css
@@ -11,7 +11,7 @@
 }
 
 .DatePicker__day {
-  min-width: 68px;
+  min-width: 72px;
 }
 
 .DatePicker__month {
@@ -21,7 +21,7 @@
 }
 
 .DatePicker__year {
-  min-width: 85px;
+  min-width: 92px;
 }
 
 .DatePicker__month .Select {

--- a/src/components/DatePicker/Readme.md
+++ b/src/components/DatePicker/Readme.md
@@ -19,9 +19,9 @@
           min={{day: 1, month: 1, year: 1901}}
           max={{day: 1, month: 1, year: 2006}}
           onDateChange={(value) => {console.log(value)}}
-          dayPlaceholder="Д"
-          monthPlaceholder="ММ"
-          yearPlaceholder="ГГ"
+          dayPlaceholder="ДД"
+          monthPlaceholder="ММММ"
+          yearPlaceholder="ГГГГ"
         />
       </FormItem>
       <FormItem top="Дата рождения">


### PR DESCRIPTION
## Изменения:
- Добавлено свойство `min-width` к `.DatePicker__day` и `.DatePicker__year`, дабы предотвратить прыжки ширины.
- Изменены плейсхолдеры в примере так, чтобы они выглядели подобно соответственно форматам даты внутри.
## Before:
![Kapture 2021-01-26 at 16 32 22](https://user-images.githubusercontent.com/36237725/105851485-345b7500-5ff4-11eb-947a-454b9769878b.gif)
## After:
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/36237725/106005270-1c9ff180-60c5-11eb-8981-22092712ddc8.png">
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/36237725/106005166-fda15f80-60c4-11eb-884c-f3e9b1015cd1.png">

