### PR TITLE
fix: Восстановить интерфейс публичного classNames

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -257,7 +257,7 @@ export { useAdaptivity } from './hooks/useAdaptivity';
 /**
  * Utils
  */
-export { classNames } from './lib/classNames';
+export { classNamesString as classNames } from './lib/classNames';
 export { default as animate } from './lib/animate';
 export { removeObjectKeys } from './lib/removeObjectKeys';
 export { SSRWrapper } from './lib/SSR';

--- a/src/lib/classNames.test.ts
+++ b/src/lib/classNames.test.ts
@@ -1,4 +1,4 @@
-import { classNames } from './classNames';
+import { classNames, classNamesString } from './classNames';
 
 describe(classNames, () => {
   it('joins string classes', () =>
@@ -13,4 +13,12 @@ describe(classNames, () => {
     expect(classNames({ b: true, no: false })).toEqual('b'));
   it('returns empty string', () =>
     expect(classNames(false, { no: false })).toEqual(''));
+});
+
+describe(classNamesString, () => {
+  it('returns classname as string', () => {
+    expect(classNamesString('A', 'B')).toBe('A B');
+    expect(classNamesString('A')).toBe('A');
+    expect(classNamesString()).toBe('');
+  });
 });

--- a/src/lib/classNames.ts
+++ b/src/lib/classNames.ts
@@ -31,3 +31,8 @@ export function classNames() {
 
   return result.length > 1 ? result : result[0] || '';
 }
+
+export function classNamesString(...args: ClassName[]) {
+  const res = classNames(...args);
+  return typeof res === 'string' ? res : res.join(' ');
+}


### PR DESCRIPTION
* `{ classNames } from '@vkontakte/vkui'` всегда возвращает строку, как раньше
* `{ classNames} from '@vkontakte/dist/utils/classNames'` теперь падает, но это и не публичный интерфейс