### PR TITLE
[e2e] Button: update screenshot tests

### DIFF
--- a/src/components/Button/Button.e2e.tsx
+++ b/src/components/Button/Button.e2e.tsx
@@ -13,6 +13,8 @@ describe('Button', () => {
     disabled: [undefined, true],
   }, {
     size: ['s', 'm', 'l'],
+    stretched: [undefined, true],
+    href: [undefined, '#'],
     $adaptivity: 'y',
   }, {
     mode: ['primary'],
@@ -33,11 +35,7 @@ describe('Button', () => {
     after: [<Counter key="counter">16</Counter>],
     size: ['l'],
   }, {
-    mode: [
-      'primary',
-      'secondary',
-      'overlay_primary',
-    ],
+    mode: ['primary', 'secondary', 'overlay_primary'],
     before: [<Icon24Camera key="icon-24" />],
     after: [<Counter key="counter">16</Counter>],
     size: ['s', 'm', 'l'],

--- a/src/components/Button/__image_snapshots__/button-android-bright_light-1-snap.png
+++ b/src/components/Button/__image_snapshots__/button-android-bright_light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:473d5e6df73fa3cfe04eedc12ac30df61a4101b5f4bc991c69df3520a2a9aeed
-size 175884
+oid sha256:88994185ad8d1aaf986a26ea55ba1fdf5ddf66bb0fe4daa3e249b4c9ad101b1a
+size 251669

--- a/src/components/Button/__image_snapshots__/button-android-space_gray-1-snap.png
+++ b/src/components/Button/__image_snapshots__/button-android-space_gray-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89f64f6eb2c3de7039974ef6f316667b093f6daf54e835726fe4b52c14643cc7
-size 186147
+oid sha256:9e8a56351c7413e297a28fefa5fddb6d18df2db59664a3ab1657f3b1740a0c9e
+size 263670

--- a/src/components/Button/__image_snapshots__/button-ios-bright_light-1-snap.png
+++ b/src/components/Button/__image_snapshots__/button-ios-bright_light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b22ad91aa0e164de677ce1677af4a7f4714e237ccf971a8bce63923a8a36766
-size 181388
+oid sha256:7e1cba87417635220b3a35b21f6fcd51fbb716878947aa12ab7b2f578cb324e3
+size 259518

--- a/src/components/Button/__image_snapshots__/button-ios-space_gray-1-snap.png
+++ b/src/components/Button/__image_snapshots__/button-ios-space_gray-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cfc66183b0f802ab43adb9874285d9bb65f84a054e7573ddec322af64d714961
-size 192978
+oid sha256:6d31b9f0d6e9a94625b40c4771f527b11e011826d80762c9bfa91af390997a1d
+size 272950

--- a/src/components/Button/__image_snapshots__/button-vkcom-vkcom-1-snap.png
+++ b/src/components/Button/__image_snapshots__/button-vkcom-vkcom-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:881eda13c5cf98c388caab25a6020c0cdca4035dc23971227db4fe05afd54b5b
-size 132326
+oid sha256:4fe001f2f6c193d027c023cd4f16864ce6bab5bbdfb052e0e520495c7df834f7
+size 158675


### PR DESCRIPTION
Состояния кнопки, зафиксированные в обновленном тесте:

- [x] `stretched`
- [x] `href="#"` 