### PR TITLE
Исправляет поломку View при быстрой смене панелек

### DIFF
--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -147,8 +147,10 @@ class View extends Component<ViewProps & DOMProps, ViewState> {
     this.props.popout && !prevProps.popout && this.blurActiveElement();
     this.props.modal && !prevProps.modal && this.blurActiveElement();
 
+    const haveTransition = this.state.prevPanel || this.state.nextPanel;
+
     // Нужен переход
-    if (prevProps.activePanel !== this.props.activePanel && !prevState.swipingBack && !prevState.browserSwipe) {
+    if (!haveTransition && prevProps.activePanel !== this.props.activePanel && !prevState.swipingBack && !prevState.browserSwipe) {
       const firstLayer = this.panels.find(
         (panel) => panel.props.id === prevProps.activePanel || panel.props.id === this.props.activePanel,
       );


### PR DESCRIPTION
Фиксит одну часть #177

В примере при клике на "Go to panel 2" срабатывает следующий сценарий:
```
  setTimeout(() => this.setState({ activePanel: 'panel2' }), 100);
  setTimeout(() => this.setState({ activePanel: 'panel3' }), 200);
  setTimeout(() => this.setState({ activePanel: 'panel2' }), 300);
  setTimeout(() => this.setState({ activePanel: 'panel3' }), 400); 
```

**До:**
![Поведение View до изменений](https://user-images.githubusercontent.com/55830579/111067736-2310ee00-84f8-11eb-8b10-f796ed9afa12.gif)

**После:**
![Поведение View после изменений](https://user-images.githubusercontent.com/55830579/111067506-366f8980-84f7-11eb-8675-16334b5c4a83.gif)
