### PR TITLE
style: Disallow index imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,29 +28,29 @@
     "no-restricted-imports": ["error", {
       "paths": [
         // prevent absolute imports from src subfolders like `import { ... } from "lib"`
-        "appearance", 
-        "components", 
-        "helpers", 
-        "hoc", 
-        "hooks", 
-        "lib", 
-        "styles", 
-        "testing", 
-        "types", 
+        "appearance",
+        "components",
+        "helpers",
+        "hoc",
+        "hooks",
+        "lib",
+        "styles",
+        "testing",
+        "types",
         "unstable"
       ],
       "patterns": [
         "@vkontakte/icons/dist/*",
         // prevent absolute imports from src subfolders like `import { ... } from "lib/platform"`
-        "appearance/*", 
-        "components/*", 
-        "helpers/*", 
-        "hoc/*", 
-        "hooks/*", 
-        "lib/*", 
-        "styles/*", 
-        "testing/*", 
-        "types/*", 
+        "appearance/*",
+        "components/*",
+        "helpers/*",
+        "hoc/*",
+        "hooks/*",
+        "lib/*",
+        "styles/*",
+        "testing/*",
+        "types/*",
         "unstable/*"
       ]
     }],
@@ -76,7 +76,13 @@
       "property": "getElementById",
       "message": "Absolutely do not use id"
     }],
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "no-restricted-syntax": ["error",
+      {
+        "selector": "ImportDeclaration[source.value=/^\\W+(index(\\.ts)?)?$/i]",
+        "message": "Do not import index"
+      }
+    ]
   },
   "overrides": [
     {

--- a/src/components/NativeSelect/NativeSelect.tsx
+++ b/src/components/NativeSelect/NativeSelect.tsx
@@ -4,7 +4,7 @@ import { Icon20Dropdown, Icon24Dropdown } from '@vkontakte/icons';
 import FormField from '../FormField/FormField';
 import { HasAlign, HasRef, HasRootRef } from '../../types';
 import { withAdaptivity, AdaptivityProps, SizeType } from '../../hoc/withAdaptivity';
-import { getClassName } from '../..';
+import { getClassName } from '../../helpers/getClassName';
 import Headline from '../Typography/Headline/Headline';
 import Text from '../Typography/Text/Text';
 import { VKCOM } from '../../lib/platform';

--- a/src/components/PanelHeaderBack/PanelHeaderBack.tsx
+++ b/src/components/PanelHeaderBack/PanelHeaderBack.tsx
@@ -3,8 +3,7 @@ import { Icon28ChevronBack, Icon28ChevronLeftOutline, Icon28ArrowLeftOutline } f
 import PanelHeaderButton, { PanelHeaderButtonProps } from '../PanelHeaderButton/PanelHeaderButton';
 import { ANDROID, VKCOM, IOS } from '../../lib/platform';
 import { usePlatform } from '../../hooks/usePlatform';
-import { withAdaptivity, SizeType } from '../../hoc/withAdaptivity';
-import { AdaptivityProps } from '../..';
+import { withAdaptivity, SizeType, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
 

--- a/src/components/PanelHeaderContent/PanelHeaderContent.tsx
+++ b/src/components/PanelHeaderContent/PanelHeaderContent.tsx
@@ -5,7 +5,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
 import Caption from '../Typography/Caption/Caption';
 import Headline from '../Typography/Headline/Headline';
-import { IOS } from '../..';
+import { IOS } from '../../lib/platform';
 
 export interface PanelHeaderContentProps extends HTMLAttributes<HTMLDivElement> {
   aside?: ReactNode;

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -17,7 +17,7 @@ import { VKUITouchEvent } from '../../lib/touch';
 import { noop } from '../../lib/utils';
 import Text from '../Typography/Text/Text';
 import Title from '../Typography/Title/Title';
-import { Separator } from '../../index';
+import Separator from '../Separator/Separator';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useEnsuredControl } from '../../hooks/useEnsuredControl';
 

--- a/src/components/SelectMimicry/SelectMimicry.tsx
+++ b/src/components/SelectMimicry/SelectMimicry.tsx
@@ -5,7 +5,7 @@ import FormField from '../FormField/FormField';
 import { HasAlign, HasRootRef } from '../../types';
 import { withAdaptivity, AdaptivityProps, SizeType } from '../../hoc/withAdaptivity';
 import { usePlatform } from '../../hooks/usePlatform';
-import { getClassName } from '../..';
+import { getClassName } from '../../helpers/getClassName';
 import Headline from '../Typography/Headline/Headline';
 import Text from '../Typography/Text/Text';
 import { VKCOM } from '../../lib/platform';

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -3,7 +3,7 @@ import { classNames } from '../../lib/classNames';
 import FormField from '../FormField/FormField';
 import { HasRef, HasRootRef } from '../../types';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
-import { getClassName, HasPlatform } from '../..';
+import { getClassName } from '../../helpers/getClassName';
 import { useEnsuredControl } from '../../hooks/useEnsuredControl';
 import { useExternRef } from '../../hooks/useExternRef';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -13,8 +13,7 @@ export interface TextareaProps extends
   TextareaHTMLAttributes<HTMLTextAreaElement>,
   HasRef<HTMLTextAreaElement>,
   HasRootRef<HTMLElement>,
-  AdaptivityProps,
-  HasPlatform {
+  AdaptivityProps {
   grow?: boolean;
   onResize?(el: HTMLTextAreaElement): void;
   defaultValue?: string;


### PR DESCRIPTION
Запрещаем импортить индекс, потому что
1. Это ломает определение измененных файлов в тестах
1. Циклические импорты нехорошо