### PR TITLE
useExternRef

### DIFF
--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -13,10 +13,11 @@ import ChipsInput, { ChipsInputOption, ChipsInputProps, ChipsInputValue, RenderC
 import CustomSelectOption, { CustomSelectOptionProps } from '../CustomSelectOption/CustomSelectOption';
 import { useChipsSelect } from './useChipsSelect';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
-import { setRef, noop } from '../../lib/utils';
+import { noop } from '../../lib/utils';
 import { useDOM } from '../../lib/dom';
 import Caption from '../Typography/Caption/Caption';
 import { prefixClass } from '../../lib/prefixClass';
+import { useExternRef } from '../../hooks/useExternRef';
 
 export interface ChipsSelectProps<Option extends ChipsInputOption> extends ChipsInputProps<Option>, AdaptivityProps {
   popupDirection?: 'top' | 'bottom';
@@ -69,7 +70,7 @@ const ChipsSelect = <Option extends ChipsInputOption>(props: ChipsSelectProps<Op
   const { document } = useDOM();
 
   const scrollBoxRef = useRef<HTMLDivElement>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const rootRef = useExternRef(getRef);
   const {
     fieldValue, selectedOptions, opened, setOpened, addOptionFromInput,
     filteredOptions, addOption, handleInputChange, clearInput,
@@ -215,12 +216,6 @@ const ChipsSelect = <Option extends ChipsInputOption>(props: ChipsSelectProps<Op
       document.removeEventListener('click', handleClickOutside);
     };
   }, []);
-
-  useEffect(() => {
-    const { current: element } = rootRef;
-
-    setRef(element, getRef);
-  }, [getRef]);
 
   const renderChipWrapper = (renderChipProps: RenderChip<Option>) => {
     const { onRemove } = renderChipProps;

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -1,9 +1,9 @@
-import { HTMLAttributes, FunctionComponent, InputHTMLAttributes, useRef } from 'react';
+import { HTMLAttributes, FunctionComponent, InputHTMLAttributes } from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import Button, { VKUIButtonProps } from '../Button/Button';
 import { HasRef, HasRootRef } from '../../types';
 import { usePlatform } from '../../hooks/usePlatform';
-import { setRef } from '../../lib/utils';
+import { useExternRef } from '../../hooks/useExternRef';
 
 export interface FileProps extends
   Omit<VKUIButtonProps, 'size' | 'type'>,
@@ -19,12 +19,7 @@ const File: FunctionComponent<FileProps> = (props: FileProps) => {
     style, getRef, getRootRef, onClick, ...restProps } = props;
 
   const platform = usePlatform();
-  const inputRef = useRef<HTMLInputElement>();
-
-  const getInputRef = (element: HTMLInputElement) => {
-    inputRef.current = element;
-    setRef(element, getRef);
-  };
+  const inputRef = useExternRef(getRef);
 
   return (
     <Button
@@ -44,7 +39,7 @@ const File: FunctionComponent<FileProps> = (props: FileProps) => {
         onClick && onClick(e);
       }}
     >
-      <input {...restProps} vkuiClass="File__input" type="file" ref={getInputRef} />
+      <input {...restProps} vkuiClass="File__input" type="file" ref={inputRef} />
       {children}
     </Button>
   );

--- a/src/components/WriteBar/WriteBar.tsx
+++ b/src/components/WriteBar/WriteBar.tsx
@@ -7,7 +7,8 @@ import {
   TextareaHTMLAttributes,
 } from 'react';
 import { usePlatform } from '../../hooks/usePlatform';
-import { hasReactNode, isFunction, setRef } from '../../lib/utils';
+import { useExternRef } from '../../hooks/useExternRef';
+import { hasReactNode, isFunction } from '../../lib/utils';
 import { getClassName } from '../../helpers/getClassName';
 import { HasRef, HasRootRef } from '../../types';
 
@@ -53,7 +54,7 @@ export const WriteBar: FC<WriteBarProps> = (props: WriteBarProps) => {
 
   const isControlledOutside = value != null;
 
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const textareaRef = useExternRef(getRef);
   const textareaMinHeightRef = useRef<number | null>(null);
 
   const resize = () => {
@@ -97,11 +98,6 @@ export const WriteBar: FC<WriteBarProps> = (props: WriteBarProps) => {
     }
   };
 
-  const getTextareaElRef = (element: HTMLTextAreaElement) => {
-    textareaRef.current = element;
-    setRef(element, getRef);
-  };
-
   useEffect(() => {
     resize();
   }, [value]);
@@ -125,7 +121,7 @@ export const WriteBar: FC<WriteBarProps> = (props: WriteBarProps) => {
             {...restProps}
             vkuiClass="WriteBar__textarea"
             onChange={onTextareaChange}
-            ref={getTextareaElRef}
+            ref={textareaRef}
             value={value}
           />
 

--- a/src/hooks/useExternRef.test.tsx
+++ b/src/hooks/useExternRef.test.tsx
@@ -1,0 +1,77 @@
+import { render } from '@testing-library/react';
+import { noop } from '../lib/utils';
+import { createRef, useLayoutEffect, useRef, FC, RefObject } from 'react';
+import { HasRef } from '../types';
+import { useExternRef } from './useExternRef';
+
+const RefForwarder = (props: HasRef<HTMLDivElement>) => <div ref={useExternRef(props.getRef)} />;
+describe(useExternRef, () => {
+  describe('manages inner ref', () => {
+    it('ensures ref exists', () => {
+      const OuterRef: FC = () => {
+        expect(useExternRef()).toBeTruthy();
+        return null;
+      };
+      render(<OuterRef />);
+    });
+    it('keeps inner ref.current up-to-date', () => {
+      let firstRef: RefObject<any>;
+      let counter = 0;
+      const RefForwarder: FC<HasRef<any>> = (props) => {
+        const ref = useExternRef(props.getRef);
+        firstRef = firstRef || ref;
+        counter += 1;
+        ref.current = counter;
+        return null;
+      };
+      render(<RefForwarder getRef={() => null} />)
+        .rerender(<RefForwarder getRef={() => null} />);
+      expect(firstRef.current).toBe(counter);
+    });
+  });
+  describe('sets outer ref to null', () => {
+    it('on wrapper unmount', () => {
+      const ref = createRef<HTMLDivElement>();
+      render(<RefForwarder getRef={ref} />).unmount();
+      expect(ref.current).toBeNull();
+    });
+    it('on inner node unmount', () => {
+      const ref = createRef();
+      const RefForwarder = (props: HasRef<any> & { hide?: boolean }) => {
+        const ref = useExternRef(props.getRef);
+        return props.hide ? null : <div ref={ref} />;
+      };
+      render(<RefForwarder getRef={ref} />).rerender(<RefForwarder getRef={ref} hide />);
+      expect(ref.current).toBeNull();
+    });
+  });
+  describe('calls outer ref', () => {
+    it('before useLayoutEffect', () => {
+      const RefUser = () => {
+        const ref = useRef();
+        useLayoutEffect(() => {
+          expect(ref.current).toBeInTheDocument();
+        }, []);
+        return <RefForwarder getRef={ref} />;
+      };
+      render(<RefUser />);
+    });
+    it('when node changes', () => {
+      const ref = createRef();
+      const RefForwarder = (props: HasRef<any> & { remountKey?: any }) => (
+        <div key={props.remountKey} ref={useExternRef(props.getRef)} />);
+      render(<RefForwarder getRef={ref} />).rerender(<RefForwarder getRef={ref} remountKey="123" />);
+      expect(ref.current).toBeInTheDocument();
+    });
+    it('when ref identity changes', () => {
+      const secondRef = jest.fn();
+      render(<RefForwarder getRef={noop} />).rerender(<RefForwarder getRef={secondRef} />);
+      expect(secondRef).toHaveBeenCalled();
+    });
+    it('once per identity', () => {
+      const ref = jest.fn();
+      render(<RefForwarder getRef={ref} />).rerender(<RefForwarder getRef={ref} />);
+      expect(ref).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/useExternRef.ts
+++ b/src/hooks/useExternRef.ts
@@ -1,0 +1,15 @@
+import { MutableRefObject, Ref, useMemo, useRef } from 'react';
+import { setRef } from '../lib/utils';
+
+export function useExternRef<T>(externRef?: Ref<T>): MutableRefObject<T> {
+  const stableRef = useRef<T>();
+  return useMemo(() => ({
+    get current() {
+      return stableRef.current;
+    },
+    set current(el) {
+      stableRef.current = el;
+      setRef(el, externRef);
+    },
+  }), [externRef]);
+}


### PR DESCRIPTION
Добавляю хук `useExternRef` для корректной обработки кейсов, где мы используем реф внутри компонента + поддерживаем `get(Root)Ref`. Мотивационные примеры, которые поддерживает реализация:
```jsx
const VkuiInput = (props) => {
  const ref = useExternRef(props.getRef);
  useEffect(() => {
    ref.current.focus();
  }, []);
  return <input ref={ref} />;
}
```
1. `<VkuiInput getRef={ref} />`: `ref.current` всегда готов в момент `useLayoutEffect`
2. `<VkuiInput getRef={useCallback(e => longRunningOp(e), [])}` вызывается только один раз
3. `props.hidden ? null : <input />`: `getRef` выставится в null при `hidden={true}`
4. `createElement(props.disabled ? 'div' : 'input', { ref }): getRef обновится при смене `input` на `div`
5. `showInput && <VkuiInput getRef={ref} />`: `ref.current = null` при `showInput = false`

Кроме того, это просто удобнее чем руками каждый раз оборачивать реф в стрелку, и типы инферрятся.