### PR TITLE
refactor: Make Tappable Wave a separate component

### DIFF
--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -13,6 +13,7 @@ import { setRef } from '../../lib/utils';
 import { withAdaptivity, AdaptivityProps } from '../../hoc/withAdaptivity';
 import { shouldTriggerClickOnEnterOrSpace } from '../../lib/accessibility';
 import { FocusVisible, FocusVisibleMode } from '../FocusVisible/FocusVisible';
+import { useTimeout } from '../../hooks/useTimeout';
 import './Tappable.css';
 
 export interface TappableProps extends React.AllHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement>, HasPlatform, AdaptivityProps {
@@ -44,13 +45,14 @@ export interface TappableProps extends React.AllHTMLAttributes<HTMLElement>, Has
   focusVisibleMode?: FocusVisibleMode;
 }
 
+interface Wave {
+  x: number;
+  y: number;
+  id: string;
+}
+
 export interface TappableState {
-  clicks?: {
-    [index: string]: {
-      x: number;
-      y: number;
-    };
-  };
+  clicks?: Wave[];
   hovered?: boolean;
   active?: boolean;
   ts?: number;
@@ -101,7 +103,7 @@ class Tappable extends React.Component<TappableProps, TappableState> {
     super(props);
     this.id = Math.round(Math.random() * 1e8).toString(16);
     this.state = {
-      clicks: {},
+      clicks: [],
       active: false,
       ts: null,
       hasHover: props.hasHover,
@@ -119,8 +121,6 @@ class Tappable extends React.Component<TappableProps, TappableState> {
   container: HTMLElement;
 
   timeout: ReturnType<typeof setTimeout>;
-
-  wavesTimeout: ReturnType<typeof setTimeout>;
 
   static defaultProps = {
     stopPropagation: false,
@@ -240,27 +240,10 @@ class Tappable extends React.Component<TappableProps, TappableState> {
       const { top, left } = getOffsetRect(this.container);
       const x = coordX(e) - left;
       const y = coordY(e) - top;
-      const key = 'wave' + Date.now().toString();
 
-      this.setState((state: TappableState): TappableState => {
-        return {
-          clicks: {
-            ...state.clicks,
-            [key]: {
-              x,
-              y,
-            },
-          },
-        };
+      this.setState({
+        clicks: [...this.state.clicks, { x, y, id: Date.now().toString() }],
       });
-
-      this.wavesTimeout = setTimeout(() => {
-        this.setState((state: TappableState): TappableState => {
-          let clicks = { ...state.clicks };
-          delete clicks[key];
-          return { clicks };
-        });
-      }, 225);
     }
   };
 
@@ -323,8 +306,6 @@ class Tappable extends React.Component<TappableProps, TappableState> {
 
       delete storage[this.id];
     }
-
-    clearTimeout(this.wavesTimeout);
   }
 
   componentDidUpdate(prevProps: TappableProps) {
@@ -334,6 +315,10 @@ class Tappable extends React.Component<TappableProps, TappableState> {
     if (!prevProps.disabled && this.props.disabled) {
       this.setState({ hovered: false });
     }
+  }
+
+  removeWave(id: Wave['id']) {
+    this.setState({ clicks: this.state.clicks.filter((c) => c.id !== id) });
   }
 
   render() {
@@ -440,8 +425,8 @@ class Tappable extends React.Component<TappableProps, TappableState> {
                     </TappableContext.Provider>
                     {platform === ANDROID && !hasMouse && hasActive && activeMode === 'background' && (
                       <span aria-hidden="true" vkuiClass="Tappable__waves">
-                        {Object.keys(clicks).map((k: string) => (
-                          <span vkuiClass="Tappable__wave" style={{ top: clicks[k].y, left: clicks[k].x }} key={k} />
+                        {clicks.map((wave) => (
+                          <Wave {...wave} key={wave.id} onClear={() => this.removeWave(wave.id)} />
                         ))}
                       </span>
                     )}
@@ -459,3 +444,9 @@ class Tappable extends React.Component<TappableProps, TappableState> {
 }
 
 export default withAdaptivity(withPlatform(Tappable), { sizeX: true, hasMouse: true });
+
+function Wave({ x, y, onClear }: Wave & { onClear: VoidFunction }) {
+  const timeout = useTimeout(onClear, 225);
+  React.useEffect(() => timeout.set(), []);
+  return <span vkuiClass="Tappable__wave" style={{ top: y, left: x }} />;
+}


### PR DESCRIPTION
Приступим! вынос волн из Tappable в компонент:
- упрощает переезд на FC, потому что таймауты можно сделать через `useTimeout`
- убирает (технический) баг, из-за которого при анмаунте после серии быстрых тапов не подчищались колбеки