### PR TITLE
Gallery: fix arrows visibility for case when multiple slides visible

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -271,11 +271,19 @@ class BaseGallery extends Component<BaseGalleryProps & DOMProps & AdaptivityProp
   onResize: VoidFunction = () => this.initializeSlides({ animation: false });
 
   get canSlideLeft() {
-    return !this.isFullyVisible && this.props.slideIndex > 0;
+    // shiftX is negative number <= 0, we can swipe back only if it is < 0
+    return !this.isFullyVisible && this.state.shiftX < 0;
   }
 
   get canSlideRight() {
-    return !this.isFullyVisible && this.props.slideIndex < this.state.slides.length - 1;
+    const { containerWidth, layerWidth, shiftX, slides } = this.state;
+    const { align, slideIndex } = this.props;
+    return !this.isFullyVisible && (
+      // we can't move right when gallery layer fully scrolled right, if gallery aligned by left side
+      align === 'left' && containerWidth - shiftX < layerWidth ||
+      // otherwise we need to check current slide index (align = right or align = center)
+      align !== 'left' && slideIndex < slides.length - 1
+    );
   }
 
   slideLeft = () => {


### PR DESCRIPTION
Before:

![CleanShot 2021-05-19 at 13 58 31](https://user-images.githubusercontent.com/827338/118802049-5bdb9380-b8aa-11eb-9a34-9d3256917b5d.gif)


After:

![CleanShot 2021-05-19 at 13 53 14](https://user-images.githubusercontent.com/827338/118801723-fdaeb080-b8a9-11eb-8408-a0d22691f849.gif)


Sandbox https://codesandbox.io/s/vkui-default-example-forked-ldd8p?file=/index.tsx