### PR TITLE
ModalRoot: fixed hang when dragging and closing modal at same time

### DIFF
--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -610,6 +610,8 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
   waitTransitionFinish(modalState: ModalsStateEntry, eventHandler: () => void) {
     if (transitionEvent.supported) {
+      // Сбрасываем состояния, которые могут помешать закрытию модального окна
+      this.setState({ touchDown: false, switching: false });
       const onceHandler = () => {
         modalState.innerElement.removeEventListener(transitionEvent.name, onceHandler);
         eventHandler();

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -373,6 +373,9 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
   };
 
   closeActiveModal() {
+    // Сбрасываем состояния, которые могут помешать закрытию модального окна
+    this.setState({ touchDown: false, switching: false });
+
     const { prevModal } = this.state;
     if (!prevModal) {
       return console.warn(`[ModalRoot.closeActiveModal] prevModal is ${prevModal}`);
@@ -610,8 +613,6 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
   waitTransitionFinish(modalState: ModalsStateEntry, eventHandler: () => void) {
     if (transitionEvent.supported) {
-      // Сбрасываем состояния, которые могут помешать закрытию модального окна
-      this.setState({ touchDown: false, switching: false });
       const onceHandler = () => {
         modalState.innerElement.removeEventListener(transitionEvent.name, onceHandler);
         eventHandler();
@@ -741,6 +742,9 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
   };
 
   private readonly doCloseModal = (modalState: ModalsStateEntry) => {
+    // Сбрасываем состояния, которые могут помешать закрытию модального окна
+    this.setState({ touchDown: false, switching: false });
+
     if (isFunction(modalState.onClose)) {
       modalState.onClose();
     } else if (isFunction(this.props.onClose)) {


### PR DESCRIPTION
## Before:
При захвате и одновременном закрытии модального окна (в данном примере через `setTimeout`) приложения зависали:

`<CellButton onClick={() => {this.setActiveModal(MODAL_PAGE_FILTERS); setTimeout(()={this.modalBack();}, 500)}}>`

![modalroot-unsuccessful-closing](https://user-images.githubusercontent.com/36237725/106593283-acc8b580-6561-11eb-8a2a-784315580640.gif)

## After:
![modalroot-successful-closing](https://user-images.githubusercontent.com/36237725/106593331-bce09500-6561-11eb-8f6c-ce4b5691bb6a.gif)
