### PR TITLE
FixedLayout: fix PanelHeader adjustment during panel transition on iOS

### DIFF
--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -11,6 +11,7 @@ import { SplitColContext, SplitColContextProps } from '../SplitCol/SplitCol';
 import { TooltipContainer } from '../Tooltip/TooltipContainer';
 import { PanelContextProps } from '../Panel/PanelContext';
 import { DOMProps, withDOM } from '../../lib/dom';
+import { IOS } from '../../lib/platform';
 
 export interface FixedLayoutProps extends
   HTMLAttributes<HTMLDivElement>,
@@ -93,8 +94,9 @@ class FixedLayout extends React.Component<FixedLayoutProps & DOMProps & PanelCon
     const fromPanelHasScroll = this.props.panel === e.detail.from && panelScroll > 0;
     const toPanelHasScroll = this.props.panel === e.detail.to && panelScroll > 0;
 
-    // если переход назад - анимация только у панели с которой уходим (detail.from), и подстраиваться под скролл надо только на ней
-    const panelAnimated = !(this.props.panel === e.detail.to && e.detail.isBack);
+    // если переход назад на Android - анимация только у панели с которой уходим (detail.from), и подстраиваться под скролл надо только на ней
+    // на iOS переход между панелями горизонтальный, поэтому там нужно подстраивать хедеры на обеих панелях
+    const panelAnimated = this.props.platform === IOS || !(this.props.panel === e.detail.to && e.detail.isBack);
 
     // Для панелей, с которых уходим всегда выставляется скролл
     // Для панелей на которые приходим надо смотреть, есть ли браузерный скролл и применяется ли к ней анимация перехода:

--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -33,6 +33,7 @@ export interface FixedLayoutProps extends
 export interface FixedLayoutState {
   position: 'absolute' | null;
   top: number;
+  bottom: number;
   width: string;
 }
 
@@ -40,6 +41,7 @@ class FixedLayout extends React.Component<FixedLayoutProps & DOMProps & PanelCon
   state: FixedLayoutState = {
     position: 'absolute',
     top: null,
+    bottom: null,
     width: '',
   };
 
@@ -103,7 +105,8 @@ class FixedLayout extends React.Component<FixedLayoutProps & DOMProps & PanelCon
     if (fromPanelHasScroll || toPanelHasScroll && this.canTargetPanelScroll && panelAnimated) {
       this.setState({
         position: 'absolute',
-        top: this.el.offsetTop + panelScroll,
+        top: this.props.vertical === 'top' || fromPanelHasScroll ? this.el.offsetTop + panelScroll : null,
+        bottom: this.props.vertical === 'bottom' && !fromPanelHasScroll ? -panelScroll : null,
         width: '',
       });
     }
@@ -113,6 +116,7 @@ class FixedLayout extends React.Component<FixedLayoutProps & DOMProps & PanelCon
     this.setState({
       position: null,
       top: null,
+      bottom: null,
     });
 
     this.doResize();


### PR DESCRIPTION
fixes #1559 

[codesandbox demo](https://codesandbox.io/s/vkui-ios-panel-transition-fix-demo-2jn5j) (wait for sandbox CI to pick it up)

| Before | After |
|-|-|
| ![CleanShot 2021-04-27 at 10 21 29](https://user-images.githubusercontent.com/827338/116201693-748cd980-a742-11eb-9e9e-f8f120d5514b.gif) | ![CleanShot 2021-04-27 at 10 23 05](https://user-images.githubusercontent.com/827338/116201822-9a19e300-a742-11eb-8d51-880831717df3.gif) |

