### PR TITLE
Убираем предупреждение о неизвестном атрибуте maxheight у img в компоненте ContentCard

### DIFF
--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -50,7 +50,7 @@ export interface ContentCardProps extends HasRootRef<HTMLDivElement>, ImgHTMLAtt
 }
 
 const ContentCard: FC<ContentCardProps> = (props) => {
-  const { getRef, onClick, subtitle, header, text, caption, className, image, disabled, mode, alt, style, getRootRef, ...restProps } = props;
+  const { getRef, onClick, subtitle, header, text, caption, className, image, maxHeight, disabled, mode, alt, style, getRootRef, ...restProps } = props;
   const platform = usePlatform();
 
   return (


### PR DESCRIPTION
В restProps попадает "maxHeight", из-за этого возникает предупреждение, т.к. React  добавляет атрибут "maxheight" к тегу img.