### PR TITLE
onSwitch теперь не добавляется к div

### DIFF
--- a/src/components/SliderSwitch/SliderSwitch.tsx
+++ b/src/components/SliderSwitch/SliderSwitch.tsx
@@ -115,7 +115,7 @@ export default class SliderSwitch extends React.Component<SliderSwitchProps, Sli
   }
 
   public render() {
-    const { name, options, activeValue: _activeValue, ...restProps } = this.props;
+    const { name, options, activeValue: _activeValue, onSwitch, ...restProps } = this.props;
     const { activeValue, hoveredOptionId } = this.state;
 
     const [firstOption, secondOption] = options;


### PR DESCRIPTION
**onSwitch** попадал в **restProps** и React пытался добавить свойство **onSwitch** к тегу **div**, что приводило к сообщению:

_Warning: Unknown event handler property `onSwitch`. It will be ignored._