### PR TITLE
Fix/slider int step

### DIFF
--- a/src/helpers/math.test.ts
+++ b/src/helpers/math.test.ts
@@ -34,4 +34,13 @@ describe(rescale, () => {
   it('rounds precision', () => {
     expect(rescale(3.1415926, [3, 4], [3, 4], { step: 0.01 })).toBe(3.14);
   });
+  describe('non-divisor step', () => {
+    it('rounds to min + k * step when min != n * step', () => {
+      expect(rescale(0.1, [0.1, 3.1], [0.1, 3.1], { step: 2 })).toBe(0.1);
+      expect(rescale(3, [1, 5], [1, 5], { step: 2 })).toBe(3);
+    });
+    it('clamps to min + min(max, min + k * step) when max != min + n * step', () => {
+      expect(rescale(3, [0, 3], [0, 3], { step: 2 })).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
Изменяем логику `step` в `Slider` / `RangeSlider`
1. Округляем к ближайшему `min + k * step`, а не `k * step` — например, `min=1, step=2, max=5 => value in { 1, 3, 5 }`, а не `{ 2, 4 }`
2. `value in [min, max]` при любом округлении
3. Если `max - min` не делится на `step`, value не доходит до `max` (потому что не попадает на `min + k * step`) — например, `min=1, step=2, max=4 => value in { 1, 3 }`, а не `{ 1, 3, 4 }`

Немного беспокоит, что это меняет текущее поведение, но новый вариант логичнее и используется в других китах:
- [ant](https://codesandbox.io/s/ant-slider-step-vs-min-qbn62)
- [material](https://codesandbox.io/s/material-slider-step-vs-min-bs9v1?file=/demo.js) (без п.3)

fixes #1677