### PR TITLE
CustomSelect & ChipsSelect: unified and enhanced default filterFn

### DIFF
--- a/babel.cjs.config.js
+++ b/babel.cjs.config.js
@@ -1,4 +1,10 @@
 module.exports = {
   extends: './babel.config.js',
-  presets: [['@babel/preset-env', { modules: "commonjs" }]],
+  presets: [['@babel/preset-env', {
+    modules: 'commonjs',
+    exclude: [
+      '@babel/plugin-proposal-unicode-property-regex',
+      '@babel/plugin-transform-unicode-regex'
+    ]
+  }]],
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,13 @@ const testFiles = [
 
 module.exports = {
   presets: [
-    ['@babel/preset-env', { modules: useModules ? false : 'commonjs' }],
+    ['@babel/preset-env', {
+      modules: useModules ? false : 'commonjs',
+      exclude: [
+        '@babel/plugin-proposal-unicode-property-regex',
+        '@babel/plugin-transform-unicode-regex'
+      ]
+    }],
     ['@babel/preset-react', {
       pragma: "createScopedElement",
       pragmaFrag: "createScopedElement.Fragment",

--- a/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -29,7 +29,7 @@ describe('ChipsSelect', () => {
 
   it('filters options', () => {
     render(<ChipsSelect options={colors} />);
-    userEvent.type(screen.getByRole('textbox'), colors[1].label.substring(0, 3));
+    userEvent.type(screen.getByRole('textbox'), colors[1].label.substring(1, 4));
     toggleDropdown();
     expect(queryListOption(colors[1])).toBeTruthy();
     expect(screen.queryAllByRole('option')).toHaveLength(1);

--- a/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -29,7 +29,7 @@ describe('ChipsSelect', () => {
 
   it('filters options', () => {
     render(<ChipsSelect options={colors} />);
-    userEvent.type(screen.getByRole('textbox'), colors[1].label.substring(1, 4));
+    userEvent.type(screen.getByRole('textbox'), colors[1].label.substring(0, 3));
     toggleDropdown();
     expect(queryListOption(colors[1])).toBeTruthy();
     expect(screen.queryAllByRole('option')).toHaveLength(1);

--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -326,7 +326,7 @@ const chipsSelectDefaultProps: ChipsSelectProps<any> = {
   options: [],
   filterFn: (value?: string, option?: ChipsInputOption, getOptionLabel?: Pick<ChipsInputProps<ChipsInputOption>, 'getOptionLabel'>['getOptionLabel']) => {
     return (
-      !value || value && getOptionLabel(option)?.toLowerCase()?.startsWith(value?.toLowerCase())
+      !value || value && getOptionLabel(option)?.toLowerCase()?.includes(value?.toLowerCase())
     );
   },
   renderOption({ option, ...restProps }: CustomSelectOptionProps): React.ReactNode {

--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -60,7 +60,7 @@ const ChipsSelect = <Option extends ChipsInputOption>(props: ChipsSelectProps<Op
     style, onFocus, onKeyDown, className, fetching, renderOption, emptyText,
     getRef, getRootRef, disabled, placeholder, tabIndex, getOptionValue, getOptionLabel, showSelected,
     getNewOptionData, renderChip, popupDirection, creatable, filterFn, inputValue, creatableText, sizeY,
-    closeAfterSelect, onChangeStart, after, ...restProps
+    closeAfterSelect, onChangeStart, after, options, ...restProps
   } = props;
 
   const { document } = useDOM();

--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -19,7 +19,7 @@ import './ChipsSelect.css';
 export interface ChipsSelectProps<Option extends ChipsInputOption> extends ChipsInputProps<Option>, AdaptivityProps {
   popupDirection?: 'top' | 'bottom';
   options?: Option[];
-  filterFn?: (value?: string, option?: Option, getOptionLabel?: Pick<ChipsInputProps<ChipsInputOption>, 'getOptionLabel'>['getOptionLabel']) => boolean;
+  filterFn?: false | ((value?: string, option?: Option, getOptionLabel?: Pick<ChipsInputProps<ChipsInputOption>, 'getOptionLabel'>['getOptionLabel']) => boolean);
   /**
    * Возможность создавать чипы которых нет в списке (по enter или с помощью пункта в меню, см creatableText)
    */

--- a/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/src/components/ChipsSelect/ChipsSelect.tsx
@@ -13,6 +13,7 @@ import Caption from '../Typography/Caption/Caption';
 import { prefixClass } from '../../lib/prefixClass';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
+import { defaultFilterFn } from '../../lib/select';
 import './ChipsSelect.css';
 
 export interface ChipsSelectProps<Option extends ChipsInputOption> extends ChipsInputProps<Option>, AdaptivityProps {
@@ -324,11 +325,7 @@ const chipsSelectDefaultProps: ChipsSelectProps<any> = {
   showSelected: true,
   closeAfterSelect: true,
   options: [],
-  filterFn: (value?: string, option?: ChipsInputOption, getOptionLabel?: Pick<ChipsInputProps<ChipsInputOption>, 'getOptionLabel'>['getOptionLabel']) => {
-    return (
-      !value || value && getOptionLabel(option)?.toLowerCase()?.includes(value?.toLowerCase())
-    );
-  },
+  filterFn: defaultFilterFn,
   renderOption({ option, ...restProps }: CustomSelectOptionProps): React.ReactNode {
     return (
       <CustomSelectOption {...restProps} />

--- a/src/components/ChipsSelect/Readme.md
+++ b/src/components/ChipsSelect/Readme.md
@@ -29,7 +29,6 @@ const Example = () => {
     value: selectedColors,
     onChange: setSelectedColors,
     options: colors,
-    top:"Выберите или добавьте цвета",
     placeholder:"Не выбраны",
     creatable: true,
   };
@@ -38,7 +37,6 @@ const Example = () => {
       value: selectedColorsCopy,
       onChange: setSelectedColorsCopy,
       options: colors,
-      top:"Выберите или добавьте цвета",
       placeholder:"Не выбраны",
       creatable: true,
       creatableText: '',

--- a/src/components/ChipsSelect/useChipsSelect.ts
+++ b/src/components/ChipsSelect/useChipsSelect.ts
@@ -22,7 +22,7 @@ export const useChipsSelect = <Option extends ChipsInputOption>(props: Partial<C
   };
 
   let filteredOptions = React.useMemo(() => {
-    return options.filter((option: Option) => filterFn(fieldValue, option, getOptionLabel));
+    return filterFn ? options.filter((option: Option) => filterFn(fieldValue, option, getOptionLabel)) : options;
   }, [options, filterFn, fieldValue, getOptionLabel]);
 
   filteredOptions = React.useMemo(() => {

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -78,7 +78,7 @@ export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormF
   /**
    * Функция для кастомной фильтрации. По-умолчанию поиск производится по option.label.
    */
-  filterFn?: false | ((value: string, option: CustomSelectOptionInterface, ) => boolean);
+  filterFn?: false | ((value: string, option: CustomSelectOptionInterface, getOptionLabel?: (option: Partial<CustomSelectOptionInterface>) => string) => boolean);
   popupDirection?: 'top' | 'bottom';
   /**
    * Рендер-проп для кастомного рендера опции.

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -15,6 +15,7 @@ import { Icon20Dropdown, Icon24Dropdown } from '@vkontakte/icons';
 import Caption from '../Typography/Caption/Caption';
 import { warnOnce } from '../../lib/warnOnce';
 import Spinner from '../Spinner/Spinner';
+import { defaultFilterFn } from '../../lib/select';
 import './CustomSelect.css';
 
 const findIndexAfter = (options: CustomSelectOptionInterface[], startIndex = -1) => {
@@ -77,7 +78,7 @@ export interface CustomSelectProps extends NativeSelectProps, HasPlatform, FormF
   /**
    * Функция для кастомной фильтрации. По-умолчанию поиск производится по option.label.
    */
-  filterFn?: false | ((value: string, option: CustomSelectOptionInterface) => boolean);
+  filterFn?: false | ((value: string, option: CustomSelectOptionInterface, ) => boolean);
   popupDirection?: 'top' | 'bottom';
   /**
    * Рендер-проп для кастомного рендера опции.
@@ -112,7 +113,7 @@ class CustomSelect extends React.Component<CustomSelectProps, CustomSelectState>
     },
     options: [],
     emptyText: 'Ничего не найдено',
-    filterFn: (value, option) => option.label.toLowerCase().includes(value.toLowerCase()),
+    filterFn: defaultFilterFn,
   };
 
   public constructor(props: CustomSelectProps) {

--- a/src/lib/select.test.ts
+++ b/src/lib/select.test.ts
@@ -31,6 +31,10 @@ describe(defaultFilterFn, () => {
     expect(defaultFilterFn('ерб', { label: 'Санкт-Петербург' })).toBeFalsy();
   });
 
+  it('skips irrelevant options', () => {
+    expect(defaultFilterFn('Моск', { label: 'Санкт-Петербург' })).toBeFalsy();
+  });
+
   it('accepts custom getOptionLabel', () => {
     expect(defaultFilterFn('гог', { description: 'Гоголь' }, (option) => option.description)).toBeTruthy();
   });

--- a/src/lib/select.test.ts
+++ b/src/lib/select.test.ts
@@ -13,6 +13,20 @@ describe(defaultFilterFn, () => {
     expect(defaultFilterFn('петер', { label: 'Санкт-Петербург' })).toBeTruthy();
   });
 
+  it('ignores quotes', () => {
+    expect(defaultFilterFn('петер', { label: 'Санкт-"Петербург"' })).toBeTruthy();
+  });
+
+  it('ignores braces', () => {
+    expect(defaultFilterFn('пите', { label: 'Санкт-Петербург (Питер)' })).toBeTruthy();
+  });
+
+  it('search from the middle of sentence', () => {
+    expect(defaultFilterFn('имя нельз', { label: 'Группа, чьё имя нельзя называть' })).toBeTruthy();
+    expect(defaultFilterFn('нельзя назы', { label: 'Группа, чьё имя нельзя называть' })).toBeTruthy();
+    expect(defaultFilterFn('имя нельз', { label: 'ельзя ывать' })).toBeFalsy();
+  });
+
   it('skips matches in the middle', () => {
     expect(defaultFilterFn('ерб', { label: 'Санкт-Петербург' })).toBeFalsy();
   });

--- a/src/lib/select.test.ts
+++ b/src/lib/select.test.ts
@@ -1,0 +1,23 @@
+import { defaultFilterFn } from './select';
+
+describe(defaultFilterFn, () => {
+  it('filters one word', () => {
+    expect(defaultFilterFn('моск', { label: 'Москва' })).toBeTruthy();
+  });
+
+  it('filters several words', () => {
+    expect(defaultFilterFn('monk', { label: 'Arctic Monkeys' })).toBeTruthy();
+  });
+
+  it('filters dashed words', () => {
+    expect(defaultFilterFn('петер', { label: 'Санкт-Петербург' })).toBeTruthy();
+  });
+
+  it('skips matches in the middle', () => {
+    expect(defaultFilterFn('ерб', { label: 'Санкт-Петербург' })).toBeFalsy();
+  });
+
+  it('accepts custom getOptionLabel', () => {
+    expect(defaultFilterFn('гог', { description: 'Гоголь' }, (option) => option.description)).toBeTruthy();
+  });
+});

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -5,6 +5,15 @@ type Option = {
 
 type GetOptionLabel = (option: Option) => string;
 
+const wordSplitters = /\p{Pd}|\p{Z}/u;
+
+/**
+ * Убирает кавычки, скобки, точки и запятые
+ */
+const cleanSentence = (sentence = '') => {
+  return sentence.replace(/\p{Ps}|\p{Pe}|\p{Pi}|\p{Pf}|"|'|,|\./gu, '');
+};
+
 export const defaultFilterFn = (
   query = '',
   option: Option,
@@ -13,11 +22,33 @@ export const defaultFilterFn = (
   if (query.length === 0) {
     return true;
   }
-  const words = getOptionLabel(option).split(/\s|-/);
+
+  query = query.toLowerCase();
+  let label = getOptionLabel(option).toLowerCase();
+
+  if (label.startsWith(query)) {
+    return true;
+  }
+
+  label = cleanSentence(label);
+  if (label.startsWith(query)) {
+    return true;
+  }
+
+  const words: string[] = label.split(wordSplitters);
+  const wordsLength = words.length;
+
+  for (let start = 0; start <= wordsLength - start; start++) {
+    for (let end = start + 2; end <= wordsLength; end++) {
+      words.push(words.slice(start, end).join(' '));
+    }
+  }
+
   for (const word of words) {
-    if (word.toLowerCase().startsWith(query.toLowerCase())) {
+    if (word.startsWith(query)) {
       return true;
     }
   }
+
   return false;
 };

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -38,7 +38,7 @@ export const defaultFilterFn = (
   const words: string[] = label.split(wordSplitters);
   const wordsLength = words.length;
 
-  for (let start = 0; start <= wordsLength - start; start++) {
+  for (let start = 0; start <= wordsLength; start++) {
     for (let end = start + 2; end <= wordsLength; end++) {
       words.push(words.slice(start, end).join(' '));
     }

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -1,0 +1,23 @@
+type Option = {
+  label?: string;
+  [index: string]: any;
+};
+
+type GetOptionLabel = (option: Option) => string;
+
+export const defaultFilterFn = (
+  query = '',
+  option: Option,
+  getOptionLabel: GetOptionLabel = (option) => option.label,
+) => {
+  if (query.length === 0) {
+    return true;
+  }
+  const words = getOptionLabel(option).split(/\s|-/);
+  for (const word of words) {
+    if (word.toLowerCase().startsWith(query.toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -43,7 +43,7 @@ export const defaultFilterFn = (
   // На момент написания флаг u не поддерживался рядом браузеров, поэтому добавили фоллбэк.
   try {
     for (const index of includes) {
-      if (!/\p{L}/u.test(label[index - 1])) {
+      if (!new RegExp('\\p{L}', 'u').test(label[index - 1])) {
         return true;
       }
     }

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -38,14 +38,14 @@ export const defaultFilterFn = (
 
   const includes = findAllIncludes(label, query);
 
-  // Если предыдущий символ не является буквой, то значит поиск валидный.
+  // Ищем вхождение перед началом которого не буква
   if (letterRegexp) {
     for (const index of includes) {
       if (!letterRegexp.test(label[index - 1])) {
         return true;
       }
     }
-  } else {
+  } else { // если regexp не поддерживается, то ищем любое вхождение
     return includes.length > 0;
   }
 

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -29,8 +29,8 @@ export const defaultFilterFn = (
   option: Option,
   getOptionLabel: GetOptionLabel = (option) => option.label,
 ) => {
-  query = query.toLowerCase();
-  let label = getOptionLabel(option).toLowerCase();
+  query = query.toLocaleLowerCase();
+  let label = getOptionLabel(option).toLocaleLowerCase();
 
   if (label.startsWith(query)) {
     return true;

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -8,14 +8,10 @@ type GetOptionLabel = (option: Option) => string;
 const findAllIncludes = (target = '', search = '') => {
   const includes = [];
 
-  for (let i = 0; i <= target.length;) {
-    const index = target.indexOf(search, i);
-    if (index >= 0) {
-      includes.push(index);
-      i = index + 1;
-    } else {
-      return includes;
-    }
+  let i = target.indexOf(search);
+  while (i !== -1) {
+    includes.push(i);
+    i = target.indexOf(search, i + 1);
   }
 
   return includes;
@@ -26,10 +22,6 @@ export const defaultFilterFn = (
   option: Option,
   getOptionLabel: GetOptionLabel = (option) => option.label,
 ) => {
-  if (query.length === 0) {
-    return true;
-  }
-
   query = query.toLowerCase();
   let label = getOptionLabel(option).toLowerCase();
 

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -17,6 +17,13 @@ const findAllIncludes = (target = '', search = '') => {
   return includes;
 };
 
+let letterRegexp: RegExp;
+
+// На момент написания флаг u не поддерживался рядом браузеров, поэтому добавили фоллбэк.
+try {
+  letterRegexp = new RegExp('\\p{L}', 'u');
+} catch (e) {}
+
 export const defaultFilterFn = (
   query = '',
   option: Option,
@@ -32,14 +39,13 @@ export const defaultFilterFn = (
   const includes = findAllIncludes(label, query);
 
   // Если предыдущий символ не является буквой, то значит поиск валидный.
-  // На момент написания флаг u не поддерживался рядом браузеров, поэтому добавили фоллбэк.
-  try {
+  if (letterRegexp) {
     for (const index of includes) {
-      if (!new RegExp('\\p{L}', 'u').test(label[index - 1])) {
+      if (!letterRegexp.test(label[index - 1])) {
         return true;
       }
     }
-  } catch (e) {
+  } else {
     return includes.length > 0;
   }
 

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -39,10 +39,16 @@ export const defaultFilterFn = (
 
   const includes = findAllIncludes(label, query);
 
-  for (const index of includes) {
-    if (!/\p{L}/u.test(label[index - 1])) {
-      return true;
+  // Если предыдущий символ не является буквой, то значит поиск валидный.
+  // На момент написания флаг u не поддерживался рядом браузеров, поэтому добавили фоллбэк.
+  try {
+    for (const index of includes) {
+      if (!/\p{L}/u.test(label[index - 1])) {
+        return true;
+      }
     }
+  } catch (e) {
+    return includes.length > 0;
   }
 
   return false;

--- a/src/lib/select.ts
+++ b/src/lib/select.ts
@@ -5,13 +5,20 @@ type Option = {
 
 type GetOptionLabel = (option: Option) => string;
 
-const wordSplitters = /\p{Pd}|\p{Z}/u;
+const findAllIncludes = (target = '', search = '') => {
+  const includes = [];
 
-/**
- * Убирает кавычки, скобки, точки и запятые
- */
-const cleanSentence = (sentence = '') => {
-  return sentence.replace(/\p{Ps}|\p{Pe}|\p{Pi}|\p{Pf}|"|'|,|\./gu, '');
+  for (let i = 0; i <= target.length;) {
+    const index = target.indexOf(search, i);
+    if (index >= 0) {
+      includes.push(index);
+      i = index + 1;
+    } else {
+      return includes;
+    }
+  }
+
+  return includes;
 };
 
 export const defaultFilterFn = (
@@ -30,22 +37,10 @@ export const defaultFilterFn = (
     return true;
   }
 
-  label = cleanSentence(label);
-  if (label.startsWith(query)) {
-    return true;
-  }
+  const includes = findAllIncludes(label, query);
 
-  const words: string[] = label.split(wordSplitters);
-  const wordsLength = words.length;
-
-  for (let start = 0; start <= wordsLength; start++) {
-    for (let end = start + 2; end <= wordsLength; end++) {
-      words.push(words.slice(start, end).join(' '));
-    }
-  }
-
-  for (const word of words) {
-    if (word.startsWith(query)) {
+  for (const index of includes) {
+    if (!/\p{L}/u.test(label[index - 1])) {
       return true;
     }
   }


### PR DESCRIPTION
- Пофиксил попадание `options` в `<input />`
- Уницифировал дефолтный алгоритм фильтрации у `ChipsSelect` и `CustomSelect`
- Улучшил его. Теперь он ищет по началу слова. Поддерживаются разные разделители слов в предложениях
- Дал возможность передавать `filterFn={false}` в ChipsSelect, чтобы отключать фильтрацию
- Поправил примеры, убрав оттуда лишний хлам