### PR TITLE
Modals: removed not necessary 'fullscreen' prop from docs

### DIFF
--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -109,7 +109,6 @@ const App = withPlatform(withAdaptivity(class App extends React.Component {
         <ModalPage
           id={MODAL_PAGE_FULLSCREEN}
           onClose={this.modalBack}
-          fullscreen
           settlingHeight={100}
           header={
             <ModalPageHeader


### PR DESCRIPTION
Убран неактуальный проп `fullscreen` из примера с модальными окнами.

#1427