### PR TITLE
Group: adopt inner group paddings for compact size

### DIFF
--- a/src/components/Group/Group.css
+++ b/src/components/Group/Group.css
@@ -39,6 +39,11 @@
   padding: 8px;
 }
 
+.Group--sizeY-compact.Group--plain > .Group__separator {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .Group:last-of-type > .Group__separator {
   display: none;
 }

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -28,7 +28,7 @@ export interface GroupProps extends HasRootRef<HTMLDivElement>, HTMLAttributes<H
 }
 
 const Group: FC<GroupProps> = (props) => {
-  const { header, description, className, children, separator, getRootRef, mode, sizeX, ...restProps } = props;
+  const { header, description, className, children, separator, getRootRef, mode, sizeX, sizeY, ...restProps } = props;
   const { isInsideModal } = useContext(ModalRootContext);
   const platform = usePlatform();
   const baseClassNames = getClassName('Group', platform);
@@ -43,7 +43,7 @@ const Group: FC<GroupProps> = (props) => {
     <section
       {...restProps}
       ref={getRootRef}
-      className={classNames(className, baseClassNames, `Group--sizeX-${sizeX}`, `Group--${computedMode}`)}
+      className={classNames(className, baseClassNames, `Group--sizeX-${sizeX}`, `Group--sizeY-${sizeY}`, `Group--${computedMode}`)}
     >
       <div className="Group__inner">
         {header}
@@ -71,4 +71,4 @@ Group.defaultProps = {
   separator: 'auto',
 };
 
-export default withAdaptivity(Group, { sizeX: true });
+export default withAdaptivity(Group, { sizeX: true, sizeY: true });


### PR DESCRIPTION
SizeX = compact

## Before:

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/827338/106254619-f9428700-6229-11eb-8f80-c9108ed460da.png">


## After:

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/827338/106254661-0790a300-622a-11eb-90f8-8771dc31af3a.png">

