### PR TITLE
HorizontalScrollArrow: safari shadow fix

### DIFF
--- a/src/components/HorizontalScroll/HorizontalScrollArrow.css
+++ b/src/components/HorizontalScroll/HorizontalScrollArrow.css
@@ -11,6 +11,9 @@
   background-color: transparent;
   transition: opacity .15s;
   transition-timing-function: var(--android-easing);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .HorizontalScroll:hover .HorizontalScrollArrow,


### PR DESCRIPTION
Эти стили мы снесли вот тут #1611 и зря
fixes #1841