### PR TITLE
ActionSheet optional props + docs fix pack

### DIFF
--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -11,29 +11,34 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { useTimeout } from '../../hooks/useTimeout';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
+import { warnOnce } from '../../lib/warnOnce';
+import { SharedDropdownProps, PopupDirection, ToggleRef } from './types';
 import './ActionSheet.css';
-
-export type PopupDirectionFunction = (elRef: React.RefObject<HTMLDivElement>) => 'top' | 'bottom';
 
 export interface ActionSheetProps extends React.HTMLAttributes<HTMLDivElement> {
   header?: React.ReactNode;
   text?: React.ReactNode;
-  onClose?: VoidFunction;
   /**
-   * Desktop only
+   * Закрыть попап по клику снаружи. В v5 будет обязательным.
    */
-  toggleRef: Element;
+  onClose?: () => {};
   /**
-   * Desktop only
+   * Элемент, рядом с которым вылезает попап на десктопе.
+   * Лучше передавать RefObject c current.
+   * В v5 будет обязательным.
    */
-  popupDirection?: 'top' | 'bottom' | PopupDirectionFunction;
+  toggleRef?: ToggleRef;
   /**
-   * iOS only
+   * Направление на десктопе
    */
-  iosCloseItem: React.ReactNode;
+  popupDirection?: PopupDirection;
+  /**
+   * Только iOS. В v5 будет обязательным.
+   */
+  iosCloseItem?: React.ReactNode;
 }
 
-export type AnimationEndCallback = (e?: AnimationEvent) => void;
+const warn = warnOnce('ActionSheet');
 
 export const ActionSheet: React.FC<ActionSheetProps> = ({
   children,
@@ -43,7 +48,7 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
   style,
   iosCloseItem,
   ...restProps
-}) => {
+}: ActionSheetProps) => {
   const platform = usePlatform();
   const [closing, setClosing] = React.useState(false);
   const onClose = () => setClosing(true);
@@ -54,6 +59,10 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
     _closeAction && _closeAction();
     setCloseAction(undefined);
   };
+
+  if (process.env.NODE_ENV === 'development' && !restProps.onClose) {
+    warn('can\'t close on outer click without onClose');
+  }
 
   const { viewWidth, viewHeight, hasMouse } = useAdaptivity();
   const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
@@ -102,7 +111,7 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
           closing={closing}
           onClose={onClose}
           onTransitionEnd={closing && !isDesktop ? afterClose : null}
-          {...restProps}
+          {...restProps as Omit<SharedDropdownProps, 'closing'>}
         >
           {(hasReactNode(header) || hasReactNode(text)) &&
             <header vkuiClass="ActionSheet__header">

--- a/src/components/ActionSheet/ActionSheetDropdown.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdown.tsx
@@ -2,23 +2,16 @@ import * as React from 'react';
 import { getClassName } from '../../helpers/getClassName';
 import { classNames } from '../../lib/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
-import { ActionSheetProps } from './ActionSheet';
+import { SharedDropdownProps } from './types';
 import './ActionSheet.css';
-
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  closing: boolean;
-  onClose(): void;
-  toggleRef: Element;
-  /** Has no effect - only for ActionSheetDropdownDesktip polymorhipsm */
-  popupDirection?: ActionSheetProps['popupDirection'];
-}
 
 const stopPropagation: React.MouseEventHandler = (e) => e.stopPropagation();
 
-export const ActionSheetDropdown: React.FC<Props> = ({
+export const ActionSheetDropdown: React.FC<SharedDropdownProps> = ({
   children,
-  toggleRef,
   closing,
+  // these 2 props are only omitted - ActionSheetDesktop compat
+  toggleRef,
   popupDirection,
   ...restProps
 }) => {

--- a/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
@@ -7,19 +7,15 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 import { warnOnce } from '../../lib/warnOnce';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
-import { ActionSheetProps } from './ActionSheet';
+import { SharedDropdownProps } from './types';
 import './ActionSheet.css';
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  closing: boolean;
-  onClose(): void;
-  popupDirection?: ActionSheetProps['popupDirection'];
-  toggleRef: Element;
+const warn = warnOnce('ActionSheet');
+function getEl(ref: SharedDropdownProps['toggleRef']): Element | null | undefined {
+  return ref && 'current' in ref ? ref.current : ref as Element | null | undefined;
 }
 
-const warn = warnOnce('ActionSheet');
-
-export const ActionSheetDropdownDesktop: React.FC<Props> = ({
+export const ActionSheetDropdownDesktop: React.FC<SharedDropdownProps> = ({
   children,
   toggleRef,
   closing,
@@ -39,14 +35,15 @@ export const ActionSheetDropdownDesktop: React.FC<Props> = ({
     pointerEvents: 'none',
   });
   useIsomorphicLayoutEffect(() => {
-    if (!toggleRef) {
+    const toggleEl = getEl(toggleRef);
+    if (!toggleEl) {
       if (process.env.NODE_ENV === 'development') {
         warn('toggleRef not passed');
       }
       return;
     }
 
-    const toggleRect = toggleRef.getBoundingClientRect();
+    const toggleRect = toggleEl.getBoundingClientRect();
     const elementRect = elementRef.current.getBoundingClientRect();
     const isTop = popupDirection === 'top' || typeof popupDirection === 'function' && popupDirection(elementRef) === 'top';
 

--- a/src/components/ActionSheet/Readme.md
+++ b/src/components/ActionSheet/Readme.md
@@ -12,238 +12,197 @@ ActionSheet – имитация [нативного компонента](https
 Для Android версии он не нужен.
 
 ```jsx
-class Example extends React.Component {
-  constructor(props) {
-    super(props);
+const [popout, setPopout] = useState(null);
+const onClose = () => setPopout(null);
+const [filter, setFilter] = useState('best');
+const onChange = e => setFilter(e.target.value);
+const baseTargetRef = React.useRef();
+const iconsTargetRef = React.useRef();
+const subtitleTargetRef = React.useRef();
+const selectableTargetRef = React.useRef();
+const titleTargetRef = React.useRef();
+const baseTopTargetRef = React.useRef();
 
-    this.state = {
-      popout: null,
-      filter: 'best'
-    }
+const openBase = () => setPopout(
+  <ActionSheet
+    onClose={onClose}
+    iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
+    toggleRef={baseTargetRef}
+  >
+    <ActionSheetItem autoclose>
+      Сохранить в закладках
+    </ActionSheetItem>
+    <ActionSheetItem autoclose>
+      Закрепить запись
+    </ActionSheetItem>
+    <ActionSheetItem autoclose>
+      Выключить комментирование
+    </ActionSheetItem>
+    <ActionSheetItem autoclose>
+      Закрепить запись
+    </ActionSheetItem>
+    <ActionSheetItem autoclose mode="destructive">
+      Удалить запись
+    </ActionSheetItem>
+  </ActionSheet>
+);
 
-    this.openBase = this.openBase.bind(this);
-    this.openIcons = this.openIcons.bind(this);
-    this.openSubtitle = this.openSubtitle.bind(this);
-    this.openSelectable = this.openSelectable.bind(this);
-    this.openTitle = this.openTitle.bind(this);
-    this.onChange = this.onChange.bind(this);
-    this.openBaseTop = this.openBaseTop.bind(this);
+const openIcons = () => setPopout(
+  <ActionSheet
+    onClose={onClose}
+    iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
+    toggleRef={iconsTargetRef}
+  >
+    <ActionSheetItem autoclose before={<Icon28EditOutline/>}>
+      Редактировать профиль
+    </ActionSheetItem>
+    <ActionSheetItem autoclose before={<Icon28ListPlayOutline/>}>
+      Слушать далее
+    </ActionSheetItem>
+    <ActionSheetItem autoclose before={<Icon28ShareOutline/>}>
+      Поделиться
+    </ActionSheetItem>
+    <ActionSheetItem autoclose before={<Icon28CopyOutline/>}>
+      Скопировать ссылку
+    </ActionSheetItem>
+    <ActionSheetItem
+      autoclose
+      before={platform === IOS ? <Icon28DeleteOutline/> : <Icon28DeleteOutlineAndroid />}
+      mode="destructive"
+    >
+      Удалить плейлист
+    </ActionSheetItem>
+  </ActionSheet>
+);
 
-    this.baseTargetRef = React.createRef();
-    this.iconsTargetRef = React.createRef();
-    this.subtitleTargetRef = React.createRef();
-    this.selectableTargetRef = React.createRef();
-    this.titleTargetRef = React.createRef();
-    this.baseTopTargetRef = React.createRef();
-  }
+const openSubtitle = () => setPopout(
+  <ActionSheet
+    onClose={onClose}
+    iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
+    toggleRef={subtitleTargetRef}
+  >
+    <ActionSheetItem before={<Icon28SettingsOutline />} autoclose subtitle="Авто">
+      Качество
+    </ActionSheetItem>
+    <ActionSheetItem before={<Icon28SubtitlesOutline />} autoclose subtitle="Отсутствуют" disabled>
+      Субтитры
+    </ActionSheetItem>
+    <ActionSheetItem before={<Icon28PlaySpeedOutline />} autoclose subtitle="Обычная">
+      Скорость воспроизведения
+    </ActionSheetItem>
+  </ActionSheet>
+);
 
-  componentDidMount() {
-    this.openBase();
-  }
+const openSelectable = () => setPopout(
+  <ActionSheet
+    onClose={onClose}
+    iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
+    toggleRef={selectableTargetRef}
+  >
+    <ActionSheetItem
+      onChange={onChange}
+      checked={filter === 'best'}
+      name="filter"
+      value="best"
+      autoclose
+      selectable
+    >
+      Лучшие друзья
+    </ActionSheetItem>
+    <ActionSheetItem
+      onChange={onChange}
+      checked={filter === 'relatives'}
+      name="filter"
+      value="relatives"
+      autoclose
+      selectable
+    >
+      Родственники
+    </ActionSheetItem>
+    <ActionSheetItem
+      onChange={onChange}
+      checked={filter === 'collegues'}
+      name="filter"
+      value="collegues"
+      autoclose
+      selectable
+    >
+      Коллеги
+    </ActionSheetItem>
+    <ActionSheetItem
+      onChange={onChange}
+      checked={filter === 'school'}
+      name="filter"
+      value="school"
+      autoclose
+      selectable
+    >
+      Друзья по школе
+    </ActionSheetItem>
+    <ActionSheetItem
+      onChange={onChange}
+      checked={filter === 'university'}
+      name="filter"
+      value="university"
+      autoclose
+      selectable
+    >
+      Друзья по вузу
+    </ActionSheetItem>
+  </ActionSheet>
+);
 
-  openBase () {
-    this.setState({ popout:
-      <ActionSheet 
-        onClose={() => this.setState({ popout: null })}
-        iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
-        toggleRef={this.baseTargetRef.current}
-      >
-        <ActionSheetItem autoclose>
-          Сохранить в закладках
-        </ActionSheetItem>
-        <ActionSheetItem autoclose>
-          Закрепить запись
-        </ActionSheetItem>
-        <ActionSheetItem autoclose>
-          Выключить комментирование
-        </ActionSheetItem>
-        <ActionSheetItem autoclose>
-          Закрепить запись
-        </ActionSheetItem>
-        <ActionSheetItem autoclose mode="destructive">
-          Удалить запись
-        </ActionSheetItem>
-      </ActionSheet>
-    });
-  }
+const openTitle = () => setPopout(
+  <ActionSheet
+    onClose={onClose}
+    iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
+    header="Вы действительно хотите удалить это видео из Ваших видео?"
+    toggleRef={titleTargetRef}
+  >
+    <ActionSheetItem autoclose mode="destructive">
+      Удалить видео
+    </ActionSheetItem>
+  </ActionSheet>
+);
 
-  openIcons () {
-    this.setState({ popout:
-      <ActionSheet 
-        onClose={() => this.setState({ popout: null })}
-        iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
-        toggleRef={this.iconsTargetRef.current}
-      >
-        <ActionSheetItem autoclose before={<Icon28EditOutline/>}>
-          Редактировать профиль
-        </ActionSheetItem>
-        <ActionSheetItem autoclose before={<Icon28ListPlayOutline/>}>
-          Слушать далее
-        </ActionSheetItem>
-        <ActionSheetItem autoclose before={<Icon28ShareOutline/>}>
-          Поделиться
-        </ActionSheetItem>
-        <ActionSheetItem autoclose before={<Icon28CopyOutline/>}>
-          Скопировать ссылку
-        </ActionSheetItem>
-        <ActionSheetItem
-          autoclose
-          before={platform === IOS ? <Icon28DeleteOutline/> : <Icon28DeleteOutlineAndroid />}
-          mode="destructive"
-        >
-          Удалить плейлист
-        </ActionSheetItem>
-      </ActionSheet>
-    });
-  }
+const openBaseTop = () => setPopout(
+  <ActionSheet
+    onClose={onClose}
+    iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
+    toggleRef={baseTopTargetRef}
+    popupDirection="top"
+  >
+    <ActionSheetItem autoclose>
+      Сохранить в закладках
+    </ActionSheetItem>
+    <ActionSheetItem autoclose>
+      Закрепить запись
+    </ActionSheetItem>
+    <ActionSheetItem autoclose>
+      Выключить комментирование
+    </ActionSheetItem>
+    <ActionSheetItem autoclose>
+      Закрепить запись
+    </ActionSheetItem>
+    <ActionSheetItem autoclose mode="destructive">
+      Удалить запись
+    </ActionSheetItem>
+  </ActionSheet>
+);
 
-  openSubtitle () {
-    this.setState({ popout:
-      <ActionSheet 
-        onClose={() => this.setState({ popout: null })}
-        iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
-        toggleRef={this.subtitleTargetRef.current}
-      >
-        <ActionSheetItem before={<Icon28SettingsOutline />} autoclose subtitle="Авто">
-          Качество
-        </ActionSheetItem>
-        <ActionSheetItem before={<Icon28SubtitlesOutline />} autoclose subtitle="Отсутствуют" disabled>
-          Субтитры
-        </ActionSheetItem>
-        <ActionSheetItem before={<Icon28PlaySpeedOutline />} autoclose subtitle="Обычная">
-          Скорость воспроизведения
-        </ActionSheetItem>
-      </ActionSheet>
-    });
-  }
+React.useEffect(openBase, []);
 
-  openSelectable () {
-    this.setState({ popout:
-      <ActionSheet 
-        onClose={() => this.setState({ popout: null })}
-        iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
-        toggleRef={this.selectableTargetRef.current}
-      >
-        <ActionSheetItem
-          onChange={this.onChange}
-          checked={this.state.filter === 'best'}
-          name="filter"
-          value="best"
-          autoclose
-          selectable
-        >
-          Лучшие друзья
-        </ActionSheetItem>
-        <ActionSheetItem
-          onChange={this.onChange}
-          checked={this.state.filter === 'relatives'} 
-          name="filter"
-          value="relatives"
-          autoclose
-          selectable
-        >
-          Родственники
-        </ActionSheetItem>
-        <ActionSheetItem
-          onChange={this.onChange}
-          checked={this.state.filter === 'collegues'} 
-          name="filter"
-          value="collegues"
-          autoclose
-          selectable
-        >
-          Коллеги
-        </ActionSheetItem>
-        <ActionSheetItem
-          onChange={this.onChange}
-          checked={this.state.filter === 'school'} 
-          name="filter"
-          value="school"
-          autoclose
-          selectable
-        >
-          Друзья по школе
-        </ActionSheetItem>
-        <ActionSheetItem
-          onChange={this.onChange}
-          checked={this.state.filter === 'university'} 
-          name="filter"
-          value="university"
-          autoclose
-          selectable
-        >
-          Друзья по вузу
-        </ActionSheetItem>
-      </ActionSheet>
-    });
-  }
-  
-  openTitle() {
-    this.setState({ popout:
-      <ActionSheet 
-        onClose={() => this.setState({ popout: null })}
-        iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
-        header="Вы действительно хотите удалить это видео из Ваших видео?"
-        toggleRef={this.titleTargetRef.current}
-      >
-        <ActionSheetItem autoclose mode="destructive">
-          Удалить видео
-        </ActionSheetItem>
-      </ActionSheet>
-    });
-  }
-
-  openBaseTop() {
-    this.setState({
-      popout: (
-        <ActionSheet
-          onClose={() => this.setState({ popout: null })}
-          iosCloseItem={<ActionSheetItem autoclose mode="cancel">Отменить</ActionSheetItem>}
-          toggleRef={this.baseTopTargetRef.current}
-          popupDirection="top"
-        >
-          <ActionSheetItem autoclose>
-            Сохранить в закладках
-          </ActionSheetItem>
-          <ActionSheetItem autoclose>
-            Закрепить запись
-          </ActionSheetItem>
-          <ActionSheetItem autoclose>
-            Выключить комментирование
-          </ActionSheetItem>
-          <ActionSheetItem autoclose>
-            Закрепить запись
-          </ActionSheetItem>
-          <ActionSheetItem autoclose mode="destructive">
-            Удалить запись
-          </ActionSheetItem>
-        </ActionSheet>
-      ),
-    });
-  }
- 
-  onChange(e) {
-    this.setState({ filter: e.target.value });
-  }
-
-  render() {
-    return (
-      <View popout={this.state.popout} activePanel="panel">
-        <Panel id="panel">
-          <PanelHeader>ActionSheet</PanelHeader>
-          <Group>
-            <CellButton getRootRef={this.baseTargetRef} onClick={this.openBase}>Базовый список</CellButton>
-            <CellButton getRootRef={this.iconsTargetRef} onClick={this.openIcons}>Список с иконками</CellButton>
-            <CellButton getRootRef={this.subtitleTargetRef} onClick={this.openSubtitle}>С подзаголовком</CellButton>
-            <CellButton getRootRef={this.selectableTargetRef} onClick={this.openSelectable}>Выделяемые</CellButton>
-            <CellButton getRootRef={this.titleTargetRef} onClick={this.openTitle}>C заголовком</CellButton>
-            <CellButton getRootRef={this.baseTopTargetRef} onClick={this.openBaseTop}>Базовый список, открывается наверх на десктопах</CellButton>
-          </Group>
-        </Panel>
-      </View>
-    )
-  }
-}
-
-<Example />
+<View popout={popout} activePanel="panel">
+  <Panel id="panel">
+    <PanelHeader>ActionSheet</PanelHeader>
+    <Group>
+      <CellButton getRootRef={baseTargetRef} onClick={openBase}>Базовый список</CellButton>
+      <CellButton getRootRef={iconsTargetRef} onClick={openIcons}>Список с иконками</CellButton>
+      <CellButton getRootRef={subtitleTargetRef} onClick={openSubtitle}>С подзаголовком</CellButton>
+      <CellButton getRootRef={selectableTargetRef} onClick={openSelectable}>Выделяемые</CellButton>
+      <CellButton getRootRef={titleTargetRef} onClick={openTitle}>C заголовком</CellButton>
+      <CellButton getRootRef={baseTopTargetRef} onClick={openBaseTop}>Базовый список, открывается наверх на десктопах</CellButton>
+    </Group>
+  </Panel>
+</View>
 ```

--- a/src/components/ActionSheet/types.ts
+++ b/src/components/ActionSheet/types.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export type PopupDirection = 'top' | 'bottom' | ((elRef: React.RefObject<HTMLDivElement>) => 'top' | 'bottom');
+export type ToggleRef = Element | null | undefined | React.RefObject<Element>;
+
+export interface SharedDropdownProps extends React.HTMLAttributes<HTMLDivElement> {
+  closing: boolean;
+  onClose: VoidFunction;
+  toggleRef: ToggleRef;
+  popupDirection: PopupDirection;
+}

--- a/src/components/FixedLayout/FixedLayout.tsx
+++ b/src/components/FixedLayout/FixedLayout.tsx
@@ -38,7 +38,7 @@ const warn = warnOnce('FixedLayout');
 const FixedLayout: React.FC<FixedLayoutProps> = ({
   children, style, vertical, getRootRef, getRef, filled,
   ...restProps
-}) => {
+}: FixedLayoutProps) => {
   const platform = usePlatform();
   const { colRef } = React.useContext(SplitColContext);
   const { window, document } = useDOM();

--- a/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -25,7 +25,7 @@ export const PopoutWrapper: React.FC<PopoutWrapperProps> = ({
   children,
   onClick,
   ...restProps
-}) => {
+}: PopoutWrapperProps) => {
   const platform = usePlatform();
   const [opened, setOpened] = React.useState(!hasMask);
   const elRef = React.useRef<HTMLDivElement>();

--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -45,7 +45,7 @@ const Root: React.FC<RootProps> = ({
   activeView: _activeView, onTransition,
   nav,
   ...restProps
-}) => {
+}: RootProps) => {
   const scroll = React.useContext(ScrollContext);
   const platform = usePlatform();
   const { document } = useDOM();

--- a/src/components/Touch/Touch.tsx
+++ b/src/components/Touch/Touch.tsx
@@ -7,17 +7,6 @@ import { useEventListener } from '../../hooks/useEventListener';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 
 export interface TouchProps extends React.AllHTMLAttributes<HTMLElement>, HasRootRef<HTMLElement> {
-  onEnter?(outputEvent: MouseEvent): void;
-  onLeave?(outputEvent: MouseEvent): void;
-  onStart?(outputEvent: TouchEvent): void;
-  onStartX?(outputEvent: TouchEvent): void;
-  onStartY?(outputEvent: TouchEvent): void;
-  onMove?(outputEvent: TouchEvent): void;
-  onMoveX?(outputEvent: TouchEvent): void;
-  onMoveY?(outputEvent: TouchEvent): void;
-  onEnd?(outputEvent: TouchEvent): void;
-  onEndX?(outputEvent: TouchEvent): void;
-  onEndY?(outputEvent: TouchEvent): void;
   /**
    * Привязать onEnter и onLeave через pointer-events - работает на disabled-инпутах
    */
@@ -26,6 +15,17 @@ export interface TouchProps extends React.AllHTMLAttributes<HTMLElement>, HasRoo
   slideThreshold?: number;
   noSlideClick?: boolean;
   Component?: React.ElementType;
+  onEnter?: HoverHandler;
+  onLeave?: HoverHandler;
+  onStart?: TouchEventHandler;
+  onStartX?: TouchEventHandler;
+  onStartY?: TouchEventHandler;
+  onMove?: TouchEventHandler;
+  onMoveX?: TouchEventHandler;
+  onMoveY?: TouchEventHandler;
+  onEnd?: TouchEventHandler;
+  onEndX?: TouchEventHandler;
+  onEndY?: TouchEventHandler;
 }
 
 export interface Gesture {
@@ -49,6 +49,7 @@ export interface TouchEvent extends Gesture {
   originalEvent: VKUITouchEvent;
 }
 
+type HoverHandler = (outputEvent: MouseEvent) => void;
 export type TouchEventHandler = (e: TouchEvent) => void;
 export type ClickHandler = (e: React.MouseEvent<HTMLElement>) => void;
 export type DragHandler = (e: React.DragEvent<HTMLElement>) => void;
@@ -73,7 +74,7 @@ export const Touch: React.FC<TouchProps> = ({
   getRootRef,
   noSlideClick = false,
   ...restProps
-}) => {
+}: TouchProps) => {
   const { document } = useDOM();
   const events = React.useMemo(getSupportedEvents, []);
   const didSlide = React.useRef(false);


### PR DESCRIPTION
- __types__ Сделал все пропы `ActionSheet` опциональными, как c v4.2 до v4.15. В 4.2 они стали опциональными случайно из-за появления `defaultProps`, в #1883 (релиз 4.15) стали обязательными, как и задумано. В __v5__ стоит исправить это поведение.
- __enhancement__ Добавил дев-ворнинг, если в `ActionSheet` не передан `onClose`
- __docs__ Вернул в доку описания пропов, потерявшиеся при переезде на FC: #1882, #1883, #1886, #1887, #1893
- __feat__ `ActionSheet` поддерживает `toggleRef: RefObject` — так чуть проще не передать null-реф.