### PR TITLE
[Bug] Скругления в модальных окнах не соответствуют макетам

### DIFF
--- a/src/components/ModalPage/ModalPage.css
+++ b/src/components/ModalPage/ModalPage.css
@@ -14,11 +14,6 @@
   justify-content: center;
 }
 
-.ModalPage--sizeX-regular .Separator:not(.Separator--wide) {
-  padding-left: 8px;
-  padding-right: 8px;
-}
-
 .ModalPage__in-wrap {
   width: 100%;
   height: 100%;

--- a/src/components/ModalPage/ModalPage.css
+++ b/src/components/ModalPage/ModalPage.css
@@ -28,6 +28,7 @@
   align-items: flex-end;
   pointer-events: initial;
   transform: translateY(100%);
+  transition: transform 320ms var(--android-easing);
 }
 
 .ModalRoot--switching .ModalPage__in-wrap {
@@ -45,6 +46,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  border-radius: 12px 12px 0 0;
 }
 
 .ModalPage__header {
@@ -97,7 +99,6 @@
 /**
  * iOS
  */
-
 .ModalPage--ios .ModalPage__in-wrap {
   transition: transform 400ms var(--ios-easing);
 }
@@ -107,20 +108,10 @@
 }
 
 /**
- * Android + vkcom
+ * VKCOM
  */
-
-.ModalPage--android .ModalPage__in-wrap,
-.ModalPage--vkcom .ModalPage__in-wrap {
-  transition: transform 320ms var(--android-easing);
-}
-
-.ModalPage--android .ModalPage__in,
 .ModalPage--vkcom .ModalPage__in {
-  border-radius: 12px 12px 0 0;
-}
-
-.ModalPage--vkcom .ModalPage__in {
+  border-radius: 8px 8px 0 0;
   width: 448px;
 }
 

--- a/src/components/Separator/Separator.css
+++ b/src/components/Separator/Separator.css
@@ -37,3 +37,12 @@
   margin-left: 12px;
   margin-right: 12px;
 }
+
+/*
+ * CMP:
+ * ModalPage
+ */
+.ModalPage--sizeX-regular .Separator:not(.Separator--wide) {
+  padding-left: 8px;
+  padding-right: 8px;
+}

--- a/src/components/Separator/Separator.css
+++ b/src/components/Separator/Separator.css
@@ -25,13 +25,15 @@
   background: transparent;
 }
 
+.Separator:not(.Separator--wide) .Separator__in {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+/**
+ * iOS
+ */
 .Separator:not(.Separator--wide).Separator--ios .Separator__in {
   margin-left: 12px;
   margin-right: 12px;
-}
-
-.Separator:not(.Separator--wide).Separator--android .Separator__in,
-.Separator:not(.Separator--wide).Separator--vkcom .Separator__in {
-  margin-left: 16px;
-  margin-right: 16px;
 }


### PR DESCRIPTION
- Поправила скругления в `ModalPage`,
- Немного причесала css,
- Перенесла относившийся к `Separator` стиль в `Separator.css`.