### PR TITLE
refactor: ContentCard

### DIFF
--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,34 +1,39 @@
 import { baselineComponent, imgOnlyAttributes } from '../../testing/utils';
 import { render, screen } from '@testing-library/react';
-import Avatar from './Avatar';
+import Avatar, { AvatarProps } from './Avatar';
+
+const AvatarTest = (props: AvatarProps) => (<Avatar {...props} data-testid="avatar" />);
+
+const avatar = () => screen.getByTestId('avatar');
+const img = () => avatar().querySelector('img');
 
 describe('Avatar', () => {
   baselineComponent(Avatar);
 
-  it('renders img only if src passed', () => {
-    const { rerender } = render(<Avatar data-testid="avatar" src="#" />);
-    const img = document.querySelector('img');
-    expect(screen.getByTestId('avatar').contains(img)).toBeTruthy();
-    rerender(<Avatar data-testid="avatar" />);
-    expect(screen.getByTestId('avatar').contains(img)).toBeFalsy();
+  it('[img] renders img if src is passed', () => {
+    render(<AvatarTest src="#" />);
+
+    expect(img()).toBeInTheDocument();
   });
 
-  it('passes ref to the img', () => {
+  it('[img] does not render img if there is no src', () => {
+    render(<AvatarTest />);
+
+    expect(img()).not.toBeInTheDocument();
+  });
+
+  it('[img] passes ref to img', () => {
     const refCallback = jest.fn();
-    render(<Avatar data-testid="avatar" src="#" getRef={refCallback} />);
+    render(<AvatarTest src="#" getRef={refCallback} />);
+
     expect(refCallback).toBeCalled();
   });
 
-  it('passes all img props to the img', () => {
-    render(
-      <Avatar
-        data-testid="avatar"
-        {...imgOnlyAttributes}
-      />,
-    );
+  it('[img] passes all img attributes to img', () => {
+    render(<AvatarTest src="#" {...imgOnlyAttributes} />);
 
-    const attributes = Object.values(document.querySelector('img').attributes).map((item) => item.name);
-
-    expect(Object.keys(imgOnlyAttributes).every((attr) => attributes.includes(attr.toLowerCase()))).toBeTruthy();
+    Object.keys(imgOnlyAttributes).forEach((attr) => {
+      expect(img()).toHaveAttribute(attr);
+    });
   });
 });

--- a/src/components/ContentCard/ContentCard.test.tsx
+++ b/src/components/ContentCard/ContentCard.test.tsx
@@ -7,14 +7,14 @@ const ContentCardTest = (props: ContentCardProps) => (
     subtitle="VKUI"
     header="ContentCard example"
     caption="VKUI Styleguide > Blocks > ContentCard"
-    image="/image.png"
+    src="/image.png"
     {...props}
     data-testid="card"
   />
 );
 
 describe('ContentCard', () => {
-  baselineComponent((props) => <ContentCard image="/image.png" {...props} />);
+  baselineComponent((props) => <ContentCard src="/image.png" {...props} />);
 
   it('onClick: ContentCard without onClick is treated as disabled', () => {
     render(<ContentCardTest />);

--- a/src/components/ContentCard/ContentCard.test.tsx
+++ b/src/components/ContentCard/ContentCard.test.tsx
@@ -1,5 +1,5 @@
 import { screen, render } from '@testing-library/react';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, imgOnlyAttributes } from '../../testing/utils';
 import ContentCard, { ContentCardProps } from './ContentCard';
 
 const ContentCardTest = (props: ContentCardProps) => (
@@ -7,16 +7,44 @@ const ContentCardTest = (props: ContentCardProps) => (
     subtitle="VKUI"
     header="ContentCard example"
     caption="VKUI Styleguide > Blocks > ContentCard"
-    src="/image.png"
     {...props}
     data-testid="card"
   />
 );
+const card = () => screen.getByTestId('card');
+const img = () => card().querySelector('img');
 
 describe('ContentCard', () => {
   baselineComponent((props) => <ContentCard src="/image.png" {...props} />);
 
-  it('onClick: ContentCard without onClick is treated as disabled', () => {
+  it('[img] renders img if src is passed', () => {
+    render(<ContentCardTest src="/image.png" />);
+
+    expect(img()).toBeInTheDocument();
+  });
+
+  it('[img] does not render img if there is no src', () => {
+    render(<ContentCardTest />);
+
+    expect(img()).not.toBeInTheDocument();
+  });
+
+  it('[img] passes ref to img', () => {
+    const refCallback = jest.fn();
+    render(<ContentCardTest src="/image.png" getRef={refCallback} />);
+
+    expect(refCallback).toBeCalled();
+  });
+
+  it('[img] passes all img attributes to img', () => {
+    render(<ContentCardTest src="/image.png" {...imgOnlyAttributes} />);
+
+    Object.keys(imgOnlyAttributes).forEach((attr) => {
+      expect(img()).toHaveAttribute(attr);
+    });
+  });
+
+  it('[onClick] is disabled when there is no onClick', () => {
     render(<ContentCardTest />);
     const tappable = screen.getByRole('button');
 

--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -30,6 +30,10 @@ export interface ContentCardProps extends HasRootRef<HTMLDivElement>, ImgHTMLAtt
   /**
     URL или путь к изображению
    */
+  src?: string;
+  /**
+    @deprecated будет удалено в 5.0.0. Используйте src
+   */
   image?: string;
   /**
     Максимальная высота изображения
@@ -78,13 +82,13 @@ const ContentCard: FC<ContentCardProps> = (props: ContentCardProps) => {
   return (
     <Card mode={mode} getRootRef={getRootRef} vkuiClass={getClassName('ContentCard', platform)} style={style} className={className}>
       <Tappable {...restProps} disabled={disabled} vkuiClass="ContentCard__tappable">
-        {image && (
+        {(image || src) && (
           <img
             ref={getRef}
-            src={image}
+            vkuiClass="ContentCard__img"
+            src={image || src}
             srcSet={srcSet}
             alt={alt}
-            vkuiClass="ContentCard__img"
             height={height}
             style={{ maxHeight }}
             width="100%"

--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -79,14 +79,16 @@ const ContentCard: FC<ContentCardProps> = (props: ContentCardProps) => {
 
   const disabled = restProps.disabled || typeof restProps.onClick !== 'function';
 
+  const source = image || src;
+
   return (
     <Card mode={mode} getRootRef={getRootRef} vkuiClass={getClassName('ContentCard', platform)} style={style} className={className}>
       <Tappable {...restProps} disabled={disabled} vkuiClass="ContentCard__tappable">
-        {(image || src) && (
+        {(source || srcSet) && (
           <img
             ref={getRef}
             vkuiClass="ContentCard__img"
-            src={image || src}
+            src={source}
             srcSet={srcSet}
             alt={alt}
             height={height}

--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -50,19 +50,46 @@ export interface ContentCardProps extends HasRootRef<HTMLDivElement>, ImgHTMLAtt
 }
 
 const ContentCard: FC<ContentCardProps> = (props: ContentCardProps) => {
-  const { getRef, onClick, subtitle, header, text, caption, className, image, maxHeight, disabled, mode, style, getRootRef, ...restProps } = props;
+  const {
+    subtitle,
+    header,
+    text,
+    caption,
+    // card props
+    className,
+    mode,
+    style,
+    getRootRef,
+    // img props
+    getRef,
+    maxHeight,
+    image,
+    src,
+    srcSet,
+    alt,
+    width,
+    height,
+    ...restProps
+  } = props;
   const platform = usePlatform();
+
+  const disabled = restProps.disabled || typeof restProps.onClick !== 'function';
 
   return (
     <Card mode={mode} getRootRef={getRootRef} vkuiClass={getClassName('ContentCard', platform)} style={style} className={className}>
-      <Tappable
-        Component="div"
-        disabled={disabled || typeof onClick !== 'function'}
-        role="button"
-        onClick={onClick}
-        vkuiClass="ContentCard__tappable"
-      >
-        {image && <img {...restProps} ref={getRef} src={image} vkuiClass="ContentCard__img" style={{ maxHeight }} width="100%" />}
+      <Tappable {...restProps} disabled={disabled} vkuiClass="ContentCard__tappable">
+        {image && (
+          <img
+            ref={getRef}
+            src={image}
+            srcSet={srcSet}
+            alt={alt}
+            vkuiClass="ContentCard__img"
+            height={height}
+            style={{ maxHeight }}
+            width="100%"
+          />
+        )}
         <div vkuiClass="ContentCard__body">
           {hasReactNode(subtitle) && <Caption caps vkuiClass="ContentCard__text" weight="semibold" level="3">{subtitle}</Caption>}
           {hasReactNode(header) && <Title vkuiClass="ContentCard__text" weight="semibold" level="3">{header}</Title>}

--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -73,6 +73,12 @@ const ContentCard: FC<ContentCardProps> = (props: ContentCardProps) => {
     alt,
     width,
     height,
+    crossOrigin,
+    decoding,
+    loading,
+    referrerPolicy,
+    sizes,
+    useMap,
     ...restProps
   } = props;
   const platform = usePlatform();
@@ -91,6 +97,12 @@ const ContentCard: FC<ContentCardProps> = (props: ContentCardProps) => {
             src={source}
             srcSet={srcSet}
             alt={alt}
+            crossOrigin={crossOrigin}
+            decoding={decoding}
+            loading={loading}
+            referrerPolicy={referrerPolicy}
+            sizes={sizes}
+            useMap={useMap}
             height={height}
             style={{ maxHeight }}
             width="100%"

--- a/src/components/ContentCard/Readme.md
+++ b/src/components/ContentCard/Readme.md
@@ -1,4 +1,21 @@
-Компонент принимает все валидные для `<img />` свойства
+Компонент на базе [Card](/#/Card). Принимает все валидные свойства для `img` и `Tappable`. 
+
+Внутри распределяет переданные свойства между своими компонентами следующим образом:
+
+- корневой компонент `Card`
+  * `mode`,
+  * `getRootRef`,
+  * `style`,
+  * `className`;
+- `img`
+  * `getRef`,
+  * `src`,
+  * `srcSet`,
+  * `alt`,
+  * `width`,
+  * `height`,
+  * `maxHeight`,
+- внутренний `Tappable` получает все остальные свойства (кроме `subtitle`, `header`, `text` и `caption`).
 
 ```jsx
 const Example = () => {
@@ -16,7 +33,7 @@ const Example = () => {
               caption="VKUI Styleguide > Blocks > ContentCard"
             />
             <ContentCard
-              image="https://images.unsplash.com/photo-1603988492906-4fb0fb251cf8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1600&q=80"
+              src="https://images.unsplash.com/photo-1603988492906-4fb0fb251cf8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1600&q=80"
               subtitle="unsplash"
               header="brown and gray mountains under blue sky during daytime photo"
               text="Mountain changji"
@@ -24,7 +41,7 @@ const Example = () => {
               maxHeight={150}
             />
             <ContentCard
-              image="https://images.unsplash.com/photo-1603928726698-a015a1015d0e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=700&q=80"
+              src="https://images.unsplash.com/photo-1603928726698-a015a1015d0e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=700&q=80"
               subtitle="unsplash"
               header="persons left hand with pink paint"
               text="Five hours of makeup and paint to achieve the human anatomy photoshoot. Thank you Steph and Shay. See more and official credit on @jawfox.photography."

--- a/src/components/ContentCard/Readme.md
+++ b/src/components/ContentCard/Readme.md
@@ -15,6 +15,12 @@
   * `width`,
   * `height`,
   * `maxHeight`,
+  * `crossOrigin`,
+  * `decoding`,
+  * `loading`,
+  * `referrerPolicy`,
+  * `sizes`,
+  * `useMap`,
 - внутренний `Tappable` получает все остальные свойства (кроме `subtitle`, `header`, `text` и `caption`).
 
 ```jsx


### PR DESCRIPTION
По мотивам комментария Артура к #1726: перекинула `{...restProps}` на `Tappable` вместо `<img />`.

Заодно предлагаю задепрекейтить проп `image` и выкинуть его в v5, а пока использовать наравне с классическим `src`.