### PR TITLE
ModalPage: set expandable if settlingHeight === 100

### DIFF
--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -275,7 +275,7 @@ class ModalRootTouchComponent extends Component<ModalRootProps & DOMProps, Modal
 
     let prevTranslateY = modalState.translateY;
 
-    modalState.expandable = contentHeight > contentElement.clientHeight;
+    modalState.expandable = contentHeight > contentElement.clientHeight || modalState.settlingHeight === 100;
 
     let collapsed = false;
     let expanded = false;


### PR DESCRIPTION
Фикс скролла для фулскрин модалок с динамиеским контентом

## Проблема

- изначально все модалки открываются не на всю высоту, и если контент больше экрана то ее нужно вытащить вверх после чего уже будет доступен скролл
- для фулскрин модалок требуется дополнительный клик чтобы скролл заработал, но он должен быть доступен сразу

Пример:

https://codesandbox.io/s/modals-example-forked-3nb2z?file=/example.tsx&resolutionWidth=320&resolutionHeight=675

По логике имплементации, модалка с settlingHeight = 100 должна быть сразу в режиме expandable