### PR TITLE
Header now cuts only long words 

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -26,7 +26,8 @@
 }
 
 .Header__content-base--multiline {
-  word-break: break-all;
+  white-space: initial;
+  word-break: break-word;
 }
 
 .Header--multiline {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -90,7 +90,9 @@ const Header: FunctionComponent<HeaderProps> = ({
           {renderChildren({
             children: (
               <Fragment>
-                <div vkuiClass={multiline ? 'Header__content-base--multiline' : 'Header__content-base'}>{children}</div>
+                <div vkuiClass={classNames('Header__content-base', {
+                  'Header__content-base--multiline': multiline,
+                })}>{children}</div>
                 {hasReactNode(indicator) && <Caption vkuiClass="Header__indicator" weight="regular" level="1">{indicator}</Caption>}
               </Fragment>
             ),

--- a/src/components/Header/Readme.md
+++ b/src/components/Header/Readme.md
@@ -18,6 +18,11 @@ const Example = withPlatform(({ platform }) => {
         <Group>
           <Header mode="tertiary">Важные</Header>
         </Group>
+        <Group>
+          <Header mode="primary" multiline>Кто может писать мне личные сообщения</Header>
+          <Header mode="tertiary" multiline>Кто может комментировать мои записи</Header>
+          <Header mode="secondary" multiline>Кто может оставлять записи на моей странице</Header>
+        </Group>
       </Panel>
     </View>  
   )   


### PR DESCRIPTION
* При `<Header multiline ...` режем только длинные слова.
* Обновлены примеры:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/36237725/111154492-5446f800-85a4-11eb-9a6c-38663ca37f3a.png">

* Обновлено условие для модификатора, `.Header__content-base` не должен быть опциональным.

По мотивам #1466.