### PR TITLE
fix(SubnavigationBar): Remove button outline

### DIFF
--- a/src/components/Alert/Alert.css
+++ b/src/components/Alert/Alert.css
@@ -83,7 +83,6 @@
   margin: 0;
   height: 44px;
   display: block;
-  outline: none;
   overflow: hidden;
   text-overflow: ellipsis;
   border-radius: 0;

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,7 +1,6 @@
 .Button {
   display: inline-block;
   box-sizing: border-box;
-  outline: none;
   text-decoration: none;
   border: none;
   min-height: 30px;

--- a/src/components/CellButton/CellButton.css
+++ b/src/components/CellButton/CellButton.css
@@ -1,6 +1,5 @@
 .CellButton {
   box-sizing: border-box;
-  outline: none;
   text-decoration: none;
   margin: 0;
   border: none;

--- a/src/components/ChipsInput/ChipsInput.css
+++ b/src/components/ChipsInput/ChipsInput.css
@@ -33,7 +33,6 @@
   font-size: 15px;
   color: var(--text_primary);
   border: none;
-  outline: none;
   width: 100%;
   box-sizing: border-box;
   box-shadow: none;
@@ -46,10 +45,6 @@
 
 .ChipsInput__el:focus {
   min-width: 64px;
-}
-
-.ChipsInput:focus {
-  outline: none;
 }
 
 .ChipsInput__el::-ms-clear {

--- a/src/components/ChipsSelect/ChipsSelect.css
+++ b/src/components/ChipsSelect/ChipsSelect.css
@@ -47,10 +47,6 @@
   padding: 10px 9px;
 }
 
-.ChipsSelect .CustomScrollView__box:focus {
-  outline: none;
-}
-
 .ChipsSelect__open:not(.ChipsSelect__open--popupDirectionTop) .FormField__border {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;

--- a/src/components/IconButton/IconButton.css
+++ b/src/components/IconButton/IconButton.css
@@ -2,7 +2,6 @@
   appearance: none;
   background: none;
   border: none;
-  outline: none;
   box-shadow: none;
   display: block;
   color: currentColor;

--- a/src/components/Input/Input.css
+++ b/src/components/Input/Input.css
@@ -19,7 +19,6 @@
   box-sizing: border-box;
   box-shadow: none;
   border: none;
-  outline: none;
   appearance: none;
   text-overflow: ellipsis;
   height: 42px;

--- a/src/components/Link/Link.css
+++ b/src/components/Link/Link.css
@@ -3,7 +3,6 @@
   text-decoration: none;
   border: 0;
   background: none;
-  outline: none;
   margin: 0;
   padding: 0;
   cursor: pointer;

--- a/src/components/PanelHeaderButton/PanelHeaderButton.css
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.css
@@ -2,7 +2,6 @@
   appearance: none;
   background: none;
   border: none;
-  outline: none;
   box-shadow: none;
   display: block;
   color: currentColor;

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -18,10 +18,6 @@
   border: none;
 }
 
-.Removable__action:focus {
-  outline: none;
-}
-
 .Removable--start .Removable__action {
   align-self: flex-start;
 }

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -37,7 +37,6 @@
   padding: 0 22px 0 36px;
   box-sizing: border-box;
   font-size: 17px;
-  outline: none;
   border-radius: 10px;
   max-width: 100%;
   flex-grow: 1;

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -3,15 +3,10 @@
   box-sizing: border-box;
 }
 
-.Select--mimicry:focus {
-  outline: none;
-}
-
 .Select__el {
   display: block;
   position: absolute;
   appearance: none;
-  outline: none;
   border: none;
   left: 0;
   top: 0;

--- a/src/components/SliderSwitch/SliderSwitch.css
+++ b/src/components/SliderSwitch/SliderSwitch.css
@@ -7,7 +7,6 @@
   box-sizing: border-box;
   background-color: var(--field_background);
   transition: all 100ms ease-out;
-  outline: none;
 }
 
 .SliderSwitch__button {
@@ -24,7 +23,6 @@
   background: transparent;
   color: var(--text_subhead);
   transition: color 100ms ease-out;
-  outline: none;
   user-select: none;
   z-index: 1;
   -webkit-appearance: none;

--- a/src/components/Textarea/Textarea.css
+++ b/src/components/Textarea/Textarea.css
@@ -7,7 +7,6 @@
   width: 100%;
   display: block;
   box-sizing: border-box;
-  outline: none;
   resize: none;
   appearance: none;
   line-height: 19px;

--- a/src/components/WriteBar/WriteBar.css
+++ b/src/components/WriteBar/WriteBar.css
@@ -28,7 +28,6 @@
   margin: 0;
   background: transparent;
   border: none;
-  outline: none;
   resize: none;
   line-height: 20px;
   color: var(--text_primary);

--- a/src/components/WriteBarIcon/WriteBarIcon.css
+++ b/src/components/WriteBarIcon/WriteBarIcon.css
@@ -1,7 +1,6 @@
 .WriteBarIcon {
   background: none;
   border: 0;
-  outline: none;
   position: relative;
   color: var(--writebar_icon);
   height: 52px;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -171,6 +171,6 @@
   font-family: inherit;
 }
 
-.vkui__root a:focus {
+.vkui__root *:focus {
   outline: none;
 }


### PR DESCRIPTION
Fixes #1682: у стрелок в `SubnavigationBar` больше нет `outline` при фокусе.

Заодно порефакторила стили `outline` в принципе — теперь они все локально убраны в одном месте, а не раскиданы по компонентам.

(`outline` обязательно вернется, но уже в процессе работы над доступностью. И выглядеть будет прилично.)