### PR TITLE
WIP: ModalRoot: removed viewport top value for vkcom platform

### DIFF
--- a/src/components/ModalRoot/ModalRoot.css
+++ b/src/components/ModalRoot/ModalRoot.css
@@ -38,8 +38,7 @@
   top: var(--safe-area-inset-top);
 }
 
-.ModalRoot--vkapps.ModalRoot--android .ModalRoot__viewport,
-.ModalRoot--vkapps.ModalRoot--vkcom .ModalRoot__viewport {
+.ModalRoot--vkapps.ModalRoot--android .ModalRoot__viewport {
   top: var(--panelheader_height_android);
 }
 

--- a/src/components/ModalRoot/ModalRoot.css
+++ b/src/components/ModalRoot/ModalRoot.css
@@ -34,15 +34,15 @@
   pointer-events: none;
 }
 
-.ModalRoot--ios .ModalRoot__viewport {
+:not(.ModalRoot--desktop).ModalRoot--ios .ModalRoot__viewport {
   top: var(--safe-area-inset-top);
 }
 
-.ModalRoot--vkapps.ModalRoot--android .ModalRoot__viewport {
+:not(.ModalRoot--desktop).ModalRoot--vkapps.ModalRoot--android .ModalRoot__viewport {
   top: var(--panelheader_height_android);
 }
 
-.ModalRoot--vkapps.ModalRoot--ios .ModalRoot__viewport {
+:not(.ModalRoot--desktop).ModalRoot--vkapps.ModalRoot--ios .ModalRoot__viewport {
   top: calc(var(--safe-area-inset-top) + var(--panelheader_height_ios));
 }
 

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -398,7 +398,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
         <div
           className={classNames(getClassName('ModalRoot', this.props.platform), {
             'ModalRoot--vkapps': this.props.configProvider.webviewType === WebviewType.VKAPPS,
-          })}
+          }, 'ModalRoot--desktop')}
         >
           <div
             className="ModalRoot__mask"


### PR DESCRIPTION
## Before: 
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/36237725/107409717-8684b600-6b1d-11eb-83a7-884fa3de457e.png">

## After: 
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/36237725/107409851-a1572a80-6b1d-11eb-9fe5-6c6f9f4c3d57.png">

Изменения заметны при `webviewType={'vkapps'}`.