### PR TITLE
feat(SplitCol): Support both number and string in width props

### DIFF
--- a/src/components/Epic/Readme.md
+++ b/src/components/Epic/Readme.md
@@ -29,7 +29,7 @@ const Example = withAdaptivity(({ viewWidth }) => {
       style={{ justifyContent: "center" }}
     >
       {isDesktop && (
-        <SplitCol fixed width="280px" maxWidth="280px">
+        <SplitCol fixed width={280} maxWidth={280}>
           <Panel>
             {hasHeader && <PanelHeader />}
             <Group>

--- a/src/components/SplitCol/SplitCol.tsx
+++ b/src/components/SplitCol/SplitCol.tsx
@@ -13,9 +13,9 @@ export const SplitColContext = React.createContext<SplitColContextProps>({
 });
 
 export interface SplitColProps extends React.HTMLAttributes<HTMLDivElement> {
-  width?: string;
-  maxWidth?: string;
-  minWidth?: string;
+  width?: number | string;
+  maxWidth?: number | string;
+  minWidth?: number | string;
   /**
    * Если false, то переходы между Panel происходят без анимации
    */
@@ -28,7 +28,7 @@ export interface SplitColProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const SplitCol: React.FC<SplitColProps> = (props: SplitColProps) => {
-  const { children, width, maxWidth, minWidth, spaced, animate, fixed, style, ...restProps } = props;
+  const { children, width, maxWidth, minWidth, spaced, animate = false, fixed, style, ...restProps } = props;
   const baseRef = React.useRef<HTMLDivElement>();
 
   const contextValue = React.useMemo(() => {
@@ -58,8 +58,4 @@ export const SplitCol: React.FC<SplitColProps> = (props: SplitColProps) => {
       </SplitColContext.Provider>
     </div>
   );
-};
-
-SplitCol.defaultProps = {
-  animate: false,
 };

--- a/src/components/SplitLayout/Readme.md
+++ b/src/components/SplitLayout/Readme.md
@@ -46,7 +46,7 @@ const Example = withAdaptivity(
         modal={modalRoot}
       >
         {isDesktop && (
-          <SplitCol fixed width="280px" maxWidth="280px">
+          <SplitCol fixed width={280} maxWidth={280}>
             <Panel>
               {hasHeader && <PanelHeader />}
               <Group>

--- a/styleguide/Components/StyleGuide/StyleGuideDesktop.js
+++ b/styleguide/Components/StyleGuide/StyleGuideDesktop.js
@@ -6,7 +6,7 @@ export const StyleGuideDesktop = ({ popout, switchStyleGuideScheme, toc, childre
     <React.Fragment>
       <StyleGuideHeader switchStyleGuideScheme={switchStyleGuideScheme} />
       <SplitLayout className="StyleGuide" popout={popout}>
-        <SplitCol minWidth="340px" width="30%" maxWidth="480px" className="StyleGuide__sidebar">
+        <SplitCol minWidth={340} width="30%" maxWidth={480} className="StyleGuide__sidebar">
           <div className="StyleGuide__sidebarIn">
             {toc}
           </div>

--- a/styleguide/Components/StyleGuide/StyleGuideHeader.js
+++ b/styleguide/Components/StyleGuide/StyleGuideHeader.js
@@ -11,7 +11,7 @@ export const StyleGuideHeader = ({ switchStyleGuideScheme }) => {
   return (
     <div className="StyleGuideHeader">
       <SplitLayout>
-        <SplitCol minWidth="340px" width="30%" maxWidth="480px" className="StyleGuideHeader__left">
+        <SplitCol minWidth={340} width="30%" maxWidth={480} className="StyleGuideHeader__left">
           <div className="StyleGuideHeader__leftIn">
             <Tappable hasActive={false} hasHover={false} Component="a" href="#/About" className="StyleGuideHeader__logo">
               <Logo />

--- a/styleguide/pages/adaptivity.md
+++ b/styleguide/pages/adaptivity.md
@@ -42,7 +42,7 @@ function App() {
       <AdaptivityProvider>
         <AppRoot>
           <SplitLayout>
-            <SplitCol width="280px">
+            <SplitCol width={280}>
               <SideCol />
             </SplitCol>
             <SplitCol>
@@ -79,7 +79,7 @@ function App({ viewWidth }) {
   // ...
     <SplitLayout header={viewWidth >= ViewWidth.SMALL_TABLET && <PanelHeader separator={false} />}>
       {viewWidth === ViewWidth.DESKTOP &&
-        <SplitCol width="280px">
+        <SplitCol width={280}>
           <Panel id="nav">Navigation</Panel>
         </SplitCol>
       }


### PR DESCRIPTION
This is convenient because these properties are passed to the `style` prop, which takes both a string and a number.