### PR TITLE
[docs] Исправленные примеры `View`

### DIFF
--- a/src/components/ActionSheet/Readme.md
+++ b/src/components/ActionSheet/Readme.md
@@ -11,7 +11,7 @@ ActionSheet – имитация [нативного компонента](https
 > В коде примера ниже можно посмотреть, как добавить такой элемент.
 Для Android версии он не нужен.
 
-```jsx
+```jsx { "props": { "layout": false, "adaptivity": true } }
 const [popout, setPopout] = useState(null);
 const onClose = () => setPopout(null);
 const [filter, setFilter] = useState('best');
@@ -192,17 +192,21 @@ const openBaseTop = () => setPopout(
 
 React.useEffect(openBase, []);
 
-<View popout={popout} activePanel="panel">
-  <Panel id="panel">
-    <PanelHeader>ActionSheet</PanelHeader>
-    <Group>
-      <CellButton getRootRef={baseTargetRef} onClick={openBase}>Базовый список</CellButton>
-      <CellButton getRootRef={iconsTargetRef} onClick={openIcons}>Список с иконками</CellButton>
-      <CellButton getRootRef={subtitleTargetRef} onClick={openSubtitle}>С подзаголовком</CellButton>
-      <CellButton getRootRef={selectableTargetRef} onClick={openSelectable}>Выделяемые</CellButton>
-      <CellButton getRootRef={titleTargetRef} onClick={openTitle}>C заголовком</CellButton>
-      <CellButton getRootRef={baseTopTargetRef} onClick={openBaseTop}>Базовый список, открывается наверх на десктопах</CellButton>
-    </Group>
-  </Panel>
-</View>
+<SplitLayout popout={popout}>
+  <SplitCol>
+  <View activePanel="panel">
+    <Panel id="panel">
+      <PanelHeader>ActionSheet</PanelHeader>
+      <Group>
+        <CellButton getRootRef={baseTargetRef} onClick={openBase}>Базовый список</CellButton>
+        <CellButton getRootRef={iconsTargetRef} onClick={openIcons}>Список с иконками</CellButton>
+        <CellButton getRootRef={subtitleTargetRef} onClick={openSubtitle}>С подзаголовком</CellButton>
+        <CellButton getRootRef={selectableTargetRef} onClick={openSelectable}>Выделяемые</CellButton>
+        <CellButton getRootRef={titleTargetRef} onClick={openTitle}>C заголовком</CellButton>
+        <CellButton getRootRef={baseTopTargetRef} onClick={openBaseTop}>Базовый список, открывается наверх на десктопах</CellButton>
+      </Group>
+    </Panel>
+  </View>
+  </SplitCol>
+</SplitLayout>
 ```

--- a/src/components/Alert/Readme.md
+++ b/src/components/Alert/Readme.md
@@ -22,7 +22,7 @@
 > 4. В VKCOM версии возможно только горизонтальное расположение кнопок.
 > 5.  Порядок кнопок должен быть одинаковым на всех платформах (см. пункт 2).
 
-```jsx
+```jsx { "props": { "layout": false, "adaptivity": true } }
 class Example extends React.Component {
   constructor(props) {
     super(props);
@@ -96,16 +96,20 @@ class Example extends React.Component {
 
   render() {
     return (
-      <View popout={this.state.popout} activePanel="alert">
-        <Panel id="alert">
-          <PanelHeader>Alert</PanelHeader>
-          <Group>
-            <CellButton onClick={this.openAction}>Лишить права</CellButton>
-            <CellButton onClick={this.openDeleteion}>Удалить документ</CellButton>
-            {this.state.actionsLog.map((value, i) => <Div key={i}>{value}</Div>)}
-          </Group>
-        </Panel>
-      </View>
+      <SplitLayout popout={this.state.popout}>
+        <SplitCol>
+        <View activePanel="alert">
+          <Panel id="alert">
+            <PanelHeader>Alert</PanelHeader>
+            <Group>
+              <CellButton onClick={this.openAction}>Лишить права</CellButton>
+              <CellButton onClick={this.openDeleteion}>Удалить документ</CellButton>
+              {this.state.actionsLog.map((value, i) => <Div key={i}>{value}</Div>)}
+            </Group>
+          </Panel>
+        </View>
+        </SplitCol>
+      </SplitLayout>
     )
   }
 }

--- a/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/src/components/FocusTrap/FocusTrap.test.tsx
@@ -11,6 +11,7 @@ import ActionSheetItem from '../ActionSheetItem/ActionSheetItem';
 import View from '../View/View';
 import { Panel } from '../Panel/Panel';
 import { SplitLayout } from '../SplitLayout/SplitLayout';
+import { SplitCol } from '../SplitCol/SplitCol';
 import { CellButton } from '../CellButton/CellButton';
 
 beforeEach(() => jest.useFakeTimers());
@@ -46,15 +47,17 @@ const ActionSheetTest: React.FC<Partial<ActionSheetProps> & Partial<FocusTrapPro
     <AppRoot>
       <AdaptivityProvider hasMouse>
         <SplitLayout popout={actionSheet}>
-          <View activePanel="panel">
-            <Panel id="panel">
-              <CellButton
-                data-testid="toggle"
-                getRootRef={toggleRef}
-                onClick={() => toggleActionSheet(_actionSheet)}
-              >Toggle ActionSheet</CellButton>
-            </Panel>
-          </View>
+          <SplitCol>
+            <View activePanel="panel">
+              <Panel id="panel">
+                <CellButton
+                  data-testid="toggle"
+                  getRootRef={toggleRef}
+                  onClick={() => toggleActionSheet(_actionSheet)}
+                >Toggle ActionSheet</CellButton>
+              </Panel>
+            </View>
+          </SplitCol>
         </SplitLayout>
       </AdaptivityProvider>
     </AppRoot>

--- a/src/components/Group/Readme.md
+++ b/src/components/Group/Readme.md
@@ -1,6 +1,6 @@
 Группа – базовый компонент для группировки контента по смыслу.
 
-```jsx
+```jsx { "props": { "layout": false, "adaptivity": true } }
 const MODAL_NAME = 'modal'
 
 class App extends React.Component {
@@ -91,21 +91,25 @@ class App extends React.Component {
     );
 
     return (
-      <View activePanel="group" modal={modal}>
-        <Panel id="group">
-          <PanelHeader>
-            Group
-          </PanelHeader>
+      <SplitLayout modal={modal}>
+        <SplitCol>
+        <View activePanel="group">
+          <Panel id="group">
+            <PanelHeader>
+              Group
+            </PanelHeader>
 
-          {this.renderGroup()}
+            {this.renderGroup()}
 
-          <Group header={<Header mode="secondary">Модальное окно с Group</Header>}>
-            <SimpleCell onClick={() => this.setState({ isModalOpened: true })}>
-              Открыть Group в модальном окне
-            </SimpleCell>
-          </Group>
-        </Panel>
-      </View>
+            <Group header={<Header mode="secondary">Модальное окно с Group</Header>}>
+              <SimpleCell onClick={() => this.setState({ isModalOpened: true })}>
+                Открыть Group в модальном окне
+              </SimpleCell>
+            </Group>
+          </Panel>
+        </View>
+        </SplitCol>
+      </SplitLayout>
     )
   }
 }

--- a/src/components/MiniInfoCell/Readme.md
+++ b/src/components/MiniInfoCell/Readme.md
@@ -1,4 +1,4 @@
-```jsx
+```jsx { "props": { "layout": false, "adaptivity": true } }
 function MiniInfoCellExample() {
   const platform = usePlatform();
   const [activeModal, setActiveModal] = React.useState(null);
@@ -72,67 +72,71 @@ function MiniInfoCellExample() {
   );
 
   return (
-    <View activePanel="information_cell" modal={modal}>
-      <Panel id="information_cell">
-        <PanelHeader>
-          Ячейка информации
-        </PanelHeader>
-    
-        <Group>
-          <MiniInfoCell
-            before={<Icon20ArticleOutline />}
-            textWrap="short"
-          >
-            ВКонтакте начинался как сайт для выпускников вузов, а сейчас это огромная экосистема с безграничными возможностями и миллионами пользователей.
-          </MiniInfoCell>
-    
-          <MiniInfoCell
-            before={<Icon20FollowersOutline />}
-            after={
-              <UsersStack
-                photos={[
-                  getAvatarUrl('user_mm'),
-                  getAvatarUrl('user_arthurstam'),
-                  getAvatarUrl('user_xyz'),
-                ]}
-              />
-            }
-          >
-            514,7K подписчиков · 77 друзей
-          </MiniInfoCell>
-    
-          <MiniInfoCell
-            before={<Icon20GlobeOutline />}
-          >
-            <Link href="https://vk.com/team">vk.com/team</Link>
-          </MiniInfoCell>
-    
-          <MiniInfoCell
-            before={<Icon20WorkOutline />}
-            after={<Avatar size={24} src="https://sun9-29.userapi.com/c623616/v623616034/1c184/MnbEYczHxSY.jpg?ava=1" />}
-          >
-            Место работы: Команда ВКонтакте
-          </MiniInfoCell>
-    
-          <MiniInfoCell
-            before={<Icon20WorkOutline />}
-            mode="add"
-            onClick={() => console.log('Указать место учёбы')}
-          >
-            Укажите место учёбы
-          </MiniInfoCell>
-    
-          <MiniInfoCell
-            before={<Icon20Info />}
-            mode="more"
-            onClick={handleExtendedInfoClick}
-          >
-            Подробная информация
-          </MiniInfoCell>
-    
-        </Group>
-      </Panel>
-    </View>
+    <SplitLayout modal={modal}>
+      <SplitCol>
+      <View activePanel="information_cell">
+        <Panel id="information_cell">
+          <PanelHeader>
+            Ячейка информации
+          </PanelHeader>
+      
+          <Group>
+            <MiniInfoCell
+              before={<Icon20ArticleOutline />}
+              textWrap="short"
+            >
+              ВКонтакте начинался как сайт для выпускников вузов, а сейчас это огромная экосистема с безграничными возможностями и миллионами пользователей.
+            </MiniInfoCell>
+      
+            <MiniInfoCell
+              before={<Icon20FollowersOutline />}
+              after={
+                <UsersStack
+                  photos={[
+                    getAvatarUrl('user_mm'),
+                    getAvatarUrl('user_arthurstam'),
+                    getAvatarUrl('user_xyz'),
+                  ]}
+                />
+              }
+            >
+              514,7K подписчиков · 77 друзей
+            </MiniInfoCell>
+      
+            <MiniInfoCell
+              before={<Icon20GlobeOutline />}
+            >
+              <Link href="https://vk.com/team">vk.com/team</Link>
+            </MiniInfoCell>
+      
+            <MiniInfoCell
+              before={<Icon20WorkOutline />}
+              after={<Avatar size={24} src="https://sun9-29.userapi.com/c623616/v623616034/1c184/MnbEYczHxSY.jpg?ava=1" />}
+            >
+              Место работы: Команда ВКонтакте
+            </MiniInfoCell>
+      
+            <MiniInfoCell
+              before={<Icon20WorkOutline />}
+              mode="add"
+              onClick={() => console.log('Указать место учёбы')}
+            >
+              Укажите место учёбы
+            </MiniInfoCell>
+      
+            <MiniInfoCell
+              before={<Icon20Info />}
+              mode="more"
+              onClick={handleExtendedInfoClick}
+            >
+              Подробная информация
+            </MiniInfoCell>
+      
+          </Group>
+        </Panel>
+      </View>
+      </SplitCol>
+    </SplitLayout>
   );
 }
 

--- a/src/components/ModalDismissButton/Readme.md
+++ b/src/components/ModalDismissButton/Readme.md
@@ -1,8 +1,7 @@
 Кнопка для закрытия модальных окон на широком экране.
 Для правильной отрисовки нужно расположить в контейнере с `position: "relative"` и отображать при достаточной ширине экрана (от `ViewWidth.SMALL_TABLET`)
 
-```jsx
-
+```jsx { "props": { "layout": false, "adaptivity": true } }
 const CustomPopout = withAdaptivity(({ onClose, viewWidth }) => {
   return (
     <PopoutWrapper onClick={onClose}>
@@ -29,14 +28,18 @@ const Example = () => {
   );
 
   return (
-    <View popout={popout} activePanel="popout">
-      <Panel id="popout">
-        <PanelHeader>ModalDismissButton</PanelHeader>
-        <Group>
-          <CellButton onClick={onClick}>Открыть модальное окно</CellButton>
-        </Group>
-      </Panel>
-    </View>
+    <SplitLayout popout={popout}>
+      <SplitCol>
+      <View activePanel="popout">
+        <Panel id="popout">
+          <PanelHeader>ModalDismissButton</PanelHeader>
+          <Group>
+            <CellButton onClick={onClick}>Открыть модальное окно</CellButton>
+          </Group>
+        </Panel>
+      </View>
+      </SplitCol>
+    </SplitLayout>
   );
 }
 

--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -8,7 +8,7 @@
 **Важно:** структура модальных страниц и карточек должна определяться единожды на старте приложения. Структура – это *декларация* приложения.
 То есть, один раз определив структуру вида:
 
-```jsx static
+```jsx static { "props": { "layout": false, "adaptivity": true } }
 class App extends Component {
   render() {
     const modal = (
@@ -23,9 +23,9 @@ class App extends Component {
     );
 
     return (
-      <View modal={modal}>
+      <SplitLayout modal={modal}>
         ...
-      </View>
+      </SplitLayout>
     );
   }
 }
@@ -410,25 +410,29 @@ const App = withPlatform(withAdaptivity(class App extends React.Component {
     );
 
     return (
-      <View activePanel="modals" modal={modal}>
-        <Panel id="modals">
-          <PanelHeader>Модальные окна</PanelHeader>
-            <Group>
-              <CellButton onClick={() => this.setActiveModal(MODAL_PAGE_FILTERS)}>
-                Открыть модальную страницу
-              </CellButton>
-              <CellButton multiline onClick={() => this.setActiveModal(MODAL_PAGE_FULLSCREEN)}>
-                Открыть полноэкранную модальную страницу
-              </CellButton>
-              <CellButton multiline onClick={() => this.setActiveModal(MODAL_PAGE_DYNAMIC)}>
-                Открыть модальную страницу с динамической высотой
-              </CellButton>
-              <CellButton onClick={() => this.setActiveModal(MODAL_CARD_MONEY_SEND)}>
-                Открыть модальные карточки
-              </CellButton>
-            </Group>
-        </Panel>
-      </View>
+      <SplitLayout modal={modal}>
+        <SplitCol>
+        <View activePanel="modals">
+          <Panel id="modals">
+            <PanelHeader>Модальные окна</PanelHeader>
+              <Group>
+                <CellButton onClick={() => this.setActiveModal(MODAL_PAGE_FILTERS)}>
+                  Открыть модальную страницу
+                </CellButton>
+                <CellButton multiline onClick={() => this.setActiveModal(MODAL_PAGE_FULLSCREEN)}>
+                  Открыть полноэкранную модальную страницу
+                </CellButton>
+                <CellButton multiline onClick={() => this.setActiveModal(MODAL_PAGE_DYNAMIC)}>
+                  Открыть модальную страницу с динамической высотой
+                </CellButton>
+                <CellButton onClick={() => this.setActiveModal(MODAL_CARD_MONEY_SEND)}>
+                  Открыть модальные карточки
+                </CellButton>
+              </Group>
+          </Panel>
+        </View>
+        </SplitCol>
+      </SplitLayout>
     );
   }
 }, {
@@ -464,11 +468,15 @@ class App extends Component {
     );
 
     return (
-      <View activePanel="main" modal={modal}>
-        <Panel id="main">
-          ...
-        </Panel>
-      </View>
+      <SplitLayout modal={modal}>
+        <SplitCol>
+        <View activePanel="main">
+          <Panel id="main">
+            ...
+          </Panel>
+        </View>
+        </SplitCol>
+      </SplitLayout>
     );
   }
 }

--- a/src/components/ScreenSpinner/Readme.md
+++ b/src/components/ScreenSpinner/Readme.md
@@ -4,7 +4,7 @@
 
 Рекомендуется использовать в случаях, когда требуется заблокировать интерфейс до завершения асинхронного процесса.
 
-```jsx
+```jsx { "props": { "layout": false, "adaptivity": true } }
 class Example extends React.Component {
 
   constructor (props) {
@@ -21,14 +21,18 @@ class Example extends React.Component {
 
   render () {
     return (
-      <View popout={this.state.popout} activePanel="spinner">
-        <Panel id="spinner">
-          <PanelHeader>ScreenSpinner</PanelHeader>
-          <Group>
-            <CellButton onClick={this.onClick.bind(this)}>Запустить долгий процесс</CellButton>
-          </Group>
-        </Panel>
-      </View>
+      <SplitLayout popout={this.state.popout}>
+        <SplitCol>
+        <View activePanel="spinner">
+          <Panel id="spinner">
+            <PanelHeader>ScreenSpinner</PanelHeader>
+            <Group>
+              <CellButton onClick={this.onClick.bind(this)}>Запустить долгий процесс</CellButton>
+            </Group>
+          </Panel>
+        </View>
+        </SplitCol>
+      </SplitLayout>
     )
   }
 }

--- a/src/components/SubnavigationBar/Readme.md
+++ b/src/components/SubnavigationBar/Readme.md
@@ -1,7 +1,7 @@
 В режиме `fixed` может потребоваться уменьшить размер шрифта у `SubnavigationButton`, чтобы текст показывался полностью.
 За это отвечает свойство `textLevel` у `SubnavigationButton`.
 
-```jsx
+```jsx { "props": { "layout": false, "adaptivity": true } }
 import { useState } from 'react';
 
 const MODAL_NAME = 'filters';
@@ -122,91 +122,95 @@ const SubnavigationBarExample = () => {
   );
 
   return (
-    <View activePanel={activePanel} modal={modal}>
-      <Panel id="example">
-        <PanelHeader>SubnavigationBar</PanelHeader>
-        <Group>
-          <SubnavigationBar>
-            <SubnavigationButton
-              before={<Icon24Filter/>}
-              selected={filtersCount > 0}
-              expandable
-              after={filtersCount > 0 && <Counter mode="primary" size="s">{filtersCount}</Counter>}
-              onClick={openModal}
-            >
-              Фильтры
-            </SubnavigationButton>
+    <SplitLayout modal={modal}>
+      <SplitCol>
+      <View activePanel={activePanel}>
+        <Panel id="example">
+          <PanelHeader>SubnavigationBar</PanelHeader>
+          <Group>
+            <SubnavigationBar>
+              <SubnavigationButton
+                before={<Icon24Filter/>}
+                selected={filtersCount > 0}
+                expandable
+                after={filtersCount > 0 && <Counter mode="primary" size="s">{filtersCount}</Counter>}
+                onClick={openModal}
+              >
+                Фильтры
+              </SubnavigationButton>
 
-            <SubnavigationButton
-              selected={sizeSelected}
-              onClick={() => setSizeSelected(!sizeSelected)}
-            >
-              Мой размер
-            </SubnavigationButton>
+              <SubnavigationButton
+                selected={sizeSelected}
+                onClick={() => setSizeSelected(!sizeSelected)}
+              >
+                Мой размер
+              </SubnavigationButton>
 
-            <SubnavigationButton
-              selected={inStockSelected}
-              onClick={() => setInStockSelected(!inStockSelected)}
-            >
-              В наличии
-            </SubnavigationButton>
+              <SubnavigationButton
+                selected={inStockSelected}
+                onClick={() => setInStockSelected(!inStockSelected)}
+              >
+                В наличии
+              </SubnavigationButton>
 
-            <SubnavigationButton
-              selected={highRatingSelected}
-              onClick={() => setHighRatingSelected(!highRatingSelected)}
-            >
-              Высокий рейтинг
-            </SubnavigationButton>
+              <SubnavigationButton
+                selected={highRatingSelected}
+                onClick={() => setHighRatingSelected(!highRatingSelected)}
+              >
+                Высокий рейтинг
+              </SubnavigationButton>
 
-            <SubnavigationButton
-              before={<Icon24FavoriteOutline/>}
-              selected={faveSelected}
-              onClick={() => setFaveSelected(!faveSelected)}
-            >
-              Избранное
-            </SubnavigationButton>
-          </SubnavigationBar>
-        </Group>
+              <SubnavigationButton
+                before={<Icon24FavoriteOutline/>}
+                selected={faveSelected}
+                onClick={() => setFaveSelected(!faveSelected)}
+              >
+                Избранное
+              </SubnavigationButton>
+            </SubnavigationBar>
+          </Group>
 
-        <Group>
-          <SubnavigationBar mode="fixed">
-            <SubnavigationButton
-              before={<Icon24ScanViewfinderOutline />}
-              size="l"
-              textLevel={viewWidth <= ViewWidth.MOBILE ? 3 : 1}
-              onClick={() => setActivePanel('add_friend')}
-            >
-              Сканировать QR
-            </SubnavigationButton>
+          <Group>
+            <SubnavigationBar mode="fixed">
+              <SubnavigationButton
+                before={<Icon24ScanViewfinderOutline />}
+                size="l"
+                textLevel={viewWidth <= ViewWidth.MOBILE ? 3 : 1}
+                onClick={() => setActivePanel('add_friend')}
+              >
+                Сканировать QR
+              </SubnavigationButton>
 
-            <SubnavigationButton
-              before={<Icon24UserAddOutline />}
-              size="l"
-              textLevel={viewWidth <= ViewWidth.MOBILE ? 3 : 1}
-              onClick={() => setActivePanel('add_friend')}
-            >
-              Добавить друга
-            </SubnavigationButton>
-          </SubnavigationBar>
+              <SubnavigationButton
+                before={<Icon24UserAddOutline />}
+                size="l"
+                textLevel={viewWidth <= ViewWidth.MOBILE ? 3 : 1}
+                onClick={() => setActivePanel('add_friend')}
+              >
+                Добавить друга
+              </SubnavigationButton>
+            </SubnavigationBar>
 
-          <Header>Важные</Header>
-          <SimpleCell before={<Avatar src={getAvatarUrl('user_wayshev')} />}>Иван Барышев</SimpleCell>
-          <SimpleCell before={<Avatar src={getAvatarUrl('user_lihachyov')} />}>Михаил Лихачёв</SimpleCell>
-          <SimpleCell before={<Avatar src={getAvatarUrl('user_arthurstam')} />}>Artur Stambultsian</SimpleCell>
-        </Group>
-      </Panel>
-      <Panel id="add_friend">
-        <PanelHeader
-          left={<PanelHeaderBack onClick={() => setActivePanel('example')} />}
-        >Добавить друга</PanelHeader>
+            <Header>Важные</Header>
+            <SimpleCell before={<Avatar src={getAvatarUrl('user_wayshev')} />}>Иван Барышев</SimpleCell>
+            <SimpleCell before={<Avatar src={getAvatarUrl('user_lihachyov')} />}>Михаил Лихачёв</SimpleCell>
+            <SimpleCell before={<Avatar src={getAvatarUrl('user_arthurstam')} />}>Artur Stambultsian</SimpleCell>
+          </Group>
+        </Panel>
+        <Panel id="add_friend">
+          <PanelHeader
+            left={<PanelHeaderBack onClick={() => setActivePanel('example')} />}
+          >Добавить друга</PanelHeader>
 
-        <Group>
-          <SimpleCell before={<Avatar src={getAvatarUrl('user_wayshev')} />}>Иван Барышев</SimpleCell>
-          <SimpleCell before={<Avatar src={getAvatarUrl('user_lihachyov')} />}>Михаил Лихачёв</SimpleCell>
-          <SimpleCell before={<Avatar src={getAvatarUrl('user_arthurstam')} />}>Artur Stambultsian</SimpleCell>
-        </Group>
-      </Panel>
-    </View>
+          <Group>
+            <SimpleCell before={<Avatar src={getAvatarUrl('user_wayshev')} />}>Иван Барышев</SimpleCell>
+            <SimpleCell before={<Avatar src={getAvatarUrl('user_lihachyov')} />}>Михаил Лихачёв</SimpleCell>
+            <SimpleCell before={<Avatar src={getAvatarUrl('user_arthurstam')} />}>Artur Stambultsian</SimpleCell>
+          </Group>
+        </Panel>
+      </View>
+      </SplitCol>
+    </SplitLayout>
   );
 };
 

--- a/styleguide/Components/Playground/PlaygroundRenderer.js
+++ b/styleguide/Components/Playground/PlaygroundRenderer.js
@@ -16,6 +16,7 @@ class PlaygroundRenderer extends React.Component {
     const {
       layout = true, // Нужны ли примеру обвесы в виде SplitLayout, SplitCol, etc
       iframe = true, // Нужно ли рендерить пример в айфреме
+      adaptivity: _adaptivity = true, // Нужно ли показывать продвинутые контролы адаптивности
       integration,
       containerStyle,
       config,
@@ -23,12 +24,16 @@ class PlaygroundRenderer extends React.Component {
     } = previewProps;
     const exampleId = `${name}-${exampleIndex}`;
 
+    let adaptivity = layout === false && _adaptivity !== true
+      ? false
+      : true;
+
     return (
       <div className="Playground">
         <SectionSubheading href={`#/${name}?id=example`}>Пример реализации</SectionSubheading>
-        <Settings layout={layout} />
+        <Settings adaptivity={adaptivity} />
         <div className="Playground__preview" {...wrapperProps} data-preview={name}>
-          {cloneElement(preview, { ...preview.props, layout, iframe, containerStyle, integration, config, exampleId })}
+          {cloneElement(preview, { ...preview.props, layout, iframe, adaptivity, containerStyle, integration, config, exampleId })}
         </div>
         {viewWidth > ViewWidth.MOBILE && (
           <>

--- a/styleguide/Components/Preview.js
+++ b/styleguide/Components/Preview.js
@@ -77,7 +77,7 @@ export default withAdaptivity(class Preview extends PreviewParent {
   }
 
   render() {
-    const { code, layout = true, iframe = true, config = {}, exampleId, viewWidth } = this.props;
+    const { code, layout = true, adaptivity = true, iframe = true, config = {}, exampleId, viewWidth } = this.props;
     const { error, schemeTarget } = this.state;
     const ready = !!schemeTarget;
 
@@ -111,12 +111,12 @@ export default withAdaptivity(class Preview extends PreviewParent {
             <div ref={this.getSchemeTargetRef} className={classNames('Preview', `Preview--${styleGuideContext.platform}`, { 'Preview--layout': layout })}>
               {ready &&
                 <React.Fragment>
-                  <div className="Preview__shadow" style={layout ? { maxWidth: width } : null} />
-                  <div className="Preview__in" style={layout ? { height: styleGuideContext.height } : null}>
+                  <div className="Preview__shadow" style={adaptivity ? { maxWidth: width } : null} />
+                  <div className="Preview__in" style={adaptivity ? { height: styleGuideContext.height } : null}>
                     {error ?
                       <PlaygroundError message={error} /> :
                       iframe ?
-                        <Frame width={layout && width} height={layout && styleGuideContext.height} scheme={styleGuideContext.scheme}>{content}</Frame> :
+                        <Frame width={adaptivity && width} height={adaptivity && styleGuideContext.height} scheme={styleGuideContext.scheme}>{content}</Frame> :
                         content
                     }
                   </div>

--- a/styleguide/Components/Settings/Settings.js
+++ b/styleguide/Components/Settings/Settings.js
@@ -10,7 +10,7 @@ import './Settings.css';
 import { Platform, useAdaptivity, ViewWidth } from '@vkui';
 import { StyleGuideContext } from '../StyleGuide/StyleGuideRenderer';
 
-export const Settings = ({ layout }) => {
+export const Settings = ({ adaptivity }) => {
   const { viewWidth } = useAdaptivity();
   const isMobile = viewWidth <= ViewWidth.MOBILE;
   return (
@@ -35,7 +35,7 @@ export const Settings = ({ layout }) => {
                   value={context.scheme}
                 />
               )}
-              {layout && !isMobile &&
+              {adaptivity && !isMobile &&
                 <Fragment>
                   <WebviewTypeSelect
                     onChange={(webviewType) => context.setContext({ webviewType })}


### PR DESCRIPTION
Отделила в документации свойство `layout` от свойства `adaptivity`: 
- теперь `layout` отвечает только за рендеринг обвязки из `SplitLayout` и `SplitCol` для примеров кода,
- `adaptivity` - новое свойство, контролирует рендеринг примеров кода.

----

Также убрала deprecated свойства `popout` и `modal` у `View` в примерах кода в документации.

**Список потроганных компонентов:**
- [x] ActionSheet
- [x] Alert
- [x] ModalDismissButton
- [x] ScreenSpinner
- [x] SubnavigationBar
- [x] Group
- [x] MiniInfoCell
- [x] ModalRoot

----
Связанная задача: #1985.