### PR TITLE
CustomSelect: fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui",
-  "version": "4.12.0",
+  "version": "4.12.1-alpha.1",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui",
-  "version": "4.12.1-alpha.1",
+  "version": "4.12.1-alpha.2",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/src/components/CustomSelect/CustomSelect.test.tsx
@@ -152,24 +152,59 @@ describe('CustomSelect', () => {
     expect(screen.getByTestId('target').textContent).toBe('New York');
   });
 
-  it('is searchable and correctly resolves changing of props.options during the search', () => {
+  it('is searchable and keeps search results up to date during props.options updates', () => {
     const { rerender } = render(<CustomSelect
       searchable
       data-testid="target"
-      options={[]}
+      options={[{ value: 0, label: 'Mike' }, { value: 1, label: 'Josh' }]}
     />);
 
     fireEvent.click(screen.getByTestId('target'));
     fireEvent.change(screen.getByTestId('target'), { target: { value: 'Mi' } });
 
+    expect(screen.getAllByRole('option').length).toEqual(1);
+
     rerender(<CustomSelect
       searchable
       data-testid="target"
-      options={[{ value: 0, label: 'Mike' }, { value: 1, label: 'Mika' }, { value: 2, label: 'Josh' }]}
+      options={[{ value: 0, label: 'Mike' }, { value: 1, label: 'Josh' }, { value: 2, label: 'Mika' }]}
     />);
 
-    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 38 }); // ArrowUp
-    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 13 }); // Enter
-    expect(screen.getByTestId('target').textContent).toBe('Mika');
+    expect(screen.getAllByRole('option').length).toEqual(2);
+  });
+
+  it('is searchable and keeps selected option up to date during props.options and props.value updates', () => {
+    const { rerender } = render(<CustomSelect
+      searchable
+      data-testid="target"
+      value={1}
+      options={[{ value: 0, label: 'Mike' }, { value: 1, label: 'Josh' }]}
+    />);
+
+    fireEvent.click(screen.getByTestId('target'));
+
+    expect(screen.getByTitle('Josh').getAttribute('aria-selected')).toEqual('true');
+
+    fireEvent.change(screen.getByTestId('target'), { target: { value: 'Jo' } });
+
+    expect(screen.getByTitle('Josh').getAttribute('aria-selected')).toEqual('true');
+
+    rerender(<CustomSelect
+      searchable
+      data-testid="target"
+      value={1}
+      options={[{ value: 0, label: 'Mike' }, { value: 2, label: 'Mika' }, { value: 1, label: 'Josh' }]}
+    />);
+
+    expect(screen.getByTitle('Josh').getAttribute('aria-selected')).toEqual('true');
+
+    rerender(<CustomSelect
+      searchable
+      data-testid="target"
+      value={3}
+      options={[{ value: 3, label: 'Joe' }, { value: 0, label: 'Mike' }, { value: 2, label: 'Mika' }, { value: 1, label: 'Josh' }]}
+    />);
+
+    expect(screen.getByTitle('Joe').getAttribute('aria-selected')).toEqual('true');
   });
 });

--- a/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/src/components/CustomSelect/CustomSelect.test.tsx
@@ -118,4 +118,58 @@ describe('CustomSelect', () => {
 
     expect(screen.getByTestId('target').textContent).toEqual('Josh');
   });
+
+  it('is searchable', () => {
+    render(<CustomSelect
+      searchable
+      data-testid="target"
+      options={[{ value: 0, label: 'Mike' }, { value: 1, label: 'Josh' }]}
+    />);
+
+    fireEvent.click(screen.getByTestId('target')); // here target is SelectMimicry
+
+    expect(screen.getByTestId('target')).toHaveFocus(); // now target is Input
+
+    fireEvent.change(screen.getByTestId('target'), { target: { value: 'Mi' } });
+    expect((screen.getByTestId('target') as HTMLInputElement).value).toBe('Mi');
+    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 40 }); // ArrowUp
+    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 13 }); // Enter
+    expect(screen.getByTestId('target').textContent).toBe('Mike');
+  });
+
+  it('is custom searchable', () => {
+    render(<CustomSelect
+      searchable
+      data-testid="target"
+      options={[{ value: 0, label: 'SPb', country: 'Russia' }, { value: 1, label: 'Moscow', country: 'Russia' }, { value: 2, label: 'New York', country: 'USA' }]}
+      filterFn={(value, option) => option.label.toLowerCase().includes(value.toLowerCase()) || option.country.toLowerCase().includes(value.toLowerCase())}
+    />);
+
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.change(screen.getByTestId('target'), { target: { value: 'usa' } });
+    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 40 }); // ArrowDown
+    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 13 }); // Enter
+    expect(screen.getByTestId('target').textContent).toBe('New York');
+  });
+
+  it('is searchable and correctly resolves changing of props.options during the search', () => {
+    const { rerender } = render(<CustomSelect
+      searchable
+      data-testid="target"
+      options={[]}
+    />);
+
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.change(screen.getByTestId('target'), { target: { value: 'Mi' } });
+
+    rerender(<CustomSelect
+      searchable
+      data-testid="target"
+      options={[{ value: 0, label: 'Mike' }, { value: 1, label: 'Mika' }, { value: 2, label: 'Josh' }]}
+    />);
+
+    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 38 }); // ArrowUp
+    fireEvent.keyDown(screen.getByTestId('target'), { keyCode: 13 }); // Enter
+    expect(screen.getByTestId('target').textContent).toBe('Mika');
+  });
 });

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -115,7 +115,6 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   public state: CustomSelectState;
   private keyboardInput: string;
   private isControlledOutside: boolean;
-  private node: HTMLLabelElement;
   private selectEl: HTMLSelectElement;
   private readonly scrollBoxRef = createRef<HTMLDivElement>();
 
@@ -213,14 +212,6 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
 
     const event = new Event('blur');
     this.selectEl.dispatchEvent(event);
-  };
-
-  handleDocumentClick = (event: Event) => {
-    const thisNode = this.node;
-
-    if (this.state.opened && thisNode && !thisNode.contains(event.target as Node)) {
-      this.onBlur();
-    }
   };
 
   private scrollToElement(index: number, center = false) {
@@ -398,16 +389,6 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
 
   handleKeyUp = debounce(this.resetKeyboardInput, 1000);
 
-  componentDidMount() {
-    document.addEventListener('click', this.handleDocumentClick, false);
-    document.addEventListener('touchend', this.handleDocumentClick, false);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this.handleDocumentClick, false);
-    document.removeEventListener('touchend', this.handleDocumentClick, false);
-  }
-
   componentDidUpdate(prevProps: CustomSelectProps) {
     if (prevProps.value !== this.props.value || prevProps.options !== this.props.options) {
       this.isControlledOutside = this.props.value !== undefined;
@@ -439,11 +420,6 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
         })}
       </React.Fragment>
     );
-  };
-
-  rootRef = (element: HTMLLabelElement) => {
-    this.node = element;
-    setRef(element, this.props.getRootRef);
   };
 
   selectRef = (element: HTMLSelectElement) => {
@@ -482,7 +458,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
         vkuiClass={getClassName('CustomSelect', platform)}
         className={className}
         style={style}
-        ref={this.rootRef}
+        ref={getRootRef}
         onClick={this.onLabelClick}
       >
         {opened && searchable ?

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -326,11 +326,16 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     if (this.props.onInputChange) {
       const options = this.props.onInputChange(e, this.props.options);
       if (options) {
-        this.setState({ options });
+        this.setState({
+          options,
+          selectedOptionIndex: this.findSelectedIndex(options, this.state.nativeSelectValue),
+        });
       }
     } else {
+      const options = this.props.options.filter((option) => option.label.toLowerCase().includes(e.target.value.toLowerCase()));
       this.setState({
-        options: this.props.options.filter((option) => option.label.toLowerCase().includes(e.target.value.toLowerCase())),
+        options,
+        selectedOptionIndex: this.findSelectedIndex(options, this.state.nativeSelectValue),
       });
     }
   };

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -100,6 +100,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
       selectedOptionIndex: this.findSelectedIndex(props.options, initialValue),
       nativeSelectValue: initialValue,
       options: props.options,
+      inputValue: '',
     };
 
     if (props.value !== undefined) {
@@ -395,12 +396,11 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     if (prevProps.value !== this.props.value || prevProps.options !== this.props.options) {
       this.isControlledOutside = this.props.value !== undefined;
       const value = this.props.value === undefined ? this.state.nativeSelectValue : this.props.value;
+      const options = this.props.searchable ? this.props.options.filter((option) => this.props.filterFn(this.state.inputValue, option)) : this.props.options;
       this.setState({
         nativeSelectValue: value,
-        selectedOptionIndex: this.findSelectedIndex(this.props.options, value),
-        options: this.props.searchable ?
-          this.props.options.filter((option) => this.props.filterFn(this.state.inputValue, option)) :
-          this.props.options,
+        selectedOptionIndex: this.findSelectedIndex(options, value),
+        options,
       });
     }
   }
@@ -510,6 +510,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
           onFocus={onFocus}
           onClick={onClick}
           value={nativeSelectValue}
+          aria-hidden={true}
           vkuiClass="CustomSelect__control"
         >
           {options.map((item) => <option key={`${item.value}`} value={item.value} />)}

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -479,7 +479,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
             onKeyDown={this.onInputKeyDown}
             onChange={this.onInputChange}
             // TODO Ожидается, что клик поймает нативный select, но его перехвает Input. К сожалению, это приводит конфликтам типизации.
-            // TODO Нужно перестать пытать превратить CustomSelect в select. Тогда эта проблема уйдёт.
+            // TODO Нужно перестать пытаться превратить CustomSelect в select. Тогда эта проблема уйдёт.
             // @ts-ignore
             onClick={onClick}
             after={sizeY === SizeType.COMPACT ? <Icon20Dropdown /> : <Icon24Dropdown />}

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -318,8 +318,10 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     if (this.props.onInputChange) {
       const options = this.props.onInputChange(e, this.props.options);
       if (options) {
-        warn('This filtration method is deprecated. Return value of onInputChange will' +
-          ' be ignored in v5.0.0. For custom filtration please update props.options by yourself or use filterFn property');
+        if (process.env.NODE_ENV === 'development') {
+          warn('This filtration method is deprecated. Return value of onInputChange will' +
+            ' be ignored in v5.0.0. For custom filtration please update props.options by yourself or use filterFn property');
+        }
         this.setState({
           options,
           selectedOptionIndex: this.findSelectedIndex(options, this.state.nativeSelectValue),

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -33,7 +33,6 @@ export interface CustomSelectOptionInterface {
 
 interface CustomSelectState {
   opened?: boolean;
-  focused?: boolean;
   focusedOptionIndex?: number;
   selectedOptionIndex?: number;
   nativeSelectValue?: SelectValue;
@@ -100,7 +99,6 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
 
     this.state = {
       opened: false,
-      focused: false,
       focusedOptionIndex: -1,
       selectedOptionIndex: this.findSelectedIndex(props.options, initialValue),
       nativeSelectValue: initialValue,
@@ -193,10 +191,6 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   onFocus = () => {
-    this.setState(() => ({
-      focused: true,
-    }));
-
     const event = new Event('focus');
     this.selectEl.dispatchEvent(event);
   };
@@ -206,7 +200,6 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
 
     this.setState(() => ({
       opened: false,
-      focused: false,
       options: this.props.options,
     }));
 

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -35,7 +35,6 @@ class Example extends React.Component {
   
   get customSearchOptions() {
     const options = [...this.state.newUsers, ...this.users]
-                        .filter(({ label }) => label.toLowerCase().includes(this.state.query.toLowerCase()));
     if (this.state.query.length > 0) {
       options.unshift({ label: `Добавить пользователя ${this.state.query}`, value: 0 });
     }
@@ -76,12 +75,7 @@ class Example extends React.Component {
             <CustomSelect
               placeholder="Введите название города или страны"
               searchable
-              onInputChange={(e, options) => { 
-                return options.filter((option) => {
-                  return option.label.toLowerCase().includes(e.target.value.toLowerCase()) ||
-                         option.description.toLowerCase().includes(e.target.value.toLowerCase())                
-                })           
-              }}
+              filterFn={(value, option) => option.label.toLowerCase().includes(value.toLowerCase()) || option.description.toLowerCase().includes(value.toLowerCase())}
               options={this.cities}
             />
           </FormItem>


### PR DESCRIPTION
* Убрал `handleDocumentClick`. Кажется, тут этот обработчик не нужен, так как `onBlur` на `Input/SelectMimicry` успешно скрывает список опций когда надо.
* Обновляю значение `selectedOptionIndex` при поиске, так как иначе выбранной подсвечивается не та опция.
* Задепрейтил фильтрацию через `return` у `onInputChange`. Такой подход приводит к конфликтам `props.options` и `state.options`.
* Добавил свойство `filterFn` для кастомной фильтрации.
* Починил `props.onClick` в `searchable` режиме.
* В режиме поиска передаю `{...restProps}` на `Input`