### PR TITLE
fix(FormField): Replace width property of after element with min-width

### DIFF
--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -19,7 +19,7 @@
   align-items: center;
   align-content: center;
   justify-content: center;
-  width: 44px;
+  min-width: 44px;
   height: 44px;
   margin: -1px;
   border-radius: inherit;
@@ -72,7 +72,7 @@
  */
 
 .FormField--sizeY-compact .FormField__after {
-  width: 36px;
+  min-width: 36px;
   height: 36px;
 }
 


### PR DESCRIPTION
This change will make it possible to pass in `after` prop not only one `Icon` or `IconButton`, but also text, which can be more than 44px.