### PR TITLE
ActionSheet fixes

### DIFF
--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -21,7 +21,7 @@ export interface ActionSheetProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Закрыть попап по клику снаружи. В v5 будет обязательным.
    */
-  onClose?: () => {};
+  onClose?: VoidFunction;
   /**
    * Элемент, рядом с которым вылезает попап на десктопе.
    * Лучше передавать RefObject c current.

--- a/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
@@ -4,7 +4,6 @@ import { classNames } from '../../lib/classNames';
 import { useDOM } from '../../lib/dom';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
-import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 import { warnOnce } from '../../lib/warnOnce';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { SharedDropdownProps } from './types';
@@ -53,12 +52,21 @@ export const ActionSheetDropdownDesktop: React.FC<SharedDropdownProps> = ({
     });
   }, [toggleRef]);
 
-  useGlobalEventListener(document.body, 'click', (e) => {
+  const onBodyClick = React.useCallback((e) => {
     const dropdownElement = elementRef?.current;
     if (dropdownElement && !dropdownElement.contains(e.target as Node)) {
       onClose();
     }
-  });
+  }, []);
+
+  React.useEffect(() => {
+    setTimeout(() => {
+      document.body.addEventListener('click', onBodyClick);
+    });
+    return () => {
+      document.body.removeEventListener('click', onBodyClick);
+    };
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
- Исправлен тип `onClose`
- Слушаем клик по body только после открытия дропдауна в `ActionSheetDesktop`