### PR TITLE
ModalRoot: responding to viewport changes

### DIFF
--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -6,7 +6,7 @@ import { classNames } from '../../lib/classNames';
 import { setTransformStyle } from '../../lib/styles';
 import { rubber } from '../../lib/touch';
 import { isFunction } from '../../lib/utils';
-import { ANDROID, VKCOM } from '../../lib/platform';
+import { ANDROID, IOS, VKCOM } from '../../lib/platform';
 import { transitionEvent } from '../../lib/supportEvents';
 import { HasPlatform } from '../../types';
 import { withPlatform } from '../../hoc/withPlatform';
@@ -139,6 +139,9 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
   componentWillUnmount() {
     this.toggleDocumentScrolling(true);
+    if (this.props.platform === IOS) {
+      this.window.removeEventListener('resize', this.updateModalTranslate, false);
+    }
   }
 
   componentDidUpdate(prevProps: ModalRootProps, prevState: ModalRootState) {
@@ -234,7 +237,9 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
     const modalState = this.modalsState[activeModal];
     // Отслеживаем изменение размеров viewport (Необходимо для iOS)
-    this.window.addEventListener('resize', this.updateModalTranslate, false);
+    if (this.props.platform === IOS) {
+      this.window.addEventListener('resize', this.updateModalTranslate, false);
+    }
 
     switch (modalState.type) {
       case ModalType.PAGE:
@@ -369,7 +374,9 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     // Сбрасываем состояния, которые могут помешать закрытию модального окна
     this.setState({ touchDown: false, switching: false });
 
-    this.window.removeEventListener('resize', this.updateModalTranslate, false);
+    if (this.props.platform === IOS) {
+      this.window.removeEventListener('resize', this.updateModalTranslate, false);
+    }
 
     const { prevModal } = this.state;
     if (!prevModal) {

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -233,6 +233,8 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     }
 
     const modalState = this.modalsState[activeModal];
+    // Отслеживаем изменение размеров viewport (Необходимо для iOS)
+    window.addEventListener('resize', this.updateModalTranslate, false);
 
     switch (modalState.type) {
       case ModalType.PAGE:
@@ -250,6 +252,16 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
     this.setState({ inited: true, switching: true });
   }
+
+  updateModalTranslate = () => {
+    const activeModal = this.state.activeModal || this.state.nextModal;
+    if (!activeModal) {
+      return;
+    }
+
+    const modalState = this.modalsState[activeModal];
+    this.animateTranslate(modalState, modalState.translateY);
+  };
 
   initPageModal(modalState: ModalsStateEntry) {
     const { contentElement } = modalState;
@@ -356,6 +368,8 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
   closeActiveModal() {
     // Сбрасываем состояния, которые могут помешать закрытию модального окна
     this.setState({ touchDown: false, switching: false });
+
+    window.removeEventListener('resize', this.updateModalTranslate, false);
 
     const { prevModal } = this.state;
     if (!prevModal) {

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -234,7 +234,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
     const modalState = this.modalsState[activeModal];
     // Отслеживаем изменение размеров viewport (Необходимо для iOS)
-    window.addEventListener('resize', this.updateModalTranslate, false);
+    this.window.addEventListener('resize', this.updateModalTranslate, false);
 
     switch (modalState.type) {
       case ModalType.PAGE:
@@ -369,7 +369,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     // Сбрасываем состояния, которые могут помешать закрытию модального окна
     this.setState({ touchDown: false, switching: false });
 
-    window.removeEventListener('resize', this.updateModalTranslate, false);
+    this.window.removeEventListener('resize', this.updateModalTranslate, false);
 
     const { prevModal } = this.state;
     if (!prevModal) {


### PR DESCRIPTION
related to #1489
## Before:
![Before](https://user-images.githubusercontent.com/36237725/112334198-50198980-8ccc-11eb-9c92-7544c7d23c4d.gif)

#### https://s0yss.csb.app/

## After:
![After](https://user-images.githubusercontent.com/36237725/112331572-15165680-8cca-11eb-9244-fa87f9b152d8.gif)

#### https://jg4u9.csb.app