### PR TITLE
Доступность кнопок и ссылок: фиксы Tappable

### DIFF
--- a/src/components/ActionSheetItem/ActionSheetItem.test.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.test.tsx
@@ -1,6 +1,27 @@
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
-import ActionSheetItem from './ActionSheetItem';
+import ActionSheetItem, { ActionSheetItemProps } from './ActionSheetItem';
+
+const ActionSheetItemTest = (props: ActionSheetItemProps) => <ActionSheetItem data-testid="item" {...props} />;
+const item = () => screen.getByTestId('item');
 
 describe('ActionSheetItem', () => {
   baselineComponent(ActionSheetItem);
+
+  it('Component: ActionSheetItem is a custom button by default', () => {
+    render(<ActionSheetItemTest>ActionSheetItem</ActionSheetItemTest>);
+    expect(item().tagName.toLowerCase()).toMatch('div');
+    expect(item()).toHaveAttribute('role', 'button');
+    expect(item()).toHaveAttribute('tabindex', '0');
+  });
+
+  it('Component: ActionSheetItem w/ href is a native link', () => {
+    render(<ActionSheetItemTest href="https://vk.com">ActionSheetItem</ActionSheetItemTest>);
+    expect(item().tagName.toLowerCase()).toMatch('a');
+  });
+
+  it('Component: ActionSheetItem[selectable] is a label', () => {
+    render(<ActionSheetItemTest selectable>ActionSheetItem</ActionSheetItemTest>);
+    expect(item().tagName.toLowerCase()).toMatch('label');
+  });
 });

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -1,4 +1,4 @@
-import React, { AnchorHTMLAttributes, ElementType, Fragment, HTMLAttributes, InputHTMLAttributes, useContext } from 'react';
+import { AnchorHTMLAttributes, ElementType, FC, Fragment, HTMLAttributes, InputHTMLAttributes, ReactNode, useContext } from 'react';
 import { classNames } from '../../lib/classNames';
 import { getClassName } from '../../helpers/getClassName';
 import Tappable from '../Tappable/Tappable';
@@ -19,15 +19,15 @@ export interface ActionSheetItemProps extends
   Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'checked' | 'value'>,
   AdaptivityProps {
   mode?: 'default' | 'destructive' | 'cancel';
-  before?: React.ReactNode;
-  meta?: React.ReactNode;
-  subtitle?: React.ReactNode;
+  before?: ReactNode;
+  meta?: ReactNode;
+  subtitle?: ReactNode;
   autoclose?: boolean;
   selectable?: boolean;
   disabled?: boolean;
 }
 
-const ActionSheetItem: React.FunctionComponent<ActionSheetItemProps> = ({
+const ActionSheetItem: FC<ActionSheetItemProps> = ({
   children,
   autoclose,
   mode,

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -66,10 +66,10 @@ const ActionSheetItem: FC<ActionSheetItemProps> = ({
         classNames(
           getClassName('ActionSheetItem', platform),
           `ActionSheetItem--${mode}`,
+          `ActionSheetItem--sizeY-${sizeY}`,
           {
             'ActionSheetItem--compact': isCompact,
             'ActionSheetItem--desktop': isDesktop,
-            [`ActionSheetItem--sizeY-${sizeY}`]: sizeY === SizeType.COMPACT,
             'ActionSheetItem--withSubtitle': hasReactNode(subtitle),
           },
         )

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -47,11 +47,9 @@ const ActionSheetItem: FC<ActionSheetItemProps> = ({
   const platform = usePlatform();
   const { onItemClick = () => noop, isDesktop } = useContext(ActionSheetContext);
 
-  let Component: ElementType = 'div';
+  let Component: ElementType = restProps.href ? 'a' : 'div';
 
-  if (restProps.href) {
-    Component = 'a';
-  } else if (selectable) {
+  if (selectable) {
     Component = 'label';
   }
 

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -2,29 +2,24 @@ import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import Button, { ButtonProps } from './Button';
 
-const ButtonTest = (props: ButtonProps) => <Button Component="div" data-testid="custom-btn" {...props} />;
+const ButtonTest = (props: ButtonProps) => <Button data-testid="custom-btn" {...props} />;
 const button = () => screen.getByTestId('custom-btn');
 
 describe('Button', () => {
   baselineComponent(Button);
 
-  it('button with valid href is handled as a native link', () => {
+  it('Component: Button is handled as a native button', () => {
+    render(<ButtonTest>Native Button</ButtonTest>);
+    expect(button().tagName.toLowerCase()).toMatch('button');
+  });
+
+  it('Component: Button with valid href is handled as a native link', () => {
     render(<ButtonTest href="#">Native Link</ButtonTest>);
-
-    expect(screen.getByRole('link')).toBe(button());
+    expect(button().tagName.toLowerCase()).toMatch('a');
   });
 
-  it('a11y: custom button has role="button" and tabindex', () => {
-    render(<ButtonTest>Custom Button</ButtonTest>);
-
-    expect(button()).toHaveAttribute('role', 'button');
-    expect(button()).toHaveAttribute('tabindex', '0');
-  });
-
-  it('a11y: button with role="link" is handled as a custom link and has tabIndex', () => {
-    render(<ButtonTest role="link">Custom Link</ButtonTest>);
-
-    expect(button()).toHaveAttribute('role', 'link');
-    expect(button()).toHaveAttribute('tabindex', '0');
+  it('Component: Button with valid href overrides passed Component', () => {
+    render(<ButtonTest href="#" Component="div">Native Link</ButtonTest>);
+    expect(button().tagName.toLowerCase()).toMatch('a');
   });
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -66,20 +66,13 @@ const ButtonTypography: FC<ButtonTypographyProps> = (props: ButtonTypographyProp
 
 const Button: FC<ButtonProps> = (props: ButtonProps) => {
   const platform = usePlatform();
-  const { size, mode, stretched, align, children, before, after, getRootRef, Component, sizeY, ...restProps } = props;
+  const { size, mode, stretched, align, children, before, after, getRootRef, sizeY, Component = 'button', ...restProps } = props;
   const hasIcons = Boolean(before || after);
-
-  const RenderedComponent = restProps.href ? 'a' : Component;
-
-  let accessibleRole: string = null;
-  if (RenderedComponent !== 'a' && RenderedComponent !== 'button' && RenderedComponent !== 'input') {
-    accessibleRole = 'button';
-  }
 
   return (
     <Tappable
-      role={accessibleRole}
       {...restProps}
+      Component={restProps.href ? 'a' : Component}
       vkuiClass={
         classNames(
           getClassName('Button', platform),
@@ -94,7 +87,6 @@ const Button: FC<ButtonProps> = (props: ButtonProps) => {
         )
       }
       getRootRef={getRootRef}
-      Component={RenderedComponent}
       activeMode="opacity"
     >
       <span vkuiClass="Button__in">
@@ -117,7 +109,6 @@ const Button: FC<ButtonProps> = (props: ButtonProps) => {
 
 Button.defaultProps = {
   mode: 'primary',
-  Component: 'button',
   align: 'center',
   size: 's',
   stretched: false,

--- a/src/components/ContentCard/ContentCard.test.tsx
+++ b/src/components/ContentCard/ContentCard.test.tsx
@@ -1,6 +1,25 @@
+import { screen, render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
-import ContentCard from './ContentCard';
+import ContentCard, { ContentCardProps } from './ContentCard';
+
+const ContentCardTest = (props: ContentCardProps) => (
+  <ContentCard
+    subtitle="VKUI"
+    header="ContentCard example"
+    caption="VKUI Styleguide > Blocks > ContentCard"
+    image="/image.png"
+    {...props}
+    data-testid="card"
+  />
+);
 
 describe('ContentCard', () => {
   baselineComponent((props) => <ContentCard image="/image.png" {...props} />);
+
+  it('onClick: ContentCard without onClick is treated as disabled', () => {
+    render(<ContentCardTest />);
+    const tappable = screen.getByRole('button');
+
+    expect(tappable).toHaveAttribute('aria-disabled', 'true');
+  });
 });

--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -52,15 +52,13 @@ const ContentCard: FC<ContentCardProps> = (props: ContentCardProps) => {
   const { getRef, onClick, subtitle, header, text, caption, className, image, maxHeight, disabled, mode, style, getRootRef, ...restProps } = props;
   const platform = usePlatform();
 
-  const isDisabled = !!onClick === false || disabled;
-
   return (
     <Card mode={mode} getRootRef={getRootRef} vkuiClass={getClassName('ContentCard', platform)} style={style} className={className}>
       <Tappable
         Component="div"
-        disabled={isDisabled}
-        role={isDisabled ? null : 'button'}
-        onClick={isDisabled ? null : onClick}
+        disabled={disabled || typeof onClick !== 'function'}
+        role="button"
+        onClick={onClick}
         vkuiClass="ContentCard__tappable"
       >
         {image && <img {...restProps} ref={getRef} src={image} vkuiClass="ContentCard__img" style={{ maxHeight }} width="100%" />}

--- a/src/components/HorizontalCell/HorizontalCell.tsx
+++ b/src/components/HorizontalCell/HorizontalCell.tsx
@@ -39,7 +39,6 @@ export const HorizontalCell: FC<HorizontalCellProps> = ({
   children = <Avatar size={56} />,
   getRootRef,
   getRef,
-  Component = 'div',
   ...restProps
 }: HorizontalCellProps) => {
   const platform = usePlatform();
@@ -53,9 +52,7 @@ export const HorizontalCell: FC<HorizontalCellProps> = ({
     >
       <Tappable
         vkuiClass="HorizontalCell__body"
-        disabled={restProps.disabled}
         getRootRef={getRef}
-        Component={restProps.href ? 'a' : Component}
         {...restProps}
       >
         {hasReactNode(children) && <div vkuiClass="HorizontalCell__image">{children}</div>}

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -1,16 +1,30 @@
 import { baselineComponent } from '../../testing/utils';
-import IconButton from './IconButton';
+import IconButton, { IconButtonProps } from './IconButton';
 import { render, screen } from '@testing-library/react';
+import { Icon28VoiceOutline } from '@vkontakte/icons';
+
+const IconButtonTest = (props: IconButtonProps) => (
+  <IconButton data-testid="button" aria-label="Тестовая кнопка" {...props}>
+    <Icon28VoiceOutline />
+  </IconButton>
+);
+const button = () => screen.getByTestId('button');
 
 describe('IconButton', () => {
   baselineComponent(IconButton);
 
-  it('correctly handles Component property', () => {
-    const { rerender } = render(<IconButton data-testid="target" />);
-    expect(screen.getByTestId('target').tagName).toEqual('BUTTON');
-    rerender(<IconButton data-testid="target" href="#" />);
-    expect(screen.getByTestId('target').tagName).toEqual('A');
-    rerender(<IconButton data-testid="target" Component="div" />);
-    expect(screen.getByTestId('target').tagName).toEqual('DIV');
+  it('Component: default IconButton is a button', () => {
+    render(<IconButtonTest />);
+    expect(button().tagName.toLowerCase()).toMatch('button');
+  });
+
+  it('Component: IconButton w/ href is a link', () => {
+    render(<IconButtonTest href="https://vk.com" />);
+    expect(button().tagName.toLowerCase()).toMatch('a');
+  });
+
+  it('Component: IconButton w/ href overrides explicit Component', () => {
+    render(<IconButtonTest href="https://vk.com" Component="div" />);
+    expect(button().tagName.toLowerCase()).toMatch('a');
   });
 });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, FunctionComponent } from 'react';
+import { ReactNode, FC } from 'react';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
@@ -11,13 +11,9 @@ export interface IconButtonProps extends TappableProps {
    * @deprecated будет удалено в 5.0.0. Используйте `children`
    */
   icon?: ReactNode;
-  /**
-   * Задайте вашей кнопке текстовое содержание для повышения ее доступности.
-   */
-  'aria-label'?: string;
 }
 
-const IconButton: FunctionComponent<IconButtonProps> = ({
+const IconButton: FC<IconButtonProps> = ({
   icon,
   sizeY,
   children,

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,6 +1,25 @@
 import { baselineComponent } from '../../testing/utils';
-import Link from './Link';
+import Link, { LinkProps } from './Link';
+import { render, screen } from '@testing-library/react';
+
+const LinkTest = (props: LinkProps) => (<Link data-testid="link" {...props}>Link</Link>);
+const link = () => screen.getByTestId('link');
 
 describe('Link', () => {
   baselineComponent(Link);
+
+  it('Component: default Link is a button', () => {
+    render(<LinkTest />);
+    expect(link().tagName.toLowerCase()).toMatch('button');
+  });
+
+  it('Component: Link w/ href is a link', () => {
+    render(<LinkTest href="https://vk.com" />);
+    expect(link().tagName.toLowerCase()).toMatch('a');
+  });
+
+  it('Component: Link w/ Component and href is [Component]', () => {
+    render(<LinkTest href="https://vk.com" Component="div" />);
+    expect(link().tagName.toLowerCase()).toMatch('div');
+  });
 });

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -7,26 +7,15 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLElement>, TappablePr
 
 const Link: FC<LinkProps> = ({
   children,
-  Component,
   ...restProps
 }: LinkProps) => {
   const platform = usePlatform();
-  const baseClassName = getClassName('Link', platform);
-
-  if (!Component) {
-    if (restProps.href) {
-      Component = 'a';
-    } else {
-      Component = 'button';
-      restProps = { type: 'button', ...restProps };
-    }
-  }
 
   return (
     <Tappable
-      Component={Component}
+      Component={restProps.href ? 'a' : 'button'}
       {...restProps}
-      vkuiClass={baseClassName}
+      vkuiClass={getClassName('Link', platform)}
       hasActive={false}
       hoverMode="opacity"
     >

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,11 +1,11 @@
-import { FunctionComponent, AnchorHTMLAttributes } from 'react';
+import { FC, AnchorHTMLAttributes } from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import { usePlatform } from '../../hooks/usePlatform';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
 
 export interface LinkProps extends AnchorHTMLAttributes<HTMLElement>, TappableProps {}
 
-const Link: FunctionComponent<LinkProps> = ({
+const Link: FC<LinkProps> = ({
   children,
   Component,
   ...restProps
@@ -29,7 +29,9 @@ const Link: FunctionComponent<LinkProps> = ({
       vkuiClass={baseClassName}
       hasActive={false}
       hoverMode="opacity"
-    >{children}</Tappable>
+    >
+      {children}
+    </Tappable>
   );
 };
 

--- a/src/components/ModalDismissButton/ModalDismissButton.tsx
+++ b/src/components/ModalDismissButton/ModalDismissButton.tsx
@@ -4,12 +4,11 @@ import Tappable from '../Tappable/Tappable';
 import { getClassName } from '../../helpers/getClassName';
 import { usePlatform } from '../../hooks/usePlatform';
 
-export type ModalDismissButtonProps = HTMLAttributes<HTMLButtonElement> & {
-  'aria-label'?: string;
-};
+export type ModalDismissButtonProps = HTMLAttributes<HTMLButtonElement>;
 
 const ModalDismissButton: FC<ModalDismissButtonProps> = (props: ModalDismissButtonProps) => {
   const platform = usePlatform();
+
   return (
     <Tappable
       vkuiClass={getClassName('ModalDismissButton', platform)}

--- a/src/components/PanelHeaderButton/PanelHeaderButton.test.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.test.tsx
@@ -1,6 +1,25 @@
 import { baselineComponent } from '../../testing/utils';
-import { PanelHeaderButton } from './PanelHeaderButton';
+import { PanelHeaderButton, PanelHeaderButtonProps } from './PanelHeaderButton';
+import { render, screen } from '@testing-library/react';
+
+const PanelHeaderButtonTest = (props: PanelHeaderButtonProps) => (<PanelHeaderButton data-testid="button" {...props} />);
+const button = () => screen.getByTestId('button');
 
 describe('PanelHeaderButton', () => {
   baselineComponent(PanelHeaderButton);
+
+  it('Component: default PanelHeaderButton is a button', () => {
+    render(<PanelHeaderButtonTest />);
+    expect(button().tagName.toLowerCase()).toMatch('button');
+  });
+
+  it('Component: PanelHeaderButton w/ href is a link', () => {
+    render(<PanelHeaderButtonTest href="https://vk.com" />);
+    expect(button().tagName.toLowerCase()).toMatch('a');
+  });
+
+  it('Component: PanelHeaderButton does not react to passed Component', () => {
+    render(<PanelHeaderButtonTest href="https://vk.com" Component="div" />);
+    expect(button().tagName.toLowerCase()).toMatch('a');
+  });
 });

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -43,7 +43,6 @@ export const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
 }: PanelHeaderButtonProps) => {
   const isPrimitive = isPrimitiveReactNode(children);
   const isPrimitiveLabel = isPrimitiveReactNode(label);
-  const Component = restProps.href ? 'a' : 'button';
   const platform = usePlatform();
 
   let hoverMode;
@@ -67,7 +66,7 @@ export const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
     <Tappable
       {...restProps}
       hoverMode={hoverMode}
-      Component={Component}
+      Component={restProps.href ? 'a' : 'button'}
       activeEffectDelay={200}
       activeMode={activeMode}
       vkuiClass={classNames(

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -8,9 +8,13 @@ import { IOS, VKCOM, ANDROID } from '../../lib/platform';
 import Text from '../Typography/Text/Text';
 import Title from '../Typography/Title/Title';
 
+export interface PanelHeaderButtonProps extends Omit<TappableProps, 'label'> {
+  primary?: boolean;
+  label?: ReactNode;
+}
+
 interface ButtonTypographyProps extends AllHTMLAttributes<HTMLElement> {
   primary?: PanelHeaderButtonProps['primary'];
-  'aria-label'?: string;
 }
 
 const ButtonTypography: FunctionComponent<ButtonTypographyProps> = ({ primary, children }: ButtonTypographyProps) => {
@@ -30,11 +34,6 @@ const ButtonTypography: FunctionComponent<ButtonTypographyProps> = ({ primary, c
     </Text>
   );
 };
-
-export interface PanelHeaderButtonProps extends Omit<TappableProps, 'label'> {
-  primary?: boolean;
-  label?: ReactNode;
-}
 
 export const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
   children,

--- a/src/components/RichCell/RichCell.tsx
+++ b/src/components/RichCell/RichCell.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
 import { getClassName } from '../../helpers/getClassName';
@@ -40,7 +40,7 @@ export interface RichCellProps extends TappableProps {
   multiline?: boolean;
 }
 
-const RichCell: FunctionComponent<RichCellProps> = ({
+const RichCell: FC<RichCellProps> = ({
   children,
   text,
   caption,

--- a/src/components/RichCell/RichCell.tsx
+++ b/src/components/RichCell/RichCell.tsx
@@ -49,25 +49,14 @@ const RichCell: FC<RichCellProps> = ({
   bottom,
   actions,
   multiline,
-  Component,
-  onClick,
   sizeY,
   ...restProps
 }) => {
   const platform = usePlatform();
-  const RootComponent = restProps.disabled ? Component : Tappable;
-  Component = restProps.disabled ? undefined : Component;
-
-  const props: RichCellProps = restProps;
-
-  if (!restProps.disabled) {
-    props.Component = restProps.href ? 'a' : Component;
-    props.onClick = onClick;
-  }
 
   return (
-    <RootComponent
-      {...props}
+    <Tappable
+      {...restProps}
       vkuiClass={
         classNames(
           getClassName('RichCell', platform),
@@ -97,12 +86,8 @@ const RichCell: FC<RichCellProps> = ({
           }
         </div>
       </div>
-    </RootComponent>
+    </Tappable>
   );
-};
-
-RichCell.defaultProps = {
-  Component: 'div',
 };
 
 export default withAdaptivity(RichCell, { sizeY: true });

--- a/src/components/SimpleCell/SimpleCell.tsx
+++ b/src/components/SimpleCell/SimpleCell.tsx
@@ -67,25 +67,15 @@ const SimpleCell: FC<SimpleCellProps> = ({
   description,
   expandable,
   multiline,
-  Component,
-  onClick,
   sizeY,
   ...restProps
 }) => {
   const platform = usePlatform();
   const hasAfter = hasReactNode(after) || expandable && platform === IOS;
-  const RootComponent = restProps.disabled ? Component : Tappable;
-
-  const props: SimpleCellProps = restProps;
-
-  if (!restProps.disabled) {
-    props.Component = restProps.href ? 'a' : Component;
-    props.onClick = onClick;
-  }
 
   return (
-    <RootComponent
-      {...props}
+    <Tappable
+      {...restProps}
       vkuiClass={
         classNames(
           getClassName('SimpleCell', platform),
@@ -118,12 +108,8 @@ const SimpleCell: FC<SimpleCellProps> = ({
           {expandable && platform === IOS && <Icon24Chevron />}
         </div>
       }
-    </RootComponent>
+    </Tappable>
   );
-};
-
-SimpleCell.defaultProps = {
-  Component: 'div',
 };
 
 export default withAdaptivity(SimpleCell, { sizeY: true });

--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -2,8 +2,7 @@
   position: relative;
 }
 
-.Tappable:not([disabled]),
-.Tappable:not([aria-disabled="true"]) {
+.Tappable:not([disabled]):not([aria-disabled="true"]) {
   cursor: pointer;
 }
 

--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -2,7 +2,8 @@
   position: relative;
 }
 
-.Tappable:not([disabled]) {
+.Tappable:not([disabled]),
+.Tappable:not([aria-disabled="true"]) {
   cursor: pointer;
 }
 

--- a/src/components/Tappable/Tappable.test.tsx
+++ b/src/components/Tappable/Tappable.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { baselineComponent } from '../../testing/utils';
 import Tappable, { TappableProps } from './Tappable';
 
-const TappableTest = (props: TappableProps) => <Tappable data-testid="tappable" hasFocusVisible={true} {...props} />;
+const TappableTest = (props: TappableProps) => <Tappable data-testid="tappable" {...props} />;
 const tappable = () => screen.getByTestId('tappable');
 
 describe('Tappable', () => {
@@ -67,12 +67,14 @@ describe('Tappable', () => {
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
-  // [a11y] remove this test once a11y work on components based on Tappable is finished
-  it('a11y: hasFocusVisible manages focus visible class', () => {
-    const { rerender } = render(<TappableTest>hasFocusVisible TRUE</TappableTest>);
-    expect(tappable()).toHaveClass('Tappable--focus-visible');
-
-    rerender(<TappableTest hasFocusVisible={false}>hasFocusVisible FALSE</TappableTest>);
+  // [a11y] remove hasFocusVisible tests once a11y work on components based on Tappable is finished
+  it('a11y: no .Tappable--focus-visible class gets added by default', () => {
+    render(<TappableTest>hasFocusVisible FALSE</TappableTest>);
     expect(tappable()).not.toHaveClass('Tappable--focus-visible');
+  });
+
+  it('a11y: hasFocusVisible adds .Tappable--focus-visible class', () => {
+    render(<TappableTest hasFocusVisible>hasFocusVisible TRUE</TappableTest>);
+    expect(tappable()).toHaveClass('Tappable--focus-visible');
   });
 });

--- a/src/components/Tappable/Tappable.test.tsx
+++ b/src/components/Tappable/Tappable.test.tsx
@@ -49,6 +49,11 @@ describe('Tappable', () => {
     expect(tappable()).toHaveAttribute('tabIndex', '0');
   });
 
+  it('a11y(tabindex): custom disabled button has no tabindex', () => {
+    render(<TappableTest disabled>Custom Disabled Button</TappableTest>);
+    expect(tappable()).not.toHaveAttribute('tabIndex');
+  });
+
   it('a11y(tabindex): custom link has tabindex={0}', () => {
     render(<TappableTest role="link">Custom Link</TappableTest>);
     expect(tappable()).toHaveAttribute('tabIndex', '0');

--- a/src/components/Tappable/Tappable.test.tsx
+++ b/src/components/Tappable/Tappable.test.tsx
@@ -9,62 +9,137 @@ const tappable = () => screen.getByTestId('tappable');
 describe('Tappable', () => {
   baselineComponent(TappableTest);
 
-  it('a11y: tabIndex is properly set for custom accessible button', () => {
-    const { rerender } = render(<TappableTest Component="button" tabIndex={0}>native element has no tabIndex</TappableTest>);
-    expect(tappable()).not.toHaveAttribute('tabIndex');
+  it('Component: if no Component is passed Tappable becomes a div', () => {
+    render(<TappableTest>Look, ma, no Component!</TappableTest>);
+    expect(tappable().tagName.toLowerCase()).toMatch('div');
+  });
 
-    rerender(<TappableTest>custom button has tabIndex 0</TappableTest>);
+  it('Component: if a href is passed w/ no Component Tappable becomes a native link', () => {
+    render(<TappableTest href="https://vk.com">VK Link</TappableTest>);
+    expect(tappable().tagName.toLowerCase()).toMatch('a');
+  });
+
+  it('Component: if a href is passed w/ Component Tappable becomes a [Component]', () => {
+    render(<TappableTest href="https://vk.com" Component="div" role="link">VK Link Div</TappableTest>);
+    expect(tappable().tagName.toLowerCase()).toMatch('div');
+  });
+
+  it('a11y(role): role gets set for custom button', () => {
+    render(<TappableTest>Custom Button</TappableTest>);
+    expect(tappable()).toHaveAttribute('role', 'button');
+  });
+
+  it('a11y(role): default role gets reassigned', () => {
+    render(<TappableTest role="link">Custom Link</TappableTest>);
+    expect(tappable()).toHaveAttribute('role', 'link');
+  });
+
+  it('a11y(role): role gets reset for native button', () => {
+    render(<TappableTest Component="button">Native Button</TappableTest>);
+    expect(tappable()).not.toHaveAttribute('role');
+  });
+
+  it('a11y(role): role gets reset for native link', () => {
+    render(<TappableTest href="#">Native Link</TappableTest>);
+    expect(tappable()).not.toHaveAttribute('role');
+  });
+
+  it('a11y(tabindex): custom button has tabindex={0}', () => {
+    render(<TappableTest>Custom Button</TappableTest>);
     expect(tappable()).toHaveAttribute('tabIndex', '0');
+  });
 
-    rerender(<TappableTest tabIndex={1}>custom button as __dangerous__ tabIndex 1</TappableTest>);
+  it('a11y(tabindex): custom link has tabindex={0}', () => {
+    render(<TappableTest role="link">Custom Link</TappableTest>);
+    expect(tappable()).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('a11y(tabindex): positive tabindex overrides default tabindex', () => {
+    render(<TappableTest tabIndex={1}>custom button has __dangerous__ tabIndex {1}</TappableTest>);
     expect(tappable()).toHaveAttribute('tabIndex', '1');
   });
 
-  it('a11y: tabIndex is properly set for custom accessible link', () => {
-    const { rerender } = render(<TappableTest Component="a" href="#" tabIndex={0}>native element has no tabIndex</TappableTest>);
+  it('a11y(tabindex): negative tabindex overrides default tabindex', () => {
+    render(<TappableTest role="link" tabIndex={-1}>custom link has tabIndex {-1}</TappableTest>);
+    expect(tappable()).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('a11y(tabindex): native button has no tabindex', () => {
+    render(<TappableTest Component="button">Native Button</TappableTest>);
     expect(tappable()).not.toHaveAttribute('tabIndex');
-
-    rerender(<TappableTest role="link">custom link has tabIndex 0</TappableTest>);
-    expect(tappable()).toHaveAttribute('tabIndex', '0');
-
-    rerender(<TappableTest role="link" tabIndex={1}>custom link has __dangerous__ tabIndex 1</TappableTest>);
-    expect(tappable()).toHaveAttribute('tabIndex', '1');
   });
 
-  it('a11y: custom button get focused on tab', () => {
-    render(<TappableTest Component="div" role="button">Focused Button</TappableTest>);
-
-    userEvent.tab();
-    expect(tappable()).toHaveFocus();
+  it('a11y(tabindex): native link has no tabindex', () => {
+    render(<TappableTest href="#">Native Link</TappableTest>);
+    expect(tappable()).not.toHaveAttribute('tabIndex');
   });
 
-  it('a11y: custom link gets focused on tab', () => {
-    render(<TappableTest Component="div" role="link">Focused Link</TappableTest>);
-
-    userEvent.tab();
-    expect(tappable()).toHaveFocus();
+  it('a11y(type): custom button has no type', () => {
+    render(<TappableTest>Custom Button</TappableTest>);
+    expect(tappable()).not.toHaveAttribute('type');
   });
 
-  it('a11y: custom button works on Enter and Space', () => {
+  it('a11y(type): native button has default type="button"', () => {
+    render(<TappableTest Component="button">Native Button</TappableTest>);
+    expect(tappable()).toHaveAttribute('type', 'button');
+  });
+
+  it('a11y(type): default type gets overwritten if type is passed to a native button', () => {
+    render(<TappableTest Component="button" type="submit">Submit Button</TappableTest>);
+    expect(tappable()).toHaveAttribute('type', 'submit');
+  });
+
+  it('a11y(type): type exists if passed to a non-button', () => {
+    render(<TappableTest href="https://google.com" type="external">Go to Google.com</TappableTest>);
+    expect(tappable()).toHaveAttribute('type', 'external');
+  });
+
+  it('a11y(disabled): custom Tappable element has aria-disabled', () => {
+    render(<TappableTest>Tappable w/ aria-disabled</TappableTest>);
+    expect(tappable()).toHaveAttribute('aria-disabled');
+  });
+
+  it('a11y(button): custom button keyboard events', () => {
     const handleClick = jest.fn();
+    render(<TappableTest onClick={handleClick}>Custom Button</TappableTest>);
 
-    render(<TappableTest role="button" onClick={handleClick}>Custom Button</TappableTest>);
+    // gets focused on tab
+    userEvent.tab();
+    expect(tappable()).toHaveFocus();
 
+    // onClick gets called on Enter and Space
     fireEvent.keyDown(tappable(), { key: 'Enter', code: 'Enter' });
-    fireEvent.keyDown(tappable(), { key: ' ', code: 'Space' });
+    expect(handleClick).toHaveBeenCalledTimes(1);
 
+    fireEvent.keyDown(tappable(), { key: ' ', code: 'Space' });
     expect(handleClick).toHaveBeenCalledTimes(2);
   });
 
-  it('a11y: custom link works on Enter and does not on Space', () => {
+  it('a11y(link): custom link keyboard events', () => {
     const handleClick = jest.fn();
-
     render(<TappableTest role="link" onClick={handleClick}>Custom Link</TappableTest>);
 
-    fireEvent.keyDown(tappable(), { key: 'Enter', code: 'Enter' });
-    fireEvent.keyDown(tappable(), { key: ' ', code: 'Space' });
+    // gets focused on tab
+    userEvent.tab();
+    expect(tappable()).toHaveFocus();
 
+    // onClick gets called on Enter only
+    fireEvent.keyDown(tappable(), { key: 'Enter', code: 'Enter' });
     expect(handleClick).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(tappable(), { key: ' ', code: 'Space' });
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disabled: default Tappable w/ disabled does not react to events', () => {
+    const handleClick = jest.fn();
+    render(<TappableTest onClick={handleClick} disabled />);
+
+    fireEvent.click(tappable());
+    expect(handleClick).toHaveBeenCalledTimes(0);
+
+    fireEvent.keyDown(tappable(), { key: 'Enter', code: 'Enter' });
+    expect(handleClick).toHaveBeenCalledTimes(0);
   });
 
   // [a11y] remove hasFocusVisible tests once a11y work on components based on Tappable is finished

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -129,7 +129,6 @@ class Tappable extends Component<TappableProps, TappableState> {
   wavesTimeout: number;
 
   static defaultProps = {
-    Component: 'div',
     role: 'button',
     stopPropagation: false,
     disabled: false,
@@ -343,9 +342,12 @@ class Tappable extends Component<TappableProps, TappableState> {
 
   render() {
     const { clicks, active, hovered, hasHover, hasActive } = this.state;
+
+    const defaultComponent: ElementType = this.props.href ? 'a' : 'div';
+
     const {
       children,
-      Component,
+      Component = defaultComponent,
       activeEffectDelay,
       stopPropagation,
       getRootRef,

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -428,7 +428,7 @@ class Tappable extends Component<TappableProps, TappableState> {
                   <RootComponent
                     {...touchProps}
                     type={Component === 'button' ? 'button' : undefined}
-                    tabIndex={isCustomElement ? 0 : undefined}
+                    tabIndex={isCustomElement && !restProps.disabled ? 0 : undefined}
                     role={isCustomElement ? role : undefined}
                     {...restProps}
                     vkuiClass={classes}

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -129,7 +129,6 @@ class Tappable extends Component<TappableProps, TappableState> {
   wavesTimeout: number;
 
   static defaultProps = {
-    role: 'button',
     stopPropagation: false,
     disabled: false,
     hasFocusVisible: false,
@@ -359,9 +358,10 @@ class Tappable extends Component<TappableProps, TappableState> {
       hasActive: propsHasActive,
       activeMode,
       hasFocusVisible,
-      tabIndex,
       ...restProps
     } = this.props;
+
+    const isCustomElement: boolean = Component !== 'a' && Component !== 'button' && !restProps.contentEditable;
 
     const isPresetHoverMode = ['opacity', 'background'].includes(hoverMode);
     const isPresetActiveMode = ['opacity', 'background'].includes(activeMode);
@@ -393,22 +393,15 @@ class Tappable extends Component<TappableProps, TappableState> {
       props.onEnd = this.onEnd;
       /* eslint-enable */
       props.getRootRef = this.getRef;
-
-      /*
-       * [a11y]
-       * Проставляет tabindex и подменяет onKeyDown для нужных кастомных доступных элементов
-       */
-      const nativeComponents: ElementType[] = ['a', 'button', 'input', 'textarea', 'label'];
-      if (!nativeComponents.includes(Component) && !restProps.contentEditable) {
-        props.tabIndex = tabIndex !== undefined ? tabIndex : 0;
-
-        if (restProps.role === 'button' || restProps.role === 'link') {
-          props.onKeyDown = this.onKeyDown;
-        }
-      }
     } else {
       props.ref = this.getRef;
     }
+
+    if (isCustomElement) {
+      props['aria-disabled'] = restProps.disabled;
+    }
+
+    const role: string = restProps.href ? 'link' : 'button';
 
     return (
       <TappableContext.Consumer>
@@ -430,6 +423,9 @@ class Tappable extends Component<TappableProps, TappableState> {
                 return (
                   <RootComponent
                     {...touchProps}
+                    type={Component === 'button' ? 'button' : undefined}
+                    tabIndex={isCustomElement ? 0 : undefined}
+                    role={isCustomElement ? role : undefined}
                     {...restProps}
                     vkuiClass={classes}
                     {...props}>

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -440,16 +440,14 @@ class Tappable extends Component<TappableProps, TappableState> {
                     >
                       {children}
                     </TappableContext.Provider>
-                    {platform === ANDROID && !hasMouse && hasActive && activeMode === 'background' &&
-                    <span vkuiClass="Tappable__waves">
-                      {Object.keys(clicks).map((k: string) => {
-                        return (
+                    {platform === ANDROID && !hasMouse && hasActive && activeMode === 'background' && (
+                      <span aria-hidden="true" vkuiClass="Tappable__waves">
+                        {Object.keys(clicks).map((k: string) => (
                           <span vkuiClass="Tappable__wave" style={{ top: clicks[k].y, left: clicks[k].x }} key={k} />
-                        );
-                      })}
-                    </span>
-                    }
-                    {hasHover && <span vkuiClass="Tappable__hoverShadow" />}
+                        ))}
+                      </span>
+                    )}
+                    {hasHover && <span aria-hidden="true" vkuiClass="Tappable__hoverShadow" />}
                   </RootComponent>
                 );
               }}

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -347,6 +347,8 @@ class Tappable extends Component<TappableProps, TappableState> {
     const {
       children,
       Component = defaultComponent,
+      onClick,
+      onKeyDown,
       activeEffectDelay,
       stopPropagation,
       getRootRef,
@@ -391,6 +393,8 @@ class Tappable extends Component<TappableProps, TappableState> {
       props.onStart = this.onStart;
       props.onMove = this.onMove;
       props.onEnd = this.onEnd;
+      props.onClick = onClick;
+      props.onKeyDown = isCustomElement ? this.onKeyDown : onKeyDown;
       /* eslint-enable */
       props.getRootRef = this.getRef;
     } else {


### PR DESCRIPTION
- Обнаружила, что в `Tappable` могли неправильно проставляться `role` и `type`. Подправила логику их проставления; заодно перенесла туда же выбор `Component` в зависимости от наличия/отсутствия `href`.

- Отрефакторила компоненты на базе `Tappable`, убрав ставший лишним код.

- Обновила юнит-тесты для `Tappable`.