### PR TITLE
fix: Support lazy slide initialization in Gallery

### DIFF
--- a/src/components/Gallery/Gallery.test.tsx
+++ b/src/components/Gallery/Gallery.test.tsx
@@ -1,6 +1,30 @@
+import { render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import Gallery from './Gallery';
 
 describe('Gallery', () => {
   baselineComponent(Gallery);
+  describe('handles slide count', () => {
+    it('prevents slideIndex outside slide count', () => {
+      let index;
+      render(<Gallery onChange={(v) => index = v} slideIndex={9}><div /><div /></Gallery>);
+      expect(index).toBe(1);
+      render(<Gallery onChange={(v) => index = v} slideIndex={-9}><div /><div /></Gallery>);
+      expect(index).toBe(0);
+    });
+    it('handles dynamic slide count', () => {
+      let index;
+      const setIndex = (v: number) => index = v;
+      const { rerender } = render((
+        <Gallery onChange={setIndex} slideIndex={1}><div /><div /></Gallery>
+      ));
+      rerender(<Gallery onChange={setIndex} slideIndex={1}><div /></Gallery>);
+      expect(index).toBe(0);
+    });
+    it('keeps slideIndex when 0 slides', () => {
+      const setIndex = jest.fn();
+      render(<Gallery onChange={setIndex} slideIndex={10} />);
+      expect(setIndex).not.toBeCalled();
+    });
+  });
 });

--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -8,6 +8,7 @@ import { canUseDOM, withDOM, useDOM, DOMProps } from '../../lib/dom';
 import { setRef } from '../../lib/utils';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import HorizontalScrollArrow from '../HorizontalScroll/HorizontalScrollArrow';
+import { clamp } from '../../helpers/math';
 
 export interface BaseGalleryProps extends
   Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'onDragStart' | 'onDragEnd'>,
@@ -364,10 +365,14 @@ class BaseGallery extends Component<BaseGalleryProps & DOMProps & AdaptivityProp
     };
 
     return (
-      <div {...restProps} vkuiClass={classNames(getClassName('Gallery', platform), `Gallery--${align}`, {
-        'Gallery--dragging': dragging,
-        'Gallery--custom-width': slideWidth === 'custom',
-      })} ref={this.getRootRef}>
+      <div
+        {...restProps}
+        vkuiClass={classNames(getClassName('Gallery', platform), `Gallery--${align}`, {
+          'Gallery--dragging': dragging,
+          'Gallery--custom-width': slideWidth === 'custom',
+        })}
+        ref={this.getRootRef}
+      >
         <Touch
           vkuiClass="Gallery__viewport"
           onStartX={this.onStart}
@@ -437,14 +442,22 @@ const Gallery: FC<GalleryProps> = ({
     const id = window.setTimeout(() => handleChange((slideIndex + 1) % childCount), timeout);
     return () => window.clearTimeout(id);
   }, [timeout, slideIndex, childCount]);
-  // prevent overflow
-  useEffect(() => handleChange(Math.min(slideIndex, childCount - 1)), [childCount]);
+
+  // prevent invalid slideIndex
+  // any slide index is invalid with no slides, just keep it as is
+  const safeSlideIndex = childCount > 0 ? clamp(slideIndex, 0, childCount - 1) : slideIndex;
+  // notify parent in controlled mode
+  useEffect(() => {
+    if (onChange && safeSlideIndex !== slideIndex) {
+      onChange(safeSlideIndex);
+    }
+  }, [safeSlideIndex]);
 
   return (
     <BaseGalleryAdaptive
-      slideIndex={slideIndex}
       isDraggable={isDraggable}
       {...props}
+      slideIndex={safeSlideIndex}
       onChange={handleChange}
     >{slides}</BaseGalleryAdaptive>
   );


### PR DESCRIPTION
если сейчас передать пустые слайды в `Gallery`, `slideIndex` встанет в `-1` и застрянет там, так что если слайды появятся, свайпать будет нельзя. Новое поведение:
1. При `slideCount == 0` не нормализуем `slideIndex`, потому что любой будет некорректным, а так поддерживаем `slideIndex={3}` с ленивой инициализацией слайдов (отскроллится на 3, когда появятся слайды)
2. `slideIndex` внутри всегда нормализуется, чтобы нельзя было сломать галерею `slideIndex` без `onChange`
3. При нормализации `slideIndex` плюем `onChange`, чтобы в controlled-режиме контроллер синхронизировался