### PR TITLE
Header: added multiline prop

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -11,13 +11,22 @@
 .Header__main {
   min-width: 0;
   overflow: hidden;
-  white-space: nowrap;
   text-overflow: ellipsis;
 }
 
 .Header__content {
   display: flex;
   align-items: baseline;
+}
+
+.Header__content-base {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.Header--multiline {
+  white-space: normal;
 }
 
 .Header__subtitle {
@@ -43,6 +52,7 @@
 .Header__indicator {
   color: var(--text_secondary);
   margin-left: 6px;
+  flex-shrink: 0;
 }
 
 .Header:not(.Header--pi) .Header__indicator {

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -25,6 +25,10 @@
   overflow: hidden;
 }
 
+.Header__content-base--multiline {
+  word-break: break-all;
+}
+
 .Header--multiline {
   white-space: normal;
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,36 +22,39 @@ export interface HeaderProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<
    * Допускаются текст, Indicator
    */
   indicator?: ReactNode;
+  multiline?: boolean;
 }
 
-function renderChildren({ children, platform, mode }: Pick<HeaderProps, 'children' | 'mode'> & HasPlatform) {
+function renderChildren({ children, platform, mode, multiline }: Pick<HeaderProps, 'children' | 'mode' | 'multiline'> & HasPlatform) {
+  const contentClassNames = classNames('Header__content', { 'Header--multiline': multiline });
+
   switch (platform) {
     case Platform.ANDROID:
       switch (mode) {
         case 'primary':
-          return <Headline className="Header__content" weight="medium">{children}</Headline>;
+          return <Headline className={contentClassNames} weight="medium">{children}</Headline>;
         case 'secondary':
-          return <Caption className="Header__content" level="1" weight="medium" caps>{children}</Caption>;
+          return <Caption className={contentClassNames} level="1" weight="medium" caps>{children}</Caption>;
         case 'tertiary':
-          return <Headline className="Header__content" weight="medium">{children}</Headline>;
+          return <Headline className={contentClassNames} weight="medium">{children}</Headline>;
       }
       break;
     case Platform.IOS:
       switch (mode) {
         case 'primary':
         case 'tertiary':
-          return <Title className="Header__content" weight="semibold" level="3">{children}</Title>;
+          return <Title className={contentClassNames} weight="semibold" level="3">{children}</Title>;
         case 'secondary':
-          return <Caption className="Header__content" level="1" weight="semibold" caps>{children}</Caption>;
+          return <Caption className={contentClassNames} level="1" weight="semibold" caps>{children}</Caption>;
       }
       break;
     case Platform.VKCOM:
       switch (mode) {
         case 'primary':
-          return <Headline className="Header__content" weight="regular">{children}</Headline>;
+          return <Headline className={contentClassNames} weight="regular">{children}</Headline>;
         case 'secondary':
         case 'tertiary':
-          return <Caption className="Header__content" level="1" weight="regular">{children}</Caption>;
+          return <Caption className={contentClassNames} level="1" weight="regular">{children}</Caption>;
       }
   }
 }
@@ -71,6 +74,7 @@ const Header: FunctionComponent<HeaderProps> = ({
   indicator,
   aside,
   getRootRef,
+  multiline,
   ...restProps
 }: HeaderProps) => {
   const platform = usePlatform();
@@ -89,12 +93,13 @@ const Header: FunctionComponent<HeaderProps> = ({
           {renderChildren({
             children: (
               <Fragment>
-                {children}
+                <div className="Header__content-base">{children}</div>
                 {hasReactNode(indicator) && <Caption className="Header__indicator" weight="regular" level="1">{indicator}</Caption>}
               </Fragment>
             ),
             platform,
             mode,
+            multiline,
           })}
           {hasReactNode(subtitle) && <Caption className="Header__subtitle" weight="regular" level="1">{subtitle}</Caption>}
         </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -91,7 +91,7 @@ const Header: FunctionComponent<HeaderProps> = ({
           {renderChildren({
             children: (
               <Fragment>
-                <div className={multiline ? null : 'Header__content-base'}>{children}</div>
+                <div className={multiline ? 'Header__content-base--multiline' : 'Header__content-base'}>{children}</div>
                 {hasReactNode(indicator) && <Caption className="Header__indicator" weight="regular" level="1">{indicator}</Caption>}
               </Fragment>
             ),

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -25,36 +25,34 @@ export interface HeaderProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<
   multiline?: boolean;
 }
 
-function renderChildren({ children, platform, mode, multiline }: Pick<HeaderProps, 'children' | 'mode' | 'multiline'> & HasPlatform) {
-  const contentClassNames = classNames('Header__content', { 'Header--multiline': multiline });
-
+function renderChildren({ children, platform, mode }: Pick<HeaderProps, 'children' | 'mode'> & HasPlatform) {
   switch (platform) {
     case Platform.ANDROID:
       switch (mode) {
         case 'primary':
-          return <Headline className={contentClassNames} weight="medium">{children}</Headline>;
+          return <Headline className="Header__content" weight="medium">{children}</Headline>;
         case 'secondary':
-          return <Caption className={contentClassNames} level="1" weight="medium" caps>{children}</Caption>;
+          return <Caption className="Header__content" level="1" weight="medium" caps>{children}</Caption>;
         case 'tertiary':
-          return <Headline className={contentClassNames} weight="medium">{children}</Headline>;
+          return <Headline className="Header__content" weight="medium">{children}</Headline>;
       }
       break;
     case Platform.IOS:
       switch (mode) {
         case 'primary':
         case 'tertiary':
-          return <Title className={contentClassNames} weight="semibold" level="3">{children}</Title>;
+          return <Title className="Header__content" weight="semibold" level="3">{children}</Title>;
         case 'secondary':
-          return <Caption className={contentClassNames} level="1" weight="semibold" caps>{children}</Caption>;
+          return <Caption className="Header__content" level="1" weight="semibold" caps>{children}</Caption>;
       }
       break;
     case Platform.VKCOM:
       switch (mode) {
         case 'primary':
-          return <Headline className={contentClassNames} weight="regular">{children}</Headline>;
+          return <Headline className="Header__content" weight="regular">{children}</Headline>;
         case 'secondary':
         case 'tertiary':
-          return <Caption className={contentClassNames} level="1" weight="regular">{children}</Caption>;
+          return <Caption className="Header__content" level="1" weight="regular">{children}</Caption>;
       }
   }
 }
@@ -93,13 +91,12 @@ const Header: FunctionComponent<HeaderProps> = ({
           {renderChildren({
             children: (
               <Fragment>
-                <div className="Header__content-base">{children}</div>
+                <div className={multiline ? null : 'Header__content-base'}>{children}</div>
                 {hasReactNode(indicator) && <Caption className="Header__indicator" weight="regular" level="1">{indicator}</Caption>}
               </Fragment>
             ),
             platform,
             mode,
-            multiline,
           })}
           {hasReactNode(subtitle) && <Caption className="Header__subtitle" weight="regular" level="1">{subtitle}</Caption>}
         </div>


### PR DESCRIPTION
## Before:
Переносы отсутствуют, текст не эллипсится, также внутри `Header` есть `indicator={<Counter ...}`, который ушёл под `Link` с текстом "Показать всё".

<img width="361" alt="image" src="https://user-images.githubusercontent.com/36237725/106913698-543a1980-6715-11eb-9f29-f096260e4c5d.png">

## After: 
Пример с Header без пропа `multiline`. Имеем `Counter` внутри indicator, который не выносится под "Показать всё". 

`children` корректно эллипсится, `subtitle` имеет переносы по-умолчанию.

<img width="348" alt="image" src="https://user-images.githubusercontent.com/36237725/106913383-fd344480-6714-11eb-9c3e-75bb8f889891.png">

Аналогичная ситуация, но с multiline:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/36237725/106915590-3e2d5880-6717-11eb-84ab-c28c6dd18abc.png">

fixes #1238
