### PR TITLE
TabsItem: updated styles for dropdown icon inside after, updated example

### DIFF
--- a/src/components/Tabs/Readme.md
+++ b/src/components/Tabs/Readme.md
@@ -24,7 +24,6 @@
     }
 
     render () {
-
       return (
         <View activePanel={this.state.activePanel}>
           <Panel id="panel1">
@@ -42,8 +41,8 @@
                     this.setState({ activeTab1: 'news' })
                   }}
                   selected={this.state.activeTab1 === 'news'}
-                  after={<Icon16Dropdown fill="var(--accent)" style={{
-                    transform: `rotate(${this.state.contextOpened ? '180deg' : '0'})`
+                  after={<Icon16Dropdown style={{
+                    transform: `rotate(${this.state.contextOpened ? '180deg' : '0'}) translateY(${this.state.contextOpened ? '-2px' : '2px'})`
                   }}/>}
                 >
                   Новости

--- a/src/components/Tabs/Readme.md
+++ b/src/components/Tabs/Readme.md
@@ -42,7 +42,7 @@
                   }}
                   selected={this.state.activeTab1 === 'news'}
                   after={<Icon16Dropdown style={{
-                    transform: `rotate(${this.state.contextOpened ? '180deg' : '0'}) translateY(${this.state.contextOpened ? '-2px' : '2px'})`
+                    transform: `rotate(${this.state.contextOpened ? '180deg' : '0'}) translateY(1px)`
                   }}/>}
                 >
                   Новости

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -101,7 +101,8 @@
 
 .TabsItem__after .Icon--dropdown_16 {
   color: var(--header_tint);
-  transform: translateY(2px);
+  transform-origin: 50% 55%;
+  transform: translateY(1px);
   margin-left: 6px;
 }
 

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -101,7 +101,7 @@
 
 .TabsItem__after .Icon--dropdown_16 {
   color: var(--header_tint);
-  transform-origin: 50% 55%;
+  transform-origin: 50% calc(50% + 1px);
   transform: translateY(1px);
   margin-left: 6px;
 }

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -99,6 +99,12 @@
   margin-left: 6px;
 }
 
+.TabsItem__after .Icon--dropdown_16 {
+  color: var(--header_tint);
+  transform: translateY(2px);
+  margin-left: 6px;
+}
+
 /*
   iOS
  */

--- a/src/components/TabsItem/TabsItem.tsx
+++ b/src/components/TabsItem/TabsItem.tsx
@@ -4,6 +4,7 @@ import Tappable, { ACTIVE_EFFECT_DELAY } from '../Tappable/Tappable';
 import classNames from '../../lib/classNames';
 import { IOS } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
+import { hasReactNode } from '../../lib/utils';
 
 export interface TabsItemProps extends HTMLAttributes<HTMLElement> {
   after?: ReactNode;
@@ -26,7 +27,7 @@ const TabsItem: FunctionComponent<TabsItemProps> = ({
       activeEffectDelay={platform === IOS ? 0 : ACTIVE_EFFECT_DELAY}
     >
       <div className="TabsItem__in">{children}</div>
-      {after && <div className="TabsItem__after">{after}</div>}
+      {hasReactNode(after) && <div className="TabsItem__after">{after}</div>}
     </Tappable>
   );
 };


### PR DESCRIPTION
## Изменения
- Добавлены стили по умолчанию для `Icon16Dropdown` в `.TabsItem__after`
- Обновлён пример

## Before
<img width="364" alt="image" src="https://user-images.githubusercontent.com/36237725/105864075-9b802600-6002-11eb-92f0-57d163ec9e7d.png">

## After
<img width="332" alt="image" src="https://user-images.githubusercontent.com/36237725/105864243-cb2f2e00-6002-11eb-9022-7b613d8fd2bd.png">
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/36237725/105870133-05033300-6009-11eb-92bd-aad0ab5fe3fb.png">



