### PR TITLE
Button's content is no longer wrapped

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -9,6 +9,7 @@
   padding: 1px 16px;
   user-select: none;
   border-radius: 8px;
+  max-width: 100%;
 }
 
 .Button[disabled] {
@@ -27,6 +28,9 @@
 .Button__content {
   padding-top: 4px;
   padding-bottom: 6px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .Button__content--caps {


### PR DESCRIPTION
Убирает перенос текста в Button.

### Before:
![image](https://user-images.githubusercontent.com/36237725/123083259-91831780-d428-11eb-97c9-597822bf962c.png)

### After:
![image](https://user-images.githubusercontent.com/36237725/123083314-9c3dac80-d428-11eb-9f3b-6b1c6081b9ad.png)

fixes #1678 