### PR TITLE
Add onClosed prop to ModalPage and ModalCard

### DIFF
--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -51,7 +51,7 @@ export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform
   /**
    * Будет вызван после заверешния анимации закрытия
    */
-  onClosed?: VoidFunction;
+  onCloseTransitionEnd?: VoidFunction;
 }
 
 const ModalCard: FC<ModalCardProps> = (props: ModalCardProps) => {
@@ -63,6 +63,7 @@ const ModalCard: FC<ModalCardProps> = (props: ModalCardProps) => {
     actions,
     actionsLayout,
     onClose,
+    onCloseTransitionEnd,
     platform,
     viewWidth,
     viewHeight,

--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -48,6 +48,10 @@ export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform
    * Будет вызван при закрытии карточки жестом
    */
   onClose?: VoidFunction;
+  /**
+   * Будет вызван после заверешния анимации закрытия
+   */
+  onClosed?: VoidFunction;
 }
 
 const ModalCard: FC<ModalCardProps> = (props: ModalCardProps) => {

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -16,6 +16,10 @@ export interface ModalPageProps extends HTMLAttributes<HTMLDivElement>, Adaptivi
   header?: ReactNode;
   onClose?: VoidFunction;
   /**
+   * Будет вызван после заверешния анимации закрытия
+   */
+  onClosed?: VoidFunction;
+  /**
    * Процент, на который изначально будет открыта модальная страница. При `settlingHeight={100}` модальная страница раскрывается на всю высоту.
    */
   settlingHeight?: number;
@@ -37,6 +41,7 @@ const ModalPage: FC<ModalPageProps> = (props: ModalPageProps) => {
     sizeX,
     hasMouse,
     onClose,
+    onClosed,
     settlingHeight,
     dynamicContentHeight,
     getModalContentRef,

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -18,7 +18,7 @@ export interface ModalPageProps extends HTMLAttributes<HTMLDivElement>, Adaptivi
   /**
    * Будет вызван после заверешния анимации закрытия
    */
-  onClosed?: VoidFunction;
+  onCloseTransitionEnd?: VoidFunction;
   /**
    * Процент, на который изначально будет открыта модальная страница. При `settlingHeight={100}` модальная страница раскрывается на всю высоту.
    */
@@ -41,7 +41,7 @@ const ModalPage: FC<ModalPageProps> = (props: ModalPageProps) => {
     sizeX,
     hasMouse,
     onClose,
-    onClosed,
+    onCloseTransitionEnd,
     settlingHeight,
     dynamicContentHeight,
     getModalContentRef,

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -120,6 +120,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
       const state: ModalsStateEntry = {
         id: Modal.props.id,
         onClose: Modal.props.onClose,
+        onClosed: Modal.props.onClosed,
         dynamicContentHeight: !!modalProps.dynamicContentHeight,
       };
 
@@ -663,6 +664,11 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     this.activeTransitions = Math.max(0, this.activeTransitions - 1);
     if (this.activeTransitions > 0) {
       return;
+    }
+
+    const prevModalState = this.modalsState[this.state.prevModal];
+    if (prevModalState && prevModalState.onClosed) {
+      prevModalState.onClosed();
     }
 
     const activeModal = this.state.nextModal;

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -120,7 +120,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
       const state: ModalsStateEntry = {
         id: Modal.props.id,
         onClose: Modal.props.onClose,
-        onClosed: Modal.props.onClosed,
+        onCloseTransitionEnd: Modal.props.onCloseTransitionEnd,
         dynamicContentHeight: !!modalProps.dynamicContentHeight,
       };
 
@@ -667,8 +667,8 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     }
 
     const prevModalState = this.modalsState[this.state.prevModal];
-    if (prevModalState && prevModalState.onClosed) {
-      prevModalState.onClosed();
+    if (prevModalState && prevModalState.onCloseTransitionEnd) {
+      prevModalState.onCloseTransitionEnd();
     }
 
     const activeModal = this.state.nextModal;

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -97,6 +97,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
       const state: ModalsStateEntry = {
         id: Modal.props.id,
         onClose: Modal.props.onClose,
+        onClosed: Modal.props.onClosed,
         dynamicContentHeight: !!modalProps.dynamicContentHeight,
       };
 
@@ -271,6 +272,11 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
     this.activeTransitions = Math.max(0, this.activeTransitions - 1);
     if (this.activeTransitions > 0) {
       return;
+    }
+
+    const prevModalState = this.modalsState[this.state.prevModal];
+    if (prevModalState && prevModalState.onClosed) {
+      prevModalState.onClosed();
     }
 
     const activeModal = this.state.nextModal;

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -97,7 +97,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
       const state: ModalsStateEntry = {
         id: Modal.props.id,
         onClose: Modal.props.onClose,
-        onClosed: Modal.props.onClosed,
+        onCloseTransitionEnd: Modal.props.onCloseTransitionEnd,
         dynamicContentHeight: !!modalProps.dynamicContentHeight,
       };
 
@@ -275,8 +275,8 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
     }
 
     const prevModalState = this.modalsState[this.state.prevModal];
-    if (prevModalState && prevModalState.onClosed) {
-      prevModalState.onClosed();
+    if (prevModalState && prevModalState.onCloseTransitionEnd) {
+      prevModalState.onCloseTransitionEnd();
     }
 
     const activeModal = this.state.nextModal;

--- a/src/components/ModalRoot/types.ts
+++ b/src/components/ModalRoot/types.ts
@@ -18,7 +18,7 @@ export interface ModalElements {
 export interface ModalsStateEntry extends ModalElements {
   id: string;
   onClose?: () => any;
-  onClosed?: () => any;
+  onCloseTransitionEnd?: () => any;
   type?: ModalType;
 
   settlingHeight?: number;

--- a/src/components/ModalRoot/types.ts
+++ b/src/components/ModalRoot/types.ts
@@ -18,6 +18,7 @@ export interface ModalElements {
 export interface ModalsStateEntry extends ModalElements {
   id: string;
   onClose?: () => any;
+  onClosed?: () => any;
   type?: ModalType;
 
   settlingHeight?: number;


### PR DESCRIPTION
- позволяет вызывать обработчик сразу после завершения анимации закрытия модалки