### PR TITLE
Доступность: focus visible у всех кнопок и ссылок

### DIFF
--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -14,3 +14,8 @@
 .Badge--prominent {
   background-color: var(--counter_prominent_background);
 }
+
+.TabsItem__after .Badge {
+  transform: translateY(-2px);
+  margin-left: 6px;
+}

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -7,6 +7,8 @@
 .Banner__in {
   position: relative;
   display: flex;
+  flex-flow: row nowrap;
+  align-items: stretch;
   padding: 12px;
   padding-left: 16px;
   background-color: var(--content_tint_background);
@@ -67,14 +69,8 @@
   flex-flow: row nowrap;
   align-content: center;
   align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-}
-
-.Banner__aside--expand {
-  align-self: center;
   justify-content: flex-end;
+  width: 28px;
   color: var(--icon_tertiary);
 }
 

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -112,7 +112,6 @@ const Banner: FC<BannerProps> = (props: BannerProps) => {
       )}
     >
       <Tappable
-        Component="div"
         vkuiClass="Banner__in"
         activeMode={platform === IOS ? 'opacity' : 'background'}
         disabled={asideMode !== 'expand'}
@@ -140,10 +139,10 @@ const Banner: FC<BannerProps> = (props: BannerProps) => {
         </div>
 
         {!!asideMode && (
-          <div vkuiClass={`Banner__aside Banner__aside--${asideMode}`}>
+          <div vkuiClass="Banner__aside">
             {asideMode === 'expand' && <Icon24Chevron />}
 
-            {asideMode === 'dismiss' &&
+            {asideMode === 'dismiss' && (
               <IconButton
                 aria-label={dismissLabel}
                 vkuiClass="Banner__dismiss"
@@ -154,7 +153,7 @@ const Banner: FC<BannerProps> = (props: BannerProps) => {
                 {(platform === ANDROID || platform === VKCOM) && <Icon24Cancel />}
                 {platform === IOS && (mode === 'image' ? <Icon24DismissDark /> : <Icon24DismissSubstract />)}
               </IconButton>
-            }
+            )}
           </div>
         )}
       </Tappable>

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -238,9 +238,9 @@
 }
 
 /**
+ * CMP:
  * ModalCardBase
  */
-
 .ModalCardBase__actions .Button {
   flex: 1;
   margin-left: 6px;
@@ -254,4 +254,12 @@
 
 .ModalCardBase__actions--v .Button + .Button {
   margin-top: 12px;
+}
+
+/**
+ * CMP:
+ * RichCell
+ */
+.RichCell__actions .Button + .Button {
+  margin-left: 8px;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -74,7 +74,7 @@ const Button: FC<ButtonProps> = (props: ButtonProps) => {
     <Tappable
       {...restProps}
       Component={restProps.href ? 'a' : Component}
-      focusVisibleOutline="outside"
+      focusVisibleMode="outside"
       vkuiClass={
         classNames(
           getClassName('Button', platform),

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -74,6 +74,7 @@ const Button: FC<ButtonProps> = (props: ButtonProps) => {
     <Tappable
       {...restProps}
       Component={restProps.href ? 'a' : Component}
+      focusVisibleOutline="outside"
       vkuiClass={
         classNames(
           getClassName('Button', platform),

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -114,7 +114,6 @@ Button.defaultProps = {
   size: 's',
   stretched: false,
   stopPropagation: true,
-  hasFocusVisible: true,
 };
 
 export default withAdaptivity(Button, {

--- a/src/components/FocusVisible/FocusVisible.css
+++ b/src/components/FocusVisible/FocusVisible.css
@@ -1,9 +1,5 @@
-/**
- * [a11y]
- * add focus-visible outline w/ rounded corners
- * without animation by default
- */
-.AppRoot--keyboard-input *:focus > .FocusVisible {
+.AppRoot--keyboard-input .Tappable:focus > .FocusVisible,
+.Tappable:focus-visible > .FocusVisible {
   position: absolute;
   top: 2px;
   left: 2px;
@@ -17,7 +13,8 @@
   z-index: 0;
 }
 
-.AppRoot--keyboard-input *:focus > .FocusVisible--outside {
+.AppRoot--keyboard-input .Tappable:focus > .FocusVisible--outside,
+.Tappable:focus-visible > .FocusVisible--outside {
   top: -2px;
   left: -2px;
   right: -2px;
@@ -31,7 +28,8 @@
  * navigating accessible vkui apps via keyboard
  */
 @media (prefers-reduced-motion: no-preference) {
-  .AppRoot--keyboard-input *:focus > .FocusVisible {
+  .AppRoot--keyboard-input .Tappable:focus > .FocusVisible,
+  .Tappable:focus-visible > .FocusVisible {
     top: 4px;
     left: 4px;
     right: 4px;
@@ -41,7 +39,8 @@
     will-change: top, left, bottom, right;
   }
 
-  .AppRoot--keyboard-input *:focus > .FocusVisible--outside {
+  .AppRoot--keyboard-input .Tappable:focus > .FocusVisible--outside,
+  .Tappable:focus-visible > .FocusVisible--outside {
     top: 0;
     left: 0;
     bottom: 0;

--- a/src/components/FocusVisible/FocusVisible.css
+++ b/src/components/FocusVisible/FocusVisible.css
@@ -1,0 +1,75 @@
+/**
+ * [a11y]
+ * add focus-visible outline w/ rounded corners
+ * without animation by default
+ */
+.AppRoot--keyboard-input *:focus > .FocusVisible {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  right: 2px;
+  bottom: 2px;
+  border-radius: inherit;
+  box-shadow: 0 0 0 2px var(--accent);
+  user-select: none;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.AppRoot--keyboard-input *:focus > .FocusVisible--outside {
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+}
+
+/**
+ * [a11y]
+ * add animation for browsers that support prefers-reduced-motion
+ * so that users with vestibular motion disorders have no problem
+ * navigating accessible vkui apps via keyboard
+ */
+@media (prefers-reduced-motion: no-preference) {
+  .AppRoot--keyboard-input *:focus > .FocusVisible {
+    top: 4px;
+    left: 4px;
+    right: 4px;
+    bottom: 4px;
+    animation: vkui-animation-focus-visible .15s ease-in-out forwards;
+    animation-delay: .01ms;
+    will-change: top, left, bottom, right;
+  }
+
+  .AppRoot--keyboard-input *:focus > .FocusVisible--outside {
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    animation-name: vkui-animation-focus-visible-outside;
+  }
+
+  @keyframes vkui-animation-focus-visible {
+    0% {}
+
+    100% {
+      top: 2px;
+      left: 2px;
+      bottom: 2px;
+      right: 2px;
+      will-change: auto;
+    }
+  }
+
+  @keyframes vkui-animation-focus-visible-outside {
+    0% {}
+
+    100% {
+      top: -2px;
+      left: -2px;
+      bottom: -2px;
+      right: -2px;
+      will-change: auto;
+    }
+  }
+}

--- a/src/components/FocusVisible/FocusVisible.tsx
+++ b/src/components/FocusVisible/FocusVisible.tsx
@@ -2,10 +2,10 @@ import { FC } from 'react';
 import { classNames } from '../../lib/classNames';
 import './FocusVisible.css';
 
-export type FocusVisibleOutline = 'inside' | 'outside';
+export type FocusVisibleMode = 'inside' | 'outside';
 
 interface FocusVisibleProps {
-  mode: FocusVisibleOutline;
+  mode: FocusVisibleMode;
 }
 
 export const FocusVisible: FC<FocusVisibleProps> = ({ mode }: FocusVisibleProps) => (

--- a/src/components/FocusVisible/FocusVisible.tsx
+++ b/src/components/FocusVisible/FocusVisible.tsx
@@ -5,9 +5,9 @@ import './FocusVisible.css';
 export type FocusVisibleOutline = 'inside' | 'outside';
 
 interface FocusVisibleProps {
-  outline: FocusVisibleOutline;
+  mode: FocusVisibleOutline;
 }
 
-export const FocusVisible: FC<FocusVisibleProps> = ({ outline }: FocusVisibleProps) => (
-  <span aria-hidden="true" vkuiClass={classNames('FocusVisible', `FocusVisible--${outline}`)} />
+export const FocusVisible: FC<FocusVisibleProps> = ({ mode }: FocusVisibleProps) => (
+  <span aria-hidden="true" vkuiClass={classNames('FocusVisible', `FocusVisible--${mode}`)} />
 );

--- a/src/components/FocusVisible/FocusVisible.tsx
+++ b/src/components/FocusVisible/FocusVisible.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { classNames } from '../../lib/classNames';
+import './FocusVisible.css';
+
+export type FocusVisibleOutline = 'inside' | 'outside';
+
+interface FocusVisibleProps {
+  outline: FocusVisibleOutline;
+}
+
+export const FocusVisible: FC<FocusVisibleProps> = ({ outline }: FocusVisibleProps) => (
+  <span aria-hidden="true" vkuiClass={classNames('FocusVisible', `FocusVisible--${outline}`)} />
+);

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -19,6 +19,7 @@ const Link: FC<LinkProps> = ({
       vkuiClass={getClassName('Link', platform)}
       hasActive={false}
       hoverMode="opacity"
+      focusVisibleOutline="outside"
     >
       {children}
     </Tappable>

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -19,7 +19,7 @@ const Link: FC<LinkProps> = ({
       vkuiClass={getClassName('Link', platform)}
       hasActive={false}
       hoverMode="opacity"
-      focusVisibleOutline="outside"
+      focusVisibleMode="outside"
     >
       {children}
     </Tappable>

--- a/src/components/MiniInfoCell/MiniInfoCell.css
+++ b/src/components/MiniInfoCell/MiniInfoCell.css
@@ -12,13 +12,13 @@
 }
 
 .MiniInfoCell__icon {
+  margin-right: 12px;
   color: var(--icon_outline_secondary);
 }
 
 .MiniInfoCell__content {
   flex: 1;
   min-width: 0;
-  margin-left: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -1,4 +1,4 @@
-import { AllHTMLAttributes, FunctionComponent, ReactNode } from 'react';
+import { AllHTMLAttributes, FC, ReactNode } from 'react';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
@@ -18,7 +18,7 @@ interface ButtonTypographyProps extends AllHTMLAttributes<HTMLElement> {
   primary?: PanelHeaderButtonProps['primary'];
 }
 
-const ButtonTypography: FunctionComponent<ButtonTypographyProps> = ({ primary, children }: ButtonTypographyProps) => {
+const ButtonTypography: FC<ButtonTypographyProps> = ({ primary, children }: ButtonTypographyProps) => {
   const platform = usePlatform();
 
   if (platform === IOS) {
@@ -36,7 +36,7 @@ const ButtonTypography: FunctionComponent<ButtonTypographyProps> = ({ primary, c
   );
 };
 
-export const PanelHeaderButton: FunctionComponent<PanelHeaderButtonProps> = ({
+export const PanelHeaderButton: FC<PanelHeaderButtonProps> = ({
   children,
   primary,
   label,

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -52,10 +52,6 @@
   overflow: hidden;
 }
 
-.Removable--ios .Removable__content {
-  transition: transform .6s var(--ios-easing);
-}
-
 .Removable--ios .Removable__action--remove {
   position: absolute;
   left: 100%;
@@ -69,7 +65,13 @@
   line-height: 45px;
   color: var(--white);
   background-color: var(--destructive);
-  transition: transform .6s var(--ios-easing);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .Removable--ios .Removable__content,
+  .Removable--ios .Removable__action--remove {
+    transition: transform .6s var(--ios-easing);
+  }
 }
 
 .Removable--ios .Removable__action--indicator {

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -48,6 +48,12 @@ export const Removable: FC<RemovableProps> = ({
     updateRemoveOffset(0);
   }));
 
+  const onRemoveTransitionEnd = () => {
+    if (isRemoveActivated) {
+      removeButtonRef?.current?.focus();
+    }
+  };
+
   const onRemoveActivateClick = (e: MouseEvent) => {
     e.nativeEvent.stopPropagation();
     e.preventDefault();
@@ -65,7 +71,6 @@ export const Removable: FC<RemovableProps> = ({
 
     if (isRemoveActivated && removeButton) {
       updateRemoveOffset(removeButton.offsetWidth);
-      setTimeout(() => removeButton.focus(), 150);
     }
   }, [isRemoveActivated]);
 
@@ -119,6 +124,7 @@ export const Removable: FC<RemovableProps> = ({
             getRootRef={removeButtonRef}
             vkuiClass="Removable__action Removable__action--remove"
             onClick={onRemoveClick}
+            onTransitionEnd={onRemoveTransitionEnd}
             style={{ transform: `translateX(-${removeOffset}px)` }}
           >
             <span vkuiClass="Removable__action-in">{removePlaceholder}</span>

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -94,15 +94,15 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
       {platform === IOS && (
         <React.Fragment>
           <div vkuiClass="Removable__content" style={{ transform: `translateX(-${removeOffset}px)` }}>
-            <button
-              type="button"
+            <IconButton
+              hasActive={false}
+              hasHover={false}
               aria-label={removePlaceholderString}
               vkuiClass="Removable__action Removable__action--indicator"
               onClick={onRemoveActivateClick}
             >
               <i vkuiClass="Removable__action-in" role="presentation" />
-            </button>
-
+            </IconButton>
             {children}
 
             <span vkuiClass="Removable__offset" aria-hidden="true"></span>

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -1,9 +1,9 @@
-import React, { AllHTMLAttributes, FC, ReactNode, MouseEvent, useEffect, useRef, useState } from 'react';
+import { AllHTMLAttributes, FC, ReactNode, MouseEvent, useEffect, useRef, useState, Fragment } from 'react';
 import { classNames } from '../../lib/classNames';
 import { getTitleFromChildren } from '../../lib/utils';
 import { usePlatform } from '../../hooks/usePlatform';
 import { getClassName } from '../../helpers/getClassName';
-import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
+import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useDOM } from '../../lib/dom';
 import { ANDROID, IOS, VKCOM } from '../../lib/platform';
 import { Icon24Cancel } from '@vkontakte/icons';
@@ -27,16 +27,15 @@ interface RemovableProps extends AllHTMLAttributes<HTMLElement>, RemovePlacehold
   onRemove?: (e: MouseEvent) => void;
 }
 
-export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovableProps & Pick<AdaptivityProps, 'sizeY'>) => {
-  const {
-    children,
-    sizeY,
-    onRemove,
-    removePlaceholder,
-    align,
-    ...restProps
-  } = props;
+export const Removable: FC<RemovableProps> = ({
+  children,
+  onRemove,
+  removePlaceholder,
+  align,
+  ...restProps
+}: RemovableProps) => {
   const platform = usePlatform();
+  const { sizeY } = useAdaptivity();
   const { document } = useDOM();
 
   const removeButtonRef = useRef(null);
@@ -96,7 +95,7 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
       )}
 
       {platform === IOS && (
-        <React.Fragment>
+        <Fragment>
           <div vkuiClass="Removable__content" style={{ transform: `translateX(-${removeOffset}px)` }}>
             <IconButton
               hasActive={false}
@@ -124,13 +123,11 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
           >
             <span vkuiClass="Removable__action-in">{removePlaceholder}</span>
           </Tappable>
-        </React.Fragment>
+        </Fragment>
       )}
     </div>
   );
-}, {
-  sizeY: true,
-});
+};
 
 Removable.defaultProps = {
   align: 'center',

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -9,6 +9,7 @@ import { ANDROID, IOS, VKCOM } from '../../lib/platform';
 import { Icon24Cancel } from '@vkontakte/icons';
 import IconButton from '../IconButton/IconButton';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
+import Tappable from '../Tappable/Tappable';
 import './Removable.css';
 
 export interface RemovePlaceholderProps {
@@ -61,8 +62,11 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
   };
 
   useEffect(() => {
-    if (isRemoveActivated && removeButtonRef?.current) {
-      updateRemoveOffset(removeButtonRef.current.offsetWidth);
+    const removeButton = removeButtonRef?.current;
+
+    if (isRemoveActivated && removeButton) {
+      updateRemoveOffset(removeButton.offsetWidth);
+      setTimeout(() => removeButton.focus(), 150);
     }
   }, [isRemoveActivated]);
 
@@ -108,16 +112,19 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
             <span vkuiClass="Removable__offset" aria-hidden="true"></span>
           </div>
 
-          <button
-            type="button"
+          <Tappable
+            Component="button"
+            hasActive={false}
+            hasHover={false}
+            disabled={!isRemoveActivated}
             tabIndex={isRemoveActivated ? null : -1}
-            ref={removeButtonRef}
+            getRootRef={removeButtonRef}
             vkuiClass="Removable__action Removable__action--remove"
             onClick={onRemoveClick}
             style={{ transform: `translateX(-${removeOffset}px)` }}
           >
             <span vkuiClass="Removable__action-in">{removePlaceholder}</span>
-          </button>
+          </Tappable>
         </React.Fragment>
       )}
     </div>

--- a/src/components/Removable/Removable.tsx
+++ b/src/components/Removable/Removable.tsx
@@ -117,7 +117,6 @@ export const Removable: FC<RemovableProps> = withAdaptivity((props: RemovablePro
             hasActive={false}
             hasHover={false}
             disabled={!isRemoveActivated}
-            tabIndex={isRemoveActivated ? null : -1}
             getRootRef={removeButtonRef}
             vkuiClass="Removable__action Removable__action--remove"
             onClick={onRemoveClick}

--- a/src/components/RichCell/RichCell.css
+++ b/src/components/RichCell/RichCell.css
@@ -90,10 +90,6 @@
   text-overflow: ellipsis;
 }
 
-.RichCell__bottom .UsersStack {
-  padding: 5px 0 0;
-}
-
 .RichCell__actions {
   display: flex;
   margin-top: 8px;

--- a/src/components/RichCell/RichCell.css
+++ b/src/components/RichCell/RichCell.css
@@ -1,6 +1,8 @@
 .RichCell {
   display: flex;
   min-height: 64px;
+  padding-right: 16px;
+  padding-left: 16px;
   box-sizing: border-box;
   white-space: nowrap;
   text-decoration: none;
@@ -104,26 +106,14 @@
 /**
  * iOS
  */
-
 .RichCell--ios {
   padding-right: 12px;
   padding-left: 12px;
 }
 
 /**
- * Android
- */
-
-.RichCell--android,
-.RichCell--vkcom {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
-/**
  * sizeY === 'compact'
  */
-
 .RichCell--sizeY-compact {
   min-height: 60px;
 }

--- a/src/components/RichCell/RichCell.css
+++ b/src/components/RichCell/RichCell.css
@@ -99,10 +99,6 @@
   margin-top: 8px;
 }
 
-.RichCell__actions .Button:not(:last-child) {
-  margin-right: 8px;
-}
-
 /**
  * iOS
  */

--- a/src/components/SubnavigationButton/SubnavigationButton.tsx
+++ b/src/components/SubnavigationButton/SubnavigationButton.tsx
@@ -62,6 +62,7 @@ export const SubnavigationButton: FC<SubnavigationButtonProps> = (props: Subnavi
     <Tappable
       {...restProps}
       hasActive={false}
+      focusVisibleOutline="outside"
       vkuiClass={classNames(
         getClassName('SubnavigationButton', platform),
         `SubnavigationButton--${size}`,

--- a/src/components/SubnavigationButton/SubnavigationButton.tsx
+++ b/src/components/SubnavigationButton/SubnavigationButton.tsx
@@ -62,7 +62,7 @@ export const SubnavigationButton: FC<SubnavigationButtonProps> = (props: Subnavi
     <Tappable
       {...restProps}
       hasActive={false}
-      focusVisibleOutline="outside"
+      focusVisibleMode="outside"
       vkuiClass={classNames(
         getClassName('SubnavigationButton', platform),
         `SubnavigationButton--${size}`,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -7,13 +7,11 @@ import { IOS } from '../../lib/platform';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import './Tabs.css';
 
-export type TabsMode = 'default' | 'buttons' | 'segmented';
-
 export interface TabsProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<HTMLDivElement>, AdaptivityProps {
-  mode?: TabsMode;
+  mode?: 'default' | 'buttons' | 'segmented';
 }
 
-export const TabsModeContext = createContext<TabsMode>('default');
+export const TabsModeContext = createContext<TabsProps['mode']>('default');
 
 const Tabs: FunctionComponent<TabsProps> = ({
   children,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -7,11 +7,13 @@ import { IOS } from '../../lib/platform';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import './Tabs.css';
 
+export type TabsMode = 'default' | 'buttons' | 'segmented';
+
 export interface TabsProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<HTMLDivElement>, AdaptivityProps {
-  mode?: 'default' | 'buttons' | 'segmented';
+  mode?: TabsMode;
 }
 
-export const TabsModeContext = createContext<TabsProps['mode']>('default');
+export const TabsModeContext = createContext<TabsMode>('default');
 
 const Tabs: FunctionComponent<TabsProps> = ({
   children,

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -88,11 +88,6 @@
   color: var(--panel_tab_active_text);
 }
 
-.TabsItem__after .Badge {
-  transform: translateY(-2px);
-  margin-left: 6px;
-}
-
 .TabsItem__after .Icon--dropdown_16 {
   color: var(--header_tint);
   transform-origin: 50% calc(50% + 1px);

--- a/src/components/TabsItem/TabsItem.tsx
+++ b/src/components/TabsItem/TabsItem.tsx
@@ -39,7 +39,7 @@ const TabsItem: FC<TabsItemProps> = ({
       vkuiClass={classNames(getClassName('TabsItem', platform), { 'TabsItem--selected': selected })}
       hasActive={mode === 'segmented'}
       activeMode="TabsItem--active"
-      focusVisibleOutline={mode === 'segmented' ? 'outside' : 'inside'}
+      focusVisibleMode={mode === 'segmented' ? 'outside' : 'inside'}
     >
       <TypographyComponent Component="span" vkuiClass="TabsItem__in" weight="medium">{children}</TypographyComponent>
       {hasReactNode(after) && <div vkuiClass="TabsItem__after">{after}</div>}

--- a/src/components/TabsItem/TabsItem.tsx
+++ b/src/components/TabsItem/TabsItem.tsx
@@ -1,11 +1,11 @@
-import { FunctionComponent, HTMLAttributes, ReactNode, useContext } from 'react';
+import { FC, HTMLAttributes, ReactNode, useContext } from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import Tappable from '../Tappable/Tappable';
 import { classNames } from '../../lib/classNames';
 import { VKCOM } from '../../lib/platform';
 import { usePlatform } from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
-import { TabsModeContext } from '../Tabs/Tabs';
+import { TabsMode, TabsModeContext } from '../Tabs/Tabs';
 import Headline from '../Typography/Headline/Headline';
 import Subhead from '../Typography/Subhead/Subhead';
 import Text from '../Typography/Text/Text';
@@ -16,14 +16,14 @@ export interface TabsItemProps extends HTMLAttributes<HTMLElement> {
   selected?: boolean;
 }
 
-const TabsItem: FunctionComponent<TabsItemProps> = ({
+const TabsItem: FC<TabsItemProps> = ({
   children,
   selected,
   after,
   ...restProps
 }: TabsItemProps) => {
   const platform = usePlatform();
-  const mode = useContext(TabsModeContext);
+  const mode: TabsMode = useContext(TabsModeContext);
 
   const TypographyComponent = platform === VKCOM
     ? Text

--- a/src/components/TabsItem/TabsItem.tsx
+++ b/src/components/TabsItem/TabsItem.tsx
@@ -5,7 +5,7 @@ import { classNames } from '../../lib/classNames';
 import { VKCOM } from '../../lib/platform';
 import { usePlatform } from '../../hooks/usePlatform';
 import { hasReactNode } from '../../lib/utils';
-import { TabsMode, TabsModeContext } from '../Tabs/Tabs';
+import { TabsProps, TabsModeContext } from '../Tabs/Tabs';
 import Headline from '../Typography/Headline/Headline';
 import Subhead from '../Typography/Subhead/Subhead';
 import Text from '../Typography/Text/Text';
@@ -23,13 +23,15 @@ const TabsItem: FC<TabsItemProps> = ({
   ...restProps
 }: TabsItemProps) => {
   const platform = usePlatform();
-  const mode: TabsMode = useContext(TabsModeContext);
+  const mode: TabsProps['mode'] = useContext(TabsModeContext);
 
-  const TypographyComponent = platform === VKCOM
-    ? Text
-    : mode === 'buttons' || mode === 'segmented'
-      ? Subhead
-      : Headline;
+  let TypographyComponent = mode === 'buttons' || mode === 'segmented'
+    ? Subhead
+    : Headline;
+
+  if (platform === VKCOM) {
+    TypographyComponent = Text;
+  }
 
   return (
     <Tappable
@@ -37,8 +39,9 @@ const TabsItem: FC<TabsItemProps> = ({
       vkuiClass={classNames(getClassName('TabsItem', platform), { 'TabsItem--selected': selected })}
       hasActive={mode === 'segmented'}
       activeMode="TabsItem--active"
+      focusVisibleMode={mode === 'segmented' ? 'outside' : 'inside'}
     >
-      <TypographyComponent vkuiClass="TabsItem__in" weight="medium">{children}</TypographyComponent>
+      <TypographyComponent Component="span" vkuiClass="TabsItem__in" weight="medium">{children}</TypographyComponent>
       {hasReactNode(after) && <div vkuiClass="TabsItem__after">{after}</div>}
     </Tappable>
   );

--- a/src/components/TabsItem/TabsItem.tsx
+++ b/src/components/TabsItem/TabsItem.tsx
@@ -39,7 +39,7 @@ const TabsItem: FC<TabsItemProps> = ({
       vkuiClass={classNames(getClassName('TabsItem', platform), { 'TabsItem--selected': selected })}
       hasActive={mode === 'segmented'}
       activeMode="TabsItem--active"
-      focusVisibleMode={mode === 'segmented' ? 'outside' : 'inside'}
+      focusVisibleOutline={mode === 'segmented' ? 'outside' : 'inside'}
     >
       <TypographyComponent Component="span" vkuiClass="TabsItem__in" weight="medium">{children}</TypographyComponent>
       {hasReactNode(after) && <div vkuiClass="TabsItem__after">{after}</div>}

--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -6,6 +6,10 @@
   cursor: pointer;
 }
 
+.AppRoot--keyboard-input .Tappable:focus-visible {
+  outline: none;
+}
+
 /**
  * active
  */

--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -9,11 +9,11 @@
 /**
  * active
  */
-.Tappable--active-background:not([disabled]) {
+.Tappable--active-background:not([disabled]):not([aria-disabled="true"]) {
   background: var(--background_highlighted);
 }
 
-.Tappable--active-opacity:not([disabled]) {
+.Tappable--active-opacity:not([disabled]):not([aria-disabled="true"]) {
   opacity: .7;
 }
 

--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -7,57 +7,6 @@
 }
 
 /**
- * [a11y]
- * add focus-visible outline w/ rounded corners via pseudo element
- * without animation by default
- */
-.AppRoot--keyboard-input .Tappable--focus-visible:focus::before {
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  right: -2px;
-  bottom: -2px;
-  border-radius: inherit;
-  box-shadow: 0 0 0 2px var(--accent);
-  user-select: none;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: 0;
-}
-
-/**
- * [a11y]
- * add animation for browsers that support prefers-reduced-motion
- * so that users with vestibular motion disorders have no problem
- * navigating accessible vkui apps via keyboard
- */
-@media (prefers-reduced-motion: no-preference) {
-  .AppRoot--keyboard-input .Tappable--focus-visible:focus::before {
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    animation: vkui-animation-focus-visible .15s ease-in-out forwards;
-    animation-delay: .01ms;
-  }
-
-  @keyframes vkui-animation-focus-visible {
-    0% {
-      will-change: top, left, bottom, right;
-    }
-
-    100% {
-      top: -2px;
-      left: -2px;
-      bottom: -2px;
-      right: -2px;
-      will-change: auto;
-    }
-  }
-}
-
-/**
  * active
  */
 .Tappable--active-background:not([disabled]) {

--- a/src/components/Tappable/Tappable.test.tsx
+++ b/src/components/Tappable/Tappable.test.tsx
@@ -147,17 +147,6 @@ describe('Tappable', () => {
     expect(handleClick).toHaveBeenCalledTimes(0);
   });
 
-  // [a11y] remove hasFocusVisible tests once a11y work on components based on Tappable is finished
-  it('a11y: no .Tappable--focus-visible class gets added by default', () => {
-    render(<TappableTest>hasFocusVisible FALSE</TappableTest>);
-    expect(tappable()).not.toHaveClass('Tappable--focus-visible');
-  });
-
-  it('a11y: hasFocusVisible adds .Tappable--focus-visible class', () => {
-    render(<TappableTest hasFocusVisible>hasFocusVisible TRUE</TappableTest>);
-    expect(tappable()).toHaveClass('Tappable--focus-visible');
-  });
-
   it('checks that hover state is removed if component becomes disabled', () => {
     const { rerender } = render(<TappableTest>Test</TappableTest>);
     fireEvent.mouseEnter(tappable());

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -44,11 +44,6 @@ export interface TappableProps extends AllHTMLAttributes<HTMLElement>, HasRootRe
    * Стиль подсветки hover-состояния. Если передать произвольную строку, она добавится как css-класс во время hover
    */
   hoverMode?: 'opacity' | 'background' | string;
-  /**
-   * @ignore Временное свойство для работы над доступностью. Указывает, должен ли компонент показывать focus ring при навигации с клавиатуры.
-   * Исчезнет после того, как мы адаптируем отображение всех компонентов на базе Tappable.
-   */
-  hasFocusVisible?: boolean;
 }
 
 export interface TappableState {
@@ -132,7 +127,6 @@ class Tappable extends Component<TappableProps, TappableState> {
   static defaultProps = {
     stopPropagation: false,
     disabled: false,
-    hasFocusVisible: false,
     hasHover,
     hoverMode: 'background',
     hasActive: true,
@@ -363,7 +357,6 @@ class Tappable extends Component<TappableProps, TappableState> {
       hoverMode,
       hasActive: propsHasActive,
       activeMode,
-      hasFocusVisible,
       ...restProps
     } = this.props;
 
@@ -381,7 +374,6 @@ class Tappable extends Component<TappableProps, TappableState> {
         'Tappable--mouse': hasMouse,
         [`Tappable--hover-${hoverMode}`]: hasHover && hovered && isPresetHoverMode,
         [`Tappable--active-${activeMode}`]: hasActive && active && isPresetActiveMode,
-        'Tappable--focus-visible': hasFocusVisible,
         [hoverMode]: hasHover && hovered && !isPresetHoverMode,
         [activeMode]: hasActive && active && !isPresetActiveMode,
       });

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -19,6 +19,7 @@ import { hasHover } from '@vkontakte/vkjs';
 import { setRef } from '../../lib/utils';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { shouldTriggerClickOnEnterOrSpace } from '../../lib/accessibility';
+import { FocusVisible, FocusVisibleOutline } from '../FocusVisible/FocusVisible';
 import './Tappable.css';
 
 export interface TappableProps extends AllHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, HasPlatform, AdaptivityProps {
@@ -44,6 +45,10 @@ export interface TappableProps extends AllHTMLAttributes<HTMLElement>, HasRootRe
    * Стиль подсветки hover-состояния. Если передать произвольную строку, она добавится как css-класс во время hover
    */
   hoverMode?: 'opacity' | 'background' | string;
+  /**
+   * Стиль аутлайна focus visible.
+   */
+  focusVisibleOutline?: FocusVisibleOutline;
 }
 
 export interface TappableState {
@@ -127,6 +132,7 @@ class Tappable extends Component<TappableProps, TappableState> {
   static defaultProps = {
     stopPropagation: false,
     disabled: false,
+    focusVisibleOutline: 'inside',
     hasHover,
     hoverMode: 'background',
     hasActive: true,
@@ -357,6 +363,7 @@ class Tappable extends Component<TappableProps, TappableState> {
       hoverMode,
       hasActive: propsHasActive,
       activeMode,
+      focusVisibleOutline,
       ...restProps
     } = this.props;
 
@@ -446,6 +453,7 @@ class Tappable extends Component<TappableProps, TappableState> {
                       </span>
                     )}
                     {hasHover && <span aria-hidden="true" vkuiClass="Tappable__hoverShadow" />}
+                    {!restProps.disabled && <FocusVisible outline={focusVisibleOutline} />}
                   </RootComponent>
                 );
               }}

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -453,7 +453,7 @@ class Tappable extends Component<TappableProps, TappableState> {
                       </span>
                     )}
                     {hasHover && <span aria-hidden="true" vkuiClass="Tappable__hoverShadow" />}
-                    {!restProps.disabled && <FocusVisible outline={focusVisibleOutline} />}
+                    {!restProps.disabled && <FocusVisible mode={focusVisibleOutline} />}
                   </RootComponent>
                 );
               }}

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -19,7 +19,7 @@ import { hasHover } from '@vkontakte/vkjs';
 import { setRef } from '../../lib/utils';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { shouldTriggerClickOnEnterOrSpace } from '../../lib/accessibility';
-import { FocusVisible, FocusVisibleOutline } from '../FocusVisible/FocusVisible';
+import { FocusVisible, FocusVisibleMode } from '../FocusVisible/FocusVisible';
 import './Tappable.css';
 
 export interface TappableProps extends AllHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, HasPlatform, AdaptivityProps {
@@ -48,7 +48,7 @@ export interface TappableProps extends AllHTMLAttributes<HTMLElement>, HasRootRe
   /**
    * Стиль аутлайна focus visible.
    */
-  focusVisibleMode?: FocusVisibleOutline;
+  focusVisibleMode?: FocusVisibleMode;
 }
 
 export interface TappableState {

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -48,7 +48,7 @@ export interface TappableProps extends AllHTMLAttributes<HTMLElement>, HasRootRe
   /**
    * Стиль аутлайна focus visible.
    */
-  focusVisibleOutline?: FocusVisibleOutline;
+  focusVisibleMode?: FocusVisibleOutline;
 }
 
 export interface TappableState {
@@ -132,7 +132,7 @@ class Tappable extends Component<TappableProps, TappableState> {
   static defaultProps = {
     stopPropagation: false,
     disabled: false,
-    focusVisibleOutline: 'inside',
+    focusVisibleMode: 'inside',
     hasHover,
     hoverMode: 'background',
     hasActive: true,
@@ -363,7 +363,7 @@ class Tappable extends Component<TappableProps, TappableState> {
       hoverMode,
       hasActive: propsHasActive,
       activeMode,
-      focusVisibleOutline,
+      focusVisibleMode,
       ...restProps
     } = this.props;
 
@@ -453,7 +453,7 @@ class Tappable extends Component<TappableProps, TappableState> {
                       </span>
                     )}
                     {hasHover && <span aria-hidden="true" vkuiClass="Tappable__hoverShadow" />}
-                    {!restProps.disabled && <FocusVisible mode={focusVisibleOutline} />}
+                    {!restProps.disabled && <FocusVisible mode={focusVisibleMode} />}
                   </RootComponent>
                 );
               }}

--- a/src/components/UsersStack/UsersStack.css
+++ b/src/components/UsersStack/UsersStack.css
@@ -87,9 +87,17 @@
 }
 
 /**
+ * CMP:
  * ModalCardBase
  */
-
 .ModalCardBase .UsersStack {
   margin-top: 20px;
+}
+
+/**
+ * CMP:
+ * RichCell
+ */
+.RichCell__bottom .UsersStack {
+  padding: 5px 0 0;
 }

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -1,6 +1,6 @@
-import { KeyboardEvent as SyntheticKeyboardEvent } from 'react';
+import { KeyboardEvent } from 'react';
 
-export function shouldTriggerClickOnEnterOrSpace(e: SyntheticKeyboardEvent<HTMLElement>) {
+export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) {
   const { target, key } = e;
   const el = target as HTMLElement;
   const { tagName } = el;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -19,6 +19,7 @@
 /* Primitives */
 @import '../components/Button/Button.css';
 @import '../components/Removable/Removable.css';
+@import '../components/FocusVisible/FocusVisible.css';
 
 /* Layout */
 @import '../components/Root/Root.css';


### PR DESCRIPTION
- Перенесла стили для аутлайна при фокусе с клавиатуры в новый компонент `FocusVisible`,
- Добавила мод `inside`, который нужен нам в большинстве компонентов для красивой подсветки, которая не уходит за границы элемента (например, для разнообразных ячеек),
- Отрефакторила `Tappable`, чтобы использовать `FocusVisible`.
- Убрала временный `hasFocusVisible`.

Должны работать все кликабельные кнопки и ссылки, включая кликабельные ячейки, **кроме**:
- `WriteBarIcon` — будет отдельно,
- Кнопка удаления чипа в `Chip` — будет поправлена в рамках задачи по доступности `ChipsInput`/`ChipsSelect`.