### PR TITLE
feat(useAdaptivity): update describeScreenshotFuzz

### DIFF
--- a/src/components/Checkbox/Checkbox.e2e.tsx
+++ b/src/components/Checkbox/Checkbox.e2e.tsx
@@ -1,9 +1,10 @@
 import { Checkbox, CheckboxProps } from './Checkbox';
 import { describeScreenshotFuzz } from '../../testing/e2e/utils';
+import { SizeType } from '../AdaptivityProvider/AdaptivityContext';
 
 describe('Checkbox', () => {
   describeScreenshotFuzz((props: CheckboxProps) => <Checkbox {...props}>label</Checkbox>, [{
     checked: [false, true],
     disabled: [undefined, true],
-  }], {});
+  }], { adaptivity: { sizeY: SizeType.REGULAR } });
 });

--- a/src/components/ChipsInput/ChipsInput.tsx
+++ b/src/components/ChipsInput/ChipsInput.tsx
@@ -14,7 +14,7 @@ import { classNames } from '../../lib/classNames';
 import Chip, { ChipProps } from '../Chip/Chip';
 import { noop } from '../../lib/utils';
 import { useChipsInput } from './useChipsInput';
-import { useAdaptivity, AdaptivityProps } from '../../hooks/useAdaptivity';
+import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { prefixClass } from '../../lib/prefixClass';
 import { useExternRef } from '../../hooks/useExternRef';
 import './ChipsInput.css';
@@ -38,8 +38,7 @@ export interface ChipsInputProps<Option extends ChipsInputOption> extends
   HasRef<HTMLInputElement>,
   HasRootRef<HTMLDivElement>,
   HasAlign,
-  FormFieldProps,
-  AdaptivityProps {
+  FormFieldProps {
   value: Option[];
   inputValue?: string;
   onChange?: (o: Option[]) => void;
@@ -54,9 +53,8 @@ export interface ChipsInputProps<Option extends ChipsInputOption> extends
 const ChipsInput = <Option extends ChipsInputOption>(props: ChipsInputProps<Option>) => {
   const { style, value, onChange, onInputChange, onKeyDown, onBlur, onFocus, children, className, inputValue,
     getRef, getRootRef, placeholder, getOptionValue, getOptionLabel, getNewOptionData, renderChip,
-    after, inputAriaLabel, sizeX: propsSizeX, sizeY: propsSizeY, ...restProps } = props;
-
-  const { sizeY } = useAdaptivity({ sizeX: propsSizeX, sizeY: propsSizeY });
+    after, inputAriaLabel, ...restProps } = props;
+  const { sizeY } = useAdaptivity();
 
   const [focused, setFocused] = useState(false);
   const { fieldValue, addOptionFromInput, removeOption, selectedOptions, handleInputChange } = useChipsInput(props);

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -45,6 +45,12 @@
   box-sizing: border-box;
 }
 
+/* TODO: remove this
+   (a very temporary fix to appease screenshot tests) */
+.Cell.Cell--android .Removable.Removable--sizeY-regular {
+  padding-right: 4px;
+}
+
 /**
  * iOS
  */

--- a/src/hooks/useAdaptivity.ts
+++ b/src/hooks/useAdaptivity.ts
@@ -1,19 +1,8 @@
 import { useContext } from 'react';
-import {
-  AdaptivityContext,
-  AdaptivityContextInterface,
-  AdaptivityProps,
-  SizeProps,
-} from '../components/AdaptivityProvider/AdaptivityContext';
+import { AdaptivityContext, AdaptivityProps } from '../components/AdaptivityProvider/AdaptivityContext';
 
 export type { AdaptivityProps };
 
-export const useAdaptivity = (props?: SizeProps): AdaptivityContextInterface => {
-  const contextProps = useContext(AdaptivityContext);
-
-  return {
-    ...contextProps,
-    sizeX: props?.sizeX || contextProps.sizeX,
-    sizeY: props?.sizeY || contextProps.sizeY,
-  };
+export const useAdaptivity = (): AdaptivityProps => {
+  return useContext(AdaptivityContext);
 };

--- a/src/testing/e2e/utils.tsx
+++ b/src/testing/e2e/utils.tsx
@@ -14,7 +14,7 @@ import AdaptivityProvider, {
   MOBILE_SIZE,
 } from '../../components/AdaptivityProvider/AdaptivityProvider';
 import { SizeType, ViewWidth } from '../../components/AdaptivityProvider/AdaptivityContext';
-import { AdaptivityProps } from '../../hoc/withAdaptivity';
+import { AdaptivityProps, withAdaptivity } from '../../hoc/withAdaptivity';
 import View from '../../components/View/View';
 import AppRoot from '../../components/AppRoot/AppRoot';
 import Group from '../../components/Group/Group';
@@ -122,6 +122,9 @@ export function describeScreenshotFuzz<Props>(
       const adaptivityProps = Object.assign(
         isVkCom ? { sizeX: SizeType.COMPACT, sizeY: SizeType.COMPACT } : {},
         adaptivity);
+
+      const AdaptiveComponent = withAdaptivity(Component, { sizeX: true, sizeY: true });
+
       (isVkCom ? [Scheme.VKCOM] : mobileSchemes).forEach((scheme) => {
         it(`${scheme}${adaptivityProps.viewWidth ? ` w_${adaptivityProps.viewWidth}` : ''}`, async () => {
           expect(await screenshot((
@@ -132,7 +135,9 @@ export function describeScreenshotFuzz<Props>(
                     {multiCartesian(propSets, { adaptive: !isVkCom }).map((props, i) => (
                       <Fragment key={i}>
                         <div>{prettyProps(props)}</div>
-                        <div><Component {...props as any} /></div>
+                        <div>
+                          <AdaptiveComponent {...props} />
+                        </div>
                       </Fragment>
                     ))}
                   </Wrapper>


### PR DESCRIPTION
По совету @thoughtspile обновила `describeScreenshotFuzz` так, чтобы в `useAdaptivity()` больше не надо было передавать пропсы для корректной работы скриншотных тестов. Ура!