### PR TITLE
PanelHeaderButton: updated insets, styles cleanup

### DIFF
--- a/src/components/ModalPageHeader/ModalPageHeader.css
+++ b/src/components/ModalPageHeader/ModalPageHeader.css
@@ -79,10 +79,6 @@
   padding-right: 12px;
 }
 
-.ModalPageHeader--ios .ModalPageHeader__left .PanelHeaderButton--primitive {
-  padding-left: 16px;
-}
-
 .ModalPageHeader--ios .ModalPageHeader__content {
   position: relative;
   z-index: 1;
@@ -106,10 +102,6 @@
 .ModalPageHeader--ios .ModalPageHeader__right .PanelHeaderButton .Icon--24 {
   padding-left: 12px;
   padding-right: 12px;
-}
-
-.ModalPageHeader--ios .ModalPageHeader__right .PanelHeaderButton--primitive {
-  padding-right: 16px;
 }
 
 .ModalPageHeader--ios.ModalPageHeader--sizeX-regular .ModalPageHeader__in {

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-bright_light-w_2-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-bright_light-w_2-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a33e121146e3df82b33a3254ab9ac04e63d42eeccb1df5476091e7f329469b4
-size 63946
+oid sha256:f710da6b42a5ee547cd114cdd97b6630ce5528b7fcff12a7ec0ad610eb744f36
+size 63939

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-bright_light-w_5-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-bright_light-w_5-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:699eeab7015c86b214072f0c158ee270d4a4e7771ebd29fd197e769356cf6b30
-size 79160
+oid sha256:167fd278c5511685d6acde4cba0c29d31ef4cac57032f7cd6d938947d5d72d17
+size 79158

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-space_gray-w_2-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-space_gray-w_2-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69066169d014cb8c8db2a0f94b83d327799d9eb0ef5257d4e3963e07d7430a92
-size 65574
+oid sha256:b20e5229e206db30ae243de79bdb4c7a535fab0cdc9bfd6355e0dc62ffea70ac
+size 65569

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-space_gray-w_5-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-space_gray-w_5-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e6a8661b3fa60380a710ce9dc6b5eae6ce44be62a6c0a1fab098156a6e31a13
-size 81876
+oid sha256:4abe2f8f2b912f91ccd39a0d22c463641ef0266e39019e610a17150f77d70886
+size 81881

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -98,10 +98,6 @@
   padding: 4px 0 4px 4px;
 }
 
-.PanelHeader--ios .PanelHeader__left .PanelHeaderButton--primitive {
-  padding-left: 12px;
-}
-
 .PanelHeader--ios .PanelHeader__left .PanelHeaderButton + .PanelHeaderButton--primitive {
   margin-left: -6px;
   padding-left: 0;
@@ -145,10 +141,6 @@
   opacity: 1;
   transition: opacity .3s var(--ios-easing);
   padding: 4px 4px 4px 0;
-}
-
-.PanelHeader--ios .PanelHeader__right .PanelHeaderButton--primitive {
-  padding-right: 12px;
 }
 
 .View--ios .View__panel--prev .PanelHeader__left,

--- a/src/components/PanelHeaderButton/PanelHeaderButton.css
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.css
@@ -36,6 +36,7 @@
 .PanelHeaderButton--ios.PanelHeaderButton--primitive {
   height: 44px;
   line-height: 44px;
+  padding: 0 12px;
 }
 
 .PanelHeaderButton--ios .Icon--24 {

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, AllHTMLAttributes, ReactNode } from 'react';
+import React, { AllHTMLAttributes, FunctionComponent, ReactNode } from 'react';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
@@ -7,6 +7,7 @@ import { isPrimitiveReactNode } from '../../lib/utils';
 import { IOS, VKCOM } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
 import Title from '../Typography/Title/Title';
+import { SizeType } from '../AdaptivityProvider/AdaptivityContext';
 
 interface ButtonTypographyProps extends AllHTMLAttributes<HTMLElement> {
   primary?: PanelHeaderButtonProps['primary'];
@@ -52,6 +53,7 @@ const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
       {...restProps}
       Component={Component}
       activeEffectDelay={200}
+      sizeX={SizeType.REGULAR}
       className={classNames(
         getClassName('PanelHeaderButton', platform),
         className,

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -7,7 +7,6 @@ import { isPrimitiveReactNode } from '../../lib/utils';
 import { IOS, VKCOM } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
 import Title from '../Typography/Title/Title';
-import { SizeType } from '../AdaptivityProvider/AdaptivityContext';
 
 interface ButtonTypographyProps extends AllHTMLAttributes<HTMLElement> {
   primary?: PanelHeaderButtonProps['primary'];
@@ -53,7 +52,6 @@ const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
       {...restProps}
       Component={Component}
       activeEffectDelay={200}
-      sizeX={SizeType.REGULAR}
       className={classNames(
         getClassName('PanelHeaderButton', platform),
         className,


### PR DESCRIPTION
## Изменения:
 * Обновлены инсеты для примитивного PanelHeaderButton (с текстом внутри), актуально для iOS.

## Before:
### PanelHeader:
![image](https://user-images.githubusercontent.com/36237725/108224487-04634580-714c-11eb-864f-616d1c6138b7.png)

### ModalPageHeader:

## After:
### PanelHeader:

![image](https://user-images.githubusercontent.com/36237725/108224403-eeee1b80-714b-11eb-9549-ac24b7641fe8.png)
### ModalPageHeader:

![image](https://user-images.githubusercontent.com/36237725/108224633-2a88e580-714c-11eb-8176-6398cf897c53.png)

