### PR TITLE
ChipsInput: fix paddings and margins

### DIFF
--- a/src/components/ChipsInput/ChipsInput.css
+++ b/src/components/ChipsInput/ChipsInput.css
@@ -2,7 +2,7 @@
   position: relative;
   display: flex;
   max-width: 100%;
-  padding: 1px 14px;
+  padding: 1px 4px;
 }
 
 .ChipsInput__container {
@@ -13,22 +13,22 @@
   flex-wrap: wrap;
   max-width: 100%;
   /* 2px горизонтального отступа ушли в chip и input-container для 2+2=4px отступа между строками при многострочном инпуте */
-  padding: 3px 12px;
-  margin: 0 -16px 0 -12px;
+  padding: 3px 4px 3px 2px;
+  margin-left: -2px;
   z-index: 2;
   overflow: hidden;
 }
 
 .ChipsInput__chip {
   max-width: 100%;
-  margin: 2px 12px 2px -8px;
+  margin: 2px;
 }
 
 .ChipsInput__input-container {
   display: flex;
   flex-direction: column;
   flex: 1;
-  margin: 2px 8px 2px 0;
+  margin: 2px 4px;
 }
 
 .ChipsInput__el {

--- a/src/components/ChipsInput/ChipsInput.css
+++ b/src/components/ChipsInput/ChipsInput.css
@@ -28,7 +28,12 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  margin: 2px 4px;
+  margin: 2px;
+  margin-left: 6px;
+}
+
+.ChipsInput__input-container:first-of-type {
+  margin-left: 10px;
 }
 
 .ChipsInput__el {
@@ -71,8 +76,8 @@
  * sizeY COMPACT
  */
 .ChipsInput--sizeY-compact {
-  padding-left: 12px;
-  padding-right: 12px;
+  padding-left: 2px;
+  padding-right: 2px;
 }
 
 .ChipsInput--sizeY-compact .ChipsInput__container {

--- a/src/components/ChipsInput/ChipsInput.css
+++ b/src/components/ChipsInput/ChipsInput.css
@@ -1,8 +1,5 @@
 .ChipsInput {
-  position: relative;
-  display: flex;
   max-width: 100%;
-  padding: 1px 4px;
 }
 
 .ChipsInput__container {
@@ -12,9 +9,7 @@
   display: flex;
   flex-wrap: wrap;
   max-width: 100%;
-  /* 2px горизонтального отступа ушли в chip и input-container для 2+2=4px отступа между строками при многострочном инпуте */
-  padding: 3px 4px 3px 2px;
-  margin-left: -2px;
+  padding: 3px;
   z-index: 2;
   overflow: hidden;
 }
@@ -29,10 +24,6 @@
   flex-direction: column;
   flex: 1;
   margin: 2px;
-  margin-left: 6px;
-}
-
-.ChipsInput__input-container:first-of-type {
   margin-left: 10px;
 }
 
@@ -75,12 +66,7 @@
 /**
  * sizeY COMPACT
  */
-.ChipsInput--sizeY-compact {
-  padding-left: 2px;
-  padding-right: 2px;
-}
 
 .ChipsInput--sizeY-compact .ChipsInput__container {
-  padding-top: 1px;
-  padding-bottom: 1px;
+  padding: 1px;
 }

--- a/src/components/ChipsInput/__image_snapshots__/chipsinput-android-bright_light-1-snap.png
+++ b/src/components/ChipsInput/__image_snapshots__/chipsinput-android-bright_light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ce22787aaae63644106c03cd2d748374ed571f32973a0a6bb53c94835d3f274
-size 65779
+oid sha256:faff45340fb5a23e4aca0c8e854667784c1602af8cff7635f07580abfbfbbcaf
+size 65850

--- a/src/components/ChipsInput/__image_snapshots__/chipsinput-ios-bright_light-1-snap.png
+++ b/src/components/ChipsInput/__image_snapshots__/chipsinput-ios-bright_light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7719a5ced01e5542c6d86b3f69ddc4dd7c09929312ccfb3fe612fc142cbce28
-size 66741
+oid sha256:eaa2558ff0aab50c89b19afd1833a8c89dcf4e673ac83f12fdaaebd8581d9af7
+size 66770

--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -27,7 +27,7 @@
 }
 
 .ChipsInput .FormField__after {
-  margin-right: -14px;
+  margin-right: -3px;
   z-index: 3;
 }
 

--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -27,7 +27,7 @@
 }
 
 .ChipsInput .FormField__after {
-  margin-right: -3px;
+  margin-right: -4px;
   z-index: 3;
 }
 
@@ -74,14 +74,13 @@
 /**
  * sizeY COMPACT
  */
-
 .FormField--sizeY-compact .FormField__after {
   min-width: 36px;
   height: 36px;
 }
 
 .FormField--sizeY-compact.ChipsInput .FormField__after {
-  margin-right: -12px;
+  margin-right: -2px;
 }
 
 /**

--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -27,7 +27,6 @@
 }
 
 .ChipsInput .FormField__after {
-  margin-right: -4px;
   z-index: 3;
 }
 
@@ -77,10 +76,6 @@
 .FormField--sizeY-compact .FormField__after {
   min-width: 36px;
   height: 36px;
-}
-
-.FormField--sizeY-compact.ChipsInput .FormField__after {
-  margin-right: -2px;
 }
 
 /**


### PR DESCRIPTION
Фикс вдогонку к #1709:
- Подправила еще паддинги-марджины для `ChipsInput` и `ChipsSelect`, чтобы скриншотные тесты не валились (а с помощью @thoughtspile избавились от дичи вообще);
- Те скриншоты, в которых был обрезанный текст в инпутах — обновила.