### PR TITLE
Фикс для двойного срабатывания OnClose в ActionSheet

### DIFF
--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -52,6 +52,7 @@ const ActionSheetItem: React.FunctionComponent<ActionSheetItemProps> = ({
   if (restProps.href) {
     Component = 'a';
   }
+
   const isCompact = hasReactNode(subtitle) || hasReactNode(meta) || selectable;
 
   return (

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -51,10 +51,7 @@ const ActionSheetItem: React.FunctionComponent<ActionSheetItemProps> = ({
 
   if (restProps.href) {
     Component = 'a';
-  } else if (selectable) {
-    Component = 'label';
   }
-
   const isCompact = hasReactNode(subtitle) || hasReactNode(meta) || selectable;
 
   return (


### PR DESCRIPTION
Фикс для этой задачи: https://github.com/VKCOM/VKUI/issues/1518
Проблема: Проблема возникала из-за того, что у ActionSheetItem label афектил еще и инпут при указании selectable проспа у ActionSheetItem
