### PR TITLE
[Bug] #1184 ChipsInput Удаляется чип, если ввести его еще раз

### DIFF
--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -3,13 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { baselineComponent } from '../../testing/utils';
 import Chip from './Chip';
 
-const getChip = () => screen.queryByText('Белый');
-
 describe('Chip', () => {
   baselineComponent(Chip);
 
   it('removes chip on onRemove click', () => {
-    const onRemove = jest.fn(() => getChip().parentElement.remove());
+    const onRemove = jest.fn();
 
     render(
       <Chip value="white" onRemove={onRemove}>Белый</Chip>,

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -1,6 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { baselineComponent } from '../../testing/utils';
 import Chip from './Chip';
 
+const getChip = () => screen.queryByText('Белый');
+
 describe('Chip', () => {
   baselineComponent(Chip);
+
+  it('renders value, before, after, and children', () => {
+    render(
+      <Chip before="before" value="white" after="after">Белый</Chip>,
+    );
+
+    expect(getChip()).not.toBeNull();
+  });
+
+  it('removes chip on onRemove click', () => {
+    const onRemove = jest.fn(() => getChip().parentElement.remove());
+
+    render(
+      <Chip value="white" onRemove={onRemove}>Белый</Chip>,
+    );
+
+    userEvent.click(screen.queryByLabelText('Удалить чип'));
+
+    expect(getChip()).toBeNull();
+  });
 });

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -8,14 +8,6 @@ const getChip = () => screen.queryByText('Белый');
 describe('Chip', () => {
   baselineComponent(Chip);
 
-  it('renders value, before, after, and children', () => {
-    render(
-      <Chip before="before" value="white" after="after">Белый</Chip>,
-    );
-
-    expect(getChip()).not.toBeNull();
-  });
-
   it('removes chip on onRemove click', () => {
     const onRemove = jest.fn(() => getChip().parentElement.remove());
 
@@ -25,6 +17,6 @@ describe('Chip', () => {
 
     userEvent.click(screen.queryByLabelText('Удалить чип'));
 
-    expect(getChip()).toBeNull();
+    expect(onRemove).toHaveBeenCalled();
   });
 });

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -7,6 +7,7 @@ type ChipValue = string | number;
 
 export interface ChipProps extends HTMLAttributes<HTMLDivElement> {
   value: ChipValue;
+  option?: { value?: ChipValue };
   onRemove?: (event?: MouseEvent, value?: ChipValue) => void;
   removable?: boolean;
   before?: ReactNode;
@@ -14,7 +15,7 @@ export interface ChipProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const Chip: FC<ChipProps> = (props: ChipProps) => {
-  const { value, onRemove, removable, before, after, children, ...restProps } = props;
+  const { value, option, onRemove, removable, before, after, children, ...restProps } = props;
   const onRemoveWrapper = useCallback((event: MouseEvent) => {
     onRemove(event, value);
   }, [onRemove, value]);

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -28,8 +28,12 @@ const Chip: FC<ChipProps> = (props: ChipProps) => {
         <Caption level="1" weight="regular" vkuiClass="Chip__content" title={title}>{children}</Caption>
         {hasReactNode(after) && <div vkuiClass="Chip__after">{after}</div>}
         {removable &&
-          <div vkuiClass="Chip__remove" onClick={onRemoveWrapper}>
-            <Icon16Cancel fill="var(--icon_secondary)" />
+          <div
+            aria-label="Удалить чип"
+            vkuiClass="Chip__remove"
+            onClick={onRemoveWrapper}
+          >
+            <Icon16Cancel fill="var(--icon_secondary)" aria-hidden="true" />
           </div>
         }
       </div>

--- a/src/components/ChipsInput/ChipsInput.test.tsx
+++ b/src/components/ChipsInput/ChipsInput.test.tsx
@@ -1,6 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
 import { baselineComponent } from '../../testing/utils';
-import ChipsInput from './ChipsInput';
+import ChipsInput, { ChipsInputOption, ChipsInputProps } from './ChipsInput';
+
+const ChipsInputController = ({ value, ...props }: ChipsInputProps<ChipsInputOption>) => {
+  return (
+    <div data-testid="chips-container">
+      <ChipsInput
+        value={value}
+        data-testid="chips-input"
+        renderChip={undefined}
+        {...props}
+      />
+    </div>
+  );
+};
+
+const getChipsContainer = () => screen.getByTestId('chips-container');
+const getChipsInput = () => screen.getByTestId('chips-input');
+const getChip = (label: string) => screen.getByText(label).parentElement;
 
 describe('ChipsInput', () => {
   baselineComponent(ChipsInput);
+
+  it('renders values passed to it', () => {
+    render(
+      <ChipsInputController
+        value={[
+          { value: 'red', label: 'Красный' },
+          { value: 'blue', label: 'Синий' },
+        ]}
+      />,
+    );
+
+    const chipRed = getChip('Красный');
+    const chipBlue = getChip('Синий');
+
+    expect(getChipsContainer()).toContainElement(chipRed);
+    expect(getChipsContainer()).toContainElement(chipBlue);
+  });
+
+  it('adds chips', () => {
+    render(<ChipsInputController value={[]} renderChip={undefined} />);
+
+    userEvent.type(getChipsInput(), 'Красный{enter}');
+
+    const chipRed = getChip('Красный');
+    expect(getChipsContainer()).toContainElement(chipRed);
+  });
+
+  it('removes chip on chip remove button click', () => {
+    render(<ChipsInputController value={[{ value: 'red', label: 'Красный' }]} />);
+
+    const chipRed = getChip('Красный');
+    const chipRedRemove: HTMLElement = chipRed.querySelector('.vkuiChip__remove');
+
+    expect(chipRed).toContainElement(chipRedRemove);
+
+    userEvent.click(chipRedRemove);
+    expect(getChipsContainer()).not.toContainElement(chipRed);
+  });
+
+  it('removes chip on hitting backspace', () => {
+    render(<ChipsInputController value={[{ value: 'red', label: 'Красный' }]} />);
+
+    const chipRed = getChip('Красный');
+
+    userEvent.type(getChipsInput(), '{backspace}');
+    expect(getChipsContainer()).not.toContainElement(chipRed);
+  });
+
+  it('has disabled state', () => {
+    render(<ChipsInputController disabled value={[{ value: 'blue', label: 'Синий' }]} />);
+
+    const chipBlue = getChip('Синий');
+
+    expect(getChipsInput()).toBeDisabled();
+
+    expect(getChipsContainer()).toContainElement(chipBlue);
+    expect(chipBlue).not.toContainElement(chipBlue.querySelector('.vkuiChip__remove'));
+  });
+
+  it('checks focus and blur', () => {
+    render(<ChipsInputController value={[]} />);
+
+    userEvent.click(getChipsInput());
+    expect(getChipsInput()).toHaveFocus();
+
+    getChipsInput().blur();
+    expect(getChipsInput()).not.toHaveFocus();
+  });
 });

--- a/src/components/ChipsInput/ChipsInput.test.tsx
+++ b/src/components/ChipsInput/ChipsInput.test.tsx
@@ -50,6 +50,23 @@ describe('ChipsInput', () => {
     expect(getChipsContainer()).toContainElement(chipRed);
   });
 
+  it('does not lose data when adding an already existing chip', () => {
+    render(
+      <ChipsInputController
+        value={[
+          { value: 'Красный', label: 'Красный' },
+          { value: 'Синий', label: 'Синий' },
+          { value: 'Белый', label: 'Белый' },
+        ]}
+      />,
+    );
+
+    userEvent.type(getChipsInput(), 'Красный{enter}');
+
+    const chipRed = getChip('Красный');
+    expect(getChipsContainer()).toContainElement(chipRed);
+  });
+
   it('removes chip on chip remove button click', () => {
     render(<ChipsInputController value={[{ value: 'red', label: 'Красный' }]} />);
 

--- a/src/components/ChipsInput/ChipsInput.test.tsx
+++ b/src/components/ChipsInput/ChipsInput.test.tsx
@@ -3,15 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { baselineComponent } from '../../testing/utils';
 import ChipsInput, { ChipsInputOption, ChipsInputProps } from './ChipsInput';
 
-const ChipsInputTest = (props: ChipsInputProps<ChipsInputOption>) => {
-  return (
-    <ChipsInput
-      data-testid="chips-input"
-      renderChip={undefined}
-      {...props}
-    />
-  );
-};
+const ChipsInputTest = (props: ChipsInputProps<ChipsInputOption>) => (
+  <ChipsInput data-testid="chips-input" {...props} />
+);
 
 const getChipsInput = () => screen.getByTestId('chips-input');
 const getChip = () => screen.queryByText('Красный');
@@ -32,27 +26,40 @@ describe('ChipsInput', () => {
   });
 
   it('adds chips', () => {
-    render(<ChipsInputTest value={[]} renderChip={undefined} />);
+    let value;
 
-    userEvent.type(getChipsInput(), 'Красный{enter}');
-
-    expect(getChip()).not.toBeNull();
-  });
-
-  it('does not lose data when adding an already existing chip', () => {
     render(
       <ChipsInputTest
-        value={[
-          { value: 'Красный', label: 'Красный' },
-          { value: 'Синий', label: 'Синий' },
-          { value: 'Белый', label: 'Белый' },
-        ]}
+        value={[]}
+        renderChip={undefined}
+        onChange={(changedValue) => value = changedValue}
       />,
     );
 
     userEvent.type(getChipsInput(), 'Красный{enter}');
 
-    expect(getChip()).not.toBeNull();
+    expect(value).toEqual([{ value: 'Красный', label: 'Красный' }]);
+  });
+
+  it('does not lose data when adding an already existing chip', () => {
+    let value;
+
+    render(
+      <ChipsInputTest
+        value={[
+          { value: 'Красный', label: 'Красный' },
+          { value: 'Синий', label: 'Синий' },
+        ]}
+        onChange={(changedValue) => value = changedValue}
+      />,
+    );
+
+    userEvent.type(getChipsInput(), 'Красный{enter}');
+
+    expect(value).toEqual([
+      { value: 'Синий', label: 'Синий' },
+      { value: 'Красный', label: 'Красный' },
+    ]);
   });
 
   it('removes chip on hitting backspace', () => {

--- a/src/components/ChipsInput/ChipsInput.test.tsx
+++ b/src/components/ChipsInput/ChipsInput.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
 import { baselineComponent } from '../../testing/utils';
 import ChipsInput, { ChipsInputOption, ChipsInputProps } from './ChipsInput';
 
@@ -15,7 +14,7 @@ const ChipsInputTest = (props: ChipsInputProps<ChipsInputOption>) => {
 };
 
 const getChipsInput = () => screen.getByTestId('chips-input');
-const getChip = (label: string) => screen.queryByText(label);
+const getChip = () => screen.queryByText('Красный');
 
 describe('ChipsInput', () => {
   baselineComponent(ChipsInput);
@@ -25,13 +24,11 @@ describe('ChipsInput', () => {
       <ChipsInputTest
         value={[
           { value: 'red', label: 'Красный' },
-          { value: 'blue', label: 'Синий' },
         ]}
       />,
     );
 
-    expect(getChip('Красный')).not.toBeNull();
-    expect(getChip('Синий')).not.toBeNull();
+    expect(getChip()).not.toBeNull();
   });
 
   it('adds chips', () => {
@@ -39,7 +36,7 @@ describe('ChipsInput', () => {
 
     userEvent.type(getChipsInput(), 'Красный{enter}');
 
-    expect(getChip('Красный')).not.toBeNull();
+    expect(getChip()).not.toBeNull();
   });
 
   it('does not lose data when adding an already existing chip', () => {
@@ -55,7 +52,7 @@ describe('ChipsInput', () => {
 
     userEvent.type(getChipsInput(), 'Красный{enter}');
 
-    expect(getChip('Красный')).not.toBeNull();
+    expect(getChip()).not.toBeNull();
   });
 
   it('removes chip on hitting backspace', () => {
@@ -63,14 +60,14 @@ describe('ChipsInput', () => {
 
     userEvent.type(getChipsInput(), '{backspace}');
 
-    expect(getChip('Красный')).toBeNull();
+    expect(getChip()).toBeNull();
   });
 
   it('does not delete chips on hitting backspace in readonly mode', () => {
-    render(<ChipsInputTest readOnly value={[{ value: 'blue', label: 'Синий' }]} />);
+    render(<ChipsInputTest readOnly value={[{ value: 'red', label: 'Красный' }]} />);
 
     userEvent.type(getChipsInput(), '{backspace}');
 
-    expect(getChip('Синий')).not.toBeNull();
+    expect(getChip()).not.toBeNull();
   });
 });

--- a/src/components/ChipsInput/ChipsInput.test.tsx
+++ b/src/components/ChipsInput/ChipsInput.test.tsx
@@ -8,7 +8,6 @@ const ChipsInputTest = (props: ChipsInputProps<ChipsInputOption>) => (
 );
 
 const getChipsInput = () => screen.getByTestId('chips-input');
-const getChip = () => screen.queryByText('Красный');
 
 describe('ChipsInput', () => {
   baselineComponent(ChipsInput);
@@ -22,16 +21,15 @@ describe('ChipsInput', () => {
       />,
     );
 
-    expect(getChip()).not.toBeNull();
+    expect(screen.queryByText('Красный')).not.toBeNull();
   });
 
   it('adds chips', () => {
-    let value;
+    let value: ChipsInputOption[];
 
     render(
       <ChipsInputTest
         value={[]}
-        renderChip={undefined}
         onChange={(changedValue) => value = changedValue}
       />,
     );
@@ -42,7 +40,7 @@ describe('ChipsInput', () => {
   });
 
   it('does not lose data when adding an already existing chip', () => {
-    let value;
+    let value: ChipsInputOption[];
 
     render(
       <ChipsInputTest
@@ -63,18 +61,33 @@ describe('ChipsInput', () => {
   });
 
   it('removes chip on hitting backspace', () => {
-    render(<ChipsInputTest value={[{ value: 'red', label: 'Красный' }]} />);
+    let value: ChipsInputOption[];
+
+    render(
+      <ChipsInputTest
+        value={[{ value: 'red', label: 'Красный' }]}
+        onChange={(changedValue) => value = changedValue}
+      />,
+    );
 
     userEvent.type(getChipsInput(), '{backspace}');
 
-    expect(getChip()).toBeNull();
+    expect(value).toEqual([]);
   });
 
   it('does not delete chips on hitting backspace in readonly mode', () => {
-    render(<ChipsInputTest readOnly value={[{ value: 'red', label: 'Красный' }]} />);
+    let value: ChipsInputOption[] = [{ value: 'red', label: 'Красный' }];
+
+    render(
+      <ChipsInputTest
+        readOnly
+        value={value}
+        onChange={(changedValue) => value = changedValue}
+      />,
+    );
 
     userEvent.type(getChipsInput(), '{backspace}');
 
-    expect(getChip()).not.toBeNull();
+    expect(value).toEqual([{ value: 'red', label: 'Красный' }]);
   });
 });

--- a/src/components/ChipsInput/ChipsInput.test.tsx
+++ b/src/components/ChipsInput/ChipsInput.test.tsx
@@ -4,29 +4,25 @@ import '@testing-library/jest-dom/extend-expect';
 import { baselineComponent } from '../../testing/utils';
 import ChipsInput, { ChipsInputOption, ChipsInputProps } from './ChipsInput';
 
-const ChipsInputController = ({ value, ...props }: ChipsInputProps<ChipsInputOption>) => {
+const ChipsInputTest = (props: ChipsInputProps<ChipsInputOption>) => {
   return (
-    <div data-testid="chips-container">
-      <ChipsInput
-        value={value}
-        data-testid="chips-input"
-        renderChip={undefined}
-        {...props}
-      />
-    </div>
+    <ChipsInput
+      data-testid="chips-input"
+      renderChip={undefined}
+      {...props}
+    />
   );
 };
 
-const getChipsContainer = () => screen.getByTestId('chips-container');
 const getChipsInput = () => screen.getByTestId('chips-input');
-const getChip = (label: string) => screen.getByText(label).parentElement;
+const getChip = (label: string) => screen.queryByText(label);
 
 describe('ChipsInput', () => {
   baselineComponent(ChipsInput);
 
   it('renders values passed to it', () => {
     render(
-      <ChipsInputController
+      <ChipsInputTest
         value={[
           { value: 'red', label: 'Красный' },
           { value: 'blue', label: 'Синий' },
@@ -34,25 +30,21 @@ describe('ChipsInput', () => {
       />,
     );
 
-    const chipRed = getChip('Красный');
-    const chipBlue = getChip('Синий');
-
-    expect(getChipsContainer()).toContainElement(chipRed);
-    expect(getChipsContainer()).toContainElement(chipBlue);
+    expect(getChip('Красный')).not.toBeNull();
+    expect(getChip('Синий')).not.toBeNull();
   });
 
   it('adds chips', () => {
-    render(<ChipsInputController value={[]} renderChip={undefined} />);
+    render(<ChipsInputTest value={[]} renderChip={undefined} />);
 
     userEvent.type(getChipsInput(), 'Красный{enter}');
 
-    const chipRed = getChip('Красный');
-    expect(getChipsContainer()).toContainElement(chipRed);
+    expect(getChip('Красный')).not.toBeNull();
   });
 
   it('does not lose data when adding an already existing chip', () => {
     render(
-      <ChipsInputController
+      <ChipsInputTest
         value={[
           { value: 'Красный', label: 'Красный' },
           { value: 'Синий', label: 'Синий' },
@@ -63,49 +55,22 @@ describe('ChipsInput', () => {
 
     userEvent.type(getChipsInput(), 'Красный{enter}');
 
-    const chipRed = getChip('Красный');
-    expect(getChipsContainer()).toContainElement(chipRed);
-  });
-
-  it('removes chip on chip remove button click', () => {
-    render(<ChipsInputController value={[{ value: 'red', label: 'Красный' }]} />);
-
-    const chipRed = getChip('Красный');
-    const chipRedRemove: HTMLElement = chipRed.querySelector('.vkuiChip__remove');
-
-    expect(chipRed).toContainElement(chipRedRemove);
-
-    userEvent.click(chipRedRemove);
-    expect(getChipsContainer()).not.toContainElement(chipRed);
+    expect(getChip('Красный')).not.toBeNull();
   });
 
   it('removes chip on hitting backspace', () => {
-    render(<ChipsInputController value={[{ value: 'red', label: 'Красный' }]} />);
-
-    const chipRed = getChip('Красный');
+    render(<ChipsInputTest value={[{ value: 'red', label: 'Красный' }]} />);
 
     userEvent.type(getChipsInput(), '{backspace}');
-    expect(getChipsContainer()).not.toContainElement(chipRed);
+
+    expect(getChip('Красный')).toBeNull();
   });
 
-  it('has disabled state', () => {
-    render(<ChipsInputController disabled value={[{ value: 'blue', label: 'Синий' }]} />);
+  it('does not delete chips on hitting backspace in readonly mode', () => {
+    render(<ChipsInputTest readOnly value={[{ value: 'blue', label: 'Синий' }]} />);
 
-    const chipBlue = getChip('Синий');
+    userEvent.type(getChipsInput(), '{backspace}');
 
-    expect(getChipsInput()).toBeDisabled();
-
-    expect(getChipsContainer()).toContainElement(chipBlue);
-    expect(chipBlue).not.toContainElement(chipBlue.querySelector('.vkuiChip__remove'));
-  });
-
-  it('checks focus and blur', () => {
-    render(<ChipsInputController value={[]} />);
-
-    userEvent.click(getChipsInput());
-    expect(getChipsInput()).toHaveFocus();
-
-    getChipsInput().blur();
-    expect(getChipsInput()).not.toHaveFocus();
+    expect(getChip('Синий')).not.toBeNull();
   });
 });

--- a/src/components/ChipsInput/ChipsInput.tsx
+++ b/src/components/ChipsInput/ChipsInput.tsx
@@ -54,6 +54,11 @@ const ChipsInput = <Option extends ChipsInputOption>(props: ChipsInputProps<Opti
   const { fieldValue, addOptionFromInput, removeOption, selectedOptions, handleInputChange } = useChipsInput(props);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled || restProps.readOnly) {
+      e.preventDefault();
+      return;
+    }
+
     onKeyDown(e);
 
     if (e.key === 'Backspace' && !e.defaultPrevented && !fieldValue && selectedOptions.length) {

--- a/src/components/ChipsInput/useChipsInput.ts
+++ b/src/components/ChipsInput/useChipsInput.ts
@@ -18,13 +18,10 @@ export const useChipsInput = <Option extends ChipsInputOption>(props: Partial<Ch
   }, [onInputChange]);
 
   const toggleOption = useCallback((newOption: Option, value?: boolean) => {
-    let newSelectedOptions = [...selectedOptions];
-    const isOptionSelected = selectedOptions.find((option: Option) => getOptionValue(newOption) === getOptionValue(option));
+    const newSelectedOptions = selectedOptions.filter((option: Option) => getOptionValue(newOption) !== getOptionValue(option));
 
-    if (isOptionSelected || value === false) {
-      newSelectedOptions = selectedOptions.filter((option: Option) => getOptionValue(option) !== getOptionValue(newOption));
-    } else if (!isOptionSelected || value === true) {
-      newSelectedOptions = [...selectedOptions, newOption];
+    if (value === true) {
+      newSelectedOptions.push(newOption);
     }
 
     setSelectedOptions(newSelectedOptions);


### PR DESCRIPTION
Fixes #1184: чип теперь не удаляется, если ввести его еще раз, а переносится в конец.

- Оптимизировала под это решение проходку по массиву опций,
- Добавила юнит-тесты для ChipsInput,
- Пофиксила передачу пропа option в Chip. 😄