### PR TITLE
infra: yarn prepare -> prepublishOnly

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,9 +2,6 @@ name: 'Pull Request'
 
 on: ['pull_request']
 
-env:
-  VKUI_SKIP_PREPARE: 1
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     }
   ],
   "scripts": {
-    "prepare": "node -e '!process.env.VKUI_SKIP_PREPARE && require(`child_process`).spawn(`yarn`, [`build`], { stdio: `inherit` })'",
+    "prepublishOnly": "yarn build",
     "size": "yarn clear && concurrently 'yarn:babel' 'yarn:postcss' && size-limit",
     "size:ci": "yarn install --frozen-lockfile --ignore-scripts && yarn build:no-types",
     "styleguide": "cross-env NODE_ENV=development styleguidist server --config=styleguide/config.js",


### PR DESCRIPTION
Убираем поддержку установки через github, потому что она вроде бы не работает и у есть codesandbox