### PR TITLE
feat: Allow nav prop instead of id for navigation items

### DIFF
--- a/src/components/Epic/Epic.tsx
+++ b/src/components/Epic/Epic.tsx
@@ -3,6 +3,7 @@ import { getClassName } from '../../helpers/getClassName';
 import { usePlatform } from '../../hooks/usePlatform';
 import { withAdaptivity, ViewWidth, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { ScrollSaver } from './ScrollSaver';
+import { getNavId } from '../../lib/getNavId';
 
 export interface EpicProps extends HTMLAttributes<HTMLDivElement>, AdaptivityProps {
   tabbar?: ReactNode;
@@ -19,7 +20,7 @@ export const Epic: FC<EpicProps> = (props: EpicProps) => {
       console.warn('[Epic] Using Epic without tabbar is not recommended on mobile');
     }
   }, [viewWidth]);
-  const story = (React.Children.toArray(children) as ReactElement[]).find((story) => story.props.id === activeStory) || null;
+  const story = (React.Children.toArray(children) as ReactElement[]).find((story) => getNavId(story.props) === activeStory) || null;
 
   return (
     <div {...restProps} vkuiClass={getClassName('Epic', platform)}>

--- a/src/components/ModalCard/ModalCard.test.tsx
+++ b/src/components/ModalCard/ModalCard.test.tsx
@@ -2,5 +2,5 @@ import { baselineComponent } from '../../testing/utils';
 import ModalCard from './ModalCard';
 
 describe('ModalCard', () => {
-  baselineComponent(ModalCard);
+  baselineComponent((p) => <ModalCard nav="id" {...p} />);
 });

--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -13,8 +13,9 @@ import Title from '../Typography/Title/Title';
 import ModalDismissButton from '../ModalDismissButton/ModalDismissButton';
 import ModalRootContext, { useModalRegistry } from '../ModalRoot/ModalRootContext';
 import { ModalType } from '../ModalRoot/types';
+import { getNavId, NavIdProps } from '../../lib/getNavId';
 
-export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform, AdaptivityProps {
+export interface ModalCardProps extends HTMLAttributes<HTMLElement>, HasPlatform, AdaptivityProps, NavIdProps {
   /**
    * Иконка.
    *
@@ -63,6 +64,7 @@ const ModalCard: FC<ModalCardProps> = (props: ModalCardProps) => {
     viewWidth,
     viewHeight,
     hasMouse,
+    nav,
     ...restProps
   } = props;
 
@@ -71,7 +73,7 @@ const ModalCard: FC<ModalCardProps> = (props: ModalCardProps) => {
   const canShowCloseBtnIos = platform === IOS && !canShowCloseBtn;
 
   const modalContext = useContext(ModalRootContext);
-  const { refs } = useModalRegistry(props.id, ModalType.CARD);
+  const { refs } = useModalRegistry(getNavId(props), ModalType.CARD);
 
   return (
     <div

--- a/src/components/ModalPage/ModalPage.test.tsx
+++ b/src/components/ModalPage/ModalPage.test.tsx
@@ -2,5 +2,5 @@ import { baselineComponent } from '../../testing/utils';
 import ModalPage from './ModalPage';
 
 describe('ModalPage', () => {
-  baselineComponent(ModalPage);
+  baselineComponent((p) => <ModalPage nav="id" {...p} />);
 });

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -8,8 +8,9 @@ import ModalDismissButton from '../ModalDismissButton/ModalDismissButton';
 import { Ref } from '../../types';
 import { multiRef } from '../../lib/utils';
 import { ModalType } from '../ModalRoot/types';
+import { getNavId, NavIdProps } from '../../lib/getNavId';
 
-export interface ModalPageProps extends HTMLAttributes<HTMLDivElement>, AdaptivityProps {
+export interface ModalPageProps extends HTMLAttributes<HTMLDivElement>, AdaptivityProps, NavIdProps {
   /**
    * Шапка модальной страницы, `<ModalPageHeader />`
    */
@@ -40,6 +41,7 @@ const ModalPage: FC<ModalPageProps> = (props: ModalPageProps) => {
     settlingHeight,
     dynamicContentHeight,
     getModalContentRef,
+    nav,
     ...restProps
   } = props;
 
@@ -51,7 +53,7 @@ const ModalPage: FC<ModalPageProps> = (props: ModalPageProps) => {
   const canShowCloseBtn = viewWidth >= ViewWidth.SMALL_TABLET;
 
   const modalContext = useContext(ModalRootContext);
-  const { refs } = useModalRegistry(props.id, ModalType.PAGE);
+  const { refs } = useModalRegistry(getNavId(props), ModalType.PAGE);
 
   return (
     <div

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -20,6 +20,7 @@ import {
 import { ModalsState, ModalsStateEntry, ModalType, TranslateRange } from './types';
 import { MODAL_PAGE_DEFAULT_PERCENT_HEIGHT } from './constants';
 import { DOMProps, withDOM } from '../../lib/dom';
+import { getNavId } from '../../lib/getNavId';
 
 function numberInRange(number: number, range: TranslateRange) {
   return number >= range[0] && number <= range[1];
@@ -118,7 +119,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     this.modalsState = this.getModals().reduce<ModalsState>((acc, Modal) => {
       const modalProps = Modal.props;
       const state: ModalsStateEntry = {
-        id: Modal.props.id,
+        id: getNavId(modalProps),
         onClose: Modal.props.onClose,
         dynamicContentHeight: !!modalProps.dynamicContentHeight,
       };
@@ -795,8 +796,8 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
             />
             <div vkuiClass="ModalRoot__viewport" ref={this.viewportRef}>
               {this.getModals().map((Modal) => {
-                const modalId = Modal.props.id;
-                if (!visibleModals.includes(Modal.props.id)) {
+                const modalId = getNavId(Modal.props);
+                if (!visibleModals.includes(modalId)) {
                   return null;
                 }
                 const modalState = { ...this.modalsState[modalId] };

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -15,6 +15,7 @@ import { ModalsStateEntry, ModalType } from './types';
 import { ANDROID, VKCOM } from '../../lib/platform';
 import { getClassName } from '../../helpers/getClassName';
 import { DOMProps, withDOM } from '../../lib/dom';
+import { getNavId } from '../../lib/getNavId';
 
 export interface ModalRootProps extends HasPlatform {
   activeModal?: string | null;
@@ -95,7 +96,7 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
     this.modalsState = this.modals.reduce<{ [id: string]: ModalsStateEntry }>((acc, Modal) => {
       const modalProps = Modal.props;
       const state: ModalsStateEntry = {
-        id: Modal.props.id,
+        id: getNavId(Modal.props),
         onClose: Modal.props.onClose,
         dynamicContentHeight: !!modalProps.dynamicContentHeight,
       };
@@ -354,8 +355,8 @@ class ModalRootDesktopComponent extends Component<ModalRootProps & DOMProps, Mod
           />
           <div vkuiClass="ModalRoot__viewport">
             {this.modals.map((Modal: ReactElement) => {
-              const modalId = Modal.props.id;
-              if (!visibleModals.includes(Modal.props.id)) {
+              const modalId = getNavId(Modal.props);
+              if (!visibleModals.includes(modalId)) {
                 return null;
               }
 

--- a/src/components/Panel/Panel.test.tsx
+++ b/src/components/Panel/Panel.test.tsx
@@ -2,5 +2,5 @@ import { baselineComponent } from '../../testing/utils';
 import Panel from './Panel';
 
 describe('Panel', () => {
-  baselineComponent(Panel);
+  baselineComponent((p) => <Panel id="id" {...p} />);
 });

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -9,9 +9,10 @@ import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { PanelContext, PanelContextProps } from './PanelContext';
 import { IOS } from '../../lib/platform';
 import { setRef } from '../../lib/utils';
+import { getNavId, NavIdProps } from '../../lib/getNavId';
 
-export interface PanelProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, HasRootRef<HTMLDivElement>, AdaptivityProps {
-  id: string;
+export interface PanelProps extends HTMLAttributes<HTMLDivElement>, HasPlatform,
+  HasRootRef<HTMLDivElement>, AdaptivityProps, NavIdProps {
   centered?: boolean;
 }
 
@@ -19,7 +20,7 @@ class Panel extends Component<PanelProps> {
   constructor(props: PanelProps) {
     super(props);
     this.childContext = {
-      panel: props.id,
+      panel: getNavId(props),
       getPanelNode: () => this.container,
     };
   }
@@ -39,7 +40,7 @@ class Panel extends Component<PanelProps> {
   };
 
   render() {
-    const { centered, children, platform, getRootRef, sizeX, ...restProps } = this.props;
+    const { centered, children, platform, getRootRef, sizeX, nav, ...restProps } = this.props;
 
     return (
       <PanelContext.Provider value={this.childContext}>

--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -11,6 +11,7 @@ import { SplitColContextProps, SplitColContext } from '../SplitCol/SplitCol';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
 import { canUseDOM, DOMProps, withDOM } from '../../lib/dom';
 import { ScrollContext, ScrollContextInterface } from '../AppRoot/ScrollContext';
+import { getNavId } from '../../lib/getNavId';
 
 export interface RootProps extends HTMLAttributes<HTMLDivElement>, HasPlatform {
   activeView: string;
@@ -79,9 +80,9 @@ class Root extends Component<RootProps & DOMProps, RootState> {
     // Нужен переход
     if (this.props.activeView !== prevProps.activeView) {
       let pageYOffset = this.props.scroll.getScroll().y;
-      const firstLayerId = [].concat(prevProps.children).find((view: ReactElement) => {
-        return view.props.id === prevProps.activeView || view.props.id === this.props.activeView;
-      }).props.id;
+      const firstLayerId = [].concat(prevProps.children)
+        .map((view) => getNavId(view.props))
+        .find((id) => id === prevProps.activeView || id === this.props.activeView);
       const isBack = firstLayerId === this.props.activeView;
 
       this.blurActiveElement();
@@ -182,7 +183,7 @@ class Root extends Component<RootProps & DOMProps, RootState> {
     const { transition, isBack, prevView, activeView, nextView } = this.state;
 
     const Views = React.Children.toArray(this.props.children).filter((view: ReactElement) => {
-      return this.state.visibleViews.includes(view.props.id);
+      return this.state.visibleViews.includes(getNavId(view.props));
     });
 
     const baseClassName = getClassName('Root', platform);
@@ -194,13 +195,14 @@ class Root extends Component<RootProps & DOMProps, RootState> {
         'Root--no-motion': disableAnimation,
       })}>
         {Views.map((view: ReactElement) => {
+          const viewId = getNavId(view.props);
           return (
-            <div key={view.props.id} ref={(e) => this.viewNodes[view.props.id] = e} vkuiClass={classNames('Root__view', {
-              'Root__view--hide-back': view.props.id === prevView && isBack,
-              'Root__view--hide-forward': view.props.id === prevView && !isBack,
-              'Root__view--show-back': view.props.id === nextView && isBack,
-              'Root__view--show-forward': view.props.id === nextView && !isBack,
-              'Root__view--active': view.props.id === activeView,
+            <div key={viewId} ref={(e) => this.viewNodes[viewId] = e} vkuiClass={classNames('Root__view', {
+              'Root__view--hide-back': viewId === prevView && isBack,
+              'Root__view--hide-forward': viewId === prevView && !isBack,
+              'Root__view--show-back': viewId === nextView && isBack,
+              'Root__view--show-forward': viewId === nextView && !isBack,
+              'Root__view--active': viewId === activeView,
             })}>
               {view}
             </div>

--- a/src/lib/getNavId.test.ts
+++ b/src/lib/getNavId.test.ts
@@ -1,0 +1,26 @@
+import { getNavId } from './getNavId';
+
+describe(getNavId, () => {
+  it('Gets "nav" prop', () => expect(getNavId({ nav: 'ok' })).toBe('ok'));
+  it('Gets "id" prop', () => expect(getNavId({ id: 'ok' })).toBe('ok'));
+  it('"nav" overrides "id"', () => expect(getNavId({ nav: 'ok', id: 'dont' })).toBe('ok'));
+  describe('strict mode', () => {
+    let spy: jest.SpyInstance;
+    beforeEach(() => spy = jest.spyOn(console, 'error').mockImplementation());
+    afterEach(() => spy.mockRestore());
+    it('does not error if nav id present', () => {
+      getNavId({ nav: 'ok' });
+      getNavId({ id: 'ok' });
+      getNavId({ nav: 'ok', id: 'dont' });
+      expect(console.error).not.toBeCalled();
+    });
+    it('errors if nav id missing', () => {
+      getNavId({});
+      expect(console.error).toBeCalled();
+    });
+    it('does not error when strict=false', () => {
+      getNavId({}, false);
+      expect(console.error).not.toBeCalled();
+    });
+  });
+});

--- a/src/lib/getNavId.ts
+++ b/src/lib/getNavId.ts
@@ -1,0 +1,12 @@
+export interface NavIdProps {
+  /** Уникальный идентификатор навигационного элемента (вместо id) */
+  nav?: string;
+  id?: string;
+};
+export function getNavId(props: NavIdProps, strict = true) {
+  const id = props.nav || props.id;
+  if (!id && strict) {
+    console.error('[VKUI] Navigation item should have "nav" or "id" prop');
+  }
+  return id;
+}


### PR DESCRIPTION
Продолжаем готовиться ко встраиванию vkui в вк. Сейчас идентификатор навигационных компонентов (`View`, `Panel`, `ModalPage`, `ModalCard`) прокидывается через проп `id`. При этом id — DOM-проп, и прокидывается на DOM-элемент. Значит, id может конфликтовать с другими id на странице — например, делать неопределенным поведение getElementById в хост-аппе. По итогам #1414, #1400, #1398 сам vkui не зависит от id.

В этом ПР:
- Поддерживаем передачу навигационного идентификатора через проп `nav`, чтобы не поощрять конфликты
- Все еще поддерживаем `id`, чтобы сохранить обратную совместимость.
- Добавляем полезный ворнинг, если нет ни одного идентификатора

Поведение `View`, который не прокидывает id в DOM — баг, но его исправление будет брейкинг ченджем.