### PR TITLE
Banner: changed z-index to not to reflect border on PanelHeaderContext

### DIFF
--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -22,7 +22,7 @@
   content: '';
   display: block;
   border: var(--thin-border) solid var(--image_border);
-  z-index: 3;
+  z-index: 2;
   box-sizing: border-box;
   border-radius: inherit;
   pointer-events: none;


### PR DESCRIPTION
## Before: 
<img width="341" alt="image" src="https://user-images.githubusercontent.com/36237725/107246453-51a33100-6a41-11eb-959b-34cb99ee32d3.png">

## After:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/36237725/107246512-6089e380-6a41-11eb-9eb8-5ba72ba52d2e.png">

## TODO
- [x] Проверить что остальные наслоения (Modals, Popout) не конфликтуют с `Banner`

<img width="323" alt="image" src="https://user-images.githubusercontent.com/36237725/107246971-db52fe80-6a41-11eb-86f9-ce3be800c50c.png">
<img width="322" alt="image" src="https://user-images.githubusercontent.com/36237725/107247191-135a4180-6a42-11eb-973c-b270c4cc7d89.png">

fixes #1062

