### PR TITLE
INFRA: Ускорить ci

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,6 +80,9 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v1
+      - uses: bahmutov/npm-install@v1.7.1
+        with:
+          install-command: yarn --frozen-lockfile --ignore-scripts
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 12
       # cached yarn install
-      - uses: bahmutov/npm-install@v1
+      - uses: bahmutov/npm-install@v1.7.1
         with:
           install-command: yarn --frozen-lockfile --ignore-scripts
       - name: Run tests
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: 12
       # cached yarn install
-      - uses: bahmutov/npm-install@v1
+      - uses: bahmutov/npm-install@v1.7.1
         with:
           install-command: yarn --frozen-lockfile --ignore-scripts
       - name: Install browser for E2E
@@ -65,7 +65,7 @@ jobs:
         with:
           node-version: 12
       # cached yarn install
-      - uses: bahmutov/npm-install@v1
+      - uses: bahmutov/npm-install@v1.7.1
         with:
           install-command: yarn --frozen-lockfile --ignore-scripts
       - run: yarn styleguide:build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_step: install
+          build_script: 'size:ci'
   deploy_styleguide:
     runs-on: ubuntu-latest
     needs: styleguide

--- a/.github/workflows/update_screens.yml
+++ b/.github/workflows/update_screens.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 12
       # cached yarn install
-      - uses: bahmutov/npm-install@v1
+      - uses: bahmutov/npm-install@v1.7.1
       - name: Update screenshots
         run: yarn test:e2e -u
       - name: Push updated screenshots

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   "scripts": {
     "prepare": "yarn build",
     "size": "yarn clear && yarn build && size-limit",
+    "size:ci": "yarn install --frozen-lockfile --ignore-scripts && yarn build:no-types",
     "styleguide": "cross-env NODE_ENV=development styleguidist server --config=styleguide/config.js",
     "styleguide:build": "cross-env NODE_ENV=production styleguidist build --config=styleguide/config.js",
     "dev": "yarn clear && yarn copy-default-scheme && concurrently \"yarn:tsc-dev\" \"yarn:babel-dev\" \"yarn:postcss-dev\" \"yarn:postcss-unstable-dev\"",
@@ -139,7 +140,9 @@
     "babel-cjs-dev": "babel --config-file ./babel.cjs.config.js src/ --out-dir dist/cjs/ --extensions .tsx,.jsx,.ts,.js --watch",
     "tsc-dev": "tsc --emitDeclarationOnly --declaration --outDir dist/ --watch --preserveWatchOutput",
     "tsc-cjs-dev": "tsc --emitDeclarationOnly --declaration --outDir dist/cjs/ --watch --preserveWatchOutput",
-    "build": "yarn tsc && yarn babel && yarn tsc-cjs && yarn babel-cjs && yarn postcss && yarn postcss-unstable && yarn copy-default-scheme",
+    "build:types": "yarn tsc && yarn tsc-cjs",
+    "build:no-types": "yarn babel && yarn babel-cjs && yarn postcss && yarn postcss-unstable && yarn copy-default-scheme",
+    "build": "yarn build:types && yarn build:no-types",
     "postcss": "cross-env NODE_ENV=production postcss src/styles/styles.css --output dist/vkui.css --verbose",
     "postcss-unstable": "NODE_ENV=production postcss src/styles/unstable.css --output dist/unstable.css --verbose",
     "babel": "cross-env NODE_ENV=production babel src/ --out-dir dist/ --source-maps --extensions .tsx,.jsx,.ts,.js",


### PR DESCRIPTION
Ускоряем пайплайн: 5:40 -> 3:10
- –20c на все джобы обновлением npm-install экшна
- –2,5 минуты на сайзлимит через --ignoreScripts + кеш нод-модулей

Сайз-лимит все еще работает, см. https://github.com/VKCOM/VKUI/pull/1379