### PR TITLE
Доступность: семантический Header

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, HTMLAttributes, ReactNode, Fragment } from 'react';
+import { FC, HTMLAttributes, ReactNode, Fragment } from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -64,7 +64,7 @@ function renderAside({ aside, platform }: { aside: HeaderProps['aside']; platfor
   return <Text weight="regular" vkuiClass="Header__aside">{aside}</Text>;
 }
 
-const Header: FunctionComponent<HeaderProps> = ({
+const Header: FC<HeaderProps> = ({
   mode,
   children,
   subtitle,
@@ -75,15 +75,17 @@ const Header: FunctionComponent<HeaderProps> = ({
   ...restProps
 }: HeaderProps) => {
   const platform = usePlatform();
-  const baseClassNames = getClassName('Header', platform);
 
   return (
-    <div
+    <header
       {...restProps}
       ref={getRootRef}
-      vkuiClass={classNames(baseClassNames, `Header--mode-${mode}`, {
-        'Header--pi': isPrimitiveReactNode(indicator),
-      })}
+      vkuiClass={classNames(
+        getClassName('Header', platform),
+        `Header--mode-${mode}`, {
+          'Header--pi': isPrimitiveReactNode(indicator),
+        },
+      )}
     >
       <div vkuiClass="Header__in">
         <div vkuiClass="Header__main">
@@ -103,7 +105,7 @@ const Header: FunctionComponent<HeaderProps> = ({
         </div>
         {hasReactNode(aside) && renderAside({ aside, platform })}
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
 import { HasPlatform, HasRootRef } from '../../types';
 import { hasReactNode, isPrimitiveReactNode } from '../../lib/utils';
-import { Platform, PlatformType } from '../../lib/platform';
+import { Platform } from '../../lib/platform';
 import Headline from '../Typography/Headline/Headline';
 import Caption from '../Typography/Caption/Caption';
 import Title from '../Typography/Title/Title';
@@ -57,12 +57,11 @@ function renderChildren({ children, platform, mode }: Pick<HeaderProps, 'childre
   }
 }
 
-function renderAside({ aside, platform }: { aside: HeaderProps['aside']; platform: PlatformType }) {
-  if (platform === Platform.VKCOM) {
-    return <Subhead weight="regular" vkuiClass="Header__aside">{aside}</Subhead>;
-  }
-  return <Text weight="regular" vkuiClass="Header__aside">{aside}</Text>;
-}
+type HeaderAsideProps = Pick<HeaderProps, 'aside'> & HasPlatform & { Component: ElementType };
+
+const HeaderAside: FC<HeaderAsideProps> = ({ platform, ...restProps }: HeaderAsideProps) => {
+  return platform === Platform.VKCOM ? <Subhead weight="regular" {...restProps} /> : <Text weight="regular" {...restProps} />;
+};
 
 const Header: FC<HeaderProps> = ({
   mode,
@@ -103,7 +102,7 @@ const Header: FC<HeaderProps> = ({
           })}
           {hasReactNode(subtitle) && <Caption Component="span" vkuiClass="Header__subtitle" weight="regular" level="1">{subtitle}</Caption>}
         </div>
-        {hasReactNode(aside) && renderAside({ aside, platform })}
+        {hasReactNode(aside) && <HeaderAside vkuiClass="Header__aside" platform={platform} Component="div">{aside}</HeaderAside>}
       </div>
     </header>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes, ReactNode, Fragment } from 'react';
+import { ElementType, FC, HTMLAttributes, ReactNode } from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -25,37 +25,38 @@ export interface HeaderProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<
   multiline?: boolean;
 }
 
-function renderChildren({ children, platform, mode }: Pick<HeaderProps, 'children' | 'mode'> & HasPlatform) {
-  switch (platform) {
-    case Platform.ANDROID:
-      switch (mode) {
-        case 'primary':
-          return <Headline vkuiClass="Header__content" weight="medium">{children}</Headline>;
-        case 'secondary':
-          return <Caption Component="h3" vkuiClass="Header__content" level="1" weight="medium" caps>{children}</Caption>;
-        case 'tertiary':
-          return <Headline vkuiClass="Header__content" weight="medium">{children}</Headline>;
-      }
-      break;
-    case Platform.IOS:
-      switch (mode) {
-        case 'primary':
-        case 'tertiary':
-          return <Title vkuiClass="Header__content" weight="semibold" level="3">{children}</Title>;
-        case 'secondary':
-          return <Caption Component="h4" vkuiClass="Header__content" level="1" weight="semibold" caps>{children}</Caption>;
-      }
-      break;
-    case Platform.VKCOM:
-      switch (mode) {
-        case 'primary':
-          return <Headline vkuiClass="Header__content" weight="regular">{children}</Headline>;
-        case 'secondary':
-        case 'tertiary':
-          return <Caption Component="h4" vkuiClass="Header__content" level="1" weight="regular">{children}</Caption>;
-      }
+type HeaderContentProps = Pick<HeaderProps, 'children' | 'mode'> & HasPlatform & { Component: ElementType };
+
+const HeaderContent: FC<HeaderContentProps> = ({ platform, mode, ...restProps }: HeaderContentProps) => {
+  if (platform === Platform.IOS) {
+    switch (mode) {
+      case 'primary':
+      case 'tertiary':
+        return <Title weight="semibold" level="3" {...restProps} />;
+      case 'secondary':
+        return <Caption level="1" weight="semibold" caps {...restProps} />;
+    }
   }
-}
+
+  if (platform === Platform.VKCOM) {
+    switch (mode) {
+      case 'primary':
+        return <Headline weight="regular" {...restProps} />;
+      case 'secondary':
+      case 'tertiary':
+        return <Caption level="1" weight="regular" {...restProps} />;
+    }
+  }
+
+  switch (mode) {
+    case 'primary':
+      return <Headline weight="medium" {...restProps} />;
+    case 'secondary':
+      return <Caption level="1" weight="medium" caps {...restProps} />;
+    case 'tertiary':
+      return <Headline weight="medium" {...restProps} />;
+  }
+};
 
 type HeaderAsideProps = Pick<HeaderProps, 'aside'> & HasPlatform & { Component: ElementType };
 
@@ -88,18 +89,12 @@ const Header: FC<HeaderProps> = ({
     >
       <div vkuiClass="Header__in">
         <div vkuiClass="Header__main">
-          {renderChildren({
-            children: (
-              <Fragment>
-                <div vkuiClass={classNames('Header__content-base', {
-                  'Header__content-base--multiline': multiline,
-                })}>{children}</div>
-                {hasReactNode(indicator) && <Caption vkuiClass="Header__indicator" weight="regular" level="1">{indicator}</Caption>}
-              </Fragment>
-            ),
-            platform,
-            mode,
-          })}
+          <HeaderContent vkuiClass="Header__content" Component="h3" mode={mode} platform={platform}>
+            <span vkuiClass={classNames('Header__content-base', {
+              'Header__content-base--multiline': multiline,
+            })}>{children}</span>
+            {hasReactNode(indicator) && <Caption vkuiClass="Header__indicator" weight="regular" level="1">{indicator}</Caption>}
+          </HeaderContent>
           {hasReactNode(subtitle) && <Caption Component="span" vkuiClass="Header__subtitle" weight="regular" level="1">{subtitle}</Caption>}
         </div>
         {hasReactNode(aside) && <HeaderAside vkuiClass="Header__aside" platform={platform} Component="div">{aside}</HeaderAside>}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -32,7 +32,7 @@ function renderChildren({ children, platform, mode }: Pick<HeaderProps, 'childre
         case 'primary':
           return <Headline vkuiClass="Header__content" weight="medium">{children}</Headline>;
         case 'secondary':
-          return <Caption vkuiClass="Header__content" level="1" weight="medium" caps>{children}</Caption>;
+          return <Caption Component="h3" vkuiClass="Header__content" level="1" weight="medium" caps>{children}</Caption>;
         case 'tertiary':
           return <Headline vkuiClass="Header__content" weight="medium">{children}</Headline>;
       }
@@ -43,7 +43,7 @@ function renderChildren({ children, platform, mode }: Pick<HeaderProps, 'childre
         case 'tertiary':
           return <Title vkuiClass="Header__content" weight="semibold" level="3">{children}</Title>;
         case 'secondary':
-          return <Caption vkuiClass="Header__content" level="1" weight="semibold" caps>{children}</Caption>;
+          return <Caption Component="h4" vkuiClass="Header__content" level="1" weight="semibold" caps>{children}</Caption>;
       }
       break;
     case Platform.VKCOM:
@@ -52,7 +52,7 @@ function renderChildren({ children, platform, mode }: Pick<HeaderProps, 'childre
           return <Headline vkuiClass="Header__content" weight="regular">{children}</Headline>;
         case 'secondary':
         case 'tertiary':
-          return <Caption vkuiClass="Header__content" level="1" weight="regular">{children}</Caption>;
+          return <Caption Component="h4" vkuiClass="Header__content" level="1" weight="regular">{children}</Caption>;
       }
   }
 }
@@ -101,7 +101,7 @@ const Header: FC<HeaderProps> = ({
             platform,
             mode,
           })}
-          {hasReactNode(subtitle) && <Caption vkuiClass="Header__subtitle" weight="regular" level="1">{subtitle}</Caption>}
+          {hasReactNode(subtitle) && <Caption Component="span" vkuiClass="Header__subtitle" weight="regular" level="1">{subtitle}</Caption>}
         </div>
         {hasReactNode(aside) && renderAside({ aside, platform })}
       </div>

--- a/src/components/Typography/Caption/Caption.css
+++ b/src/components/Typography/Caption/Caption.css
@@ -1,3 +1,7 @@
+.Caption {
+  margin: 0;
+}
+
 .Caption--caps {
   text-transform: uppercase;
 }


### PR DESCRIPTION
- Добавила семантики для `<Header/>`,
- Добавила в типографический `Caption` ресет марджина, чтобы можно было передавать ему заголовки как `Component`,
- Порефакторила внутренности:
  - `renderChildren()` => `HeaderContent`
  - `renderAside()` => `HeaderAside`