### PR TITLE
WIP: Added opportunity to render multioptions item

### DIFF
--- a/src/components/ChipsSelect/useChipsSelect.ts
+++ b/src/components/ChipsSelect/useChipsSelect.ts
@@ -4,7 +4,7 @@ import { useChipsInput } from '../ChipsInput/useChipsInput';
 import { ChipsSelectProps } from './ChipsSelect';
 
 export const useChipsSelect = <Option extends ChipsInputOption>(props: Partial<ChipsSelectProps<Option>>) => {
-  const { options, filterFn, getOptionLabel, getOptionValue, showSelected } = props;
+  const { options, filterFn, getOptionLabel, getOptionValue, showSelected, getItemsFromOptions } = props;
 
   const [opened, setOpened] = useState(false);
   const [focusedOptionIndex, setFocusedOptionIndex] = useState<number>(0);
@@ -42,8 +42,10 @@ export const useChipsSelect = <Option extends ChipsInputOption>(props: Partial<C
     return [...filteredSet];
   }, [showSelected, filteredOptions, selectedOptions]);
 
+  const suggestItems = useMemo(() => getItemsFromOptions(filteredOptions), [filteredOptions, getItemsFromOptions])
+
   return {
     ...chipsInputState, fieldValue, handleInputChange, opened, setOpened, filteredOptions,
-    focusedOptionIndex, setFocusedOptionIndex, focusedOption, setFocusedOption, selectedOptions,
+    focusedOptionIndex, setFocusedOptionIndex, focusedOption, setFocusedOption, selectedOptions, suggestItems,
   };
 };


### PR DESCRIPTION
### Описание проблемы: 
Есть потребность сделать селект подобного вида:

<details>
  <summary>Скриншот</summary>
  
  ![Гиперселект](https://sun9-7.userapi.com/impg/qZbqfD57gHBvaVqZ320Mx8C18sNSdzdqbAVRtw/oMz-WeAlr2g.jpg?size=896x650&quality=96&sign=2d268eb344c6da8139274881033453a2&type=album)
</details>



Таким образом, один итем саджеста должен содержать несколько опшенов. Сейчас так сделать нельзя так как опшены рендерятся в итемы саджеста один к одному с жесткой привязкой. 

Тоесть с помощью кастомных `renderOption` можно отрисовать саджест подобной структуры, если передавать в `options` массив структур `Item`, где сгруппированы по 6 вариантов настоящих опций, которые можно выбирать. Но так как `ChipsSelect` оперирует внутренним стейтом, ставит и реплейсит в инпуте именно сущности, переданные в массиве `options` и из-за жесткой привязки, как например [тут](https://github.com/VKCOM/VKUI/blob/master/src/components/ChipsSelect/ChipsSelect.tsx#L308),  селектить опции в сущностях `Item` в текущей реализации не представляется возможным.

---

### Описание решения: 

Получается, что выделяется сущность `SuggestItem`, которая может быть как `option`, так и содержать в себе несколько `option`, ее так же можно кастомно рендерить и самое главное с новой сущность каждый `option` не будет привязан к итему саджеста в соотношении один к одному.

- Для того чтобы замапить `options` в `SuggestItems` вводится новый проп `getItemsFromOptions` - [дефолтная реализация](https://github.com/VKCOM/VKUI/pull/1520/files#diff-37faafaf80a691262744bcf9ac84bae0263fd2359e694ff23e76c49a5649d997R375) оставляет маппинг `options` в `SuggestItems` один к одному
- Для кастомного отображения итемов саджеста вводится проп `renderItem`, куда должен передаваться `renderOption` и ф-ция по получению свойств `option` - [дефолтная реализация](https://github.com/VKCOM/VKUI/pull/1520/files#diff-37faafaf80a691262744bcf9ac84bae0263fd2359e694ff23e76c49a5649d997R364) 
- Для извлечения `options` из `SuggestItem` вводится проп `getOptionsFromItem`

При таком решении и с дефолтной реализацией новых методов остается обратная совместимость

**_Данный пулл-реквест - черновик, показывающий примерную реализацию в коде, который не учитывает пока всего (например правки при навигации клавишами), а просто иллюстрирует идею._**

---

Есть также альтернатива, сделать полностью кастомное отображение саджеста: 
- с одной стороны большие возможности кастомизации 
- с другой стороны - это возможность дает переписывать, реализовывать заново около половины всего компонента
