### PR TITLE
Custom select fixes

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -114,7 +114,7 @@ const warn = warnOnce('CustomSelect');
 class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState> {
   static defaultProps: CustomSelectProps = {
     searchable: false,
-    renderOption(props: CustomSelectOptionProps): ReactNode {
+    renderOption({ option, ...props }): ReactNode {
       return (
         <CustomSelectOption {...props} />
       );

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -305,7 +305,14 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   handleOptionHover: MouseEventHandler = (e: MouseEvent<HTMLElement>) => {
-    this.focusOptionByIndex(Array.prototype.indexOf.call(e.currentTarget.parentNode.children, e.currentTarget));
+    const index = Array.prototype.indexOf.call(e.currentTarget.parentNode.children, e.currentTarget);
+    const option = this.state.options[index];
+
+    if (!option || option.disabled) {
+      this.resetFocusedOption();
+    } else {
+      this.focusOptionByIndex(index);
+    }
   };
 
   handleOptionDown: MouseEventHandler = (e: MouseEvent<HTMLElement>) => {
@@ -313,9 +320,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   resetFocusedOption = () => {
-    this.setState(() => ({
-      focusedOptionIndex: -1,
-    }));
+    this.setState({ focusedOptionIndex: -1 });
   };
 
   onKeyboardInput = (key: string) => {

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -305,18 +305,20 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
   };
 
   handleOptionHover: MouseEventHandler = (e: MouseEvent<HTMLElement>) => {
-    const index = Array.prototype.indexOf.call(e.currentTarget.parentNode.children, e.currentTarget);
-    const option = this.state.options[index];
-
-    if (!option || option.disabled) {
-      this.resetFocusedOption();
-    } else {
-      this.focusOptionByIndex(index);
-    }
+    this.focusOptionByIndex(Array.prototype.indexOf.call(e.currentTarget.parentNode.children, e.currentTarget));
   };
 
   handleOptionDown: MouseEventHandler = (e: MouseEvent<HTMLElement>) => {
     e.preventDefault();
+  };
+
+  handleOptionClick: MouseEventHandler = (e: MouseEvent<HTMLElement>) => {
+    const index = Array.prototype.indexOf.call(e.currentTarget.parentNode.children, e.currentTarget);
+    const option = this.state.options[index];
+
+    if (option && !option.disabled) {
+      this.selectFocused();
+    }
   };
 
   resetFocusedOption = () => {
@@ -473,7 +475,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
           children: option.label,
           selected,
           disabled: option.disabled,
-          onClick: this.selectFocused,
+          onClick: this.handleOptionClick,
           onMouseDown: this.handleOptionDown,
           onMouseEnter: this.handleOptionHover,
         })}

--- a/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -6,13 +6,10 @@ import Text from '../Typography/Text/Text';
 import Caption from '../Typography/Caption/Caption';
 import { HasRootRef } from '../../types';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
+import { warnOnce } from '../../lib/warnOnce';
 import './CustomSelectOption.css';
 
 export interface CustomSelectOptionProps extends HTMLAttributes<HTMLDivElement>, HasRootRef<HTMLDivElement> {
-  /**
-   * @deprecated
-   * Свойство было добавлено по ошибке будет и удалено в 5.0.0
-   */
   option?: any;
   selected?: boolean;
   focused?: boolean;
@@ -22,6 +19,8 @@ export interface CustomSelectOptionProps extends HTMLAttributes<HTMLDivElement>,
   description?: ReactNode;
   disabled?: boolean;
 }
+
+const warn = warnOnce('CustomSelectOption');
 
 const CustomSelectOption: FC<CustomSelectOptionProps> = ({
   children,
@@ -36,6 +35,10 @@ const CustomSelectOption: FC<CustomSelectOptionProps> = ({
 }: CustomSelectOptionProps) => {
   const title = typeof children === 'string' ? children : null;
   const { sizeY } = useAdaptivity();
+
+  if (!!option && process.env.NODE_ENV === 'development') {
+    warn('Свойство option было добавлено по ошибке будет и удалено в 5.0.0');
+  }
 
   return (
     <Text


### PR DESCRIPTION
* Убираем `option` deprecate внутрь `CustomSelectOption`. Сейчас ts ругается, когда человек обращается к `option` внутри `renderOption` (в аргументе этой функции тип описан через `CustomSelectOptionProps`). Можно было бы разделить эти два интерфейса, но кажется, что унести ворнинг проще.
* ~~Обрабатываем `onMouseEnter` на `disabled` опции. Сейчас если сначала навести на разблокированную опцию, а потом на `disabled`, то при клике по `disabled` выберется разблокированная.~~
* Обрабатываем `onClick` по `disabled` опции. Сейчас если сначала навести на разблокированную опцию, а потом на `disabled`, то при клике по `disabled` выберется разблокированная. Сначала я попробовал решить эту проблему с помощью mouseenter, но там начались сложные приколы с наведенной на disabled мышкой и клавиатурной навигацией.