### PR TITLE
FixedLayout: fix scroll adjustment during panel transitions

### DIFF
--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -92,9 +92,12 @@ class FixedLayout extends React.Component<FixedLayoutProps & DOMProps & PanelCon
     const fromPanelHasScroll = this.props.panel === e.detail.from && panelScroll > 0;
     const toPanelHasScroll = this.props.panel === e.detail.to && panelScroll > 0;
 
+    // если переход назад - анимация только у панели с которой уходим (detail.from), и подстраиваться под скролл надо только на ней
+    const panelAnimated = !(this.props.panel === e.detail.to && e.detail.isBack);
+
     // Для панелей, с которых уходим всегда выставляется скролл
-    // Для панелей на которые приходим надо смотреть, есть ли браузерный скролл
-    if (fromPanelHasScroll || toPanelHasScroll && this.canTargetPanelScroll) {
+    // Для панелей на которые приходим надо смотреть, есть ли браузерный скролл и применяется ли к ней анимация перехода:
+    if (fromPanelHasScroll || toPanelHasScroll && this.canTargetPanelScroll && panelAnimated) {
       this.setState({
         position: 'absolute',
         top: this.el.offsetTop + panelScroll,

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -27,6 +27,7 @@ export type TransitionStartEventDetail = {
   scrolls: Scrolls;
   from: string;
   to: string;
+  isBack: boolean;
 };
 
 interface ViewsScrolls {
@@ -200,6 +201,7 @@ class View extends Component<ViewProps & DOMProps, ViewState> {
         detail: {
           from: this.state.prevPanel,
           to: this.state.nextPanel,
+          isBack: this.state.isBack,
           scrolls,
         },
       };


### PR DESCRIPTION
### Проблема:

при переходе назад на панель, с отскроленным контентом хедер скачет после перехода

в фиксе #1250 был добавлен обработчик, подстраивающий FixedLayout внутри PanelHeader под высоту скролла во время перехода

| Before | After |
|-|-|
|![CleanShot 2021-03-15 at 13 27 39](https://user-images.githubusercontent.com/827338/111139641-6cae1700-8592-11eb-9417-d8332947260f.gif)|![CleanShot 2021-03-15 at 13 30 24](https://user-images.githubusercontent.com/827338/111139855-b26adf80-8592-11eb-9858-c169cbacdcdd.gif)|
