### PR TITLE
ActionSheet: ignoring PopoutWrapper event on desktop platforms

### DIFF
--- a/src/components/ActionSheet/ActionSheet.css
+++ b/src/components/ActionSheet/ActionSheet.css
@@ -76,8 +76,7 @@
   background: var(--modal_card_background);
 }
 
-.ActionSheet--android.ActionSheet--closing,
-.ActionSheet--vkcom.ActionSheet--closing {
+.ActionSheet--android.ActionSheet--closing {
   transform: translateY(calc(100% + 20px));
   transition: transform .2s var(--android-easing);
 }

--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -112,7 +112,7 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
         alignY="bottom"
         className={className}
         style={style}
-        onClick={this.onClose}
+        onClick={!isDesktop ? this.onClose : null}
         hasMask={!isDesktop}
         fixed={!isDesktop}
       >

--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -73,7 +73,7 @@ class ActionSheet extends Component<ActionSheetProps, ActionSheetState> {
 
   waitTransitionFinish(eventHandler: AnimationEndCallback) {
     if (this.isDesktop) {
-      eventHandler();
+      return eventHandler();
     }
 
     if (transitionEvent.supported) {


### PR DESCRIPTION
## Before:
![actionsheet-wrong-beh-onclose](https://user-images.githubusercontent.com/36237725/107533257-cf954280-6bcf-11eb-91d3-471f18c9b1a8.gif)

## After:
![actionsheet-ok-beh-onclose](https://user-images.githubusercontent.com/36237725/107533300-dd4ac800-6bcf-11eb-949f-01e9f74ea214.gif)

fixes #1385 