### PR TITLE
[Bug] Search: отрицательный margin внутри Group

### DIFF
--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -338,7 +338,11 @@
 }
 
 .Group--card .Search--vkcom {
-  margin: -8px -8px 0;
+  margin: 0 -8px;
+}
+
+.Group--card .Search--vkcom:first-child {
+  margin-top: -8px;
 }
 
 .Group--card .Search--vkcom:not(:last-child) {


### PR DESCRIPTION
Пофиксила отрицательный `margin-top` у `Search` внутри `Group`: теперь он применяется, только если `Search` – первый child у `Group`.