### PR TITLE
[Bug] Не срабатывает onChange у ActionSheet

### DIFF
--- a/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/src/components/ActionSheet/ActionSheet.test.tsx
@@ -1,12 +1,29 @@
+import { render, screen } from '@testing-library/react';
 import { ViewWidth } from '../../hoc/withAdaptivity';
 import { baselineComponent } from '../../testing/utils';
 import ActionSheet from './ActionSheet';
+import ActionSheetItem from '../ActionSheetItem/ActionSheetItem';
+import userEvent from '@testing-library/user-event';
+import AdaptivityProvider from '../AdaptivityProvider/AdaptivityProvider';
 
 describe('ActionSheet', () => {
   describe('desktop', () => {
     const toggle = document.createElement('div');
-    baselineComponent((p) => <ActionSheet {...p} toggleRef={toggle} />, {
-      adaptivity: { viewWidth: ViewWidth.DESKTOP, hasMouse: true },
+    const adaptivity = { viewWidth: ViewWidth.DESKTOP, hasMouse: true };
+    baselineComponent((p) => <ActionSheet {...p} toggleRef={toggle} />, { adaptivity });
+
+    // force desktop mode because no transition event in jsdom
+    it('calls onChange when autoclose=true', () => {
+      const onChange = jest.fn();
+      const { unmount } = render((
+        <AdaptivityProvider {...adaptivity}>
+          <ActionSheet toggleRef={toggle} onClose={() => unmount()}>
+            <ActionSheetItem selectable autoclose onChange={onChange} data-testid="item" />
+          </ActionSheet>
+        </AdaptivityProvider>
+      ));
+      userEvent.click(screen.getByTestId('item'));
+      expect(onChange).toBeCalled();
     });
   });
   describe('mobile', () =>

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -60,7 +60,7 @@ const ActionSheetItem: React.FunctionComponent<ActionSheetItemProps> = ({
   return (
     <Tappable
       {...restProps}
-      onClick={onItemClick(onClick, autoclose)}
+      onClick={selectable ? onClick : onItemClick(onClick, autoclose)}
       activeMode="ActionSheetItem--active"
       vkuiClass={
         classNames(
@@ -131,6 +131,7 @@ const ActionSheetItem: React.FunctionComponent<ActionSheetItemProps> = ({
             name={name}
             value={value}
             onChange={onChange}
+            onClick={onItemClick(noop, autoclose)}
             defaultChecked={defaultChecked}
             checked={checked}
             disabled={restProps.disabled}


### PR DESCRIPTION
fixes #1491
Детали бага:
1. Клик по `<label class="ActionSheetItem">`
2. Срабатывает onItemClick 
3. в ActionSheet из-за autoclose вылетает onClose
4. onClose анмаунтит ActionSheet
5. клик с label не успевает продублироваться на `input`

Без autoclose бага нет, потому что ActionSheet не анмаунтится
На мобилке бага нет, потому что `onClose` срабатывает после анимации, и за это время как раз отрабатывает `onChange`