### PR TITLE
[Bug] useKeyboardInputTracker()

### DIFF
--- a/src/components/AppRoot/AppRoot.test.tsx
+++ b/src/components/AppRoot/AppRoot.test.tsx
@@ -1,10 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { AppRootContext } from './AppRootContext';
 import AppRoot from './AppRoot';
 import { SizeType } from '../../hoc/withAdaptivity';
-import Button from '../Button/Button';
 
 describe('AppRoot', () => {
   baselineComponent(AppRoot);
@@ -66,24 +64,6 @@ describe('AppRoot', () => {
       ));
       render(<AppRoot mode="embedded" />).unmount();
       expect(document.body).toContainElement(portalRoot1);
-    });
-  });
-  describe('Manages a11y properly', () => {
-    it('has class .AppRoot--keyboard-input on keyboard navigation', () => {
-      render(<AppRoot data-testid="root" mode="embedded"><Button>Hello world</Button></AppRoot>);
-      const root = screen.getByTestId('root');
-
-      // test keyboard nav and outline
-      userEvent.tab();
-      expect(root).toHaveClass('AppRoot--keyboard-input');
-    });
-    it('has no class .AppRoot--keyboard-input on mouse click', () => {
-      render(<AppRoot data-testid="root" mode="embedded"><Button>Hello world</Button></AppRoot>);
-      const root = screen.getByTestId('root');
-
-      // test click and no outline
-      userEvent.click(screen.getByRole('button'));
-      expect(root).not.toHaveClass('AppRoot--keyboard-input');
     });
   });
 });

--- a/src/hooks/useKeyboardInputTracker.test.tsx
+++ b/src/hooks/useKeyboardInputTracker.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AppRoot from '../components/AppRoot/AppRoot';
+import Button from '../components/Button/Button';
+
+const AppRootTest = () => <AppRoot data-testid="root" mode="embedded"><Button>Hello world</Button></AppRoot>;
+const root = () => screen.getByTestId('root');
+const btn = () => screen.getByRole('button');
+const keyboardClass = 'AppRoot--keyboard-input';
+
+describe('useKeyboardInputTracker()', () => {
+  describe('Manages a11y via AppRoot', () => {
+    it(`has no .${keyboardClass} by default`, () => {
+      render(<AppRootTest />);
+
+      expect(root()).not.toHaveClass(keyboardClass);
+    });
+    it(`has .${keyboardClass} on keyboard navigation`, () => {
+      render(<AppRootTest />);
+
+      userEvent.tab();
+
+      expect(btn()).toHaveFocus();
+      expect(root()).toHaveClass(keyboardClass);
+    });
+    it(`keeps .${keyboardClass} on typing keys other than TAB`, () => {
+      render(<AppRootTest />);
+
+      userEvent.tab();
+      userEvent.keyboard('{esc}');
+
+      expect(root()).toHaveClass(keyboardClass);
+    });
+    it(`has no .${keyboardClass} on mouse click`, () => {
+      render(<AppRootTest />);
+
+      userEvent.click(btn());
+
+      expect(root()).not.toHaveClass(keyboardClass);
+    });
+    it(`manages .${keyboardClass} on multiple events`, () => {
+      render(<AppRootTest />);
+
+      userEvent.tab();
+
+      expect(root()).toHaveClass(keyboardClass);
+
+      userEvent.click(btn());
+
+      expect(root()).not.toHaveClass(keyboardClass);
+    });
+  });
+});

--- a/src/hooks/useKeyboardInputTracker.ts
+++ b/src/hooks/useKeyboardInputTracker.ts
@@ -9,7 +9,9 @@ export function useKeyboardInputTracker(): boolean {
   const [isKeyboardInputActive, toggleKeyboardInput] = React.useState<boolean>(false);
 
   const enableKeyboardInput = React.useCallback((e: KeyboardEvent) => {
-    toggleKeyboardInput(pressedKey(e) === Keys.TAB);
+    if (pressedKey(e) === Keys.TAB) {
+      toggleKeyboardInput(true);
+    }
   }, []);
 
   const disableKeyboardInput = React.useCallback(() => {


### PR DESCRIPTION
- поправила баг, нарисовавшийся после переезда на `pressedKey(e)`
- обновила и пофиксила тесты
- вынесла тесты, фактически относящиеся к работе `useKeyboardInputTracker()`, в отдельный файл