### PR TITLE
fix(Banner): Check actions prop emptiness

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode, HTMLAttributes, MouseEventHandler } from 'react';
+import { Children, FunctionComponent, ReactNode, HTMLAttributes, MouseEventHandler } from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -124,7 +124,7 @@ const Banner: FunctionComponent<BannerProps> = (props: BannerProps) => {
           {hasReactNode(header) && renderHeader({ size, header })}
           {hasReactNode(subheader) && renderSubheader({ size, subheader })}
           {hasReactNode(text) && <Text weight="regular" vkuiClass="Banner__text">{text}</Text>}
-          {actions &&
+          {hasReactNode(actions) && Children.count(actions) > 0 &&
           <div vkuiClass="Banner__actions">{actions}</div>
           }
         </div>


### PR DESCRIPTION
If you pass an empty array to actions prop, the component renders empty .Banner__actions div

**Before:**

![image](https://user-images.githubusercontent.com/25563268/111141198-4f7a4800-8594-11eb-8981-90b2e0d0c615.png)

**After:**

![image](https://user-images.githubusercontent.com/25563268/111141219-56a15600-8594-11eb-9712-e64f802e6a0e.png)
