### PR TITLE
fix: use import type instead of import for AdaptivityProps

### DIFF
--- a/src/hoc/withAdaptivity.tsx
+++ b/src/hoc/withAdaptivity.tsx
@@ -1,11 +1,11 @@
 import { useContext } from 'react';
 import {
   AdaptivityContext,
-  AdaptivityProps,
   SizeType,
   ViewHeight,
   ViewWidth,
 } from '../components/AdaptivityProvider/AdaptivityContext';
+import type { AdaptivityProps } from '../components/AdaptivityProvider/AdaptivityContext';
 
 export { SizeType, ViewWidth, ViewHeight };
 export type { AdaptivityProps };

--- a/src/hooks/useAdaptivity.ts
+++ b/src/hooks/useAdaptivity.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
-import { AdaptivityContext, AdaptivityProps } from '../components/AdaptivityProvider/AdaptivityContext';
+import { AdaptivityContext } from '../components/AdaptivityProvider/AdaptivityContext';
+import type { AdaptivityProps } from '../components/AdaptivityProvider/AdaptivityContext';
 
 export type { AdaptivityProps };
 


### PR DESCRIPTION
Если использовать `vite` с `VKUI`, то выдаёт следующую ошибку:

![image](https://user-images.githubusercontent.com/24193020/132100016-0e031164-c016-4bfb-a826-a31b975ce197.png)

Это происходит из-за того, что в готовых `js` файлах идет импорт типа `AdaptivityProps`. Теперь вместо обычного импорта используется `import type`, что фиксит это поведение и ошибка больше не возникает.