### PR TITLE
feat: Allow nav prop in Root

### DIFF
--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -11,9 +11,9 @@ import { SplitColContextProps, SplitColContext } from '../SplitCol/SplitCol';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
 import { canUseDOM, DOMProps, withDOM } from '../../lib/dom';
 import { ScrollContext, ScrollContextInterface } from '../AppRoot/ScrollContext';
-import { getNavId } from '../../lib/getNavId';
+import { getNavId, NavIdProps } from '../../lib/getNavId';
 
-export interface RootProps extends HTMLAttributes<HTMLDivElement>, HasPlatform {
+export interface RootProps extends HTMLAttributes<HTMLDivElement>, HasPlatform, NavIdProps {
   activeView: string;
   onTransition?(params: { isBack: boolean; from: string; to: string }): void;
   /**


### PR DESCRIPTION
- fixes #1655 
- Просто тип добавил, всё куда можно пихнуть `Root` вроде поддерживает `nav`