### PR TITLE
Refactor/normalize shared css

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "./dist/index.js",
     "./dist/cjs/lib/polyfills.js",
     "./dist/cjs/index.js",
+    "./dist/cssm/lib/polyfills.js",
+    "./dist/cssm/index.js",
     "*.css"
   ],
   "devDependencies": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,7 +8,7 @@ const csso = require('postcss-csso');
 const checkKeyframes = require('./tasks/postcss-check-keyframes');
 const { defaultSchemeId } = require('./package.json');
 
-const animationsSource = path.join(__dirname, 'src/styles/animations.css')
+const animationsSource = path.join(__dirname, 'src/styles/animations.css');
 const cssPropSources = [
   path.join(__dirname, 'src/styles/bright_light.css'),
   path.join(__dirname, 'src/styles/constants.css'),

--- a/src/components/AppRoot/AppRoot.css
+++ b/src/components/AppRoot/AppRoot.css
@@ -1,0 +1,20 @@
+.vkui__root--embedded {
+  transform: translate3d(0, 0, 0);
+  overflow-x: hidden;
+}
+
+.AppRoot {
+  height: 100%;
+}
+
+.vkui__root--embedded .AppRoot {
+  overflow: auto;
+}
+
+.vkui--sizeX-regular {
+  background: var(--background_page);
+}
+
+.AppRoot--no-mouse {
+  user-select: none;
+}

--- a/src/components/ModalRoot/ModalRoot.css
+++ b/src/components/ModalRoot/ModalRoot.css
@@ -53,3 +53,13 @@
   box-sizing: border-box;
   z-index: 1;
 }
+
+@keyframes vkui-animation-fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -1,17 +1,3 @@
-:root {
-  --duration: .7s;
-}
-
-@keyframes vkui-animation-fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 @keyframes vkui-rotator {
   0% {
     transform: rotate(0deg);

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -22,27 +22,6 @@
   color: var(--text_primary);
 }
 
-.vkui__root--embedded {
-  transform: translate3d(0, 0, 0);
-  overflow-x: hidden;
-}
-
-.AppRoot {
-  height: 100%;
-}
-
-.vkui__root--embedded .AppRoot {
-  overflow: auto;
-}
-
-.vkui--sizeX-regular {
-  background: var(--background_page);
-}
-
-.AppRoot--no-mouse {
-  user-select: none;
-}
-
 .vkui__root input,
 .vkui__root textarea,
 .vkui__root select,

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5,6 +5,8 @@
  * чтобы в каждом файле были доступны CSS переменные без их дублирования.
  */
 
+@import '../components/AppRoot/AppRoot.css';
+
 /* Typography */
 @import '../components/Typography/Title/Title.css';
 @import '../components/Typography/Headline/Headline.css';

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -29,6 +29,9 @@
   --safe-area-inset-right: 0px;
   --safe-area-inset-bottom: 0px;
   --safe-area-inset-left: 0px;
+
+  /* animations */
+  --duration: .7s;
 }
 
 @media (min-resolution: 2dppx) {


### PR DESCRIPTION
1. Объявляем `cssm/index` как sideEffect, потому что сейчас не подтягивается общий цсс
2. `@keyframes fadeIn` переносим в `ModalRoot.css`, потому что больше он нигде не используется
3. Стили для классов AppRoot (`.AppRoot, .vkui__root--embedded, .vkui--sizeX-regular`) выносим в `AppRoot.css`, потому что AppRoot может и не быть