### PR TITLE
Добавил информацию о текущей версии 2kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,5 +180,10 @@
     "@popperjs/core": "^2.9.2",
     "@vkontakte/vkjs": "^0.22.1",
     "react-popper": "^2.2.5"
+  },
+  "config": {
+    "2kit": {
+      "version": "8.0.0"
+    }
   }
 }


### PR DESCRIPTION
Эта информация нужна, чтобы мы могли установить соответствие между релизной версией VKUI и релизной версией 2kit на то время, пока мы совсем не откажемся от 2kit в отдельном репозитории.