### PR TITLE
Исправляет поломку Root при быстрой смене вьюшек

### DIFF
--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -75,8 +75,10 @@ class Root extends Component<RootProps & DOMProps, RootState> {
       this.blurActiveElement();
     }
 
+    const haveTransition = this.state.prevView || this.state.nextView;
+
     // Нужен переход
-    if (this.props.activeView !== prevProps.activeView) {
+    if (!haveTransition && this.props.activeView !== prevProps.activeView) {
       let pageYOffset = this.window.pageYOffset;
       const firstLayerId = [].concat(prevProps.children).find((view: ReactElement) => {
         return view.props.id === prevProps.activeView || view.props.id === this.props.activeView;
@@ -148,14 +150,15 @@ class Root extends Component<RootProps & DOMProps, RootState> {
       'root-ios-animation-hide-back',
       'root-ios-animation-show-forward',
     ].includes(e.animationName)) {
+      const activeView = this.props.activeView;
       const isBack = this.state.isBack;
       const prevView = this.state.prevView;
       const nextView = this.state.nextView;
       this.setState({
-        activeView: nextView,
+        activeView: activeView,
         prevView: null,
         nextView: null,
-        visibleViews: [nextView],
+        visibleViews: [activeView],
         transition: false,
         isBack: undefined,
       }, () => {


### PR DESCRIPTION
Фиксит одну часть #177

В примере при клике на "Open View 2" срабатывает следующий сценарий:
 ```
setTimeout(() => this.setState({ activeView: 'view2'}), 100);
setTimeout(() => this.setState({ activeView: 'view3'}), 200);
setTimeout(() => this.setState({ activeView: 'view2'}), 300);
setTimeout(() => this.setState({ activeView: 'view3'}), 400);
```

**До:**
![Поведение Root до моего решения](https://user-images.githubusercontent.com/55830579/111068251-9ae01800-84fa-11eb-875e-b76b4e5b7139.gif)

**После:**
![Поведение Root после моего решения](https://user-images.githubusercontent.com/55830579/111068298-d37ff180-84fa-11eb-9ae7-a4880a4d2116.gif)

