### PR TITLE
feat: Поддержать noLegacyClasses на ConfigProvider

### DIFF
--- a/src/components/AppRoot/AppRoot.test.tsx
+++ b/src/components/AppRoot/AppRoot.test.tsx
@@ -1,7 +1,10 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { AppRootContext } from './AppRootContext';
 import AppRoot from './AppRoot';
+import { classScopingMode } from '../../lib/classScopingMode';
+import { Icon24Add } from '@vkontakte/icons';
+import ConfigProvider from '../ConfigProvider/ConfigProvider';
 
 describe('AppRoot', () => {
   baselineComponent(AppRoot);
@@ -36,6 +39,56 @@ describe('AppRoot', () => {
       ));
       render(<AppRoot embedded />).unmount();
       expect(document.body).toContainElement(portalRoot1);
+    });
+  });
+  describe('configures class prefix', () => {
+    const Hello = () => <div vkuiClass="Hello" data-testid="hello" />;
+    const resetScoping = () => Object.assign(classScopingMode, { _isSet: false, _noConflict: false });
+    afterEach(resetScoping);
+    beforeEach(resetScoping);
+    it('enables global classes by default', () => {
+      render(<AppRoot><Hello /></AppRoot>);
+      expect(screen.getByTestId('hello')).toHaveClass('Hello');
+    });
+    it('can disable global classes', () => {
+      render(<AppRoot noLegacyClasses><Hello /></AppRoot>);
+      expect(screen.getByTestId('hello')).not.toHaveClass('Hello');
+    });
+    describe('icons', () => {
+      it('sets icon prefix', () => {
+        render(<AppRoot><Icon24Add data-testid="icon" /></AppRoot>);
+        expect(screen.getByTestId('icon')).toHaveClass('vkuiIcon Icon');
+      });
+      it('can disable global icon classes', () => {
+        render(<AppRoot noLegacyClasses><Icon24Add data-testid="icon" /></AppRoot>);
+        expect(screen.getByTestId('icon')).not.toHaveClass('Icon');
+      });
+    });
+    describe('works inside ConfigProvider', () => {
+      it('disables global classes inside config provider', () => {
+        render((
+          <ConfigProvider>
+            <AppRoot noLegacyClasses>
+              <Hello />
+              <Icon24Add data-testid="icon" />
+            </AppRoot>
+          </ConfigProvider>
+        ));
+        expect(screen.getByTestId('icon')).not.toHaveClass('Icon');
+        expect(screen.getByTestId('hello')).not.toHaveClass('Hello');
+      });
+      it('inherits config provider prefix setting when set', () => {
+        render((
+          <ConfigProvider noLegacyClasses>
+            <AppRoot>
+              <Hello />
+              <Icon24Add data-testid="icon" />
+            </AppRoot>
+          </ConfigProvider>
+        ));
+        expect(screen.getByTestId('icon')).not.toHaveClass('Icon');
+        expect(screen.getByTestId('hello')).not.toHaveClass('Hello');
+      });
     });
   });
 });

--- a/src/components/AppRoot/AppRoot.tsx
+++ b/src/components/AppRoot/AppRoot.tsx
@@ -27,7 +27,7 @@ function applyAdaptivityStyles(container: HTMLElement, sizeX: SizeType) {
   }
 }
 
-const AppRoot: FC<AppRootProps> = ({ children, embedded, sizeX, hasMouse, noLegacyClasses = false, scroll = 'global', ...props }) => {
+const AppRoot: FC<AppRootProps> = ({ children, embedded, sizeX, hasMouse, noLegacyClasses, scroll = 'global', ...props }) => {
   const rootRef = useRef<HTMLDivElement>();
   const [portalRoot, setPortalRoot] = useState<HTMLDivElement>(null);
   const { window, document } = useDOM();
@@ -98,7 +98,8 @@ const AppRoot: FC<AppRootProps> = ({ children, embedded, sizeX, hasMouse, noLega
         embedded,
       }}>
         <ScrollContext.Provider value={scrollController}>
-          <IconSettingsProvider classPrefix="vkui" globalClasses={!noLegacyClasses}>
+          {/* Наследуем noLegacyClasses от ConfigProvider через classScopingMode */}
+          <IconSettingsProvider classPrefix="vkui" globalClasses={!classScopingMode.noConflict}>
             {children}
           </IconSettingsProvider>
         </ScrollContext.Provider>

--- a/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -1,8 +1,10 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useContext, FC } from 'react';
 import { ANDROID, VKCOM } from '../../lib/platform';
 import { baselineComponent } from '../../testing/utils';
 import ConfigProvider from './ConfigProvider';
+import { classScopingMode } from '../../lib/classScopingMode';
+import { Icon24Add } from '@vkontakte/icons';
 import { ConfigProviderContext, ConfigProviderContextInterface, WebviewType } from './ConfigProviderContext';
 
 describe('ConfigProvider', () => {
@@ -65,6 +67,30 @@ describe('ConfigProvider', () => {
     it('enforces vkcom scheme on vkcom platform', () => {
       render(<ConfigProvider scheme="bright_light" platform={VKCOM} />);
       expect(document.body).toHaveAttribute('scheme', 'vkcom');
+    });
+  });
+  describe('configures class prefix', () => {
+    const Hello = () => <div vkuiClass="Hello" data-testid="hello" />;
+    const resetScoping = () => Object.assign(classScopingMode, { _isSet: false, _noConflict: false });
+    afterEach(resetScoping);
+    beforeEach(resetScoping);
+    it('enables global classes by default', () => {
+      render(<ConfigProvider><Hello /></ConfigProvider>);
+      expect(screen.getByTestId('hello')).toHaveClass('Hello');
+    });
+    it('can disable global classes', () => {
+      render(<ConfigProvider noLegacyClasses><Hello /></ConfigProvider>);
+      expect(screen.getByTestId('hello')).not.toHaveClass('Hello');
+    });
+    describe('icons', () => {
+      it('sets icon prefix', () => {
+        render(<ConfigProvider><Icon24Add data-testid="icon" /></ConfigProvider>);
+        expect(screen.getByTestId('icon')).toHaveClass('vkuiIcon Icon');
+      });
+      it('can disable global icon classes', () => {
+        render(<ConfigProvider noLegacyClasses><Icon24Add data-testid="icon" /></ConfigProvider>);
+        expect(screen.getByTestId('icon')).not.toHaveClass('Icon');
+      });
     });
   });
 });

--- a/src/lib/classScopingMode.ts
+++ b/src/lib/classScopingMode.ts
@@ -6,6 +6,9 @@ export const __controller = {
     return this._noConflict;
   },
   set noConflict(v: boolean) {
+    if (v == null) {
+      return;
+    }
     if (this._isSet && v !== this.noConflict) {
       setTimeout(() => {
         throw new Error('[vkui]: Single VKUI instance can not have different globalClassName settings');

--- a/styleguide/Components/Preview.js
+++ b/styleguide/Components/Preview.js
@@ -146,7 +146,7 @@ export default class Preview extends PreviewParent {
             />
           );
           example = autoLayout === 'all' ? <DefaultLayout>{example}</DefaultLayout> : example;
-          example = isPartial || autoLayout === 'none' ? example : <AppRoot embedded={isEmbedded} noLegacyClasses>{example}</AppRoot>;
+          example = isPartial || autoLayout === 'none' ? example : <AppRoot embedded={isEmbedded}>{example}</AppRoot>;
 
           const frameStyle = {
             height: styleGuideContext.height,
@@ -198,6 +198,7 @@ export default class Preview extends PreviewParent {
                         platform={styleGuideContext.platform}
                         scheme={styleGuideContext.scheme}
                         webviewType={styleGuideContext.webviewType}
+                        noLegacyClasses
                         {...config}
                       >
                         <AdaptivityProvider hasMouse={styleGuideContext.hasMouse}>

--- a/styleguide/pages/modes.md
+++ b/styleguide/pages/modes.md
@@ -38,7 +38,7 @@
 
 **Важно:** В режиме `embedded`, `AppRoot` компоненту нужно указать свойство `embedded`: `<AppRoot embedded>`.
 
-**new** Чтобы отключить css-классы без префиксов (как `.Button`), которые могут конфликтовать с классами основного приложения, используйте `<AppRoot noLegacyClasses>`. В таком режиме на элементах vkui классы вида `class="vkuiButton vkuiButton--primary"`.
+**new** Чтобы отключить css-классы без префиксов (как `.Button`), которые могут конфликтовать с классами основного приложения, используйте `<ConfigProvider noLegacyClasses>` (или `<AppRoot noLegacyClasses />`). В таком режиме на элементах vkui классы вида `class="vkuiButton vkuiButton--primary"`.
 
 ### Режимы скролла
 


### PR DESCRIPTION
Сейчас в partial-режиме есть 2 проблемы:
- Нельзя использовать `noLegacyClasses`, потому что он вешается на `AppRoot` ([#1380](https://github.com/VKCOM/VKUI/pull/1380/files?file-filters%5B%5D=#diff-299fcdd669d66db53e39043ceb322b86bc59fd5947bb2cc64b7f81be11e4a4bf))
- Сломаны стили vkui для иконок, потому что `IconSettingsProvider` встроен в `AppRoot` (#1445)

Этот ПР добавляет возможность передавать `noLegacyClasses` через `<ConfigProvider>` — это исправляет обе проблемы с сохранением обратной совместимости.

__Ограничения__
- Не поддерживается порядок `<AppRoot><ConfigProvider>` (или `<AppRoot><Init>` для `vkui-common`)
- Приложение обязательно должно быть обернуто хотя бы один из `ConfigProvider` или `AppRoot`, иначе сломаются иконки.

Оба кейса не укладываются в vkui-конвенции — см. [Hello World,](https://vkcom.github.io/VKUI/#!/Hello%20World) [Концепция,](https://vkcom.github.io/VKUI/#!/Концепция) [сандбокс,](https://codesandbox.io/s/vkui-hello-world-mi77q?file=/index.tsx) [create-vk-mini-app](https://github.com/VKCOM/create-vk-mini-app/blob/master/src/App.js) и точно не используются ни в одном внутреннем приложении.