### PR TITLE
Refactor: скролл View при переходах

### DIFF
--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -54,24 +54,6 @@ class FixedLayout extends React.Component<FixedLayoutProps & DOMProps & PanelCon
     return this.props.window;
   }
 
-  get currentPanel(): HTMLElement {
-    const elem = this.props.getPanelNode();
-
-    if (!elem) {
-      console.warn('[VKUI/FixedLayout] Panel element not found');
-    }
-
-    return elem;
-  }
-
-  get canTargetPanelScroll() {
-    const panelEl = this.currentPanel;
-    if (!panelEl) {
-      return true; // Всегда предпологаем, что может быть скролл в случае, если нет document
-    }
-    return panelEl.scrollHeight > panelEl.clientHeight;
-  }
-
   componentDidMount() {
     this.onMountResizeTimeout = setTimeout(() => this.doResize());
     this.window.addEventListener('resize', this.doResize);
@@ -89,16 +71,11 @@ class FixedLayout extends React.Component<FixedLayoutProps & DOMProps & PanelCon
   }
 
   onViewTransitionStart: EventListener = (e: CustomEvent<TransitionStartEventDetail>) => {
-    let panelScroll = e.detail.scrolls[this.props.panel] || 0;
-    const fromPanelHasScroll = this.props.panel === e.detail.from && panelScroll > 0;
-    const toPanelHasScroll = this.props.panel === e.detail.to && panelScroll > 0;
+    const { scrolls, from, to } = e.detail;
+    const { panel } = this.props;
+    let panelScroll = scrolls[panel] || 0;
 
-    // если переход назад - анимация только у панели с которой уходим (detail.from), и подстраиваться под скролл надо только на ней
-    const panelAnimated = !(this.props.panel === e.detail.to && e.detail.isBack);
-
-    // Для панелей, с которых уходим всегда выставляется скролл
-    // Для панелей на которые приходим надо смотреть, есть ли браузерный скролл и применяется ли к ней анимация перехода:
-    if (fromPanelHasScroll || toPanelHasScroll && this.canTargetPanelScroll && panelAnimated) {
+    if (panelScroll > 0 && (panel === from || panel === to)) {
       this.setState({
         position: 'absolute',
         top: this.el.offsetTop + panelScroll,

--- a/src/components/View/View.css
+++ b/src/components/View/View.css
@@ -7,11 +7,6 @@
   word-wrap: break-word;
 }
 
-.View--animated,
-.View--swiping-back {
-  overflow: hidden;
-}
-
 .View__header {
   z-index: 2;
   position: fixed;
@@ -42,8 +37,8 @@
   height: 100%;
 }
 
-.View--animated .View__panel,
-.View--swiping-back .View__panel {
+.View--animated .View__panel--next,
+.View--swiping-back .View__panel--swipe-back-next {
   position: fixed;
   top: 0;
   left: 0;

--- a/src/components/View/View.css
+++ b/src/components/View/View.css
@@ -42,7 +42,6 @@
   position: fixed;
   top: 0;
   left: 0;
-  overflow: hidden;
 }
 
 .View__popout {

--- a/src/components/View/View.css
+++ b/src/components/View/View.css
@@ -83,6 +83,11 @@
 /**
  * Panel transition
  */
+
+.View--animated .View__panel {
+  transform: translateZ(0);
+}
+
 .View__panel--next ~ .View__panel--prev {
   animation: vkui-animation-view-prev-back .3s var(--android-easing);
 }

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -4,7 +4,6 @@ import { transitionEvent, animationEvent } from '../../lib/supportEvents';
 import { getClassName } from '../../helpers/getClassName';
 import { IOS, ANDROID, VKCOM } from '../../lib/platform';
 import Touch, { TouchEvent } from '../Touch/Touch';
-import { removeObjectKeys } from '../../lib/removeObjectKeys';
 import { HasPlatform } from '../../types';
 import { withPlatform } from '../../hoc/withPlatform';
 import { withContext } from '../../hoc/withContext';
@@ -184,7 +183,6 @@ class View extends Component<ViewProps & DOMProps, ViewState> {
         swipeBackShift: 0,
         activePanel: nextPanel,
         visiblePanels: [nextPanel],
-        scrolls: removeObjectKeys(prevState.scrolls, [prevState.swipeBackPrevPanel]),
       }, () => {
         this.document.dispatchEvent(createCustomEvent(this.window, transitionEndEventName));
         this.pickPanel(this.state.activePanel).style.top = null;
@@ -304,7 +302,6 @@ class View extends Component<ViewProps & DOMProps, ViewState> {
         activePanel: activePanel,
         animated: false,
         isBack: undefined,
-        scrolls: isBack ? removeObjectKeys(this.state.scrolls, [prevPanel]) : this.state.scrolls,
       }, () => {
         this.pickPanel(activePanel).style.top = null;
         this.window.scrollTo(0, isBack ? this.state.scrolls[activePanel] : 0);

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -27,7 +27,6 @@ export type TransitionStartEventDetail = {
   scrolls: Scrolls;
   from: string;
   to: string;
-  isBack: boolean;
 };
 
 interface ViewsScrolls {
@@ -201,7 +200,6 @@ class View extends Component<ViewProps & DOMProps, ViewState> {
         detail: {
           from: this.state.prevPanel,
           to: this.state.nextPanel,
-          isBack: this.state.isBack,
           scrolls,
         },
       };


### PR DESCRIPTION
До перехода на следующую панель сохраняем скролл предыдущей
- Высота приложения не схлопывается во время перехода
- fixes #1187 (кажется)