### PR TITLE
refactor: Типографические компоненты

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -105,7 +105,6 @@ const Button: FC<ButtonProps> = (props: ButtonProps) => {
             sizeY={sizeY}
             platform={platform}
             vkuiClass="Button__content"
-            Component="span"
           >
             {children}
           </ButtonTypography>

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -36,7 +36,7 @@ const PanelHeaderInTypography: FC<PanelHeaderProps> = ({ children }: PanelHeader
   const platform = usePlatform();
 
   return platform === VKCOM
-    ? <Text Component="span" weight="medium">{children}</Text>
+    ? <Text weight="medium">{children}</Text>
     : <span vkuiClass="PanelHeader__content-in">{children}</span>;
 };
 

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -25,7 +25,7 @@ const ButtonTypography: FunctionComponent<ButtonTypographyProps> = ({ primary, c
   }
 
   return (
-    <Text Component="span" weight={platform === VKCOM ? 'regular' : 'medium'}>
+    <Text weight={platform === VKCOM ? 'regular' : 'medium'}>
       {children}
     </Text>
   );

--- a/src/components/SliderSwitch/SliderSwitchButton.tsx
+++ b/src/components/SliderSwitch/SliderSwitchButton.tsx
@@ -42,7 +42,7 @@ const SliderSwitchButton: FunctionComponent<ButtonProps> = (props: ButtonProps) 
     hasActive={false}
     hoverMode="opacity"
   >
-    <Text Component="span" weight="medium">{children}</Text>
+    <Text weight="medium">{children}</Text>
   </Tappable>;
 };
 

--- a/src/components/Typography/Caption/Caption.css
+++ b/src/components/Typography/Caption/Caption.css
@@ -46,3 +46,10 @@
 .Caption--w-heavy {
   font-weight: 800;
 }
+
+/**
+ * ANDROID
+ */
+.Caption--android.Caption--w-semibold {
+  font-weight: 500;
+}

--- a/src/components/Typography/Caption/Caption.css
+++ b/src/components/Typography/Caption/Caption.css
@@ -1,4 +1,5 @@
 .Caption {
+  display: block;
   margin: 0;
 }
 

--- a/src/components/Typography/Caption/Caption.tsx
+++ b/src/components/Typography/Caption/Caption.tsx
@@ -2,7 +2,6 @@ import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
-import { ANDROID } from '../../../lib/platform';
 
 export interface CaptionProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'regular' | 'medium' | 'semibold' | 'bold';
@@ -21,21 +20,13 @@ const Caption: FC<CaptionProps> = ({
 }: CaptionProps) => {
   const platform = usePlatform();
 
-  let captionWeight: CaptionProps['weight'] = weight;
-
-  if (platform === ANDROID) {
-    if (weight === 'semibold') {
-      captionWeight = 'medium';
-    }
-  }
-
   return (
     <Component
       {...restProps}
       vkuiClass={
         classNames(
           getClassName('Caption', platform),
-          `Caption--w-${captionWeight}`,
+          `Caption--w-${weight}`,
           `Caption--l-${level}`,
           {
             'Caption--caps': caps,

--- a/src/components/Typography/Caption/Caption.tsx
+++ b/src/components/Typography/Caption/Caption.tsx
@@ -1,4 +1,4 @@
-import { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
+import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
@@ -11,7 +11,7 @@ export interface CaptionProps extends AllHTMLAttributes<HTMLElement> {
   Component?: ElementType;
 }
 
-const Caption: FunctionComponent<CaptionProps> = ({
+const Caption: FC<CaptionProps> = ({
   children,
   weight,
   level,

--- a/src/components/Typography/Caption/Caption.tsx
+++ b/src/components/Typography/Caption/Caption.tsx
@@ -49,7 +49,7 @@ const Caption: FC<CaptionProps> = ({
 };
 
 Caption.defaultProps = {
-  Component: 'div',
+  Component: 'span',
 };
 
 export default Caption;

--- a/src/components/Typography/Caption/Caption.tsx
+++ b/src/components/Typography/Caption/Caption.tsx
@@ -15,7 +15,7 @@ const Caption: FC<CaptionProps> = ({
   weight,
   level,
   caps,
-  Component,
+  Component = 'span',
   ...restProps
 }: CaptionProps) => {
   const platform = usePlatform();
@@ -37,10 +37,6 @@ const Caption: FC<CaptionProps> = ({
       {children}
     </Component>
   );
-};
-
-Caption.defaultProps = {
-  Component: 'span',
 };
 
 export default Caption;

--- a/src/components/Typography/Headline/Headline.css
+++ b/src/components/Typography/Headline/Headline.css
@@ -16,3 +16,10 @@
 .Headline--w-semibold {
   font-weight: 600;
 }
+
+/**
+ * ANDROID
+ */
+.Headline--android.Headline--w-semibold {
+  font-weight: 500;
+}

--- a/src/components/Typography/Headline/Headline.css
+++ b/src/components/Typography/Headline/Headline.css
@@ -1,4 +1,5 @@
 .Headline {
+  display: block;
   margin: 0;
   font-size: 16px;
   line-height: 20px;

--- a/src/components/Typography/Headline/Headline.tsx
+++ b/src/components/Typography/Headline/Headline.tsx
@@ -11,7 +11,7 @@ export interface HeadlineProps extends AllHTMLAttributes<HTMLElement> {
 const Headline: FC<HeadlineProps> = ({
   children,
   weight,
-  Component,
+  Component = 'h3',
   ...restProps
 }: HeadlineProps) => {
   const platform = usePlatform();
@@ -24,10 +24,6 @@ const Headline: FC<HeadlineProps> = ({
       {children}
     </Component>
   );
-};
-
-Headline.defaultProps = {
-  Component: 'h3',
 };
 
 export default Headline;

--- a/src/components/Typography/Headline/Headline.tsx
+++ b/src/components/Typography/Headline/Headline.tsx
@@ -1,4 +1,4 @@
-import { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
+import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
@@ -9,7 +9,7 @@ export interface HeadlineProps extends AllHTMLAttributes<HTMLElement> {
   Component?: ElementType;
 }
 
-const Headline: FunctionComponent<HeadlineProps> = ({
+const Headline: FC<HeadlineProps> = ({
   children,
   weight,
   Component,

--- a/src/components/Typography/Headline/Headline.tsx
+++ b/src/components/Typography/Headline/Headline.tsx
@@ -2,7 +2,6 @@ import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
-import { ANDROID } from '../../../lib/platform';
 
 export interface HeadlineProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'regular' | 'medium' | 'semibold';
@@ -17,10 +16,6 @@ const Headline: FC<HeadlineProps> = ({
 }: HeadlineProps) => {
   const platform = usePlatform();
 
-  if (!Component) {
-    Component = platform === ANDROID ? 'h3' : 'h4';
-  }
-
   return (
     <Component
       {...restProps}
@@ -29,6 +24,10 @@ const Headline: FC<HeadlineProps> = ({
       {children}
     </Component>
   );
+};
+
+Headline.defaultProps = {
+  Component: 'h3',
 };
 
 export default Headline;

--- a/src/components/Typography/Headline/Headline.tsx
+++ b/src/components/Typography/Headline/Headline.tsx
@@ -16,25 +16,18 @@ const Headline: FC<HeadlineProps> = ({
   ...restProps
 }: HeadlineProps) => {
   const platform = usePlatform();
-  let HeadlineComponent = Component;
 
   if (!Component) {
-    HeadlineComponent = platform === ANDROID ? 'h3' : 'h4';
-  }
-
-  let headlineWeight: HeadlineProps['weight'] = weight;
-
-  if (platform === ANDROID && weight === 'semibold') {
-    headlineWeight = 'medium';
+    Component = platform === ANDROID ? 'h3' : 'h4';
   }
 
   return (
-    <HeadlineComponent
+    <Component
       {...restProps}
-      vkuiClass={classNames(getClassName('Headline', platform), `Headline--w-${headlineWeight}`)}
+      vkuiClass={classNames(getClassName('Headline', platform), `Headline--w-${weight}`)}
     >
       {children}
-    </HeadlineComponent>
+    </Component>
   );
 };
 

--- a/src/components/Typography/Subhead/Subhead.css
+++ b/src/components/Typography/Subhead/Subhead.css
@@ -12,10 +12,14 @@
   font-weight: 500;
 }
 
-.Subhead--w-semibold {
+.Subhead--w-semibold,
+.Subhead--w-bold {
   font-weight: 600;
 }
 
-.Subhead--w-bold {
-  font-weight: 600;
+/**
+ * ANDROID
+ */
+.Subhead--android.Subhead--w-semibold {
+  font-weight: 500;
 }

--- a/src/components/Typography/Subhead/Subhead.css
+++ b/src/components/Typography/Subhead/Subhead.css
@@ -12,9 +12,12 @@
   font-weight: 500;
 }
 
-.Subhead--w-semibold,
-.Subhead--w-bold {
+.Subhead--w-semibold {
   font-weight: 600;
+}
+
+.Subhead--w-bold {
+  font-weight: 700;
 }
 
 /**

--- a/src/components/Typography/Subhead/Subhead.tsx
+++ b/src/components/Typography/Subhead/Subhead.tsx
@@ -17,19 +17,17 @@ const Subhead: FC<SubheadProps> = ({
 }: SubheadProps) => {
   const platform = usePlatform();
 
-  let SubheadComponent: ElementType = Component;
-
   if (!Component) {
-    SubheadComponent = platform === ANDROID ? 'h4' : 'h5';
+    Component = platform === ANDROID ? 'h4' : 'h5';
   }
 
   return (
-    <SubheadComponent
+    <Component
       {...restProps}
-      vkuiClass={classNames(getClassName('Subhead', platform), `Subhead--w-${subheadWeight}`)}
+      vkuiClass={classNames(getClassName('Subhead', platform), `Subhead--w-${weight}`)}
     >
       {children}
-    </SubheadComponent>
+    </Component>
   );
 };
 

--- a/src/components/Typography/Subhead/Subhead.tsx
+++ b/src/components/Typography/Subhead/Subhead.tsx
@@ -11,7 +11,7 @@ export interface SubheadProps extends AllHTMLAttributes<HTMLElement> {
 const Subhead: FC<SubheadProps> = ({
   children,
   weight,
-  Component,
+  Component = 'h4',
   ...restProps
 }: SubheadProps) => {
   const platform = usePlatform();
@@ -24,10 +24,6 @@ const Subhead: FC<SubheadProps> = ({
       {children}
     </Component>
   );
-};
-
-Subhead.defaultProps = {
-  Component: 'h4',
 };
 
 export default Subhead;

--- a/src/components/Typography/Subhead/Subhead.tsx
+++ b/src/components/Typography/Subhead/Subhead.tsx
@@ -2,7 +2,6 @@ import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
-import { ANDROID } from '../../../lib/platform';
 
 export interface SubheadProps extends AllHTMLAttributes<HTMLElement> {
   weight: 'regular' | 'medium' | 'semibold' | 'bold';
@@ -17,10 +16,6 @@ const Subhead: FC<SubheadProps> = ({
 }: SubheadProps) => {
   const platform = usePlatform();
 
-  if (!Component) {
-    Component = platform === ANDROID ? 'h4' : 'h5';
-  }
-
   return (
     <Component
       {...restProps}
@@ -29,6 +24,10 @@ const Subhead: FC<SubheadProps> = ({
       {children}
     </Component>
   );
+};
+
+Subhead.defaultProps = {
+  Component: 'h4',
 };
 
 export default Subhead;

--- a/src/components/Typography/Subhead/Subhead.tsx
+++ b/src/components/Typography/Subhead/Subhead.tsx
@@ -1,4 +1,4 @@
-import React, { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
+import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
@@ -9,7 +9,7 @@ export interface SubheadProps extends AllHTMLAttributes<HTMLElement> {
   Component?: ElementType;
 }
 
-const Subhead: FunctionComponent<SubheadProps> = ({
+const Subhead: FC<SubheadProps> = ({
   children,
   weight,
   Component,
@@ -17,8 +17,7 @@ const Subhead: FunctionComponent<SubheadProps> = ({
 }: SubheadProps) => {
   const platform = usePlatform();
 
-  let SubheadComponent: React.ElementType = Component;
-  let subheadWeight: SubheadProps['weight'] = platform === ANDROID && weight === 'semibold' ? 'medium' : weight;
+  let SubheadComponent: ElementType = Component;
 
   if (!Component) {
     SubheadComponent = platform === ANDROID ? 'h4' : 'h5';

--- a/src/components/Typography/Text/Text.css
+++ b/src/components/Typography/Text/Text.css
@@ -16,3 +16,10 @@
 .Text--w-semibold {
   font-weight: 600;
 }
+
+/**
+ * ANDROID
+ */
+.Text--android.Text--w-semibold {
+  font-weight: 500;
+}

--- a/src/components/Typography/Text/Text.css
+++ b/src/components/Typography/Text/Text.css
@@ -1,4 +1,6 @@
 .Text {
+  display: block;
+  margin: 0;
   font-size: 15px;
   line-height: 20px;
 }

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -14,7 +14,7 @@ const warn = warnOnce('Text');
 const Text: FC<TextProps> = ({
   children,
   weight,
-  Component,
+  Component = 'span',
   getRootRef,
   ...restProps
 }: TextProps) => {
@@ -33,10 +33,6 @@ const Text: FC<TextProps> = ({
       {children}
     </Component>
   );
-};
-
-Text.defaultProps = {
-  Component: 'span',
 };
 
 export default Text;

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -1,4 +1,4 @@
-import { AllHTMLAttributes, ElementType, FunctionComponent } from 'react';
+import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
@@ -12,7 +12,7 @@ export interface TextProps extends AllHTMLAttributes<HTMLElement>, HasRootRef<HT
 }
 
 const warn = warnOnce('Text');
-const Text: FunctionComponent<TextProps> = ({
+const Text: FC<TextProps> = ({
   children,
   weight,
   Component,

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -45,7 +45,7 @@ const Text: FC<TextProps> = ({
 };
 
 Text.defaultProps = {
-  Component: 'div',
+  Component: 'span',
 };
 
 export default Text;

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -2,7 +2,6 @@ import { AllHTMLAttributes, ElementType, FC } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
-import { ANDROID } from '../../../lib/platform';
 import { HasRootRef } from '../../../types';
 import { warnOnce } from '../../../lib/warnOnce';
 
@@ -21,14 +20,6 @@ const Text: FC<TextProps> = ({
 }: TextProps) => {
   const platform = usePlatform();
 
-  let textWeight: TextProps['weight'] = weight;
-
-  if (platform === ANDROID) {
-    if (weight === 'semibold') {
-      textWeight = 'medium';
-    }
-  }
-
   if (process.env.NODE_ENV === 'development' && typeof Component !== 'string' && getRootRef) {
     warn('getRootRef can only be used with DOM components');
   }
@@ -37,7 +28,7 @@ const Text: FC<TextProps> = ({
     <Component
       {...restProps}
       ref={getRootRef}
-      vkuiClass={classNames(getClassName('Text', platform), `Text--w-${textWeight}`)}
+      vkuiClass={classNames(getClassName('Text', platform), `Text--w-${weight}`)}
     >
       {children}
     </Component>

--- a/src/components/Typography/Title/Title.css
+++ b/src/components/Typography/Title/Title.css
@@ -1,4 +1,5 @@
 .Title {
+  display: block;
   margin: 0;
 }
 
@@ -35,4 +36,15 @@
 
 .Title--w-heavy {
   font-weight: 800;
+}
+
+/**
+ * ANDROID
+ */
+.Title--android.Title--w-semibold {
+  font-weight: 500;
+}
+
+.Title--android.Title--w-heavy {
+  font-weight: 700;
 }

--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -15,14 +15,10 @@ const Title: FC<TitleProps> = ({
   children,
   weight,
   level,
-  Component,
+  Component = ('h' + level) as ElementType,
   ...restProps
 }: TitleProps) => {
   const platform = usePlatform();
-
-  if (!Component) {
-    Component = ('h' + level) as ElementType;
-  }
 
   if (platform === ANDROID && level === '3') {
     const headlineWeight: HeadlineProps['weight'] = weight === 'regular' ? weight : 'medium';

--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -32,13 +32,15 @@ const Title: FC<TitleProps> = ({
   if (platform === ANDROID && level === '3') {
     const headlineWeight: HeadlineProps['weight'] = weight === 'regular' ? weight : 'medium';
 
-    return <Headline
-      Component={TitleComponent}
-      {...restProps}
-      weight={headlineWeight}
-    >
-      {children}
-    </Headline>;
+    return (
+      <Headline
+        Component={TitleComponent}
+        {...restProps}
+        weight={headlineWeight}
+      >
+        {children}
+      </Headline>
+    );
   }
 
   return (

--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -19,22 +19,6 @@ const getComponent = (level: TitleProps['level']): ElementType => {
   return ('h' + level) as ElementType;
 };
 
-const getAndroidTitleWeight = (level: TitleProps['level'], weight: TitleProps['weight']): TitleProps['weight'] => {
-  if (level === '3') {
-    return weight === 'regular' ? weight : 'medium';
-  }
-
-  if (level === '2' && weight === 'semibold') {
-    return 'medium';
-  }
-
-  if (weight === 'heavy') {
-    return 'bold';
-  }
-
-  return weight;
-};
-
 const Title: FC<TitleProps> = ({
   children,
   weight,
@@ -44,13 +28,14 @@ const Title: FC<TitleProps> = ({
 }: TitleProps) => {
   const platform = usePlatform();
   const TitleComponent = Component || getComponent(level);
-  let titleWeight = platform === ANDROID ? getAndroidTitleWeight(level, weight) : weight;
 
   if (platform === ANDROID && level === '3') {
+    const headlineWeight: HeadlineProps['weight'] = weight === 'regular' ? weight : 'medium';
+
     return <Headline
       Component={TitleComponent}
       {...restProps}
-      weight={titleWeight as HeadlineProps['weight']}
+      weight={headlineWeight}
     >
       {children}
     </Headline>;
@@ -62,7 +47,7 @@ const Title: FC<TitleProps> = ({
       vkuiClass={
         classNames(
           getClassName('Title', platform),
-          `Title--w-${titleWeight}`,
+          `Title--w-${weight}`,
           `Title--l-${level}`,
         )
       }

--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -11,14 +11,6 @@ export interface TitleProps extends AllHTMLAttributes<HTMLElement> {
   Component?: ElementType;
 }
 
-const getComponent = (level: TitleProps['level']): ElementType => {
-  if (!level) {
-    return 'div';
-  }
-
-  return ('h' + level) as ElementType;
-};
-
 const Title: FC<TitleProps> = ({
   children,
   weight,
@@ -27,14 +19,17 @@ const Title: FC<TitleProps> = ({
   ...restProps
 }: TitleProps) => {
   const platform = usePlatform();
-  const TitleComponent = Component || getComponent(level);
+
+  if (!Component) {
+    Component = ('h' + level) as ElementType;
+  }
 
   if (platform === ANDROID && level === '3') {
     const headlineWeight: HeadlineProps['weight'] = weight === 'regular' ? weight : 'medium';
 
     return (
       <Headline
-        Component={TitleComponent}
+        Component={Component}
         {...restProps}
         weight={headlineWeight}
       >
@@ -44,7 +39,7 @@ const Title: FC<TitleProps> = ({
   }
 
   return (
-    <TitleComponent
+    <Component
       {...restProps}
       vkuiClass={
         classNames(
@@ -55,7 +50,7 @@ const Title: FC<TitleProps> = ({
       }
     >
       {children}
-    </TitleComponent>
+    </Component>
   );
 };
 

--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -1,4 +1,4 @@
-import { ElementType, FunctionComponent, AllHTMLAttributes } from 'react';
+import { ElementType, FC, AllHTMLAttributes } from 'react';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { classNames } from '../../../lib/classNames';
 import { getClassName } from '../../../helpers/getClassName';
@@ -35,7 +35,7 @@ const getAndroidTitleWeight = (level: TitleProps['level'], weight: TitleProps['w
   return weight;
 };
 
-const Title: FunctionComponent<TitleProps> = ({
+const Title: FC<TitleProps> = ({
   children,
   weight,
   level,

--- a/src/components/Typography/Title/__image_snapshots__/title-android-bright_light-1-snap.png
+++ b/src/components/Typography/Title/__image_snapshots__/title-android-bright_light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd8981976bbafcc82067712cb30c4c5795423426abd98fde0b3aa02eb3bae374
-size 39091
+oid sha256:bd25f4de57af33e1b5b9b008cefdd88ca783facf4e236f4381bdc25b78fbd93e
+size 39126

--- a/src/components/Typography/Title/__image_snapshots__/title-android-space_gray-1-snap.png
+++ b/src/components/Typography/Title/__image_snapshots__/title-android-space_gray-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93eb9077aa0872d9adc3d32dfa47d98a194c2d65d217105d516a62681bf3d5d5
-size 39656
+oid sha256:a3b25d81ee64784758e604e9848d1c412b1373e06053bddc63008b7477f4ee9f
+size 39690

--- a/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -68,7 +68,7 @@ export const WriteBarIcon: FC<WriteBarIconProps> = (props: WriteBarIconProps) =>
       })}
     >
       {icon || children}
-      {count && <Caption Component="span" vkuiClass="WriteBarIcon__count" weight="regular" level="2">{count}</Caption>}
+      {count && <Caption vkuiClass="WriteBarIcon__count" weight="regular" level="2">{count}</Caption>}
     </button>
   );
 };


### PR DESCRIPTION
Подчистила типографические компоненты:
- упростила то, как задаются `weight` и `Component`, передоверила упрощения стилей для андроида css;
- проставила для `Text` и `Caption` в качестве дефолтного компонента `span` с `display: block;` в стилях;
- добавила скриншотные тесты (и, кажется, отловила ошибку в `Title`) — _переехало в #1735_;
- выкинула лишние `Component="span"`. 😄 