### PR TITLE
Use top inset to calculate layout offset properly on iOS

### DIFF
--- a/src/components/SplitLayout/SplitLayout.css
+++ b/src/components/SplitLayout/SplitLayout.css
@@ -19,7 +19,7 @@
 }
 
 .SplitLayout--ios .SplitLayout__inner--header {
-  margin-top: calc(-1 * var(--panelheader_height_ios));
+  margin-top: calc(-1 * calc(var(--panelheader_height_ios) + var(--safe-area-inset-top)));
 }
 
 .SplitLayout--android .SplitLayout__inner--header,


### PR DESCRIPTION
Проблема: на iOS при наличии PanelHeader в SplitLayout, основной контент поднимается вверх только на высоту хедера, без учета safe-area-inset

### Before:

<img width="1648" alt="CleanShot 2021-03-29 at 11 55 47@2x" src="https://user-images.githubusercontent.com/827338/112812698-18bd2b00-9086-11eb-871c-976011e7084c.png">

### After:

<img width="1648" alt="CleanShot 2021-03-29 at 11 56 10@2x" src="https://user-images.githubusercontent.com/827338/112812707-1a86ee80-9086-11eb-8b51-460ffa159ecb.png">
