### PR TITLE
[bug] getRootRef в FormItem

### DIFF
--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -50,7 +50,7 @@ export const FormItem: FC<FormItemProps> = withAdaptivity((props: FormItemProps 
   return (
     <Component
       {...restProps}
-      getRootRef={rootEl}
+      ref={rootEl}
       vkuiClass={classNames(
         getClassName('FormItem', platform),
         `FormItem--${status}`,

--- a/src/components/FormLayoutGroup/FormLayoutGroup.tsx
+++ b/src/components/FormLayoutGroup/FormLayoutGroup.tsx
@@ -32,6 +32,7 @@ const FormLayoutGroup: FC<FormLayoutGroupProps> = ({
 
   return (
     <div
+      ref={rootEl}
       vkuiClass={classNames(
         getClassName('FormLayoutGroup', platform),
         `FormLayoutGroup--sizeY-${sizeY}`,


### PR DESCRIPTION
- пофиксила баг в патче
- сходила проверить, нет ли такого же в `FormLayoutGroup`, и обнаружила, что там в принципе реф не висел на контейнере