### PR TITLE
ModalRoot: check page content only if modal type is ModalPage

### DIFF
--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -333,7 +333,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
     const modalId = activeModal || nextModal;
 
     const modalState = this.modalsState[modalId];
-    if (modalState?.modalElement) {
+    if (modalState?.type === ModalType.PAGE && modalState?.modalElement) {
       const prevModalState = { ...modalState };
       this.initPageModal(modalState);
       const currentModalState = { ...modalState };


### PR DESCRIPTION
fixes #1585 

bug reproduction - https://codesandbox.io/s/modals-example-forked-voidz?file=/example.tsx (sandbox with fix - https://github.com/VKCOM/VKUI/pull/1610#issuecomment-844016686)