### PR TITLE
fix: ambiguous path in type imports of HasRootRef causing typecheck errors

### DIFF
--- a/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -3,7 +3,7 @@ import { Icon16Done } from '@vkontakte/icons';
 import { classNames } from '../../lib/classNames';
 import { hasReactNode } from '../../lib/utils';
 import Text from '../Typography/Text/Text';
-import { HasRootRef } from 'types';
+import { HasRootRef } from '../../types';
 
 export interface CustomSelectOptionProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<HTMLDivElement> {
   option?: any;

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -3,7 +3,7 @@ import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
 import { ANDROID } from '../../../lib/platform';
-import { HasRootRef } from 'types';
+import { HasRootRef } from '../../../types';
 
 export interface TextProps extends AllHTMLAttributes<HTMLElement>, HasRootRef<HTMLDivElement> {
   weight: 'regular' | 'medium' | 'semibold';


### PR DESCRIPTION
### Проблема

В некоторых файлах импорт типа HasRootRef был через неоднозначный путь. В итоге в сторонних проектах при импорте этих компонентов тайпчекер TS ругается на неизвестный модуль 'types'.  
Из-за этого невозможно использовать компоненты в проектах с typescript проверкой самого vkui.

Пример ошибки:

```
node_modules/@vkontakte/vkui/dist/components/CustomSelectOption/CustomSelectOption.d.ts:2:28 - error TS2307: Cannot find module 'types' or its corresponding type declarations.

2 import { HasRootRef } from 'types';
                             ~~~~~~~

node_modules/@vkontakte/vkui/dist/components/Typography/Text/Text.d.ts:2:28 - error TS2307: Cannot find module 'types' or its corresponding type declarations.

2 import { HasRootRef } from 'types';
                             ~~~~~~~


Found 2 errors.
```

### Решение

Пути заменены на однозначные относительные.