### PR TITLE
ModalPageHeader: updated paddings for PanelHeaderButton and docs

### DIFF
--- a/src/components/ModalPageHeader/ModalPageHeader.css
+++ b/src/components/ModalPageHeader/ModalPageHeader.css
@@ -80,7 +80,7 @@
 
 .ModalPageHeader--ios .ModalPageHeader__left .PanelHeaderButton--primitive,
 .ModalPageHeader--ios .ModalPageHeader__right .PanelHeaderButton--primitive {
-  padding: 0 16px;
+  padding: 0 12px;
 }
 
 .ModalPageHeader--ios .ModalPageHeader__content {

--- a/src/components/ModalPageHeader/ModalPageHeader.css
+++ b/src/components/ModalPageHeader/ModalPageHeader.css
@@ -70,7 +70,6 @@
 .ModalPageHeader--ios .ModalPageHeader__left {
   flex-grow: 1;
   flex-basis: 0;
-  padding-right: 12px;
   font-size: 17px;
 }
 
@@ -96,7 +95,6 @@
 .ModalPageHeader--ios .ModalPageHeader__right {
   flex-grow: 1;
   flex-basis: 0;
-  padding-left: 12px;
   font-size: 17px;
 }
 

--- a/src/components/ModalPageHeader/ModalPageHeader.css
+++ b/src/components/ModalPageHeader/ModalPageHeader.css
@@ -79,8 +79,9 @@
   padding-right: 12px;
 }
 
-.ModalPageHeader--ios .ModalPageHeader__left .PanelHeaderButton--primitive {
-  padding-left: 16px;
+.ModalPageHeader--ios .ModalPageHeader__left .PanelHeaderButton--primitive,
+.ModalPageHeader--ios .ModalPageHeader__right .PanelHeaderButton--primitive {
+  padding: 0 16px;
 }
 
 .ModalPageHeader--ios .ModalPageHeader__content {
@@ -106,10 +107,6 @@
 .ModalPageHeader--ios .ModalPageHeader__right .PanelHeaderButton .Icon--24 {
   padding-left: 12px;
   padding-right: 12px;
-}
-
-.ModalPageHeader--ios .ModalPageHeader__right .PanelHeaderButton--primitive {
-  padding-right: 16px;
 }
 
 .ModalPageHeader--ios.ModalPageHeader--sizeX-regular .ModalPageHeader__in {

--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -59,7 +59,7 @@ const MODAL_CARD_ABOUT = 'say-about';
 const MODAL_CARD_NOTIFICATIONS = 'notifications';
 const MODAL_CARD_CHAT_INVITE = 'chat-invite';
 
-const App = withAdaptivity(class App extends React.Component {
+const App = withPlatform(withAdaptivity(class App extends React.Component {
   constructor(props) {
     super(props);
 
@@ -99,6 +99,8 @@ const App = withAdaptivity(class App extends React.Component {
 
   render() {
     const isMobile = this.props.viewWidth <= ViewWidth.MOBILE;
+    const platform = this.props.platform;
+    
     const modal = (
       <ModalRoot
         activeModal={this.state.activeModal}
@@ -111,8 +113,8 @@ const App = withAdaptivity(class App extends React.Component {
           settlingHeight={100}
           header={
             <ModalPageHeader
-              left={isMobile && IS_PLATFORM_ANDROID && <PanelHeaderButton onClick={this.modalBack}><Icon24Cancel /></PanelHeaderButton>}
-              right={<PanelHeaderButton onClick={this.modalBack}>{IS_PLATFORM_IOS ? 'Готово' : <Icon24Done />}</PanelHeaderButton>}
+              left={isMobile && platform === 'android' && <PanelHeaderButton onClick={this.modalBack}><Icon24Cancel /></PanelHeaderButton>}
+              right={<PanelHeaderButton onClick={this.modalBack}>{platform === 'ios' ? 'Готово' : <Icon24Done />}</PanelHeaderButton>}
             >
               @{this.randomUser.screen_name}
             </ModalPageHeader>
@@ -147,8 +149,8 @@ const App = withAdaptivity(class App extends React.Component {
           onClose={this.modalBack}
           header={
             <ModalPageHeader
-              left={isMobile && IS_PLATFORM_ANDROID && <PanelHeaderButton onClick={this.modalBack}><Icon24Cancel /></PanelHeaderButton>}
-              right={<PanelHeaderButton onClick={this.modalBack}>{IS_PLATFORM_IOS ? 'Готово' : <Icon24Done />}</PanelHeaderButton>}
+              left={isMobile && platform === 'android' && <PanelHeaderButton onClick={this.modalBack}><Icon24Cancel /></PanelHeaderButton>}
+              right={<PanelHeaderButton onClick={this.modalBack}>{platform === 'ios' ? 'Готово' : <Icon24Done />}</PanelHeaderButton>}
             >
               Фильтры
             </ModalPageHeader>
@@ -209,7 +211,7 @@ const App = withAdaptivity(class App extends React.Component {
           header={
             <ModalPageHeader
               left={<PanelHeaderBack label="Назад" onClick={this.modalBack} />}
-              right={IS_PLATFORM_IOS && <PanelHeaderButton onClick={this.modalBack}><Icon24Dismiss /></PanelHeaderButton>}
+              right={platform === 'ios' && <PanelHeaderButton onClick={this.modalBack}><Icon24Dismiss /></PanelHeaderButton>}
             >
               Выберите страну
             </ModalPageHeader>
@@ -235,7 +237,7 @@ const App = withAdaptivity(class App extends React.Component {
           header={
             <ModalPageHeader
               left={<PanelHeaderBack label="Назад" onClick={this.modalBack} />}
-              right={IS_PLATFORM_IOS && <PanelHeaderButton onClick={this.modalBack}><Icon24Dismiss /></PanelHeaderButton>}
+              right={platform === 'ios' && <PanelHeaderButton onClick={this.modalBack}><Icon24Dismiss /></PanelHeaderButton>}
             >
               Просмотры истории
             </ModalPageHeader>
@@ -260,7 +262,7 @@ const App = withAdaptivity(class App extends React.Component {
           header={
             <ModalPageHeader
               left={<PanelHeaderBack label="Назад" onClick={this.modalBack} />}
-              right={IS_PLATFORM_IOS && <PanelHeaderButton onClick={this.modalBack}><Icon24Dismiss /></PanelHeaderButton>}
+              right={platform === 'ios' && <PanelHeaderButton onClick={this.modalBack}><Icon24Dismiss /></PanelHeaderButton>}
             >
               Информация о пользователе
             </ModalPageHeader>
@@ -395,7 +397,7 @@ const App = withAdaptivity(class App extends React.Component {
   }
 }, {
   viewWidth: true
-});
+}));
 
 <App />
 ```

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -98,8 +98,9 @@
   padding: 4px 0 4px 4px;
 }
 
-.PanelHeader--ios .PanelHeader__left .PanelHeaderButton--primitive {
-  padding-left: 12px;
+.PanelHeader--ios .PanelHeader__left .PanelHeaderButton--primitive,
+.PanelHeader--ios .PanelHeader__right .PanelHeaderButton--primitive {
+  padding: 0 12px;
 }
 
 .PanelHeader--ios .PanelHeader__left .PanelHeaderButton + .PanelHeaderButton--primitive {


### PR DESCRIPTION
## Изменения:
 * `Modals`: Поправлено определение платформы в примере с модалками.
 * `PanelHeader` | `ModalPageHeader`: Переопределены инсеты для PanelHeaderButton для iOS.
 
## Before:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/36237725/107790908-60048c00-6d64-11eb-869b-6d59d6c576bc.png">
<img width="356" alt="image" src="https://user-images.githubusercontent.com/36237725/107790952-6eeb3e80-6d64-11eb-8330-8db13de8c415.png">

## After:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/36237725/107791612-3435d600-6d65-11eb-8ebf-99ec884434ba.png">
<img width="356" alt="image" src="https://user-images.githubusercontent.com/36237725/107791574-2aac6e00-6d65-11eb-80e5-c566a7e5dbce.png">
