### PR TITLE
Fix: Allow scheme=inherit on VKCOM

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -47,6 +47,10 @@ describe('ConfigProvider', () => {
         render(<ConfigProvider scheme="inherit" />);
         expect(document.body).not.toHaveAttribute('scheme');
       });
+      it('does not set body[scheme] to inherit when platform=VKCOM', () => {
+        render(<ConfigProvider scheme="inherit" platform={VKCOM} />);
+        expect(document.body).not.toHaveAttribute('scheme');
+      });
       it('does not remove body[scheme] on unmount when scheme="inherit"', () => {
         document.body.setAttribute('scheme', 'extern');
         render(<ConfigProvider scheme="inherit" />).unmount();

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -7,7 +7,7 @@ import {
   AppearanceScheme,
   defaultConfigProviderProps,
 } from './ConfigProviderContext';
-import { VKCOM } from '../../lib/platform';
+import { PlatformType, VKCOM } from '../../lib/platform';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { noop } from '../../lib/utils';
@@ -19,7 +19,13 @@ export interface ConfigProviderProps extends ConfigProviderContextInterface {
   scheme?: AppearanceScheme;
 }
 
-function mapOldScheme(scheme: AppearanceScheme): AppearanceScheme {
+function normalizeScheme(scheme: AppearanceScheme, platform: PlatformType): AppearanceScheme {
+  if (scheme === 'inherit') {
+    return scheme;
+  }
+  if (platform === VKCOM) {
+    return Scheme.VKCOM;
+  }
   switch (scheme) {
     case Scheme.DEPRECATED_CLIENT_LIGHT:
       return Scheme.BRIGHT_LIGHT;
@@ -31,7 +37,7 @@ function mapOldScheme(scheme: AppearanceScheme): AppearanceScheme {
 }
 
 const ConfigProvider: FC<ConfigProviderProps> = ({ children, ...config }) => {
-  const scheme = config.platform === VKCOM ? Scheme.VKCOM : mapOldScheme(config.scheme);
+  const scheme = normalizeScheme(config.scheme, config.platform);
 
   const { document } = useDOM();
   const setScheme = () => {

--- a/styleguide/pages/modes.md
+++ b/styleguide/pages/modes.md
@@ -147,4 +147,4 @@ console.log(hasModal);
 
 ### Наследование темы
 
-__Advanced__ Если ваше приложение само определяет цвета через css-переменные аналогично [https://github.com/VKCOM/VKUI/blob/master/package.json](bright_light.css), используйте `<ConfigProvider theme="inherit">`, а стили подключайте через `import '@vkontakte/vkui/components.css'`.
+> __Advanced__ Если ваше приложение само определяет цвета через css-переменные аналогично [https://github.com/VKCOM/VKUI/blob/master/package.json](bright_light.css), используйте `<ConfigProvider scheme="inherit">`, а стили подключайте через `import '@vkontakte/vkui/components.css'`.


### PR DESCRIPTION
Текущее поведение: `<ConfigProvider platform={VKCOM} scheme="inherit">` форсирует `scheme="vkcom"` и перезаписывает `body[scheme]` при встраивании в vk.com

После фикса `scheme="inherit"` сохраняется для любой платформы

