### PR TITLE
refactor: Add useEventListener hook

### DIFF
--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -18,6 +18,7 @@ import { useDOM } from '../../lib/dom';
 import Caption from '../Typography/Caption/Caption';
 import { prefixClass } from '../../lib/prefixClass';
 import { useExternRef } from '../../hooks/useExternRef';
+import { useEventListener } from '../../hooks/useEventListener';
 
 export interface ChipsSelectProps<Option extends ChipsInputOption> extends ChipsInputProps<Option>, AdaptivityProps {
   popupDirection?: 'top' | 'bottom';
@@ -209,13 +210,8 @@ const ChipsSelect = <Option extends ChipsInputOption>(props: ChipsSelectProps<Op
     }
   }, [filteredOptions, focusedOption, showCreatable, closeAfterSelect]);
 
-  useEffect(() => {
-    document.addEventListener('click', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, []);
+  const clickEvent = useEventListener('click', handleClickOutside);
+  useEffect(() => clickEvent.add(document), []);
 
   const renderChipWrapper = (renderChipProps: RenderChip<Option>) => {
     const { onRemove } = renderChipProps;

--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -18,7 +18,7 @@ import { useDOM } from '../../lib/dom';
 import Caption from '../Typography/Caption/Caption';
 import { prefixClass } from '../../lib/prefixClass';
 import { useExternRef } from '../../hooks/useExternRef';
-import { useEventListener } from '../../hooks/useEventListener';
+import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 
 export interface ChipsSelectProps<Option extends ChipsInputOption> extends ChipsInputProps<Option>, AdaptivityProps {
   popupDirection?: 'top' | 'bottom';
@@ -210,8 +210,7 @@ const ChipsSelect = <Option extends ChipsInputOption>(props: ChipsSelectProps<Op
     }
   }, [filteredOptions, focusedOption, showCreatable, closeAfterSelect]);
 
-  const clickEvent = useEventListener('click', handleClickOutside);
-  useEffect(() => clickEvent.add(document), []);
+  useGlobalEventListener(document, 'click', handleClickOutside);
 
   const renderChipWrapper = (renderChipProps: RenderChip<Option>) => {
     const { onRemove } = renderChipProps;

--- a/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -4,6 +4,7 @@ import { getClassName } from '../../helpers/getClassName';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import HorizontalScrollArrow from './HorizontalScrollArrow';
 import { easeInOutSine } from '../../lib/fx';
+import { useEventListener } from '../../hooks/useEventListener';
 
 interface ScrollContext {
   scrollElement: HTMLElement | null;
@@ -154,11 +155,8 @@ const HorizontalScroll: FC<HorizontalScrollProps> = (props: HorizontalScrollProp
     }
   }, [hasMouse]);
 
-  useEffect(() => {
-    scrollerRef.current && scrollerRef.current.addEventListener('scroll', onscroll);
-    return () => scrollerRef.current && scrollerRef.current.removeEventListener('scroll', onscroll);
-  }, []);
-
+  const scrollEvent = useEventListener('scroll', onscroll);
+  useEffect(() => scrollEvent.add(scrollerRef.current), []);
   useEffect(onscroll, [scrollerRef, children]);
 
   return (

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -1,4 +1,4 @@
-import React, { AllHTMLAttributes, FC, ReactNode, MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
+import React, { AllHTMLAttributes, FC, ReactNode, MouseEvent, useEffect, useRef, useState } from 'react';
 import { classNames } from '../../lib/classNames';
 import { getTitleFromChildren } from '../../lib/utils';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -8,6 +8,7 @@ import { useDOM } from '../../lib/dom';
 import { ANDROID, IOS, VKCOM } from '../../lib/platform';
 import { Icon24Cancel } from '@vkontakte/icons';
 import IconButton from '../IconButton/IconButton';
+import { useEventListener } from '../../hooks/useEventListener';
 
 export interface RemovePlaceholderProps {
   /**
@@ -41,19 +42,18 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
   const [isRemoveActivated, setRemoveActivated] = useState(false);
   const [removeOffset, updateRemoveOffset] = useState(0);
 
-  const deactivateRemove = useCallback(() => {
+  const deactivateRemoveEvent = useEventListener('click', () => {
     setRemoveActivated(false);
     updateRemoveOffset(0);
-
-    document.removeEventListener('click', deactivateRemove);
-  }, [setRemoveActivated, updateRemoveOffset]);
+    deactivateRemoveEvent.remove();
+  });
 
   const onRemoveActivateClick = (e: MouseEvent) => {
     e.nativeEvent.stopPropagation();
     e.preventDefault();
     setRemoveActivated(true);
 
-    document.addEventListener('click', deactivateRemove);
+    deactivateRemoveEvent.add(document);
   };
 
   const onRemoveClick = (e: MouseEvent) => {
@@ -67,12 +67,6 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
       updateRemoveOffset(removeButtonRef.current.offsetWidth);
     }
   }, [isRemoveActivated]);
-
-  useEffect(() => {
-    return () => {
-      document.removeEventListener('click', deactivateRemove);
-    };
-  }, [deactivateRemove]);
 
   const removePlaceholderString: string = getTitleFromChildren(removePlaceholder);
 

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -8,7 +8,7 @@ import { useDOM } from '../../lib/dom';
 import { ANDROID, IOS, VKCOM } from '../../lib/platform';
 import { Icon24Cancel } from '@vkontakte/icons';
 import IconButton from '../IconButton/IconButton';
-import { useEventListener } from '../../hooks/useEventListener';
+import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 
 export interface RemovePlaceholderProps {
   /**
@@ -42,18 +42,15 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
   const [isRemoveActivated, setRemoveActivated] = useState(false);
   const [removeOffset, updateRemoveOffset] = useState(0);
 
-  const deactivateRemoveEvent = useEventListener('click', () => {
+  useGlobalEventListener(document, 'click', isRemoveActivated && (() => {
     setRemoveActivated(false);
     updateRemoveOffset(0);
-    deactivateRemoveEvent.remove();
-  });
+  }));
 
   const onRemoveActivateClick = (e: MouseEvent) => {
     e.nativeEvent.stopPropagation();
     e.preventDefault();
     setRemoveActivated(true);
-
-    deactivateRemoveEvent.add(document);
   };
 
   const onRemoveClick = (e: MouseEvent) => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@ import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import Subhead from '../Typography/Subhead/Subhead';
 import { tooltipContainerAttr } from './TooltipContainer';
 import { useExternRef } from '../../hooks/useExternRef';
+import { useEventListener } from '../../hooks/useEventListener';
 
 interface TooltipPortalProps extends Partial<TooltipProps> {
   target?: HTMLElement;
@@ -43,10 +44,8 @@ const TooltipPortal: FC<TooltipPortalProps> = ({
   const portalTarget = useMemo(() => target.closest(`[${tooltipContainerAttr}]`), [target]);
   /* eslint-enable no-restricted-properties */
 
-  useIsomorphicLayoutEffect(() => {
-    document.addEventListener('click', onClose);
-    return () => document.removeEventListener('click', onClose);
-  }, [onClose]);
+  const clickEvent = useEventListener('click', onClose);
+  useIsomorphicLayoutEffect(() => clickEvent.add(document), []);
 
   useIsomorphicLayoutEffect(() => {
     const container = containerRef.current;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -11,7 +11,7 @@ import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import Subhead from '../Typography/Subhead/Subhead';
 import { tooltipContainerAttr } from './TooltipContainer';
 import { useExternRef } from '../../hooks/useExternRef';
-import { useEventListener } from '../../hooks/useEventListener';
+import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 
 interface TooltipPortalProps extends Partial<TooltipProps> {
   target?: HTMLElement;
@@ -44,8 +44,7 @@ const TooltipPortal: FC<TooltipPortalProps> = ({
   const portalTarget = useMemo(() => target.closest(`[${tooltipContainerAttr}]`), [target]);
   /* eslint-enable no-restricted-properties */
 
-  const clickEvent = useEventListener('click', onClose);
-  useIsomorphicLayoutEffect(() => clickEvent.add(document), []);
+  useGlobalEventListener(document, 'click', onClose);
 
   useIsomorphicLayoutEffect(() => {
     const container = containerRef.current;

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -1,0 +1,41 @@
+import { noop } from '../lib/utils';
+import { useCallback, useEffect, useRef } from 'react';
+import { canUseDOM } from '../lib/dom';
+import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
+
+interface EventListenerHandle {
+  add(el: HTMLElement | Document): void;
+  remove(): void;
+}
+
+export function useEventListener<K extends keyof GlobalEventHandlersEventMap>(
+  event: K,
+  _cb: (ev: GlobalEventHandlersEventMap[K]) => any,
+  _options?: AddEventListenerOptions,
+): EventListenerHandle;
+export function useEventListener(event: string, _cb: (ev: Event) => any, _options?: AddEventListenerOptions): EventListenerHandle;
+export function useEventListener(event: string, _cb: (ev: Event) => any, _options?: AddEventListenerOptions) {
+  const cbRef = useRef(_cb);
+  useIsomorphicLayoutEffect(() => {
+    cbRef.current = _cb;
+  }, [_cb]);
+  const cb = useCallback<typeof _cb>((e) => cbRef.current(e), []);
+
+  const detach = useRef(noop);
+  const remove = useCallback(() => detach.current(), []);
+  const add = useCallback((el: HTMLElement | Document) => {
+    if (!canUseDOM) {
+      return;
+    }
+    remove();
+    const options = { ..._options };
+    el.addEventListener(event, cb, options);
+    detach.current = () => {
+      el.removeEventListener(event, cb, options);
+      detach.current = noop;
+    };
+  }, []);
+  useEffect(() => remove, []);
+
+  return { add, remove };
+}

--- a/src/hooks/useGlobalEventListener.ts
+++ b/src/hooks/useGlobalEventListener.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useEventListener } from './useEventListener';
+
+export function useGlobalEventListener<K extends keyof GlobalEventHandlersEventMap>(
+  element: HTMLElement | HTMLDocument | Window,
+  event: K,
+  cb: false | null | ((ev: GlobalEventHandlersEventMap[K]) => any),
+  options?: AddEventListenerOptions,
+): void;
+export function useGlobalEventListener(
+  element: HTMLElement | HTMLDocument | Window,
+  event: string,
+  cb: false | null | ((ev: Event) => any),
+  options?: AddEventListenerOptions,
+): void;
+export function useGlobalEventListener(element: any, event: string, cb: (ev: Event) => any, options?: AddEventListenerOptions) {
+  const listener = useEventListener(event, cb, options);
+  useEffect(() => cb ? listener.add(element) : listener.remove(), [Boolean(cb)]);
+}


### PR DESCRIPTION
`useEventListener`:
- не привязывается к элементу два раза
- сам удаляется при анмаунте
- всегда вызывает актуальный колбек

`useGlobalEventListener` заодно автоматически подвязывается к стабильному элементу