### PR TITLE
types: Export NavIdProps from package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -272,5 +272,6 @@ export { ViewWidth, ViewHeight, SizeType } from './components/AdaptivityProvider
  * Types
  */
 export type { AlignType, HasPlatform, HasInsets } from './types';
+export type { NavIdProps } from './lib/getNavId';
 export type { PlatformType } from './lib/platform';
 export type { AdaptivityProps } from './hoc/withAdaptivity';


### PR DESCRIPTION
Экспортируем тип `NavIdProps` для:
- использования в кастомных навигационных элементах 
- возможности безопасного депрекейта `id`  

fixes #1660 