### PR TITLE
Tappable: hoverMode and activeMode props

### DIFF
--- a/src/components/ActionSheetItem/ActionSheetItem.css
+++ b/src/components/ActionSheetItem/ActionSheetItem.css
@@ -158,7 +158,7 @@
   content: none;
 }
 
-.ActionSheetItem--ios.Tappable--active::before {
+.ActionSheetItem--ios.ActionSheetItem--active::before {
   background: var(--separator_common);
   opacity: 1;
   transition: none;
@@ -203,7 +203,7 @@
   border-radius: 0;
 }
 
-.ActionSheetItem--android.Tappable--active {
+.ActionSheetItem--android.ActionSheetItem--active {
   background-color: var(--action_sheet_separator);
 }
 
@@ -230,7 +230,7 @@
   border-radius: 0;
 }
 
-.ActionSheetItem--vkcom.Tappable--active {
+.ActionSheetItem--vkcom.ActionSheetItem--active {
   background-color: var(--action_sheet_separator);
 }
 

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -7,7 +7,7 @@ import { hasReactNode, noop } from '../../lib/utils';
 import Subhead from '../Typography/Subhead/Subhead';
 import Title from '../Typography/Title/Title';
 import Text from '../Typography/Text/Text';
-import { ANDROID, IOS, VKCOM } from '../../lib/platform';
+import { ANDROID, VKCOM } from '../../lib/platform';
 import { Icon16Done, Icon24Done } from '@vkontakte/icons';
 import { ActionSheetContext } from '../ActionSheet/ActionSheetContext';
 import Caption from '../Typography/Caption/Caption';
@@ -62,7 +62,7 @@ const ActionSheetItem: React.FunctionComponent<ActionSheetItemProps> = ({
     <Tappable
       {...restProps}
       onClick={onItemClick(onClick, autoclose)}
-      activeHighlighted={platform !== IOS}
+      activeMode="ActionSheetItem--active"
       className={
         classNames(
           getClassName('ActionSheetItem', platform),

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -9,10 +9,6 @@
   overflow: hidden;
 }
 
-.Banner__in.Tappable--active {
-  opacity: .6;
-}
-
 .Banner__in::before {
   position: absolute;
   left: 0;
@@ -138,8 +134,7 @@
  * Mode "tint"
  */
 
-.Banner--md-tint .Banner__in,
-.Banner--md-tint .Banner__in.Tappable--active {
+.Banner--md-tint .Banner__in {
   background-color: var(--content_tint_background);
 }
 
@@ -171,8 +166,7 @@
  * Mode "image"
  */
 
-.Banner--md-image .Banner__in,
-.Banner--md-image .Banner__in.Tappable--active {
+.Banner--md-image .Banner__in {
   background-color: var(--content_tint_background);
   padding: 12px 16px;
 }

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -108,7 +108,7 @@ const Banner: FunctionComponent<BannerProps> = (props: BannerProps) => {
         }, className,
       )}
     >
-      <InnerComponent className="Banner__in" activeHighlighted={platform !== IOS}>
+      <InnerComponent className="Banner__in" activeMode={platform === IOS ? 'opacity' : 'background'}>
         {mode === 'image' && background &&
         <div className="Banner__bg">
           {background}

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -18,10 +18,6 @@
   margin-left: -4px;
 }
 
-.Button.Tappable--active {
-  opacity: .6;
-}
-
 .Button[disabled] {
   opacity: .4;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -101,7 +101,7 @@ const Button: FunctionComponent<ButtonProps> = (props: ButtonProps) => {
     }
     getRootRef={getRootRef}
     Component={restProps.href ? 'a' : Component}
-    activeHighlighted={false}
+    activeMode="opacity"
   >
     <div className="Button__in">
       {before && <div className="Button__before">{before}</div>}

--- a/src/components/IconButton/IconButton.css
+++ b/src/components/IconButton/IconButton.css
@@ -50,14 +50,6 @@
 }
 
 /*
- * iOS
- */
-
-.IconButton--ios.Tappable--active {
-  opacity: .7;
-}
-
-/*
  * Android
  */
 
@@ -66,8 +58,8 @@
   border-radius: 50%;
 }
 
-.IconButton--android.Tappable--active .Icon,
-.IconButton--vkcom.Tappable--active .Icon {
+.IconButton--android.IconButton--active .Icon,
+.IconButton--vkcom.IconButton--active .Icon {
   transition: inherit;
   border-radius: inherit;
   background-color: var(--background_highlighted);

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -4,6 +4,7 @@ import getClassName from '../../helpers/getClassName';
 import classNames from '../../lib/classNames';
 import usePlatform from '../../hooks/usePlatform';
 import withAdaptivity from '../../hoc/withAdaptivity';
+import { IOS } from '../..';
 
 export interface IconButtonProps extends TappableProps {
   /**
@@ -27,7 +28,7 @@ const IconButton: FunctionComponent<IconButtonProps> = ({
       {...restProps}
       Component={Component}
       activeEffectDelay={200}
-      activeHighlighted={false}
+      activeMode={platform === IOS ? 'opacity' : 'IconButton--active'}
       className={classNames(
         getClassName('IconButton', platform),
         className,

--- a/src/components/Link/Link.css
+++ b/src/components/Link/Link.css
@@ -16,8 +16,3 @@
   display: inline-block;
   vertical-align: middle;
 }
-
-.Link.Tappable--shadowHovered,
-.Link.Tappable--active {
-  opacity: .72;
-}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -29,8 +29,8 @@ const Link: FunctionComponent<LinkProps> = ({
       Component={Component}
       {...restProps}
       className={classNames(baseClassName, className)}
-      activeHighlighted={false}
-      hoverBackground={false}
+      hasActive={false}
+      hoverMode="opacity"
     >{children}</Tappable>
   );
 };

--- a/src/components/ModalDismissButton/ModalDismissButton.css
+++ b/src/components/ModalDismissButton/ModalDismissButton.css
@@ -28,10 +28,10 @@
   transform: translateX(0);
 }
 
-.ModalDismissButton.Tappable--shadowHovered {
+.ModalDismissButton--hover {
   opacity: .6;
 }
 
-.ModalDismissButton.Tappable--shadowHovered.Tappable--active {
+.ModalDismissButton--active {
   opacity: 1;
 }

--- a/src/components/ModalDismissButton/ModalDismissButton.tsx
+++ b/src/components/ModalDismissButton/ModalDismissButton.tsx
@@ -13,8 +13,8 @@ const ModalDismissButton: FC<ModalDismissButtonProps> = ({ className, ...props }
     <Tappable
       className={classNames(getClassName('ModalDismissButton', platform), className)}
       {...props}
-      activeHighlighted={false}
-      hoverBackground={false}
+      activeMode="ModalDismissButton--active"
+      hoverMode="ModalDismissButton--hover"
     >
       <Icon20Cancel />
     </Tappable>

--- a/src/components/PanelHeaderButton/PanelHeaderButton.css
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.css
@@ -46,10 +46,6 @@
   padding: 8px;
 }
 
-.PanelHeaderButton--ios.Tappable--active {
-  opacity: .7;
-}
-
 /*
  * Android
  */
@@ -72,10 +68,6 @@
   padding: 10px;
 }
 
-.PanelHeaderButton--android.Tappable--active {
-  background-color: var(--background_highlighted);
-}
-
 /**
 * VKCOM
 */
@@ -86,11 +78,6 @@
 .PanelHeaderButton--vkcom > :not(.Counter) {
   transition: opacity .3s;
   opacity: .7;
-}
-
-.PanelHeaderButton--vkcom.Tappable--shadowHovered > :not(.Counter),
-.PanelHeaderButton--vkcom.Tappable--active > :not(.Counter) {
-  opacity: 1;
 }
 
 .PanelHeaderButton--vkcom {

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -50,10 +50,11 @@ const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
   return (
     <Tappable
       {...restProps}
-      activeHighlighted={false}
-      hoverBackground={platform !== VKCOM}
+      hoverMode={platform === VKCOM ? 'opacity' : 'background'}
       Component={Component}
       activeEffectDelay={200}
+      hasActive={platform !== VKCOM}
+      activeMode={platform === IOS ? 'opacity' : 'background'}
       className={classNames(
         getClassName('PanelHeaderButton', platform),
         className,

--- a/src/components/PanelHeaderContent/PanelHeaderContent.css
+++ b/src/components/PanelHeaderContent/PanelHeaderContent.css
@@ -65,25 +65,10 @@
   width: 1000px;
 }
 
-/*
-  iOS
- */
-.PanelHeaderContent--ios .PanelHeaderContent__in.Tappable--active {
-  opacity: .7;
-}
-
 .PanelHeaderContent--ios .PanelHeaderContent__before ~ .PanelHeaderContent__in {
   align-items: flex-start;
 }
 
 .PanelHeaderContent--ios .PanelHeaderContent__in {
   align-items: center;
-}
-
-/*
-  Android
- */
-.PanelHeaderContent--android .PanelHeaderContent__in.Tappable--active,
-.PanelHeaderContent--vkcom .PanelHeaderContent__in.Tappable--active {
-  background-color: rgba(255, 255, 255, .1);
 }

--- a/src/components/PanelHeaderContent/PanelHeaderContent.tsx
+++ b/src/components/PanelHeaderContent/PanelHeaderContent.tsx
@@ -6,6 +6,7 @@ import usePlatform from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
 import Caption from '../Typography/Caption/Caption';
 import Headline from '../Typography/Headline/Headline';
+import { IOS } from '../..';
 
 interface PanelHeaderContentProps extends HTMLAttributes<HTMLDivElement> {
   aside?: ReactNode;
@@ -32,7 +33,13 @@ const PanelHeaderContent: FunctionComponent<PanelHeaderContentProps> = ({
   return (
     <div {...rootProps} className={classNames(baseClassNames, className)} style={style}>
       {hasReactNode(before) && <div className="PanelHeaderContent__before">{before}</div>}
-      <InComponent {...inProps} className="PanelHeaderContent__in" onClick={onClick} activeHighlighted={false}>
+      <InComponent
+        {...inProps}
+        className="PanelHeaderContent__in"
+        onClick={onClick}
+        hasActive={platform === IOS}
+        activeMode="opacity"
+      >
         {hasReactNode(status) &&
           <Caption level="1" weight="regular" className="PanelHeaderContent__status">
             {status}

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -126,10 +126,6 @@
   justify-content: center;
 }
 
-.Search__icon.Tappable--active {
-  opacity: .7;
-}
-
 .Search__after {
   position: absolute;
   left: 100%;

--- a/src/components/SliderSwitch/SliderSwitchButton.tsx
+++ b/src/components/SliderSwitch/SliderSwitchButton.tsx
@@ -39,8 +39,8 @@ const SliderSwitchButton: FunctionComponent<ButtonProps> = (props: ButtonProps) 
     onFocus={toggleFocus}
     onBlur={toggleFocus}
     tabIndex={0}
-    activeHighlighted={false}
-    hoverBackground={false}
+    hasActive={false}
+    hoverMode="opacity"
   >
     <Text Component="span" weight="medium">{children}</Text>
   </Tappable>;

--- a/src/components/SubnavigationButton/SubnavigationButton.tsx
+++ b/src/components/SubnavigationButton/SubnavigationButton.tsx
@@ -70,7 +70,7 @@ export const SubnavigationButton: FC<SubnavigationButtonProps> = (props: Subnavi
   return (
     <Tappable
       {...restProps}
-      activeHighlighted={false}
+      hasActive={false}
       className={classNames(
         getClassName('SubnavigationButton', platform),
         `SubnavigationButton--${size}`,

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -141,11 +141,11 @@
   color: var(--background_content);
 }
 
-.Tabs--ios.Tabs--segmented .TabsItem:not(.TabsItem--selected).Tappable--active {
+.Tabs--ios.Tabs--segmented .TabsItem:not(.TabsItem--selected).TabsItem--active {
   background: var(--separator_common);
 }
 
-.PanelHeader--ios .Tabs--segmented.TabsItem:not(.TabsItem--selected).Tappable--active .TabsItem__in {
+.PanelHeader--ios .Tabs--segmented.TabsItem:not(.TabsItem--selected).TabsItem--active .TabsItem__in {
   opacity: .7;
 }
 
@@ -157,15 +157,6 @@
 .Tabs--ios.Tabs--segmented.Tabs--header .TabsItem--selected {
   background-color: var(--header_tint);
   color: var(--header_background);
-}
-
-/*
-  Android
- */
-
-.TabsItem--android .Tappable__waves,
-.TabsItem--vkcom .Tappable__waves {
-  display: none;
 }
 
 /*

--- a/src/components/TabsItem/TabsItem.tsx
+++ b/src/components/TabsItem/TabsItem.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent, HTMLAttributes, ReactNode, useContext } from 'react';
 import getClassName from '../../helpers/getClassName';
-import Tappable, { ACTIVE_EFFECT_DELAY } from '../Tappable/Tappable';
+import Tappable from '../Tappable/Tappable';
 import classNames from '../../lib/classNames';
-import { IOS, VKCOM } from '../../lib/platform';
+import { VKCOM } from '../../lib/platform';
 import usePlatform from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
 import { TabsModeContext } from '../Tabs/Tabs';
@@ -35,8 +35,8 @@ const TabsItem: FunctionComponent<TabsItemProps> = ({
     <Tappable
       {...restProps}
       className={classNames(getClassName('TabsItem', platform), { 'TabsItem--selected': selected }, className)}
-      activeEffectDelay={platform === IOS ? 0 : ACTIVE_EFFECT_DELAY}
-      activeHighlighted={false}
+      hasActive={mode === 'segmented'}
+      activeMode="TabsItem--active"
     >
       <TypographyComponent className="TabsItem__in" weight="medium">{children}</TypographyComponent>
       {hasReactNode(after) && <div className="TabsItem__after">{after}</div>}

--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -1,5 +1,56 @@
+.Tappable {
+  position: relative;
+}
+
 .Tappable:not([disabled]) {
   cursor: pointer;
+}
+
+/**
+ * active
+ */
+
+.Tappable--active-background:not([disabled]) {
+  background: var(--background_highlighted);
+}
+
+.Tappable--active-opacity:not([disabled]) {
+  opacity: .7;
+}
+
+/**
+ * hover
+ */
+
+.Tappable__hoverShadow {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.Tappable--hover-background > .Tappable__hoverShadow {
+  background: var(--background_hover);
+}
+
+.Tappable--hover-opacity {
+  opacity: .8;
+}
+
+/**
+ * mouse
+ */
+
+.Tappable--mouse {
+  transition: opacity .15s ease-out;
+}
+
+.Tappable--mouse .Tappable__hoverShadow {
+  transition: background-color .15s ease-out;
 }
 
 /**
@@ -11,11 +62,7 @@
   transition: background-color .15s ease-out;
 }
 
-.Tappable--activeHighlighted.Tappable--active:not([disabled]) {
-  background: var(--background_highlighted);
-}
-
-.Tappable--ios.Tappable--activeHighlighted.Tappable--active:not([disabled]) {
+.Tappable--ios.Tappable--active-background.Tappable--active:not([disabled]) {
   transition: none;
 }
 
@@ -28,18 +75,6 @@
   border-radius: 8px;
 }
 
-/**
- * VKCOM tappable
- */
-.Tappable--vkcom {
-  position: relative;
-  transition: background-color .15s ease-out;
-  border-radius: 8px;
-}
-
-/**
- * Waves container
- */
 .Tappable--android .Tappable__waves {
   position: absolute;
   top: 0;
@@ -53,9 +88,6 @@
   will-change: transform;
 }
 
-/**
- * Wave
- */
 .Tappable--android .Tappable__wave {
   position: absolute;
   top: 0;
@@ -70,35 +102,20 @@
   animation: animation-wave .3s var(--android-easing);
 }
 
-.Tappable__hoverShadow {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  pointer-events: none;
-  overflow: hidden;
-  border-radius: inherit;
+/**
+ * VKCOM tappable
+ */
+.Tappable--vkcom {
+  transition: background-color .15s ease-out;
+  border-radius: 8px;
 }
 
-.Tappable--hoverBackground.Tappable--shadowHovered > .Tappable__hoverShadow {
-  background: var(--background_hover);
-}
-
-.Tappable--opacityHovered {
-  opacity: .8;
-}
+/**
+ * overrides
+ */
 
 .Tappable--sizeX-compact {
   border-radius: 0;
-}
-
-.Tappable--mouse {
-  transition: opacity .15s ease-out;
-}
-
-.Tappable--mouse .Tappable__hoverShadow {
-  transition: background-color .15s ease-out;
 }
 
 /**


### PR DESCRIPTION
Вместо `activeHighlighted` и `hoverBackground` добавил свойства `activeMode` и `hoverMode` соответственно.

Преимущества:
1. Можно задать более двух значений. `background`, `opacity` или произвольно (о нём ниже)
2. Проще читается (субъективно)
3. Избавляет от нужды обращаться к классам `.Tappable` внутри стилей компонент, его использующих. Пример: `ModalDismissButton`. Если в `activeMode` (или `hoverMode`) передать произвольную строку, она навесится на `Tappable` как css-класс. 