### PR TITLE
CustomSelectOption: prevented text area overflow

### DIFF
--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -10,7 +10,7 @@
       <FormItem top="Администратор">
         <Select
           placeholder="Не выбран" 
-          options={getRandomUsers(10).map(user => ({ label: user.name+"123123123123123123123123", value: user.id, avatar: user.photo_100 }))}
+          options={getRandomUsers(10).map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
           renderOption={({ option, ...restProps }) => (
             <CustomSelectOption {...restProps} before={<Avatar size={24} src={option.avatar} />} />
           )}

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -10,7 +10,7 @@
       <FormItem top="Администратор">
         <Select
           placeholder="Не выбран" 
-          options={getRandomUsers(10).map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+          options={getRandomUsers(10).map(user => ({ label: user.name+"123123123123123123123123", value: user.id, avatar: user.photo_100 }))}
           renderOption={({ option, ...restProps }) => (
             <CustomSelectOption {...restProps} before={<Avatar size={24} src={option.avatar} />} />
           )}

--- a/src/components/CustomSelectOption/CustomSelectOption.css
+++ b/src/components/CustomSelectOption/CustomSelectOption.css
@@ -19,6 +19,11 @@
   margin-right: 7px;
 }
 
+.CustomSelectOption__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .CustomSelectOption__after {
   margin-left: 7px;
 }

--- a/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -37,7 +37,7 @@ const CustomSelectOption: FC<CustomSelectOptionProps> = ({
       })}
     >
       {hasReactNode(before) && <div className="CustomSelectOption__before">{before}</div>}
-      {children}
+      <div className="CustomSelectOption__label">{children}</div>
       {hasReactNode(after) && <div className="CustomSelectOption__after">{after}</div>}
       {selected && (
         <div className="CustomSelectOption__selectedIcon">


### PR DESCRIPTION
## Before:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/36237725/106477769-8cddb700-64b9-11eb-9f84-4359472196b9.png">

## After:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/36237725/106477817-9cf59680-64b9-11eb-819c-5902fd1ea09c.png">

fixes #1351