### PR TITLE
fix: Import irregularly named CSS files

### DIFF
--- a/src/components/ActionSheet/ActionSheetDropdown.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdown.tsx
@@ -3,6 +3,7 @@ import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
 import { ActionSheetProps } from './ActionSheet';
+import './ActionSheet.css';
 
 interface Props {
   closing: boolean;

--- a/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
@@ -6,6 +6,7 @@ import { HasPlatform } from '../../types';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { DOMProps, withDOM } from '../../lib/dom';
 import { ActionSheetProps } from './ActionSheet';
+import './ActionSheet.css';
 
 interface Props extends HTMLAttributes<HTMLDivElement>, HasPlatform, AdaptivityProps {
   closing: boolean;

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -17,6 +17,7 @@ import { getClassName } from '../../helpers/getClassName';
 import { DOMProps, withDOM } from '../../lib/dom';
 import { getNavId } from '../../lib/getNavId';
 import { warnOnce } from '../../lib/warnOnce';
+import './ModalRoot.css';
 
 const warn = warnOnce('ModalRoot');
 const IS_DEV = process.env.NODE_ENV === 'development';

--- a/src/components/NativeSelect/NativeSelect.tsx
+++ b/src/components/NativeSelect/NativeSelect.tsx
@@ -12,6 +12,7 @@ import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { useEnsuredControl } from '../../hooks/useEnsuredControl';
 import { useExternRef } from '../../hooks/useExternRef';
 import { usePlatform } from '../../hooks/usePlatform';
+import '../Select/Select.css';
 
 export interface NativeSelectProps extends
   SelectHTMLAttributes<HTMLSelectElement>,

--- a/src/components/PullToRefresh/PullToRefreshSpinner.tsx
+++ b/src/components/PullToRefresh/PullToRefreshSpinner.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import { classNames } from '../../lib/classNames';
+import './PullToRefresh.css';
 
 function calcStrokeDashOffset(value: number, radius: number) {
   const progress = value / 100;

--- a/src/components/RangeSlider/UniversalSlider.tsx
+++ b/src/components/RangeSlider/UniversalSlider.tsx
@@ -7,6 +7,7 @@ import { rescale } from '../../helpers/math';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
 import { usePlatform } from '../../hooks/usePlatform';
+import '../Slider/Slider.css';
 
 export type UniversalValue = [number | null, number];
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -2,7 +2,6 @@ import { FunctionComponent } from 'react';
 import NativeSelect from '../NativeSelect/NativeSelect';
 import CustomSelect, { CustomSelectProps } from '../CustomSelect/CustomSelect';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
-import './Select.css';
 
 export interface SelectProps extends CustomSelectProps, AdaptivityProps {}
 

--- a/src/components/SelectMimicry/SelectMimicry.tsx
+++ b/src/components/SelectMimicry/SelectMimicry.tsx
@@ -9,6 +9,7 @@ import { getClassName } from '../../helpers/getClassName';
 import Headline from '../Typography/Headline/Headline';
 import Text from '../Typography/Text/Text';
 import { VKCOM } from '../../lib/platform';
+import '../Select/Select.css';
 
 export interface SelectMimicryProps extends
   HTMLAttributes<HTMLElement>,

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { clamp } from '../../helpers/math';
 import { UniversalSlider, UniversalSliderProps, UniversalValue } from '../RangeSlider/UniversalSlider';
-import './Slider.css';
 
 export type SliderProps = UniversalSliderProps<number>;
 

--- a/src/components/SliderSwitch/SliderSwitchButton.tsx
+++ b/src/components/SliderSwitch/SliderSwitchButton.tsx
@@ -5,6 +5,7 @@ import { classNames } from '../../lib/classNames';
 import { HasRootRef } from '../../types';
 import { usePlatform } from '../../hooks/usePlatform';
 import Text from '../Typography/Text/Text';
+import './SliderSwitch.css';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
   active?: boolean;

--- a/src/components/View/ViewInfinite.tsx
+++ b/src/components/View/ViewInfinite.tsx
@@ -15,6 +15,7 @@ import { canUseDOM, withDOM, DOMProps } from '../../lib/dom';
 import { ScrollContext, ScrollContextInterface } from '../AppRoot/ScrollContext';
 import { getNavId, NavIdProps } from '../../lib/getNavId';
 import { warnOnce } from '../../lib/warnOnce';
+import './View.css';
 
 const warn = warnOnce('ViewInfinite');
 export const transitionStartEventName = 'VKUI:View:transition-start';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import './lib/polyfills';
 
 import './styles/constants.css';
 import './styles/animations.css';
+import './styles/common.css';
 
 /**
  * Layout


### PR DESCRIPTION
Потерялись импорты CSS в случаях, когда `Component.tsx` использует CSS не из `./Component.css`