### PR TITLE
PTR: left property caused improper spinner position in multi-colon structures

### DIFF
--- a/src/components/PullToRefresh/PullToRefresh.css
+++ b/src/components/PullToRefresh/PullToRefresh.css
@@ -8,7 +8,6 @@
 }
 
 .PullToRefresh__controls {
-  left: 0;
   width: 100%;
   pointer-events: none;
   /* Прямо под шапкой, см https://github.com/VKCOM/VKUI/issues/1207 */


### PR DESCRIPTION
## Before:
![Before](https://user-images.githubusercontent.com/36237725/112637166-ed043000-8e4e-11eb-98c6-9f54578199f9.gif)

## After:
![After](https://user-images.githubusercontent.com/36237725/112637186-f2fa1100-8e4e-11eb-8369-186f81083900.gif)

relates to #1483;