### PR TITLE
[Bug] #1527 Cell с атрибутом removable не обрезает children

### DIFF
--- a/src/components/Cell/Cell.css
+++ b/src/components/Cell/Cell.css
@@ -41,6 +41,10 @@
   display: none;
 }
 
+.Cell--selectable .Cell__marker {
+  margin-right: 16px;
+}
+
 .Cell--selectable.Cell--disabled {
   opacity: .6;
 }
@@ -53,42 +57,35 @@
   display: none;
 }
 
-/* iOS */
+.Cell--removable .SimpleCell {
+  max-width: 100%;
+  flex-grow: 1;
+  min-width: 0;
+  padding-right: 2px;
+  flex-shrink: initial;
+  overflow: hidden;
+}
 
+/**
+ * iOS
+ */
 .Cell--ios .Cell__in {
   transition: transform .6s var(--ios-easing);
 }
 
-.Cell--ios .Cell__marker {
+.Cell--ios.Cell--selectable .Cell__marker {
   margin-right: 12px;
-}
-
-.Cell--ios .Removable {
-  padding-left: 12px;
 }
 
 .Cell--ios.Cell--removable .SimpleCell {
   padding-left: 0;
+  padding-right: 12px;
 }
 
-/* Android */
-
+/**
+ * ANDROID & VKCOM
+ */
 .Cell--android .Cell__dragger,
 .Cell--vkcom .Cell__dragger {
   padding-right: 16px;
-}
-
-.Cell--android .Cell__marker,
-.Cell--vkcom .Cell__marker {
-  margin-right: 16px;
-}
-
-.Cell--android .Removable,
-.Cell--vkcom .Removable {
-  padding-right: 6px;
-}
-
-.Cell--android.Cell--removable .SimpleCell,
-.Cell--vkcom.Cell--removable .SimpleCell {
-  padding-right: 0;
 }

--- a/src/components/Cell/Cell.e2e.tsx
+++ b/src/components/Cell/Cell.e2e.tsx
@@ -1,0 +1,27 @@
+import { Cell } from './Cell';
+import { describeScreenshotFuzz } from '../../testing/e2e/utils';
+import Avatar from '../Avatar/Avatar';
+
+describe('Cell', () => {
+  describeScreenshotFuzz(Cell, [{
+    selectable: [true],
+    before: [<Avatar key="avatar" />],
+    children: ['Мария Саломея Склодовская-Кюри', 'Михаил Лихачев'],
+    $adaptivity: 'y',
+    checked: [true, false],
+    disabled: [true, false],
+    multiline: [true, false],
+  },
+  {
+    removable: [true],
+    $adaptivity: 'y',
+    children: ['Мария Саломея Склодовская-Кюри', 'Евгения Полозова'],
+    multiline: [true, false],
+  },
+  {
+    draggable: [true],
+    $adaptivity: 'y',
+    children: ['Мария Саломея Склодовская-Кюри', 'Артур Стамбульцян'],
+    multiline: [true, false],
+  }]);
+});

--- a/src/components/Cell/__image_snapshots__/cell-android-bright_light-1-snap.png
+++ b/src/components/Cell/__image_snapshots__/cell-android-bright_light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e793fb3a6c47e1cec281d282218eed93d79a908ccc619c3487ed48ac4e884470
+size 537800

--- a/src/components/Cell/__image_snapshots__/cell-android-space_gray-1-snap.png
+++ b/src/components/Cell/__image_snapshots__/cell-android-space_gray-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe5b740c10788f9baa3825953a4906a239ab5cfdeedae1a1443af9d1cae4dd52
+size 540953

--- a/src/components/Cell/__image_snapshots__/cell-ios-bright_light-1-snap.png
+++ b/src/components/Cell/__image_snapshots__/cell-ios-bright_light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35f512c1f17d6afb25cb6138f3b6ed6ee42fb5bc686424b6a2952a18b8fb2d64
+size 541385

--- a/src/components/Cell/__image_snapshots__/cell-ios-space_gray-1-snap.png
+++ b/src/components/Cell/__image_snapshots__/cell-ios-space_gray-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99482f63928f9c36d081bcaef0818879a972c5cc8ceacb262a3f99ddfe81ea6f
+size 544772

--- a/src/components/Cell/__image_snapshots__/cell-vkcom-vkcom-1-snap.png
+++ b/src/components/Cell/__image_snapshots__/cell-vkcom-vkcom-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7d8659f0964b014dc9591c565368fbac1197ecbbefbc7bcfcb3f448836ee97d
+size 233190

--- a/src/components/FormItem/FormItem.css
+++ b/src/components/FormItem/FormItem.css
@@ -1,6 +1,14 @@
 .FormItem {
-  padding: 12px 16px;
   display: block;
+  padding: 12px 16px;
+}
+
+.FormItem__removable {
+  flex-grow: 1;
+  flex-shrink: initial;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .FormItem__top {
@@ -50,8 +58,7 @@
  * iOS
  */
 
-.FormItem--ios,
-.FormItem--ios .Removable {
+.FormItem--ios {
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -61,27 +68,7 @@
 .FormItem--ios .RichCell,
 .FormItem--ios .CellButton,
 .FormItem--ios .Radio,
-.FormItem--ios .Checkbox,
-.FormItem--ios .Removable {
+.FormItem--ios .Checkbox {
   margin-left: -12px;
   margin-right: -12px;
-}
-
-/**
- * ANDROID & VKCOM
- */
-
-.FormItem--android .Removable__remove,
-.FormItem--vkcom .Removable__remove {
-  margin-top: -2px;
-  margin-bottom: -2px;
-  margin-right: -16px;
-}
-
-.FormItem--android.FormItem--sizeY-compact .Removable__remove,
-.FormItem--vkcom.FormItem--sizeY-compact .Removable__remove {
-  margin-left: 2px;
-  margin-right: -14px;
-  margin-top: -4px;
-  margin-bottom: -4px;
 }

--- a/src/components/FormItem/FormItem.css
+++ b/src/components/FormItem/FormItem.css
@@ -72,3 +72,11 @@
   margin-left: -12px;
   margin-right: -12px;
 }
+
+.FormLayoutGroup .Removable .FormItem--ios.FormItem--withTop {
+  margin-top: -28px;
+}
+
+.FormLayoutGroup .Removable .FormItem--ios.FormItem--sizeY-compact.FormItem--withTop {
+  margin-top: -26px;
+}

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -60,7 +60,9 @@ export const FormItem: FC<FormItemProps> = withAdaptivity((props: FormItemProps 
     >
       {removable ? (
         <Removable align="start" onRemove={onRemove} removePlaceholder={removePlaceholder}>
-          <div>{wrappedChildren}</div>
+          <div vkuiClass="FormItem__removable">
+            {wrappedChildren}
+          </div>
         </Removable>
       ) : wrappedChildren}
     </Component>

--- a/src/components/FormLayoutGroup/FormLayoutGroup.css
+++ b/src/components/FormLayoutGroup/FormLayoutGroup.css
@@ -1,7 +1,7 @@
 .FormLayoutGroup--horizontal {
   padding: 12px 16px;
   display: flex;
-  flex-direction: row;
+  flex-flow: row nowrap;
 }
 
 .FormLayoutGroup--horizontal .FormItem {
@@ -24,30 +24,4 @@
 .FormLayoutGroup--ios.FormLayoutGroup--horizontal {
   padding-left: 12px;
   padding-right: 12px;
-}
-
-.FormLayoutGroup--ios .Removable {
-  margin-left: -12px;
-  margin-right: -12px;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-/**
- * ANDROID & VKCOM
- */
-
-.FormLayoutGroup--android .Removable__remove,
-.FormLayoutGroup--vkcom .Removable__remove {
-  margin-top: -2px;
-  margin-bottom: -2px;
-  margin-right: -16px;
-}
-
-.FormLayoutGroup--android.FormLayoutGroup--sizeY-compact .Removable__remove,
-.FormLayoutGroup--vkcom.FormLayoutGroup--sizeY-compact .Removable__remove {
-  margin-left: 2px;
-  margin-right: -14px;
-  margin-top: -4px;
-  margin-bottom: -4px;
 }

--- a/src/components/IconButton/IconButton.css
+++ b/src/components/IconButton/IconButton.css
@@ -49,6 +49,10 @@
   opacity: .6;
 }
 
+.Removable .IconButton {
+  color: var(--icon_secondary);
+}
+
 /*
  * Android
  */

--- a/src/components/IconButton/IconButton.css
+++ b/src/components/IconButton/IconButton.css
@@ -49,7 +49,7 @@
   opacity: .6;
 }
 
-.Removable .IconButton {
+.Removable__action .IconButton .Icon {
   color: var(--icon_secondary);
 }
 

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -36,7 +36,8 @@
   align-self: flex-start;
 }
 
-.FormItem .Removable {
+.FormItem .Removable,
+.FormLayoutGroup .Removable {
   padding-left: 16px;
   padding-right: 16px;
   margin-left: -16px;
@@ -131,7 +132,8 @@
   margin-right: 0;
 }
 
-.FormItem .Removable--ios {
+.FormItem .Removable--ios,
+.FormLayoutGroup .Removable--ios {
   padding-left: 12px;
   padding-right: 12px;
   margin-left: -12px;
@@ -142,14 +144,18 @@
  * ANDROID & VKCOM
  */
 .FormItem .Removable--android .Removable__remove,
-.FormItem .Removable--vkcom .Removable__remove {
+.FormItem .Removable--vkcom .Removable__remove,
+.FormLayoutGroup .Removable--android .Removable__remove,
+.FormLayoutGroup .Removable--vkcom .Removable__remove {
    margin-top: -2px;
    margin-right: -16px;
    margin-bottom: -2px;
 }
 
 .FormItem--sizeY-compact .Removable--android .Removable__remove,
-.FormItem--sizeY-compact .Removable--vkcom .Removable__remove {
+.FormItem--sizeY-compact .Removable--vkcom .Removable__remove,
+.FormLayoutGroup--sizeY-compact .Removable--android .Removable__remove,
+.FormLayoutGroup--sizeY-compact .Removable--vkcom .Removable__remove {
    margin-left: 2px;
    margin-top: -4px;
    margin-right: -14px;

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -18,10 +18,6 @@
   border: none;
 }
 
-.Removable__action.Removable__action {
-  color: var(--icon_secondary);
-}
-
 .Removable__action:focus {
   outline: none;
 }

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -1,8 +1,8 @@
 .Removable {
   position: relative;
-  box-sizing: border-box;
   min-width: 0;
-  flex-grow: 1;
+  width: 100%;
+  max-width: 100%;
 }
 
 .Removable__content {
@@ -45,6 +45,11 @@
 .FormItem--withTop .Removable--sizeY-compact .Removable__control,
 .Removable--sizeY-compact .FormItem--withTop ~ .Removable__control {
   top: 26px;
+}
+
+.Cell .Removable {
+  padding-right: 6px;
+  box-sizing: border-box;
 }
 
 /**
@@ -112,6 +117,14 @@
   background-color: var(--white);
 }
 
+.Cell .Removable--ios {
+  padding-right: 0;
+}
+
+.Cell .Removable--ios .Removable__indicator {
+  margin-left: 0;
+  margin-right: 0;
+}
 /**
  * Android & VKCOM
  */

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -11,10 +11,6 @@
   align-items: center;
 }
 
-.Removable__indicator {
-  order: -1;
-}
-
 .Removable__control,
 .Removable__remove {
   position: relative;
@@ -128,7 +124,7 @@
 }
 
 .Cell .Removable--ios .Removable__indicator {
-  margin-left: 0;
+  margin-left: 2px;
   margin-right: 0;
 }
 
@@ -138,6 +134,21 @@
   padding-right: 12px;
   margin-left: -12px;
   margin-right: -12px;
+}
+
+.FormLayoutGroup .Removable--ios .Removable__content {
+  flex-wrap: wrap;
+}
+
+.FormLayoutGroup .Removable--ios .FormItem--withTop ~ .Removable__offset {
+  order: -1;
+  display: block;
+  width: 100%;
+  height: 28px;
+}
+
+.FormLayoutGroup .Removable--ios.Removable--sizeY-compact .FormItem--withTop ~ .Removable__offset {
+  height: 26px;
 }
 
 /**

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -11,24 +11,22 @@
   align-items: center;
 }
 
-.Removable__control,
-.Removable__remove {
+.Removable__action {
   position: relative;
   flex-grow: 0;
   flex-shrink: 0;
   border: none;
 }
 
-.Removable__control.Removable__remove {
+.Removable__action.Removable__action {
   color: var(--icon_secondary);
 }
 
-.Removable__control:focus,
-.Removable__remove:focus {
+.Removable__action:focus {
   outline: none;
 }
 
-.Removable--start .Removable__control {
+.Removable--start .Removable__action {
   align-self: flex-start;
 }
 
@@ -40,13 +38,13 @@
   margin-right: -16px;
 }
 
-.FormItem--withTop .Removable__control,
-.FormItem--withTop ~ .Removable__control {
+.FormItem--withTop .Removable__action,
+.FormItem--withTop ~ .Removable__action {
   top: 28px;
 }
 
-.FormItem--withTop .Removable--sizeY-compact .Removable__control,
-.Removable--sizeY-compact .FormItem--withTop ~ .Removable__control {
+.FormItem--withTop .Removable--sizeY-compact .Removable__action,
+.Removable--sizeY-compact .FormItem--withTop ~ .Removable__action {
   top: 26px;
 }
 
@@ -66,7 +64,7 @@
   transition: transform .6s var(--ios-easing);
 }
 
-.Removable--ios .Removable__remove {
+.Removable--ios .Removable__action--remove {
   position: absolute;
   left: 100%;
   top: 0;
@@ -82,7 +80,7 @@
   transition: transform .6s var(--ios-easing);
 }
 
-.Removable--ios .Removable__indicator {
+.Removable--ios .Removable__action--indicator {
   display: block;
   width: 44px;
   height: 44px;
@@ -92,13 +90,13 @@
   background: none;
 }
 
-.Removable--ios.Removable--sizeY-compact .Removable__indicator {
+.Removable--ios.Removable--sizeY-compact .Removable__action--indicator {
   height: 36px;
   padding-top: 7px;
   padding-bottom: 7px;
 }
 
-.Removable--ios .Removable__indicator-in {
+.Removable--ios .Removable__action--indicator .Removable__action-in {
   position: relative;
   display: block;
   width: 22px;
@@ -108,7 +106,7 @@
   border: none;
 }
 
-.Removable--ios .Removable__indicator-in::before {
+.Removable--ios .Removable__action--indicator .Removable__action-in::before {
   content: "";
   position: absolute;
   top: 10px;
@@ -123,7 +121,7 @@
   padding-right: 0;
 }
 
-.Cell .Removable--ios .Removable__indicator {
+.Cell .Removable--ios .Removable__action--indicator {
   margin-left: 2px;
   margin-right: 0;
 }
@@ -154,19 +152,19 @@
 /**
  * ANDROID & VKCOM
  */
-.FormItem .Removable--android .Removable__remove,
-.FormItem .Removable--vkcom .Removable__remove,
-.FormLayoutGroup .Removable--android .Removable__remove,
-.FormLayoutGroup .Removable--vkcom .Removable__remove {
+.FormItem .Removable--android .Removable__action,
+.FormItem .Removable--vkcom .Removable__action,
+.FormLayoutGroup .Removable--android .Removable__action,
+.FormLayoutGroup .Removable--vkcom .Removable__action {
    margin-top: -2px;
    margin-right: -16px;
    margin-bottom: -2px;
 }
 
-.FormItem--sizeY-compact .Removable--android .Removable__remove,
-.FormItem--sizeY-compact .Removable--vkcom .Removable__remove,
-.FormLayoutGroup--sizeY-compact .Removable--android .Removable__remove,
-.FormLayoutGroup--sizeY-compact .Removable--vkcom .Removable__remove {
+.FormItem--sizeY-compact .Removable--android .Removable__action,
+.FormItem--sizeY-compact .Removable--vkcom .Removable__action,
+.FormLayoutGroup--sizeY-compact .Removable--android .Removable__action,
+.FormLayoutGroup--sizeY-compact .Removable--vkcom .Removable__action {
    margin-left: 2px;
    margin-top: -4px;
    margin-right: -14px;

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -9,25 +9,25 @@
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
-  max-width: 100%;
-}
-
-.Removable__content > * {
-  flex-grow: 1;
 }
 
 .Removable__indicator {
   order: -1;
 }
 
-.Removable__indicator,
+.Removable__control,
 .Removable__remove {
+  position: relative;
   flex-grow: 0;
   flex-shrink: 0;
   border: none;
 }
 
-.Removable__indicator:focus,
+.Removable__control.Removable__remove {
+  color: var(--icon_secondary);
+}
+
+.Removable__control:focus,
 .Removable__remove:focus {
   outline: none;
 }
@@ -36,9 +36,15 @@
   align-self: flex-start;
 }
 
+.FormItem .Removable {
+  padding-left: 16px;
+  padding-right: 16px;
+  margin-left: -16px;
+  margin-right: -16px;
+}
+
 .FormItem--withTop .Removable__control,
 .FormItem--withTop ~ .Removable__control {
-  position: relative;
   top: 28px;
 }
 
@@ -55,7 +61,6 @@
 /**
  * iOS
  */
-
 .Removable--ios {
   overflow: hidden;
 }
@@ -125,11 +130,28 @@
   margin-left: 0;
   margin-right: 0;
 }
-/**
- * Android & VKCOM
- */
 
-.Removable--android .Removable__remove,
-.Removable--vkcom .Removable__remove {
-  color: var(--icon_secondary);
+.FormItem .Removable--ios {
+  padding-left: 12px;
+  padding-right: 12px;
+  margin-left: -12px;
+  margin-right: -12px;
+}
+
+/**
+ * ANDROID & VKCOM
+ */
+.FormItem .Removable--android .Removable__remove,
+.FormItem .Removable--vkcom .Removable__remove {
+   margin-top: -2px;
+   margin-right: -16px;
+   margin-bottom: -2px;
+}
+
+.FormItem--sizeY-compact .Removable--android .Removable__remove,
+.FormItem--sizeY-compact .Removable--vkcom .Removable__remove {
+   margin-left: 2px;
+   margin-top: -4px;
+   margin-right: -14px;
+   margin-bottom: -4px;
 }

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -1,5 +1,6 @@
 import { AllHTMLAttributes, FC, ReactNode, MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { classNames } from '../../lib/classNames';
+import { getTitleFromChildren } from '../../lib/utils';
 import { usePlatform } from '../../hooks/usePlatform';
 import { getClassName } from '../../helpers/getClassName';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
@@ -73,7 +74,7 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
     };
   }, [deactivateRemove]);
 
-  const removePlaceholderString: string = removePlaceholder.toString();
+  const removePlaceholderString: string = getTitleFromChildren(removePlaceholder);
 
   return (
     <div

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -73,6 +73,8 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
     };
   }, [deactivateRemove]);
 
+  const removePlaceholderString: string = removePlaceholder.toString();
+
   return (
     <div
       {...restProps}
@@ -86,13 +88,22 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
         {children}
 
         {(platform === ANDROID || platform === VKCOM) &&
-          <IconButton vkuiClass="Removable__control Removable__remove" onClick={onRemoveClick}>
-            <Icon24Cancel />
+          <IconButton
+            aria-label={removePlaceholderString}
+            vkuiClass="Removable__control Removable__remove"
+            onClick={onRemoveClick}
+          >
+            <Icon24Cancel aria-hidden="true" />
           </IconButton>
         }
+
         {platform === IOS && (
-          <button vkuiClass="Removable__control Removable__indicator" onClick={onRemoveActivateClick}>
-            <i vkuiClass="Removable__indicator-in" />
+          <button
+            aria-label={removePlaceholderString}
+            vkuiClass="Removable__control Removable__indicator"
+            onClick={onRemoveActivateClick}
+          >
+            <i vkuiClass="Removable__indicator-in" aria-hidden="true" />
           </button>
         )}
       </div>

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -85,6 +85,16 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
       )}
     >
       <div vkuiClass="Removable__content" style={platform === IOS ? { transform: `translateX(-${removeOffset}px)` } : null}>
+        {platform === IOS && (
+          <button
+            aria-label={removePlaceholderString}
+            vkuiClass="Removable__control Removable__indicator"
+            onClick={onRemoveActivateClick}
+          >
+            <i vkuiClass="Removable__indicator-in" aria-hidden="true" />
+          </button>
+        )}
+
         {children}
 
         {(platform === ANDROID || platform === VKCOM) &&
@@ -97,19 +107,12 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
           </IconButton>
         }
 
-        {platform === IOS && (
-          <button
-            aria-label={removePlaceholderString}
-            vkuiClass="Removable__control Removable__indicator"
-            onClick={onRemoveActivateClick}
-          >
-            <i vkuiClass="Removable__indicator-in" aria-hidden="true" />
-          </button>
-        )}
+        <span vkuiClass="Removable__offset" aria-hidden="true"></span>
       </div>
 
       {platform === IOS &&
         <button
+          tabIndex={isRemoveActivated ? null : -1}
           ref={removeButtonRef}
           vkuiClass="Removable__remove"
           onClick={onRemoveClick}

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -1,4 +1,4 @@
-import { AllHTMLAttributes, FC, ReactNode, MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
+import React, { AllHTMLAttributes, FC, ReactNode, MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { classNames } from '../../lib/classNames';
 import { getTitleFromChildren } from '../../lib/utils';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -85,20 +85,10 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
         `Removable--sizeY-${sizeY}`,
       )}
     >
-      <div vkuiClass="Removable__content" style={platform === IOS ? { transform: `translateX(-${removeOffset}px)` } : null}>
-        {platform === IOS && (
-          <button
-            aria-label={removePlaceholderString}
-            vkuiClass="Removable__action Removable__action--indicator"
-            onClick={onRemoveActivateClick}
-          >
-            <i vkuiClass="Removable__action-in" aria-hidden="true" />
-          </button>
-        )}
+      {(platform === ANDROID || platform === VKCOM) && (
+        <div vkuiClass="Removable__content">
+          {children}
 
-        {children}
-
-        {(platform === ANDROID || platform === VKCOM) &&
           <IconButton
             aria-label={removePlaceholderString}
             vkuiClass="Removable__action Removable__action--remove"
@@ -106,22 +96,36 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
           >
             <Icon24Cancel aria-hidden="true" />
           </IconButton>
-        }
+        </div>
+      )}
 
-        <span vkuiClass="Removable__offset" aria-hidden="true"></span>
-      </div>
+      {platform === IOS && (
+        <React.Fragment>
+          <div vkuiClass="Removable__content" style={{ transform: `translateX(-${removeOffset}px)` }}>
+            <button
+              aria-label={removePlaceholderString}
+              vkuiClass="Removable__action Removable__action--indicator"
+              onClick={onRemoveActivateClick}
+            >
+              <i vkuiClass="Removable__action-in" aria-hidden="true" />
+            </button>
 
-      {platform === IOS &&
-        <button
-          tabIndex={isRemoveActivated ? null : -1}
-          ref={removeButtonRef}
-          vkuiClass="Removable__action Removable__action--remove"
-          onClick={onRemoveClick}
-          style={{ transform: `translateX(-${removeOffset}px)` }}
-        >
-          <span vkuiClass="Removable__action-in">{removePlaceholder}</span>
-        </button>
-      }
+            {children}
+
+            <span vkuiClass="Removable__offset" aria-hidden="true"></span>
+          </div>
+
+          <button
+            tabIndex={isRemoveActivated ? null : -1}
+            ref={removeButtonRef}
+            vkuiClass="Removable__action Removable__action--remove"
+            onClick={onRemoveClick}
+            style={{ transform: `translateX(-${removeOffset}px)` }}
+          >
+            <span vkuiClass="Removable__action-in">{removePlaceholder}</span>
+          </button>
+        </React.Fragment>
+      )}
     </div>
   );
 }, {

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -89,10 +89,10 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
         {platform === IOS && (
           <button
             aria-label={removePlaceholderString}
-            vkuiClass="Removable__control Removable__indicator"
+            vkuiClass="Removable__action Removable__action--indicator"
             onClick={onRemoveActivateClick}
           >
-            <i vkuiClass="Removable__indicator-in" aria-hidden="true" />
+            <i vkuiClass="Removable__action-in" aria-hidden="true" />
           </button>
         )}
 
@@ -101,7 +101,7 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
         {(platform === ANDROID || platform === VKCOM) &&
           <IconButton
             aria-label={removePlaceholderString}
-            vkuiClass="Removable__control Removable__remove"
+            vkuiClass="Removable__action Removable__action--remove"
             onClick={onRemoveClick}
           >
             <Icon24Cancel aria-hidden="true" />
@@ -115,11 +115,11 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
         <button
           tabIndex={isRemoveActivated ? null : -1}
           ref={removeButtonRef}
-          vkuiClass="Removable__remove"
+          vkuiClass="Removable__action Removable__action--remove"
           onClick={onRemoveClick}
           style={{ transform: `translateX(-${removeOffset}px)` }}
         >
-          <span vkuiClass="Removable__remove-in">{removePlaceholder}</span>
+          <span vkuiClass="Removable__action-in">{removePlaceholder}</span>
         </button>
       }
     </div>


### PR DESCRIPTION
Fixes #1527: при отсутствии пропа multiline в Cell с removable приходящие внутрь children теперь обрезаются так, как нужно.

Дополнительно:
+ пофиксила a11y для Removable для правильного tab order,
+ добавила e2e-тесты и скриншоты для разных состояний Cell,
+ попереносила и поправила Removable-стили для всех removable компонентов.