### PR TITLE
Доступность: alt, role и aria-атрибуты для компонентов с изображениями и иконками

### DIFF
--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -57,3 +57,14 @@
 .CellButton--danger > .Avatar .Icon {
   color: var(--destructive);
 }
+
+/**
+ * .PanelHeader
+ */
+.PanelHeader__left .Avatar {
+  margin-left: 8px;
+}
+
+.PanelHeader__right .Avatar {
+  margin-right: 8px;
+}

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -18,7 +18,8 @@
   border-radius: inherit;
 }
 
-.Avatar__shadow {
+.Avatar--shadow .Avatar__in::after {
+  content: '';
   position: absolute;
   left: 0;
   top: 0;

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -3,44 +3,42 @@
   color: var(--placeholder_icon_background);
 }
 
-.Avatar__in {
-  position: relative;
-}
-
+.Avatar__in,
 .Avatar__img {
-  background: currentColor;
-  border: none;
+  position: relative;
   display: block;
   width: 100%;
   height: 100%;
-  position: relative;
+  border: none;
+  border-radius: inherit;
   z-index: 1;
+}
+
+.Avatar__in {
+  background: currentColor;
+  pointer-events: none;
+}
+
+.Avatar__children,
+.Avatar--shadow .Avatar__in::after {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
   border-radius: inherit;
 }
 
 .Avatar--shadow .Avatar__in::after {
   content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
   box-shadow: inset 0 0 0 var(--thin-border) var(--image_border);
-  pointer-events: none;
-  z-index: 2;
-  border-radius: inherit;
+  z-index: 3;
 }
 
 .Avatar__children {
-  position: absolute;
-  left: 0;
-  top: 0;
-  z-index: 2;
-  width: 100%;
-  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: inherit;
   color: var(--icon_secondary);
+  z-index: 2;
 }

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -83,3 +83,48 @@
   padding-top: 6px;
   padding-bottom: 6px;
 }
+
+/**
+ * .SimpleCell
+ */
+.SimpleCell > .Avatar {
+  padding-right: 12px;
+}
+
+.SimpleCell > .Avatar--sz-28,
+.SimpleCell > .Avatar--sz-32 {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.SimpleCell > .Avatar--sz-40 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.SimpleCell > .Avatar--sz-48,
+.SimpleCell > .Avatar--sz-72 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.SimpleCell--ios > .Avatar--sz-28,
+.SimpleCell--ios > .Avatar--sz-32 {
+  padding-left: 4px;
+}
+
+.SimpleCell--sizeY-compact > .Avatar--sz-28,
+.SimpleCell--sizeY-compact > .Avatar--sz-32 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.SimpleCell--sizeY-compact > .Avatar--sz-40 {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
+.SimpleCell--sizeY-compact > .Avatar--sz-48 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -1,4 +1,5 @@
 .Avatar {
+  flex-shrink: 0;
   box-sizing: border-box;
   color: var(--placeholder_icon_background);
 }
@@ -67,4 +68,18 @@
 
 .PanelHeader__right .Avatar {
   margin-right: 8px;
+}
+
+/**
+ * .RichCell
+ */
+.RichCell > .Avatar {
+  padding-right: 12px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.RichCell > .Avatar--sz-48 {
+  padding-top: 6px;
+  padding-bottom: 6px;
 }

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -42,3 +42,18 @@
   color: var(--icon_secondary);
   z-index: 2;
 }
+
+/**
+ * .CellButton
+ */
+.CellButton > .Avatar {
+  color: var(--button_muted_background);
+}
+
+.CellButton > .Avatar .Icon {
+  color: var(--accent);
+}
+
+.CellButton--danger > .Avatar .Icon {
+  color: var(--destructive);
+}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ImgHTMLAttributes } from 'react';
+import { FC, ImgHTMLAttributes } from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -9,12 +9,11 @@ export interface AvatarProps extends ImgHTMLAttributes<HTMLElement>, HasRootRef<
    * Рекомендуемый сет значений: 96 | 88 | 80 | 72 | 64 | 56 | 48 | 44 | 40 | 36 | 32 | 28 | 24
    */
   size?: number;
-  src?: string;
   mode?: 'default' | 'image' | 'app';
   shadow?: boolean;
 }
 
-const Avatar: FunctionComponent<AvatarProps> = ({
+const Avatar: FC<AvatarProps> = ({
   src,
   size,
   shadow,

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -21,9 +21,11 @@ const Avatar: FC<AvatarProps> = ({
   className,
   children,
   getRootRef,
+  style,
+  alt,
+  'aria-label': ariaLabel,
   ...restProps
 }: AvatarProps) => {
-  const Component = src ? 'img' : 'div';
   const platform = usePlatform();
 
   let borderRadius: string | number = '50%';
@@ -52,13 +54,11 @@ const Avatar: FC<AvatarProps> = ({
       })}
       className={className}
       ref={getRootRef}
+      role={src ? 'img' : 'presentation'}
+      aria-label={ariaLabel}
     >
-      <div vkuiClass="Avatar__in" style={{ width: size, height: size, borderRadius }}>
-        <Component
-          {...restProps}
-          vkuiClass="Avatar__img"
-          src={src}
-        />
+      <div {...restProps} aria-hidden="true" vkuiClass="Avatar__in" style={{ ...style, width: size, height: size, borderRadius }}>
+        {src && <img vkuiClass="Avatar__img" src={src} alt="" />}
         {children && <div vkuiClass="Avatar__children">{children}</div>}
       </div>
     </div>

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -26,12 +26,10 @@ const Avatar: FunctionComponent<AvatarProps> = ({
 }: AvatarProps) => {
   const Component = src ? 'img' : 'div';
   const platform = usePlatform();
-  let borderRadius;
+
+  let borderRadius: string | number = '50%';
 
   switch (mode) {
-    case 'default':
-      borderRadius = '50%';
-      break;
     case 'image':
       size < 64 && (borderRadius = 4);
       size >= 64 && size < 96 && (borderRadius = 6);
@@ -43,6 +41,8 @@ const Avatar: FunctionComponent<AvatarProps> = ({
       size >= 56 && size < 64 && (borderRadius = 12);
       size >= 64 && size < 84 && (borderRadius = 16);
       size >= 84 && (borderRadius = 18);
+      break;
+    default:
       break;
   }
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -48,7 +48,9 @@ const Avatar: FunctionComponent<AvatarProps> = ({
 
   return (
     <div
-      vkuiClass={classNames(getClassName('Avatar', platform), `Avatar--type-${mode}`, `Avatar--sz-${size}`)}
+      vkuiClass={classNames(getClassName('Avatar', platform), `Avatar--type-${mode}`, `Avatar--sz-${size}`, {
+        'Avatar--shadow': shadow,
+      })}
       className={className}
       ref={getRootRef}
     >
@@ -59,7 +61,6 @@ const Avatar: FunctionComponent<AvatarProps> = ({
           src={src}
         />
         {children && <div vkuiClass="Avatar__children">{children}</div>}
-        {shadow && <span vkuiClass="Avatar__shadow" />}
       </div>
     </div>
   );

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -55,7 +55,7 @@ const Avatar: FC<AvatarProps> = ({
       className={className}
       ref={getRootRef}
       role={src ? 'img' : 'presentation'}
-      aria-label={ariaLabel}
+      aria-label={alt || ariaLabel}
     >
       <div {...restProps} aria-hidden="true" vkuiClass="Avatar__in" style={{ ...style, width: size, height: size, borderRadius }}>
         {src && <img vkuiClass="Avatar__img" src={src} alt="" />}

--- a/src/components/CellButton/CellButton.css
+++ b/src/components/CellButton/CellButton.css
@@ -29,18 +29,12 @@
   padding-right: 8px;
 }
 
-.CellButton > .Avatar {
-  color: var(--button_muted_background);
-}
-
-.CellButton--primary,
-.CellButton--primary > .Icon,
-.CellButton--primary > .Avatar .Icon {
+.CellButton,
+.CellButton > .Icon {
   color: var(--accent);
 }
 
 .CellButton--danger,
-.CellButton--danger > .Icon,
-.CellButton--danger > .Avatar .Icon {
+.CellButton--danger > .Icon {
   color: var(--destructive);
 }

--- a/src/components/Gradient/Gradient.tsx
+++ b/src/components/Gradient/Gradient.tsx
@@ -9,6 +9,7 @@ export interface GradientProps extends HTMLAttributes<HTMLDivElement> {
 const Gradient: FunctionComponent<GradientProps> = ({ mode, children, to, ...restProps }) => {
   return (
     <div
+      role="presentation"
       {...restProps}
       vkuiClass={classNames('Gradient', `Gradient--md-${mode}`, `Gradient--to-${to}`)}
     >

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -35,10 +35,6 @@
   flex-shrink: 0;
 }
 
-.PanelHeader__left .Avatar {
-  margin-left: 8px;
-}
-
 .PanelHeader__content {
   overflow: hidden;
 }
@@ -60,10 +56,6 @@
   justify-content: flex-end;
   box-sizing: border-box;
   color: var(--header_tint);
-}
-
-.PanelHeader__right .Avatar {
-  margin-right: 8px;
 }
 
 .PanelHeader--vkapps .PanelHeader__right {

--- a/src/components/RichCell/RichCell.css
+++ b/src/components/RichCell/RichCell.css
@@ -17,13 +17,6 @@
   text-overflow: initial;
 }
 
-.RichCell > .Avatar {
-  padding-right: 12px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  flex-shrink: 0;
-}
-
 .RichCell__in {
   flex-grow: 1;
   max-width: 100%;
@@ -133,11 +126,6 @@
 
 .RichCell--sizeY-compact {
   min-height: 60px;
-}
-
-.RichCell > .Avatar--sz-48 {
-  padding-top: 6px;
-  padding-bottom: 6px;
 }
 
 .RichCell--sizeY-compact .RichCell__actions {

--- a/src/components/SimpleCell/SimpleCell.css
+++ b/src/components/SimpleCell/SimpleCell.css
@@ -16,15 +16,6 @@
   text-overflow: initial;
 }
 
-.SimpleCell > .Avatar,
-.SimpleCell > .Icon {
-  flex-shrink: 0;
-}
-
-.SimpleCell > .Icon {
-  color: var(--accent);
-}
-
 .SimpleCell__main {
   max-width: 100%;
   flex-grow: 1;
@@ -33,31 +24,16 @@
   overflow: hidden;
 }
 
-.SimpleCell > .Icon,
-.SimpleCell > .Avatar {
+.SimpleCell > .Icon {
+  padding-top: 10px;
+  padding-bottom: 10px;
   padding-right: 12px;
+  flex-shrink: 0;
+  color: var(--accent);
 }
 
 .SimpleCell > .Icon--28 {
   padding-right: 16px;
-}
-
-.SimpleCell > .Icon,
-.SimpleCell > .Avatar--sz-32,
-.SimpleCell > .Avatar--sz-28 {
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
-.SimpleCell > .Avatar--sz-40 {
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
-.SimpleCell > .Avatar--sz-48,
-.SimpleCell > .Avatar--sz-72 {
-  padding-top: 6px;
-  padding-bottom: 6px;
 }
 
 .SimpleCell__description {
@@ -175,9 +151,7 @@
   padding-bottom: 11px;
 }
 
-.SimpleCell--ios > .Icon--28,
-.SimpleCell--ios > .Avatar--sz-32,
-.SimpleCell--ios > .Avatar--sz-28 {
+.SimpleCell--ios > .Icon--28 {
   padding-left: 4px;
 }
 
@@ -233,23 +207,6 @@
 .SimpleCell--sizeY-compact .SimpleCell__indicator {
   padding-top: 10px;
   padding-bottom: 10px;
-}
-
-.SimpleCell--sizeY-compact > .Avatar--sz-40 {
-  padding-top: 2px;
-  padding-bottom: 2px;
-}
-
-.SimpleCell--sizeY-compact > .Avatar--sz-48 {
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
-.SimpleCell--sizeY-compact > .Icon,
-.SimpleCell--sizeY-compact > .Avatar--sz-32,
-.SimpleCell--sizeY-compact > .Avatar--sz-28 {
-  padding-top: 8px;
-  padding-bottom: 8px;
 }
 
 .SimpleCell--sizeY-compact .SimpleCell__description,


### PR DESCRIPTION
- [x] `Avatar`: добавила нужные `role` и `aria`-атрибуты (а также переделала тень на псевдо-элемент)
- [x] `Gradient`: добавила `role="presentation"`