### PR TITLE
HorizontalScroll: show arrows by default; fix props docs

### DIFF
--- a/src/components/HorizontalScroll/HorizontalScroll.e2e.tsx
+++ b/src/components/HorizontalScroll/HorizontalScroll.e2e.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { describeScreenshotFuzz } from '../../testing/e2e/utils';
+import HorizontalScroll from './HorizontalScroll';
+import { HorizontalCell } from '../HorizontalCell/HorizontalCell';
+import Avatar from '../Avatar/Avatar';
+import { ANDROID } from '../../lib/platform';
+import { ViewWidth } from '../../hoc/withAdaptivity';
+import { mount, screenshot } from '../../testing/e2e';
+import AdaptivityProvider from '../AdaptivityProvider/AdaptivityProvider';
+import AppRoot from '../AppRoot/AppRoot';
+import ConfigProvider from '../ConfigProvider/ConfigProvider';
+import { Scheme } from '../ConfigProvider/ConfigProviderContext';
+
+describe('HorizontalScroll', () => {
+  const items = new Array(20).fill(0).map((_, i) => (
+    <HorizontalCell key={i} header={`item ${i}`}>
+      <Avatar size={56} />
+    </HorizontalCell>
+  ));
+
+  describeScreenshotFuzz(HorizontalScroll, [{
+    children: [
+      <div key="0" style={{ display: 'flex' }}>
+        {items}
+      </div>,
+    ],
+  }], {
+    platforms: [ANDROID],
+    adaptivity: {
+      viewWidth: ViewWidth.MOBILE,
+      hasMouse: false,
+    },
+  });
+
+  describeScreenshotFuzz(HorizontalScroll, [{
+    children: [
+      <div key="0" style={{ display: 'flex' }}>
+        {items}
+      </div>,
+    ],
+  }], {
+    platforms: [ANDROID],
+    adaptivity: {
+      viewWidth: ViewWidth.SMALL_TABLET,
+      hasMouse: true,
+    },
+  });
+
+  it('has arrows on mouse hover', async () => {
+    jest.setTimeout(5000);
+    await mount((
+      <ConfigProvider scheme={Scheme.BRIGHT_LIGHT}>
+        <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET} hasMouse>
+          <AppRoot>
+            <HorizontalScroll>
+              <div key="0" style={{ display: 'flex' }}>
+                {items}
+              </div>
+            </HorizontalScroll>
+          </AppRoot>
+        </AdaptivityProvider>
+      </ConfigProvider>
+    ));
+
+    await page.hover('.HorizontalScroll');
+
+    expect(await screenshot(null, {
+      selector: '.HorizontalScroll',
+    })).toMatchImageSnapshot();
+  });
+
+  it('does not have arrows without mouse', async () => {
+    jest.setTimeout(5000);
+    await mount((
+      <ConfigProvider scheme={Scheme.BRIGHT_LIGHT}>
+        <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET} hasMouse={false}>
+          <AppRoot>
+            <HorizontalScroll>
+              <div key="0" style={{ display: 'flex' }}>
+                {items}
+              </div>
+            </HorizontalScroll>
+          </AppRoot>
+        </AdaptivityProvider>
+      </ConfigProvider>
+    ));
+
+    await page.hover('.HorizontalScroll');
+
+    expect(await screenshot(null, {
+      selector: '.HorizontalScroll',
+    })).toMatchImageSnapshot();
+  });
+});

--- a/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -106,12 +106,12 @@ function doScroll({
   })();
 }
 
-const HorizontalScroll: FC<HorizontalScrollProps> = (props) => {
+const HorizontalScroll: FC<HorizontalScrollProps> = (props: HorizontalScrollProps) => {
   const {
     children,
     getScrollToLeft,
     getScrollToRight,
-    showArrows = false,
+    showArrows,
     scrollAnimationDuration,
     className,
     hasMouse,
@@ -184,6 +184,10 @@ const HorizontalScroll: FC<HorizontalScrollProps> = (props) => {
       </div>
     </div>
   );
+};
+
+HorizontalScroll.defaultProps = {
+  showArrows: true,
 };
 
 export default withAdaptivity(HorizontalScroll, {

--- a/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-bright_light-w_2-1-snap.png
+++ b/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-bright_light-w_2-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66d4ad82b5f239a20b99ef3b648f942ed6d467ce99e68fa38b0e2a6a1fbf160c
+size 5448

--- a/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-bright_light-w_3-1-snap.png
+++ b/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-bright_light-w_3-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:febf06c2c856e8187d7152c1662ff6fa52d75bcff25399a7c8fec4b6107d7ef4
+size 8603

--- a/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-space_gray-w_2-1-snap.png
+++ b/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-space_gray-w_2-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6317a5c21544afac53300f0d1c810af0a486da9f5a39aaa53ff5c27265b5a800
+size 5538

--- a/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-space_gray-w_3-1-snap.png
+++ b/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-android-space_gray-w_3-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcd75568dcab67f5d612ab04f8b29329ebe48eec4b08a48adfaf7a7320b1b792
+size 8644

--- a/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-does-not-have-arrows-on-mouse-hover-1-snap.png
+++ b/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-does-not-have-arrows-on-mouse-hover-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29fb791ce87268a60f1d3efb0288b31e0588671bcada4e80f4ce8594c2ee916a
+size 7432

--- a/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-does-not-have-arrows-without-mouse-1-snap.png
+++ b/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-does-not-have-arrows-without-mouse-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29fb791ce87268a60f1d3efb0288b31e0588671bcada4e80f4ce8594c2ee916a
+size 7432

--- a/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-has-arrows-on-mouse-hover-1-snap.png
+++ b/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-has-arrows-on-mouse-hover-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1324df538cf5bd7a040bf4f08a1b20554b8a383d7414937aa7d98cc5698269e4
+size 10336


### PR DESCRIPTION
- Стрелки навигации будут показываться по дефолту при наличии мышки
- hover в e2e тестах:

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/827338/107915929-73874100-6f76-11eb-8a02-2b2e65af70a5.png">
