### PR TITLE
Docs: Add react profiler in styleguide

### DIFF
--- a/styleguide/Components/PlaygroundRenderer.js
+++ b/styleguide/Components/PlaygroundRenderer.js
@@ -32,7 +32,8 @@ class PlaygroundRenderer extends React.Component {
       previewProps,
       tabButtons,
       tabBody,
-      toolbar
+      toolbar,
+      exampleIndex,
     } = this.props;
     const {
       autoLayout,
@@ -41,11 +42,12 @@ class PlaygroundRenderer extends React.Component {
       config,
       ...wrapperProps
     } = previewProps;
+    const exampleId = `${name}-${exampleIndex}`;
 
     return (
       <div className={classes.root}>
         <div className={cx(classes.preview, wrapperProps.className)} {...wrapperProps} data-preview={name}>
-          { cloneElement(preview, { ...preview.props, autoLayout, containerStyle, integration, config }) }
+          { cloneElement(preview, { ...preview.props, autoLayout, containerStyle, integration, config, exampleId }) }
         </div>
         <div className={classes.controls}>
           <div className={classes.tabs}>{tabButtons}</div>

--- a/styleguide/Components/Preview.js
+++ b/styleguide/Components/Preview.js
@@ -7,8 +7,9 @@ import ReactFrame  from 'react-frame-component';
 import { StyleGuideContext } from './StyleGuideRenderer';
 import { VKCOM, SplitCol, SplitLayout, withAdaptivity, ViewWidth, PanelHeader, usePlatform, AppRoot, ConfigProvider, AdaptivityProvider } from '../../src';
 import { DOMContext } from '../../src/lib/dom';
+import { perfLogger } from '../utils';
 
-const logPerf = (id, phase, time) => console.log(id, phase, time);
+const logPerf = (id, phase, time) => perfLogger.log(`${id}.${phase}`, time);
 
 class FrameDomProvider extends React.Component {
   static contextTypes = {
@@ -125,7 +126,7 @@ export default class Preview extends PreviewParent {
   frameRef = React.createRef();
 
   render() {
-    const { code, autoLayout = 'all', config = {} } = this.props;
+    const { code, autoLayout = 'all', config = {}, exampleId } = this.props;
     const { error, isVisible } = this.state;
     return (
       <StyleGuideContext.Consumer>
@@ -190,7 +191,7 @@ export default class Preview extends PreviewParent {
               >
                 <FrameDomProvider>
                   {!(isEmbedded && this.state.hideEmbeddedApp) &&
-                    <Profiler id="App" onRender={logPerf}>
+                    <Profiler id={exampleId} onRender={logPerf}>
                       <ConfigProvider
                         platform={styleGuideContext.platform}
                         scheme={styleGuideContext.scheme}

--- a/styleguide/Components/Preview.js
+++ b/styleguide/Components/Preview.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Profiler } from 'react';
 import PreviewParent from 'react-styleguidist/lib/client/rsg-components/Preview/Preview';
 import ReactExample from 'react-styleguidist/lib/client/rsg-components/ReactExample/ReactExample';
 import PlaygroundError from 'react-styleguidist/lib/client/rsg-components/PlaygroundError';
@@ -7,6 +7,8 @@ import ReactFrame  from 'react-frame-component';
 import { StyleGuideContext } from './StyleGuideRenderer';
 import { VKCOM, SplitCol, SplitLayout, withAdaptivity, ViewWidth, PanelHeader, usePlatform, AppRoot, ConfigProvider, AdaptivityProvider } from '../../src';
 import { DOMContext } from '../../src/lib/dom';
+
+const logPerf = (id, phase, time) => console.log(id, phase, time);
 
 class FrameDomProvider extends React.Component {
   static contextTypes = {
@@ -188,16 +190,18 @@ export default class Preview extends PreviewParent {
               >
                 <FrameDomProvider>
                   {!(isEmbedded && this.state.hideEmbeddedApp) &&
-                    <ConfigProvider
-                      platform={styleGuideContext.platform}
-                      scheme={styleGuideContext.scheme}
-                      webviewType={styleGuideContext.webviewType}
-                      {...config}
-                    >
-                      <AdaptivityProvider hasMouse={styleGuideContext.hasMouse}>
-                        {example}
-                      </AdaptivityProvider>
-                    </ConfigProvider>
+                    <Profiler id="App" onRender={logPerf}>
+                      <ConfigProvider
+                        platform={styleGuideContext.platform}
+                        scheme={styleGuideContext.scheme}
+                        webviewType={styleGuideContext.webviewType}
+                        {...config}
+                      >
+                        <AdaptivityProvider hasMouse={styleGuideContext.hasMouse}>
+                          {example}
+                        </AdaptivityProvider>
+                      </ConfigProvider>
+                    </Profiler>
                   }
                 </FrameDomProvider>
               </div>

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -237,7 +237,9 @@ module.exports = {
   webpackConfig: merge(webpackConfig, {
     resolve: {
       alias: {
-        'rsg-components/Preview': path.join(__dirname, './Components/Preview')
+        'rsg-components/Preview': path.join(__dirname, './Components/Preview'),
+        'react-dom$': 'react-dom/profiling',
+        'scheduler/tracing': 'scheduler/tracing-profiling',
       }
     }
   })

--- a/styleguide/setup.js
+++ b/styleguide/setup.js
@@ -7,7 +7,7 @@ import * as VKUI from '../src';
 import * as VKUIUnstable from '../src/unstable';
 import { createMasks } from '../src/components/UsersStack/masks';
 import * as Icons from '@vkontakte/icons';
-import { getRandomInt, getRandomUser, getRandomUsers, importantCountries, getAvatarUrl } from './utils';
+import { getRandomInt, getRandomUser, getRandomUsers, importantCountries, getAvatarUrl, perfLogger } from './utils';
 
 const ui = { ...VKUI, ...VKUIUnstable };
 
@@ -44,6 +44,7 @@ window.getRandomUser = getRandomUser;
 window.getRandomUsers = getRandomUsers;
 window.importantCountries = importantCountries;
 window.getAvatarUrl = getAvatarUrl;
+window.perfLogger = perfLogger;
 
 window.useState = useState;
 window.useRef = useRef;

--- a/styleguide/utils.js
+++ b/styleguide/utils.js
@@ -157,3 +157,19 @@ export const importantCountries = [{
   id: 18,
   title: 'Узбекистан',
 }];
+
+export const perfLogger = {
+  _isEnabled: localStorage.getItem('vkui:perf-logging') === 'true',
+  set isEnabled(value) {
+    localStorage.setItem('vkui:perf-logging', value);
+    this._isEnabled = value;
+  },
+  get isEnabled() {
+    return this._isEnabled;
+  },
+  log(event, duration) {
+    if (this.isEnabled) {
+      console.log(event, Number(duration.toFixed(2)));
+    }
+  }
+};


### PR DESCRIPTION
1. В проде используем профилировочную сборку реакта
2. В консоли можно `perfLogger.isEnabled = true`, и тайминги примеров будут падать в консоль