### PR TITLE
feat: Make AdaptivityProvider optional

### DIFF
--- a/src/components/AdaptivityProvider/AdaptivityContext.tsx
+++ b/src/components/AdaptivityProvider/AdaptivityContext.tsx
@@ -19,7 +19,7 @@ export enum ViewHeight {
   MEDIUM
 }
 
-export interface AdaptivityContextInterface {
+export interface AdaptivityData {
   sizeX?: SizeType;
   sizeY?: SizeType;
   viewWidth?: ViewWidth;
@@ -27,7 +27,12 @@ export interface AdaptivityContextInterface {
   hasMouse?: boolean;
 }
 
+export interface AdaptivityContextInterface extends AdaptivityData {
+  isFallback?: true;
+}
+
 export const AdaptivityContext = createContext<AdaptivityContextInterface>({
   sizeX: SizeType.COMPACT,
   sizeY: SizeType.REGULAR,
+  isFallback: true,
 });

--- a/src/hoc/withAdaptivity.tsx
+++ b/src/hoc/withAdaptivity.tsx
@@ -1,8 +1,8 @@
 import { useAdaptivity } from '../hooks/useAdaptivity';
-import { AdaptivityContext, SizeType, ViewHeight, ViewWidth } from '../components/AdaptivityProvider/AdaptivityContext';
+import { AdaptivityContext, AdaptivityData, SizeType, ViewHeight, ViewWidth } from '../components/AdaptivityProvider/AdaptivityContext';
 import { useObjectMemo } from '../hooks/useObjectMemo';
 
-type Config = { [K in keyof AdaptivityProps]?: boolean };
+type Config = { [K in keyof AdaptivityData]?: boolean };
 
 export { SizeType, ViewWidth, ViewHeight };
 

--- a/src/hooks/useAdaptivity.ts
+++ b/src/hooks/useAdaptivity.ts
@@ -1,7 +1,12 @@
-import { useContext } from 'react';
+import { noop } from '@vkontakte/vkjs';
+import { useContext, useEffect, useState } from 'react';
 import { AdaptivityContext } from '../components/AdaptivityProvider/AdaptivityContext';
+import { defAdaptivity } from '../components/AdaptivityProvider/AdaptivityProvider';
 import { AdaptivityProps } from '../hoc/withAdaptivity';
 
 export const useAdaptivity = (): AdaptivityProps => {
-  return useContext(AdaptivityContext);
+  const context = useContext(AdaptivityContext);
+  const [globalState, setState] = useState(defAdaptivity.state);
+  useEffect(() => context.isFallback ? defAdaptivity.observe(setState) : noop, []);
+  return context.isFallback ? globalState : context;
 };


### PR DESCRIPTION
Концепт опционального `AdaptivityProvider` — если контекст не нашелся, привязываемся к глобальному объекту адаптивности. Также убираем лишние перерендеры, когда адаптивность не изменилась.