### PR TITLE
refactor: Nested Tappable hovers

### DIFF
--- a/src/components/Tappable/Tappable.test.tsx
+++ b/src/components/Tappable/Tappable.test.tsx
@@ -192,7 +192,7 @@ describe('Tappable', () => {
         render(<Tappable data-testid="x"><Tappable data-testid="c" /></Tappable>);
         userEvent.hover(screen.getByTestId('c'));
         expect(isHovered()).toBe(false);
-        fireEvent.mouseLeave(screen.getByTestId('c'));
+        fireEvent.pointerLeave(screen.getByTestId('c'));
         expect(isHovered()).toBe(true);
       });
       it('restores hover on child unmount', () => {

--- a/src/components/Tappable/Tappable.test.tsx
+++ b/src/components/Tappable/Tappable.test.tsx
@@ -147,11 +147,88 @@ describe('Tappable', () => {
     expect(handleClick).toHaveBeenCalledTimes(0);
   });
 
-  it('checks that hover state is removed if component becomes disabled', () => {
-    const { rerender } = render(<TappableTest>Test</TappableTest>);
-    fireEvent.mouseEnter(tappable());
-    expect(tappable()).toHaveClass('Tappable--hover-background');
-    rerender(<TappableTest disabled>Test</TappableTest>);
-    expect(tappable()).not.toHaveClass('Tappable--hover-background');
+  describe('hover', () => {
+    const isHovered = (testId = 'x') => screen.getByTestId(testId).classList.contains('Tappable--hover-background');
+
+    it('is not hovered by default', () => {
+      render(<Tappable data-testid="x" />);
+      expect(isHovered()).toBe(false);
+    });
+    it('tracks mouse', () => {
+      render(<Tappable data-testid="x" />);
+      userEvent.hover(screen.getByTestId('x'));
+      expect(isHovered()).toBe(true);
+      userEvent.unhover(screen.getByTestId('x'));
+      expect(isHovered()).toBe(false);
+    });
+    describe('no hover when disabled', () => {
+      describe.each([
+        ['as form item', 'button'],
+        ['as div', 'div'],
+      ] as const)('%s', (_, cmp) => {
+        it('does not hover when disabled', () => {
+          render(<Tappable Component={cmp} data-testid="x" disabled />);
+          userEvent.hover(screen.getByTestId('x'));
+          expect(isHovered()).toBe(false);
+        });
+        it('suspends hover while disabled', () => {
+          const h = render(<Tappable Component={cmp} data-testid="x" />);
+          userEvent.hover(screen.getByTestId('x'));
+          h.rerender(<Tappable Component={cmp} data-testid="x" disabled />);
+          expect(isHovered()).toBe(false);
+          h.rerender(<Tappable Component={cmp} data-testid="x" />);
+          expect(isHovered()).toBe(true);
+        });
+        it('tracks hover occurred while disabled', () => {
+          const h = render(<Tappable Component={cmp} data-testid="x" disabled />);
+          userEvent.hover(screen.getByTestId('x'));
+          h.rerender(<Tappable Component={cmp} data-testid="x" />);
+          expect(isHovered()).toBe(true);
+        });
+      });
+    });
+    describe('nested hover', () => {
+      it('unhovers on child hover', () => {
+        render(<Tappable data-testid="x"><Tappable data-testid="c" /></Tappable>);
+        userEvent.hover(screen.getByTestId('c'));
+        expect(isHovered()).toBe(false);
+        fireEvent.mouseLeave(screen.getByTestId('c'));
+        expect(isHovered()).toBe(true);
+      });
+      it('restores hover on child unmount', () => {
+        const h = render(<Tappable data-testid="x"><Tappable data-testid="c" /></Tappable>);
+        userEvent.hover(screen.getByTestId('c'));
+        h.rerender(<Tappable data-testid="x" />);
+        expect(isHovered()).toBe(true);
+      });
+      describe('handles disabled children', () => {
+        describe.each([
+          ['as form item', 'button'],
+          ['as div', 'div'],
+        ] as const)('%s', (_, cmp) => {
+          it('hovers on disabled child hover', () => {
+            render((
+              <Tappable data-testid="x">
+                <Tappable Component={cmp} data-testid="c" disabled />
+              </Tappable>
+            ));
+            userEvent.hover(screen.getByTestId('c'));
+            expect(isHovered()).toBe(true);
+          });
+          it('restores hover on child disable', () => {
+            const h = render(<Tappable data-testid="x"><Tappable data-testid="c" /></Tappable>);
+            userEvent.hover(screen.getByTestId('c'));
+            h.rerender((
+              <Tappable data-testid="x">
+                <Tappable Component={cmp} data-testid="c" disabled />
+              </Tappable>
+            ));
+            expect(isHovered()).toBe(true);
+            h.rerender(<Tappable data-testid="x"><Tappable data-testid="c" /></Tappable>);
+            expect(isHovered()).toBe(false);
+          });
+        });
+      });
+    });
   });
 });

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -411,6 +411,7 @@ class Tappable extends React.Component<TappableProps & TappableContextInterface,
               tabIndex={isCustomElement && !restProps.disabled ? 0 : undefined}
               role={isCustomElement ? role : undefined}
               {...restProps}
+              usePointerHover
               vkuiClass={classes}
               Component={Component}
               getRootRef={this.getRef}

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -262,6 +262,11 @@ class Tappable extends React.Component<TappableProps & TappableContextInterface,
     this.setState({ hovered: false });
   };
 
+  childContext: TappableContextInterface= {
+    onEnter: () => this.setState({ childHover: true }),
+    onLeave: () => this.setState({ childHover: false }),
+  };
+
   /*
    * Устанавливает активное выделение
    */
@@ -410,12 +415,7 @@ class Tappable extends React.Component<TappableProps & TappableContextInterface,
               Component={Component}
               getRootRef={this.getRef}
               {...props}>
-              <TappableContext.Provider
-                value={{
-                  onEnter: () => this.setState({ childHover: true }),
-                  onLeave: () => this.setState({ childHover: false }),
-                }}
-              >
+              <TappableContext.Provider value={this.childContext}>
                 {children}
               </TappableContext.Provider>
               {platform === ANDROID && !hasMouse && hasActive && activeMode === 'background' && (

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -367,23 +367,13 @@ class Tappable extends React.Component<TappableProps, TappableState> {
         [activeMode]: hasActive && active && !isPresetActiveMode,
       });
 
-    const RootComponent = restProps.disabled
-      ? Component
-      : Touch;
-
-    let props: RootComponentProps = {};
+    const props: RootComponentProps = {};
     if (!restProps.disabled) {
-      props.Component = Component;
-      /* eslint-disable */
       props.onStart = this.onStart;
       props.onMove = this.onMove;
       props.onEnd = this.onEnd;
       props.onClick = onClick;
       props.onKeyDown = isCustomElement ? this.onKeyDown : onKeyDown;
-      /* eslint-enable */
-      props.getRootRef = this.getRef;
-    } else {
-      props.ref = this.getRef;
     }
 
     if (isCustomElement) {
@@ -410,13 +400,15 @@ class Tappable extends React.Component<TappableProps, TappableState> {
                   },
                 };
                 return (
-                  <RootComponent
+                  <Touch
                     {...touchProps}
                     type={Component === 'button' ? 'button' : undefined}
                     tabIndex={isCustomElement && !restProps.disabled ? 0 : undefined}
                     role={isCustomElement ? role : undefined}
                     {...restProps}
                     vkuiClass={classes}
+                    Component={Component}
+                    getRootRef={this.getRef}
                     {...props}>
                     <TappableContext.Provider
                       value={{
@@ -436,7 +428,7 @@ class Tappable extends React.Component<TappableProps, TappableState> {
                     )}
                     {hasHover && hoverMode === 'background' && <span aria-hidden="true" vkuiClass="Tappable__hoverShadow" />}
                     {!restProps.disabled && <FocusVisible mode={focusVisibleMode} />}
-                  </RootComponent>
+                  </Touch>
                 );
               }}
             </TouchRootContext.Consumer>

--- a/src/components/Touch/Touch.tsx
+++ b/src/components/Touch/Touch.tsx
@@ -18,6 +18,10 @@ export interface TouchProps extends React.AllHTMLAttributes<HTMLElement>, HasRoo
   onEnd?(outputEvent: TouchEvent): void;
   onEndX?(outputEvent: TouchEvent): void;
   onEndY?(outputEvent: TouchEvent): void;
+  /**
+   * Привязать onEnter и onLeave через pointer-events - работает на disabled-инпутах
+   */
+  usePointerHover?: boolean;
   useCapture?: boolean;
   noSlideClick?: boolean;
   Component?: React.ElementType;
@@ -60,6 +64,7 @@ export const Touch: React.FC<TouchProps> = ({
   onEndX,
   onEndY,
   onClickCapture,
+  usePointerHover,
   useCapture = false,
   Component = 'div',
   getRootRef,
@@ -74,8 +79,8 @@ export const Touch: React.FC<TouchProps> = ({
     cb && cb({ ...gesture.current, originalEvent: e });
   });
 
-  const mouseEnterHandler = useEventListener('mouseenter', onEnter);
-  const mouseLeaveHandler = useEventListener('mouseleave', onLeave);
+  const enterHandler = useEventListener(usePointerHover ? 'pointerenter' : 'mouseenter', onEnter);
+  const leaveHandler = useEventListener(usePointerHover ? 'pointerleave' : 'mouseleave', onLeave);
   const startHandler = useEventListener(events[0], (e: VKUITouchEvent) => {
     gesture.current = {
       startX: coordX(e),
@@ -91,8 +96,8 @@ export const Touch: React.FC<TouchProps> = ({
 
   useIsomorphicLayoutEffect(() => {
     const el = containerRef.current;
-    mouseEnterHandler.add(el);
-    mouseLeaveHandler.add(el);
+    enterHandler.add(el);
+    leaveHandler.add(el);
     startHandler.add(el);
     touchEnabled() && subscribe(el);
   }, [Component]);


### PR DESCRIPTION
1. Используем Touch даже для Tappable disabled
2. За опцией завязываем onEnter/Leave в Touch на пойнтер-ивенты, чтобы вылетало в disabled-инпутах

Испраявляет:
- Изменение пропов hasActive / hasHover во время ховера на вложенном Tappable не возвращает ховер / активность на родителя.
- Ховер возвращается на Tappable:
  - При анмаунте вложенного Tappable под ховером 
  - При переходе вложенного Tappable в disabled
  - При отключении disabled на самом Tappable
- Tappable теряет ховер:
  - При отключении disabled на вложенном Tappable под ховером
  - При переходе в disabled

Улучшает:
- При изменении disabled контент Tappable не ремаунтится, потому что компонент-обертка не меняется
- При рендере Tappable не перерисовываются все вложенные Tappable, потому что контекст стал стабильным