### PR TITLE
CustomSelect: search

### DIFF
--- a/src/components/CustomSelect/CustomSelect.css
+++ b/src/components/CustomSelect/CustomSelect.css
@@ -23,6 +23,12 @@
   z-index: 4;
 }
 
+.CustomSelect__empty {
+  text-align: center;
+  color: var(--text_secondary);
+  padding: 12px 0;
+}
+
 .CustomSelect__options--popupDirectionTop {
   bottom: 100%;
   border-radius: 8px 8px 0 0;

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -2,6 +2,7 @@ import React, {
   ChangeEventHandler,
   createRef,
   KeyboardEvent,
+  KeyboardEventHandler,
   MouseEvent,
   ReactNode,
   SelectHTMLAttributes,
@@ -11,12 +12,15 @@ import { debounce, setRef } from '../../lib/utils';
 import { classNames } from '../../lib/classNames';
 import { NativeSelectProps } from '../NativeSelect/NativeSelect';
 import CustomScrollView from '../CustomScrollView/CustomScrollView';
-import { withAdaptivity } from '../../hoc/withAdaptivity';
+import { SizeType, withAdaptivity } from '../../hoc/withAdaptivity';
 import { withPlatform } from '../../hoc/withPlatform';
 import CustomSelectOption, { CustomSelectOptionProps } from '../CustomSelectOption/CustomSelectOption';
 import { getClassName } from '../../helpers/getClassName';
 import { FormFieldProps } from '../FormField/FormField';
 import { HasPlatform } from '../../types';
+import Input from '../Input/Input';
+import { Icon20Dropdown, Icon24Dropdown } from '@vkontakte/icons';
+import Footer from '../Footer/Footer';
 
 type SelectValue = SelectHTMLAttributes<HTMLSelectElement>['value'];
 
@@ -32,9 +36,13 @@ interface CustomSelectState {
   focusedOptionIndex?: number;
   selectedOptionIndex?: number;
   nativeSelectValue?: SelectValue;
+  options?: CustomSelectOptionInterface[];
 }
 
 export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormFieldProps {
+  searchable?: boolean;
+  emptyText?: string;
+  onSearchChange?: ChangeEventHandler<HTMLInputElement>;
   options: Array<{
     value: SelectValue;
     label: string;
@@ -51,12 +59,14 @@ type MouseEventHandler = (event: MouseEvent<HTMLElement>) => void;
 
 class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState> {
   static defaultProps: CustomSelectProps = {
+    searchable: false,
     renderOption(props: CustomSelectOptionProps): ReactNode {
       return (
         <CustomSelectOption {...props} />
       );
     },
     options: [],
+    emptyText: 'Ничего не найдено',
   };
 
   public constructor(props: CustomSelectProps) {
@@ -74,6 +84,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       focusedOptionIndex: -1,
       selectedOptionIndex: this.findSelectedIndex(props.options, initialValue),
       nativeSelectValue: initialValue,
+      options: props.options,
     };
 
     if (props.value !== undefined) {
@@ -93,8 +104,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   private readonly getSelectedItem = () => {
-    const { selectedOptionIndex } = this.state;
-    const { options } = this.props;
+    const { selectedOptionIndex, options } = this.state;
 
     if (!options.length) {
       return null;
@@ -129,11 +139,12 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     this.setState(() => ({
       opened: false,
       focusedOptionIndex: -1,
+      options: this.props.options,
     }));
   };
 
   private isValidIndex(index: number) {
-    return index >= 0 && index < this.props.options.length;
+    return index >= 0 && index < this.state.options.length;
   }
 
   selectFocused = () => {
@@ -143,13 +154,11 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   select = (index: number) => {
-    const { options } = this.props;
-
     if (!this.isValidIndex(index)) {
       return;
     }
 
-    const item = options[index];
+    const item = this.state.options[index];
 
     this.setState({
       nativeSelectValue: item.value,
@@ -179,6 +188,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     this.setState(() => ({
       opened: false,
       focused: false,
+      options: this.props.options,
     }));
 
     const event = new Event('blur');
@@ -217,12 +227,11 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
 
   focusOptionByIndex = (index: number) => {
     const { focusedOptionIndex } = this.state;
-    const { options } = this.props;
     const oldIndex = focusedOptionIndex;
 
     if (index < 0) {
-      index = options.length - 1;
-    } else if (index >= options.length) {
+      index = this.state.options.length - 1;
+    } else if (index >= this.state.options.length) {
       index = 0;
     }
 
@@ -267,10 +276,9 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   onKeyboardInput = (key: string) => {
-    const { options } = this.props;
     const fullInput = this.keyboardInput + key;
 
-    const optionIndex = options.findIndex((option) => {
+    const optionIndex = this.state.options.findIndex((option) => {
       return option.label.toLowerCase().includes(fullInput);
     });
 
@@ -285,11 +293,42 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     const value = e.currentTarget.value;
     if (!this.isControlledOutside) {
       this.setState({
-        selectedOptionIndex: this.findSelectedIndex(this.props.options, value),
+        selectedOptionIndex: this.findSelectedIndex(this.state.options, value),
       });
     }
     if (this.props.onChange) {
       this.props.onChange(e);
+    }
+  };
+
+  onInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (this.props.onSearchChange) {
+      this.props.onSearchChange(e);
+    } else {
+      this.setState({
+        options: this.props.options.filter((option) => option.label.toLowerCase().includes(e.target.value.toLowerCase())),
+      });
+    }
+  };
+
+  onInputKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    switch (event.key) {
+      case 'ArrowUp':
+        event.preventDefault();
+        this.focusOption('prev');
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        this.focusOption('next');
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.close();
+        break;
+      case 'Enter':
+        event.preventDefault();
+        this.selectFocused();
+        break;
     }
   };
 
@@ -343,6 +382,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       this.setState({
         nativeSelectValue: value,
         selectedOptionIndex: this.findSelectedIndex(this.props.options, value),
+        options: this.props.options,
       });
     }
   }
@@ -381,6 +421,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   render() {
     const { opened, nativeSelectValue } = this.state;
     const {
+      searchable,
       name,
       className,
       getRef,
@@ -395,6 +436,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       onFocus,
       renderOption,
       children,
+      emptyText,
       ...restProps
     } = this.props;
     const selected = this.getSelectedItem();
@@ -407,22 +449,36 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
         style={style}
         ref={this.rootRef}
       >
-        <SelectMimicry
-          {...restProps}
-          aria-hidden={true}
-          onClick={this.onClick}
-          onKeyDown={this.handleKeyDownSelect}
-          onKeyUp={this.handleKeyUp}
-          onFocus={this.onFocus}
-          onBlur={this.onBlur}
-          vkuiClass={classNames({
-            'CustomSelect__open': opened,
-            'CustomSelect__open--popupDirectionTop': popupDirection === 'top',
-          })}
-          className={className}
-        >
-          {label}
-        </SelectMimicry>
+        {opened && searchable ?
+          <Input
+            autoFocus
+            onBlur={this.onBlur}
+            vkuiClass={classNames({
+              'CustomSelect__open': opened,
+              'CustomSelect__open--popupDirectionTop': popupDirection === 'top',
+            })}
+            onKeyDown={this.onInputKeyDown}
+            onChange={this.onInputChange}
+            after={sizeY === SizeType.COMPACT ? <Icon20Dropdown /> : <Icon24Dropdown />}
+            placeholder={restProps.placeholder}
+          /> :
+          <SelectMimicry
+            {...restProps}
+            aria-hidden={true}
+            onClick={this.onClick}
+            onKeyDown={this.handleKeyDownSelect}
+            onKeyUp={this.handleKeyUp}
+            onFocus={this.onFocus}
+            onBlur={this.onBlur}
+            vkuiClass={classNames({
+              'CustomSelect__open': opened,
+              'CustomSelect__open--popupDirectionTop': popupDirection === 'top',
+            })}
+            className={className}
+          >
+            {label}
+          </SelectMimicry>
+        }
         <select
           ref={this.selectRef}
           name={name}
@@ -442,7 +498,8 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
           onMouseLeave={this.resetFocusedOption}
         >
           <CustomScrollView boxRef={this.scrollBoxRef}>
-            {options.map(this.renderOption)}
+            {this.state.options.map(this.renderOption)}
+            {this.state.options.length === 0 && <Footer>{emptyText}</Footer>}
           </CustomScrollView>
         </div>
         }

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -21,7 +21,7 @@ import { FormFieldProps } from '../FormField/FormField';
 import { HasPlatform } from '../../types';
 import Input from '../Input/Input';
 import { Icon20Dropdown, Icon24Dropdown } from '@vkontakte/icons';
-import Footer from '../Footer/Footer';
+import Caption from '../Typography/Caption/Caption';
 
 type SelectValue = SelectHTMLAttributes<HTMLSelectElement>['value'];
 
@@ -523,7 +523,11 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
         >
           <CustomScrollView boxRef={this.scrollBoxRef}>
             {this.state.options.map(this.renderOption)}
-            {this.state.options.length === 0 && <Footer>{emptyText}</Footer>}
+            {this.state.options.length === 0 &&
+              <Caption level="1" weight="regular" vkuiClass="CustomSelect__empty">
+                {emptyText}
+              </Caption>
+            }
           </CustomScrollView>
         </div>
         }

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -62,7 +62,7 @@ export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormF
    * на верхнем уровне и обновил свойство `options`.
    *
    */
-  onSearchChange?: (e: ChangeEvent, options: CustomSelectOptionInterface[]) => void | CustomSelectOptionInterface[];
+  onInputChange?: (e: ChangeEvent, options: CustomSelectOptionInterface[]) => void | CustomSelectOptionInterface[];
   options: Array<{
     value: SelectValue;
     label: string;
@@ -322,8 +322,8 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   onInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    if (this.props.onSearchChange) {
-      const options = this.props.onSearchChange(e, this.props.options);
+    if (this.props.onInputChange) {
+      const options = this.props.onInputChange(e, this.props.options);
       if (options) {
         this.setState({ options });
       }
@@ -460,7 +460,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       renderOption,
       children,
       emptyText,
-      onSearchChange,
+      onInputChange,
       ...restProps
     } = this.props;
     const selected = this.getSelectedItem();

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -40,8 +40,19 @@ interface CustomSelectState {
 }
 
 export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormFieldProps {
+  /**
+   * Если true, то при клике на селект в нём появится текстовое поле для поиска по options. По умолчанию поиск
+   * производится по `option.label`.
+   */
   searchable?: boolean;
+  /**
+   * Текст, который будет отображен, если приходит пустой `options`
+   */
   emptyText?: string;
+  /**
+   * Если передан, то дефолтный алгоритм поиска отключается. Используйте этот метод, если вам требуется написать
+   * собственный алгоритм фильтрации `options` при поиске.
+   */
   onSearchChange?: ChangeEventHandler<HTMLInputElement>;
   options: Array<{
     value: SelectValue;
@@ -437,6 +448,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       renderOption,
       children,
       emptyText,
+      onSearchChange,
       ...restProps
     } = this.props;
     const selected = this.getSelectedItem();

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -62,7 +62,7 @@ export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormF
    * на верхнем уровне и обновил свойство `options`.
    *
    */
-  onSearchChange?: (e: ChangeEvent) => void | CustomSelectOptionInterface[];
+  onSearchChange?: (e: ChangeEvent, options: CustomSelectOptionInterface[]) => void | CustomSelectOptionInterface[];
   options: Array<{
     value: SelectValue;
     label: string;
@@ -323,7 +323,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
 
   onInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     if (this.props.onSearchChange) {
-      const options = this.props.onSearchChange(e);
+      const options = this.props.onSearchChange(e, this.props.options);
       if (options) {
         this.setState({ options });
       }

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -1,4 +1,5 @@
 import React, {
+  ChangeEvent,
   ChangeEventHandler,
   createRef,
   KeyboardEvent,
@@ -41,7 +42,7 @@ interface CustomSelectState {
 
 export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormFieldProps {
   /**
-   * Если true, то при клике на селект в нём появится текстовое поле для поиска по options. По умолчанию поиск
+   * Если `true`, то при клике на селект в нём появится текстовое поле для поиска по `options`. По умолчанию поиск
    * производится по `option.label`.
    */
   searchable?: boolean;
@@ -50,10 +51,18 @@ export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormF
    */
   emptyText?: string;
   /**
-   * Если передан, то дефолтный алгоритм поиска отключается. Используйте этот метод, если вам требуется написать
-   * собственный алгоритм фильтрации `options` при поиске.
+   * Коллбэк для кастомизации алгоритма поиска. Учитывается только если `searchable: true`
+   *
+   * Если коллбэк не передан, то фильтрация производится автоматически по `option.label`
+   *
+   * Если передан и возвращает значение, то оно используется в качестве результата
+   * фильтрации.
+   *
+   * Если переданная функция ничего не возвращает, то подразумевается, что разработчик выполнил фильтрацию
+   * на верхнем уровне и обновил свойство `options`.
+   *
    */
-  onSearchChange?: ChangeEventHandler<HTMLInputElement>;
+  onSearchChange?: (e: ChangeEvent) => void | CustomSelectOptionInterface[];
   options: Array<{
     value: SelectValue;
     label: string;
@@ -314,7 +323,10 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
 
   onInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     if (this.props.onSearchChange) {
-      this.props.onSearchChange(e);
+      const options = this.props.onSearchChange(e);
+      if (options) {
+        this.setState({ options });
+      }
     } else {
       this.setState({
         options: this.props.options.filter((option) => option.label.toLowerCase().includes(e.target.value.toLowerCase())),

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -76,8 +76,8 @@ class Example extends React.Component {
             <CustomSelect
               placeholder="Введите название города или страны"
               searchable
-              onSearchChange={(e) => { 
-                return this.cities.filter((option) => {
+              onSearchChange={(e, options) => { 
+                return options.filter((option) => {
                   return option.label.toLowerCase().includes(e.target.value.toLowerCase()) ||
                          option.description.toLowerCase().includes(e.target.value.toLowerCase())                
                 })           

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -76,7 +76,7 @@ class Example extends React.Component {
             <CustomSelect
               placeholder="Введите название города или страны"
               searchable
-              onSearchChange={(e, options) => { 
+              onInputChange={(e, options) => { 
                 return options.filter((option) => {
                   return option.label.toLowerCase().includes(e.target.value.toLowerCase()) ||
                          option.description.toLowerCase().includes(e.target.value.toLowerCase())                
@@ -90,7 +90,7 @@ class Example extends React.Component {
               popupDirection="top"
               placeholder="Введите имя пользователя"
               searchable
-              onSearchChange={(e) => { this.setState({ query: e.target.value }) }}
+              onInputChange={(e) => { this.setState({ query: e.target.value }) }}
               options={this.customSearchOptions}
               renderOption={({ option, ...restProps }) => (
                 <CustomSelectOption {...restProps}>

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -30,13 +30,13 @@ class Example extends React.Component {
           CustomSelect
         </PanelHeader>
         <Group>
-          <FormItem top="Базовое использование">
+          <FormItem top="Администратор" bottom="Базовый пример использования">
             <CustomSelect
               placeholder="Не выбран"
               options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
             />
           </FormItem>
-          <FormItem top="Кастомные элементы списка">
+          <FormItem top="Администратор" bottom="Кастомный дизайн элементов списка">
             <CustomSelect
               placeholder="Не выбран"
               options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
@@ -45,16 +45,16 @@ class Example extends React.Component {
               )}
             />
           </FormItem>
-          <FormItem top="Поиск">
+          <FormItem top="Администратор" bottom="Поиск по списку">
             <CustomSelect
-              placeholder="Не выбран"
+              placeholder="Введите имя пользователя"
               searchable
               options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
             />
           </FormItem>
-          <FormItem top="Кастомный поиск">
+          <FormItem top="Администратор" bottom="Кастомный алгоритм поиска">
             <CustomSelect
-              placeholder="Не выбран"
+              placeholder="Введите имя пользователя"
               searchable
               onSearchChange={(e) => { this.setState({ query: e.target.value }) }}
               options={this.customSearchOptions}

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -1,22 +1,93 @@
-Делает из [SelectMimicry](#!/SelectMimicry) селект с выпадающим списком
+Делает из [SelectMimicry](#!/SelectMimicry) селект с выпадающим списком. Используется внутри [Select](#!/Select).
 
 ```jsx
-<View activePanel="select">
-  <Panel id="select">
-    <PanelHeader>
-      CustomSelect
-    </PanelHeader>
-    <Group>
-      <FormItem top="Администратор">
-        <Select
-          placeholder="Не выбран" 
-          options={getRandomUsers(10).map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
-          renderOption={({ option, ...restProps }) => (
-            <CustomSelectOption {...restProps} before={<Avatar size={24} src={option.avatar} />} />
-          )}
-        />
-      </FormItem>
-    </Group>
-  </Panel>
-</View>
+class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.data = getRandomUsers(10);
+
+    this.state = {
+      query: '',
+      newUsers: [],
+    } 
+  }
+  
+  get customSearchOptions() {
+    const options = [...this.state.newUsers, ...this.data]
+                        .map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))
+                        .filter(({ label }) => label.toLowerCase().includes(this.state.query.toLowerCase()));
+    if (this.state.query.length > 0) {
+      options.unshift({ label: `Добавить пользователя ${this.state.query}`, value: 0 });
+    }
+    return options;
+  }
+
+  render() {
+    return (
+    <View activePanel="select">
+      <Panel id="select">
+        <PanelHeader>
+          CustomSelect
+        </PanelHeader>
+        <Group>
+          <FormItem top="Базовое использование">
+            <CustomSelect
+              placeholder="Не выбран"
+              options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+            />
+          </FormItem>
+          <FormItem top="Кастомные элементы списка">
+            <CustomSelect
+              placeholder="Не выбран"
+              options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+              renderOption={({ option, ...restProps }) => (
+                <CustomSelectOption {...restProps} before={<Avatar size={24} src={option.avatar} />} />
+              )}
+            />
+          </FormItem>
+          <FormItem top="Поиск">
+            <CustomSelect
+              placeholder="Не выбран"
+              searchable
+              options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+            />
+          </FormItem>
+          <FormItem top="Кастомный поиск">
+            <CustomSelect
+              placeholder="Не выбран"
+              searchable
+              onSearchChange={(e) => { this.setState({ query: e.target.value }) }}
+              options={this.customSearchOptions}
+              renderOption={({ option, ...restProps }) => (
+                <CustomSelectOption {...restProps}>
+                  {option.value === 0 ? <span style={{ color: 'var(--accent)' }}>{option.label}</span> : option.label}
+                </CustomSelectOption>
+              )}
+              onChange={(e) => {
+                if (e.target.value === '0') {
+                  const query = this.state.query;
+                  this.setState({
+                    newUsers: [...this.state.newUsers, { name: query, id: query }],
+                    query: ''
+                  }, () => {
+                    this.setState({ value: query })
+                  })
+                } else {
+                  this.setState({
+                    query: '',
+                    value: e.target.value,
+                  })
+                } 
+              }}
+              value={this.state.value}
+            />
+          </FormItem>
+        </Group>
+      </Panel>
+    </View>
+    );
+  }
+}
+
+<Example />
 ```

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -4,7 +4,28 @@
 class Example extends React.Component {
   constructor(props) {
     super(props);
-    this.data = getRandomUsers(10);
+    this.users = getRandomUsers(10).map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }));
+    this.cities = [{
+      label: 'Санкт-Петербург',
+      description: 'Россия',
+      value: 0
+    }, {
+      label: 'Москва',
+      description: 'Россия',
+      value: 1
+    }, {
+      label: 'Новосибирск',
+      description: 'Россия',
+      value: 2
+    }, {
+      label: 'Нью-Йорк',
+      description: 'США',
+      value: 3
+    }, {
+      label: 'Чикаго',
+      description: 'США',
+      value: 4
+    }]  
 
     this.state = {
       query: '',
@@ -13,8 +34,7 @@ class Example extends React.Component {
   }
   
   get customSearchOptions() {
-    const options = [...this.state.newUsers, ...this.data]
-                        .map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))
+    const options = [...this.state.newUsers, ...this.users]
                         .filter(({ label }) => label.toLowerCase().includes(this.state.query.toLowerCase()));
     if (this.state.query.length > 0) {
       options.unshift({ label: `Добавить пользователя ${this.state.query}`, value: 0 });
@@ -33,13 +53,13 @@ class Example extends React.Component {
           <FormItem top="Администратор" bottom="Базовый пример использования">
             <CustomSelect
               placeholder="Не выбран"
-              options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+              options={this.users}
             />
           </FormItem>
           <FormItem top="Администратор" bottom="Кастомный дизайн элементов списка">
             <CustomSelect
               placeholder="Не выбран"
-              options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+              options={this.users}
               renderOption={({ option, ...restProps }) => (
                 <CustomSelectOption {...restProps} before={<Avatar size={24} src={option.avatar} />} />
               )}
@@ -49,11 +69,25 @@ class Example extends React.Component {
             <CustomSelect
               placeholder="Введите имя пользователя"
               searchable
-              options={this.data.map(user => ({ label: user.name, value: user.id, avatar: user.photo_100 }))}
+              options={this.users}
             />
           </FormItem>
-          <FormItem top="Администратор" bottom="Кастомный алгоритм поиска">
+          <FormItem top="Город" bottom="Кастомный алгоритм поиска">
             <CustomSelect
+              placeholder="Введите название города или страны"
+              searchable
+              onSearchChange={(e) => { 
+                return this.cities.filter((option) => {
+                  return option.label.toLowerCase().includes(e.target.value.toLowerCase()) ||
+                         option.description.toLowerCase().includes(e.target.value.toLowerCase())                
+                })           
+              }}
+              options={this.cities}
+            />
+          </FormItem>
+          <FormItem top="Администратор" bottom="Кастомное поведение при поиске">
+            <CustomSelect
+              popupDirection="top"
               placeholder="Введите имя пользователя"
               searchable
               onSearchChange={(e) => { this.setState({ query: e.target.value }) }}
@@ -67,7 +101,7 @@ class Example extends React.Component {
                 if (e.target.value === '0') {
                   const query = this.state.query;
                   this.setState({
-                    newUsers: [...this.state.newUsers, { name: query, id: query }],
+                    newUsers: [...this.state.newUsers, { label: query, value: query }],
                     query: ''
                   }, () => {
                     this.setState({ value: query })


### PR DESCRIPTION
Режим поиска в `CustomSearch`. [Пример](https://vkcom.github.io/VKUI/pull/1727/#/CustomSelect).

Добавлены три свойства:
- `searchable` включает/выключает этот режим
- `emptyText` отвечает за отображение состояния пустых `options`
- `onSearchChange` предназначено для гибкой настройки поведения поиска
    - Если свойство не передано, то поиск осуществляет автоматически по `option.label`. Пример "Поиск по списку"
    - Если свойство передано и возвращает массив, то компонент воспринимает его как результат кастомного поиска и рисует по нему список опций. Пример "Кастомный алгоритм поиска"
    - Если свойство передано и ничего не возвращает, то компонент подразумевает, что разработчик самостоятельно обновит свойство `options`. Пример "Кастомное поведение при поиске"
 
fixes #1551