### PR TITLE
ModalPageHeader: more wide header content

### DIFF
--- a/src/components/ModalPageHeader/ModalPageHeader.css
+++ b/src/components/ModalPageHeader/ModalPageHeader.css
@@ -92,6 +92,12 @@
   justify-content: center;
 }
 
+@media (min-width: 320px) {
+  .ModalPageHeader--ios .ModalPageHeader__content {
+    flex-grow: 3;
+  }
+}
+
 .ModalPageHeader--ios .ModalPageHeader__right {
   flex-grow: 1;
   flex-basis: 0;


### PR DESCRIPTION
Для iOS устройств с шириной вьюпорта >= 320px, заголовок модалки будет растягиваться сильнее по отношению к боковым кнопкам (1|3|1)

Live example https://vkui-cra-rewired-app-git-modal-page-header.ewgenius.vercel.app

| Before | After |
|-|-|
| <img width="460" alt="image" src="https://user-images.githubusercontent.com/827338/108590406-74541480-7374-11eb-95d6-f49cc147cd61.png"> | <img width="461" alt="image" src="https://user-images.githubusercontent.com/827338/108590411-80d86d00-7374-11eb-89f2-b8320984adfe.png"> |

## Другие варианты расположения кнопок:

<img width="395" alt="image" src="https://user-images.githubusercontent.com/827338/108590431-9e0d3b80-7374-11eb-9d96-d0e87bbaf71d.png">

<img width="402" alt="image" src="https://user-images.githubusercontent.com/827338/108590440-a9f8fd80-7374-11eb-916f-8bfafdc85908.png">

<img width="403" alt="image" src="https://user-images.githubusercontent.com/827338/108590444-af564800-7374-11eb-86b9-8cf53869ee53.png">

<img width="399" alt="image" src="https://user-images.githubusercontent.com/827338/108590449-b54c2900-7374-11eb-92f3-cdd15fdbe766.png">

<img width="405" alt="image" src="https://user-images.githubusercontent.com/827338/108590456-bed59100-7374-11eb-89ea-90239c6ca8d6.png">

<img width="511" alt="image" src="https://user-images.githubusercontent.com/827338/108590490-e88eb800-7374-11eb-91c3-7edb202e78e3.png">
