### PR TITLE
a11y: `pressedKey()` helper

### DIFF
--- a/src/hooks/useKeyboardInputTracker.ts
+++ b/src/hooks/useKeyboardInputTracker.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { KeyCode, pressedKey } from '../lib/accessibility';
+import { Keys, pressedKey } from '../lib/accessibility';
 import { useDOM } from '../lib/dom';
 import { useGlobalEventListener } from './useGlobalEventListener';
 
@@ -9,7 +9,7 @@ export function useKeyboardInputTracker(): boolean {
   const [isKeyboardInputActive, toggleKeyboardInput] = useState<boolean>(true);
 
   const enableKeyboardInput = useCallback((e: KeyboardEvent) => {
-    if (pressedKey(e) === KeyCode.TAB) {
+    if (pressedKey(e) === Keys.TAB) {
       toggleKeyboardInput(true);
     }
   }, []);

--- a/src/hooks/useKeyboardInputTracker.ts
+++ b/src/hooks/useKeyboardInputTracker.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { KeyCode, pressedKey } from '../lib/accessibility';
 import { useDOM } from '../lib/dom';
 import { useGlobalEventListener } from './useGlobalEventListener';
 
@@ -7,8 +8,8 @@ export function useKeyboardInputTracker(): boolean {
 
   const [isKeyboardInputActive, toggleKeyboardInput] = useState<boolean>(true);
 
-  const enableKeyboardInput = useCallback(({ key, keyCode }: KeyboardEvent) => {
-    if (key?.toUpperCase() === 'TAB' || keyCode === 9) {
+  const enableKeyboardInput = useCallback((e: KeyboardEvent) => {
+    if (pressedKey(e) === KeyCode.TAB) {
       toggleKeyboardInput(true);
     }
   }, []);

--- a/src/hooks/useKeyboardInputTracker.ts
+++ b/src/hooks/useKeyboardInputTracker.ts
@@ -9,9 +9,7 @@ export function useKeyboardInputTracker(): boolean {
   const [isKeyboardInputActive, toggleKeyboardInput] = useState<boolean>(true);
 
   const enableKeyboardInput = useCallback((e: KeyboardEvent) => {
-    if (pressedKey(e) === Keys.TAB) {
-      toggleKeyboardInput(true);
-    }
+    toggleKeyboardInput(pressedKey(e) === Keys.TAB);
   }, []);
 
   const disableKeyboardInput = useCallback(() => {

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -12,7 +12,7 @@ interface AccessibleKey {
   keyCode: number;
 }
 
-export const ACCESSIBLE_KEYS: AccessibleKey[] = [
+const ACCESSIBLE_KEYS: AccessibleKey[] = [
   {
     code: Keys.ENTER,
     key: ['Enter'],

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -1,36 +1,36 @@
 import { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
-export enum KeyCode {
+export enum Keys {
   ENTER = 'Enter',
   SPACE = 'Space',
   TAB = 'Tab',
 }
 
 interface AccessibleKey {
-  code: KeyCode;
+  code: Keys;
   key: string[];
   keyCode: number;
 }
 
 export const ACCESSIBLE_KEYS: AccessibleKey[] = [
   {
-    code: KeyCode.ENTER,
+    code: Keys.ENTER,
     key: ['Enter'],
     keyCode: 13,
   },
   {
-    code: KeyCode.SPACE,
+    code: Keys.SPACE,
     key: ['Space', 'Spacebar', ' '],
     keyCode: 32,
   },
   {
-    code: KeyCode.TAB,
+    code: Keys.TAB,
     key: ['Tab'],
     keyCode: 9,
   },
 ];
 
-export function pressedKey(e: KeyboardEvent): KeyCode {
+export function pressedKey(e: KeyboardEvent): Keys {
   return ACCESSIBLE_KEYS.find(({ key, keyCode }) => key.includes(e.key) || keyCode === e.keyCode)?.code || null;
 }
 
@@ -50,9 +50,9 @@ export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent | ReactKeyboar
 
   return isValidKeyboardEventTarget && (
     // trigger buttons on Space
-    _pressedKey === KeyCode.SPACE && role === 'button'
+    _pressedKey === Keys.SPACE && role === 'button'
     ||
     // trigger non-native links and buttons on Enter
-    _pressedKey === KeyCode.ENTER && !isNativeAnchorEl
+    _pressedKey === Keys.ENTER && !isNativeAnchorEl
   );
 }

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -1,4 +1,4 @@
-import { KeyboardEvent } from 'react';
+import { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 export enum KeyCode {
   ENTER = 'Enter',
@@ -34,7 +34,7 @@ export function pressedKey(e: KeyboardEvent): KeyCode {
   return ACCESSIBLE_KEYS.find(({ key, keyCode }) => key.includes(e.key) || keyCode === e.keyCode)?.code || null;
 }
 
-export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) {
+export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent | ReactKeyboardEvent<HTMLElement>) {
   const el = e.target as HTMLElement;
   const { tagName } = el;
 
@@ -46,12 +46,13 @@ export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) 
     && (role === 'button' || role === 'link');
 
   const isNativeAnchorEl = tagName === 'A' && el.hasAttribute('href');
+  const _pressedKey = pressedKey(e as KeyboardEvent);
 
   return isValidKeyboardEventTarget && (
     // trigger buttons on Space
-    pressedKey(e) === KeyCode.SPACE && role === 'button'
+    _pressedKey === KeyCode.SPACE && role === 'button'
     ||
     // trigger non-native links and buttons on Enter
-    pressedKey(e) === KeyCode.ENTER && !isNativeAnchorEl
+    _pressedKey === KeyCode.ENTER && !isNativeAnchorEl
   );
 }

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -45,11 +45,13 @@ export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) 
     && tagName !== 'TEXTAREA'
     && (role === 'button' || role === 'link');
 
+  const isNativeAnchorEl = tagName === 'A' && el.hasAttribute('href');
+
   return isValidKeyboardEventTarget && (
     // trigger buttons on Space
     pressedKey(e) === KeyCode.SPACE && role === 'button'
-    // trigger links and buttons on Enter
-    // if this is NOT a native anchor element
-    || pressedKey(e) === KeyCode.ENTER && !(tagName === 'A' && el.hasAttribute('href'))
+    ||
+    // trigger non-native links and buttons on Enter
+    pressedKey(e) === KeyCode.ENTER && !isNativeAnchorEl
   );
 }

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -1,5 +1,34 @@
 import { KeyboardEvent } from 'react';
 
+export enum KeyCode {
+  ENTER = 'Enter',
+  SPACE = 'Space',
+  TAB = 'Tab',
+}
+
+interface AccessibleKey {
+  code: KeyCode;
+  key: string[];
+  keyCode: number;
+}
+
+export const ACCESSIBLE_KEYS: AccessibleKey[] = [
+  {
+    code: KeyCode.ENTER,
+    key: ['Enter'],
+    keyCode: 13,
+  },
+  {
+    code: KeyCode.SPACE,
+    key: ['Space', 'Spacebar', ' '],
+    keyCode: 32,
+  },
+  {
+    code: KeyCode.TAB,
+    key: ['Tab'],
+    keyCode: 9,
+  },
+];
 export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) {
   const { target, key } = e;
   const el = target as HTMLElement;

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -35,8 +35,7 @@ export function pressedKey(e: KeyboardEvent): KeyCode {
 }
 
 export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) {
-  const { target, key } = e;
-  const el = target as HTMLElement;
+  const el = e.target as HTMLElement;
   const { tagName } = el;
 
   const role = el.getAttribute('role');
@@ -48,9 +47,9 @@ export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) 
 
   return isValidKeyboardEventTarget && (
     // trigger buttons on Space
-    (key === ' ' || key === 'Spacebar') && role === 'button'
+    pressedKey(e) === KeyCode.SPACE && role === 'button'
     // trigger links and buttons on Enter
     // if this is NOT a native anchor element
-    || !(tagName === 'A' && el.hasAttribute('href')) && key === 'Enter'
+    || pressedKey(e) === KeyCode.ENTER && !(tagName === 'A' && el.hasAttribute('href'))
   );
 }

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -29,6 +29,11 @@ export const ACCESSIBLE_KEYS: AccessibleKey[] = [
     keyCode: 9,
   },
 ];
+
+export function pressedKey(e: KeyboardEvent): KeyCode {
+  return ACCESSIBLE_KEYS.find(({ key, keyCode }) => key.includes(e.key) || keyCode === e.keyCode)?.code || null;
+}
+
 export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent<HTMLElement>) {
   const { target, key } = e;
   const el = target as HTMLElement;

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -46,13 +46,13 @@ export function shouldTriggerClickOnEnterOrSpace(e: KeyboardEvent | ReactKeyboar
     && (role === 'button' || role === 'link');
 
   const isNativeAnchorEl = tagName === 'A' && el.hasAttribute('href');
-  const _pressedKey = pressedKey(e as KeyboardEvent);
+  const keyPressed = pressedKey(e as KeyboardEvent);
 
   return isValidKeyboardEventTarget && (
     // trigger buttons on Space
-    _pressedKey === Keys.SPACE && role === 'button'
+    keyPressed === Keys.SPACE && role === 'button'
     ||
     // trigger non-native links and buttons on Enter
-    _pressedKey === Keys.ENTER && !isNativeAnchorEl
+    keyPressed === Keys.ENTER && !isNativeAnchorEl
   );
 }


### PR DESCRIPTION
Добавила хелпер  `pressedKey()`, чтобы каждый раз не писать руками проверку на `key` (и фоллбек на `keyCode` для старых браузеров).