### PR TITLE
Textarea: supported rows

### DIFF
--- a/src/components/Textarea/Readme.md
+++ b/src/components/Textarea/Readme.md
@@ -10,6 +10,9 @@
         <FormItem top="Любимая музыка">
           <Textarea placeholder="Группы, исполнители, продюсеры" />
         </FormItem>
+        <FormItem top="Прикидываемся Input">
+          <Textarea rows={1} placeholder="Once upon a time" />
+        </FormItem>
       </Group>
     </Panel>
   </View>

--- a/src/components/Textarea/Textarea.css
+++ b/src/components/Textarea/Textarea.css
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   resize: none;
   appearance: none;
-  line-height: 19px;
+  line-height: 20px;
   font-size: 16px;
   color: var(--text_primary);
   padding: 11px;
@@ -25,8 +25,11 @@
   padding-top: 7px;
   padding-bottom: 7px;
   font-size: 15px;
-  line-height: 20px;
   min-height: 54px;
+}
+
+.Textarea__el[rows] {
+  min-height: 0;
 }
 
 .Textarea__el::placeholder {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -30,7 +30,7 @@ const Textarea: React.FC<TextareaProps> = React.memo(({
   getRef,
   sizeY,
   ...restProps
-}) => {
+}: TextareaProps) => {
   const [value, onChange] = useEnsuredControl(restProps, { defaultValue });
   const elementRef = useExternRef(getRef);
   const platform = usePlatform();


### PR DESCRIPTION
Если передан row, то мы обнуляем `min-height`. Таким образом можно рендерить `Textarea`, который выглядит как `Input`.