### PR TITLE
INFRA: Faster yarn size local runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   ],
   "scripts": {
     "prepare": "node -e '!process.env.VKUI_SKIP_PREPARE && require(`child_process`).spawn(`yarn`, [`build`], { stdio: `inherit` })'",
-    "size": "yarn clear && yarn build && size-limit",
+    "size": "yarn clear && concurrently 'yarn:babel' 'yarn:postcss' && size-limit",
     "size:ci": "yarn install --frozen-lockfile --ignore-scripts && yarn build:no-types",
     "styleguide": "cross-env NODE_ENV=development styleguidist server --config=styleguide/config.js",
     "styleguide:build": "cross-env NODE_ENV=production styleguidist build --config=styleguide/config.js",


### PR DESCRIPTION
Не собираем cjs и d.ts, которые не нужны для анализа размера + параллелим css и js = 80 -> 22c на локальный анализ размера