### PR TITLE
test(Touch): Add Touch unit tests

### DIFF
--- a/src/components/Touch/Touch.test.tsx
+++ b/src/components/Touch/Touch.test.tsx
@@ -3,14 +3,41 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { noop } from '../../lib/utils';
 import Touch from './Touch';
+import { createElement } from 'react';
+
+// Настоящего Touch нет в jsdom: https://github.com/jsdom/jsdom/issues/1508
+const asClientPos = ([clientX = 0, clientY = 0] = []): Touch & MouseEvent => ({ clientX, clientY }) as any;
+
+function fireMouseSwipe(e: HTMLElement, [start, ...move]: any[], ops: { startEl?: HTMLElement } = {}) {
+  fireEvent.mouseDown(ops.startEl || e, asClientPos(start));
+  move.forEach((p) => fireEvent.mouseMove(e, asClientPos(p)));
+  fireEvent.mouseUp(e, asClientPos(move[move.length - 1]));
+  return fireEvent.click(e, asClientPos(move[move.length - 1]));
+}
+
+function fireTouchSwipe(e: HTMLElement, [start, ...move]: any[]) {
+  let prevTouches: number[][] = [];
+  const eventProps = (p: any) => {
+    const touches: number[][] = Array.isArray(p[0]) ? p : [p];
+    const changedTouches = touches
+      .filter((t, i) => !prevTouches[i] || prevTouches[i].some((pos, j) => t[j] !== pos))
+      .concat(prevTouches.slice(touches.length));
+    if (!changedTouches.length) {
+      throw new Error('no changed touches');
+    }
+    prevTouches = touches;
+    return { changedTouches: changedTouches.map(asClientPos), touches: touches.map(asClientPos) };
+  };
+  fireEvent.touchStart(e, eventProps(start));
+  move.forEach((p) => fireEvent.touchMove(e, eventProps(p)));
+  fireEvent.touchEnd(e, eventProps([]));
+};
 
 const threshold = 10;
-const slideRight = (target: HTMLElement) => {
-  fireEvent.mouseDown(target, { clientX: 0 });
-  fireEvent.mouseMove(target, { clientX: threshold });
-  fireEvent.mouseUp(target, { clientX: threshold });
-  fireEvent.click(target);
-};
+const slideRight = (target: HTMLElement) => fireMouseSwipe(target, [[0, 0], [threshold, 0]]);
+
+// reset touch detection
+afterEach(() => delete window['ontouchstart']);
 
 describe('Touch', () => {
   baselineComponent(Touch);
@@ -24,30 +51,139 @@ describe('Touch', () => {
     expect(moved).toBe(false);
   });
 
+  describe('prevents browser drag behavior', () => {
+    it.each(['img', 'a'])('for %s', (tag) => {
+      render(<Touch>{createElement(tag, { 'data-testid': '__el__' })}</Touch>);
+      const hasDefault = fireEvent.dragStart(screen.getByTestId('__el__'));
+      expect(hasDefault).toBe(false);
+    });
+    it('not for an explicitly draggable element', () => {
+      render(<Touch><div draggable data-testid="__el__" /></Touch>);
+      const hasDefault = fireEvent.dragStart(screen.getByTestId('__el__'));
+      expect(hasDefault).toBe(true);
+    });
+  });
+
+  describe('hover', () => {
+    it('calls onEnter / onLeave with mouse', () => {
+      const onEnter = jest.fn();
+      const onLeave = jest.fn();
+      render(<Touch data-testid="__t__" onEnter={onEnter} onLeave={onLeave} />);
+      fireEvent.mouseEnter(screen.getByTestId('__t__'));
+      expect(onEnter).toBeCalledTimes(1);
+      fireEvent.mouseLeave(screen.getByTestId('__t__'));
+      expect(onLeave).toBeCalledTimes(1);
+    });
+    it('simulates onLeave with touch', () => {
+      window['ontouchstart'] = null;
+      const onLeave = jest.fn();
+      render(<Touch data-testid="__t__" onLeave={onLeave} />);
+      fireTouchSwipe(screen.getByTestId('__t__'), [[0, 0]]);
+      expect(onLeave).toBeCalledTimes(1);
+    });
+  });
+
+  describe('handles slide gestures', () => {
+    const keys = ['onStart', 'onStartX', 'onStartY', 'onMove', 'onMoveX', 'onMoveY', 'onEnd', 'onEndX', 'onEndY'] as const;
+    const makeHandlers = (): { [k in typeof keys[number]]: jest.Mock } => {
+      return keys.reduce<any>((acc, k) => ({ ...acc, [k]: jest.fn() }), {});
+    };
+    describe.each(['touch', 'mouse'])('using %s', (input) => {
+      const fireGesture = input === 'touch' ? fireTouchSwipe : fireMouseSwipe;
+      if (input === 'touch') {
+        beforeEach(() => window['ontouchstart'] = null);
+      }
+      it.each([
+        ['left', [-3, 0]],
+        ['right', [3, 0]],
+        ['up', [0, -3]],
+        ['down', [0, 3]],
+      ])('detects slide %s', (_name, [vx, vy]) => {
+        const handlers = makeHandlers();
+        render(<Touch {...handlers} data-testid="__t__" />);
+        fireGesture(screen.getByTestId('__t__'), [0, 1, 2, 3].map((t) => [20 + vx * t, 20 + vy * t]));
+        expect(handlers.onStartX).toBeCalledTimes(1);
+        expect(handlers.onStartY).toBeCalledTimes(1);
+        expect(handlers.onMoveX).toBeCalledTimes(vx ? 2 : 0);
+        expect(handlers.onMoveY).toBeCalledTimes(vy ? 2 : 0);
+        expect(handlers.onEndX).toBeCalledTimes(vx ? 1 : 0);
+        expect(handlers.onEndY).toBeCalledTimes(vy ? 1 : 0);
+      });
+      it('does not detect slide on small movement', () => {
+        const handlers = makeHandlers();
+        render(<Touch {...handlers} data-testid="__t__" />);
+        fireGesture(screen.getByTestId('__t__'), [[20, 20], [17, 23], [23, 20], [20, 17]]);
+        expect(handlers.onStartY).toBeCalledTimes(1);
+        expect(handlers.onMoveY).not.toBeCalled();
+        expect(handlers.onEndY).not.toBeCalled();
+      });
+      it('does not detect slide if onMove[X|Y] not passed', () => {
+        const { onMoveX, onMoveY, onMove, ...handlers } = makeHandlers();
+        render(<Touch {...handlers} data-testid="__t__" />);
+        fireGesture(screen.getByTestId('__t__'), [[20, 20], [20, 30]]);
+        expect(handlers.onEnd).toBeCalledTimes(1);
+        expect(handlers.onEnd).toBeCalledWith(expect.objectContaining({
+          isSlideX: false,
+          isSlideY: false,
+        }));
+      });
+      it('snaps slide direction', () => {
+        const handlers = makeHandlers();
+        render(<Touch {...handlers} data-testid="__t__" />);
+        fireGesture(screen.getByTestId('__t__'), [[20, 20], [20, 30], [20, 20], [30, 20]]);
+        expect(handlers.onMoveX).not.toBeCalled();
+        expect(handlers.onEndX).not.toBeCalled();
+        expect(handlers.onEnd).toBeCalledWith(expect.objectContaining({
+          isSlide: true,
+          isSlideY: true,
+          isSlideX: false,
+        }));
+      });
+      if (input === 'touch') {
+        it('stops gesture if multitouch', () => {
+          const handlers = makeHandlers();
+          render(<Touch {...handlers} data-testid="__t__" />);
+          fireGesture(screen.getByTestId('__t__'), [[20, 20], [20, 26], [[20, 26], [25, 25]], [[20, 26], [25, 30]]]);
+          expect(handlers.onMove).toBeCalledTimes(1);
+          expect(handlers.onEnd).toBeCalledWith(expect.objectContaining({ shiftX: 0, shiftY: 6 }));
+        });
+      }
+      if (input === 'mouse') {
+        it('detects slide under target change', () => {
+          const handlers = makeHandlers();
+          render(<Touch {...handlers} data-testid="__t__" />);
+          fireMouseSwipe(
+            document.body,
+            [[20, 20], [20, 26], [20, 30]],
+            { startEl: screen.getByTestId('__t__') });
+          expect(handlers.onStart).toBeCalledTimes(1);
+          expect(handlers.onMoveY).toBeCalledTimes(2);
+          expect(handlers.onEnd).toBeCalledTimes(1);
+          expect(handlers.onEnd).toBeCalledWith(expect.objectContaining({ isSlideY: true, shiftY: 10 }));
+        });
+      }
+    });
+  });
+
   describe('prevents click after slide', () => {
     it('does not prevent link click', () => {
-      let event: Event;
-      render(
-        <Touch>
-          <a href="/hello" onClick={(e) => event = e.nativeEvent}>link</a>
-        </Touch>);
-      userEvent.click(screen.getByText('link'));
-      expect(event.defaultPrevented).toBe(false);
+      render(<Touch><a href="/hello" /></Touch>);
+      const hasDefault = fireMouseSwipe(screen.getByRole('link'), [[10, 10], [10, 10]]);
+      expect(hasDefault).toBe(true);
     });
     it('prevents link click after slide', () => {
-      let event: Event;
-      render(
-        <Touch onMove={noop}>
-          <a href="/hello" onClick={(e) => event = e.nativeEvent}>link</a>
-        </Touch>);
-      slideRight(screen.getByRole('link'));
-      expect(event.defaultPrevented).toBe(true);
+      render(<Touch onMove={noop}><a href="/hello" /></Touch>);
+      const hasDefault = slideRight(screen.getByRole('link'));
+      expect(hasDefault).toBe(false);
     });
     it('handles onClickCapture', () => {
       const cb = jest.fn(() => null);
-      render(<Touch onClickCapture={cb} data-testid="touch" />);
+      render(<Touch onClickCapture={cb} onMove={noop} data-testid="touch" />);
       userEvent.click(screen.getByTestId('touch'));
-      expect(cb).toBeCalled();
+      expect(cb).toBeCalledTimes(1);
+      cb.mockReset();
+      slideRight(screen.getByTestId('touch'));
+      expect(cb).toBeCalledTimes(1);
     });
     it('does not fire click after slide if noSlideClick=true', () => {
       const clicked = new Set();

--- a/src/components/Touch/Touch.tsx
+++ b/src/components/Touch/Touch.tsx
@@ -52,8 +52,6 @@ export type TouchEventHandler = (e: TouchEvent) => void;
 export type ClickHandler = (e: React.MouseEvent<HTMLElement>) => void;
 export type DragHandler = (e: React.DragEvent<HTMLElement>) => void;
 
-const events = getSupportedEvents();
-
 class Touch extends React.Component<TouchProps & DOMProps> {
   didSlide = false;
   gesture: Partial<Gesture> = {};
@@ -70,10 +68,12 @@ class Touch extends React.Component<TouchProps & DOMProps> {
     return this.props.document;
   }
 
+  private readonly events = getSupportedEvents();
+
   componentDidMount() {
     if (canUseDOM) {
-      this.container.addEventListener(events[0], this.onStart, { capture: this.props.useCapture, passive: false });
-      touchEnabled && this.subscribe(this.container);
+      this.container.addEventListener(this.events[0], this.onStart, { capture: this.props.useCapture, passive: false });
+      touchEnabled() && this.subscribe(this.container);
 
       this.container.addEventListener('mouseenter', this.onEnter, { capture: this.props.useCapture, passive: true });
       this.container.addEventListener('mouseleave', this.onLeave, { capture: this.props.useCapture, passive: true });
@@ -81,7 +81,7 @@ class Touch extends React.Component<TouchProps & DOMProps> {
   }
 
   componentWillUnmount() {
-    this.container.removeEventListener(events[0], this.onStart);
+    this.container.removeEventListener(this.events[0], this.onStart);
     this.unsubscribe();
 
     this.container.removeEventListener('mouseenter', this.onEnter);
@@ -145,7 +145,7 @@ class Touch extends React.Component<TouchProps & DOMProps> {
       this.props.onStartY(outputEvent);
     }
 
-    !touchEnabled && this.subscribe(this.document);
+    !touchEnabled() && this.subscribe(this.document);
   };
 
   /**
@@ -175,8 +175,8 @@ class Touch extends React.Component<TouchProps & DOMProps> {
       if (!isX && !isY) {
         let willBeX = shiftXAbs >= 5 && shiftXAbs > shiftYAbs;
         let willBeY = shiftYAbs >= 5 && shiftYAbs > shiftXAbs;
-        let willBeSlidedX = willBeX && !!this.props.onMoveX || !!this.props.onMove;
-        let willBeSlidedY = willBeY && !!this.props.onMoveY || !!this.props.onMove;
+        let willBeSlidedX = willBeX && (!!this.props.onMoveX || !!this.props.onMove);
+        let willBeSlidedY = willBeY && (!!this.props.onMoveY || !!this.props.onMove);
 
         this.gesture.isY = willBeY;
         this.gesture.isX = willBeX;
@@ -249,22 +249,22 @@ class Touch extends React.Component<TouchProps & DOMProps> {
       this.onLeave(e);
     }
 
-    !touchEnabled && this.unsubscribe();
+    !touchEnabled() && this.unsubscribe();
   };
 
   subscribe(element: HTMLElement | Document) {
     this.unsubscribe();
     const listenerParams = { capture: this.props.useCapture, passive: false };
-    element.addEventListener(events[1], this.onMove, listenerParams);
-    element.addEventListener(events[2], this.onEnd, listenerParams);
-    element.addEventListener(events[3], this.onEnd, listenerParams);
+    element.addEventListener(this.events[1], this.onMove, listenerParams);
+    element.addEventListener(this.events[2], this.onEnd, listenerParams);
+    element.addEventListener(this.events[3], this.onEnd, listenerParams);
     this.unsubscribe = () => {
       // Здесь нужен последний аргумент с такими же параметрами, потому что
       // некоторые браузеры на странных вендорах типа Meizu не удаляют обработчик.
       // https://github.com/VKCOM/VKUI/issues/444
-      element.removeEventListener(events[1], this.onMove, listenerParams);
-      element.removeEventListener(events[2], this.onEnd, listenerParams);
-      element.removeEventListener(events[3], this.onEnd, listenerParams);
+      element.removeEventListener(this.events[1], this.onMove, listenerParams);
+      element.removeEventListener(this.events[2], this.onEnd, listenerParams);
+      element.removeEventListener(this.events[3], this.onEnd, listenerParams);
       this.unsubscribe = noop;
     };
   }

--- a/src/lib/touch.ts
+++ b/src/lib/touch.ts
@@ -24,7 +24,7 @@ const coordY = (e: VKUITouchEvent): number => {
 };
 
 // eslint-disable-next-line no-restricted-globals
-const touchEnabled: boolean = canUseDOM && 'ontouchstart' in window;
+const touchEnabled = () => canUseDOM && 'ontouchstart' in window;
 
 /*
  * Возвращает массив поддерживаемых событий
@@ -32,7 +32,7 @@ const touchEnabled: boolean = canUseDOM && 'ontouchstart' in window;
  * Если нет, используем события мыши
  */
 function getSupportedEvents(): string[] {
-  if (touchEnabled) {
+  if (touchEnabled()) {
     return ['touchstart', 'touchmove', 'touchend', 'touchcancel'];
   }
 


### PR DESCRIPTION
Открыто для обсуждения:
- Исправил явный баг — при переданном `onMove` при любое перемещение определяется как slideX и slideY одновременно. Сломается ли при этом что-нибудь из нашего кода?
- Можем ли мы завязаться на [pointer-events](https://caniuse.com/pointer-events) вместо явного переключения по `window.ontouchstart`?
    - Не нужен трюк с глобальными листенерами для mouseMove — есть [setPointerCapture](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture)
    - Не нужна полиморфная обработка clientX / clientY
- Почему `onStartX` (и Y) вызываются, даже если жест не будет свайпом? Почему это поведение отличается от `onEndX / onMoveX`, которые вызываются только если определен свайп? Нужны ли они вообще?
- Почему наличие `onMove(X|Y)?` влияет на определение жеста? Возможно, я хотел бы получить информацию о жесте через `onEnd`
- Создает ли функция определения свайпов какую-то ценность или дублируется в компонентах на уровень выше?