### PR TITLE
ActionSheet

### DIFF
--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -53,12 +53,10 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
   const [closing, setClosing] = React.useState(false);
   const onClose = () => setClosing(true);
 
-  const [_closeAction, setCloseAction] = React.useState<VoidFunction>();
+  const closeAction = React.useRef<VoidFunction>();
   const afterClose = () => {
-    const closeAction = _closeAction;
-    setCloseAction(undefined);
     restProps.onClose();
-    closeAction && closeAction();
+    closeAction.current && closeAction.current();
   };
 
   if (process.env.NODE_ENV === 'development' && !restProps.onClose) {
@@ -87,7 +85,7 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
     event.persist();
 
     if (autoclose) {
-      setCloseAction(() => () => action && action(event));
+      closeAction.current = () => action && action(event);
       setClosing(true);
     } else {
       action && action(event);

--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -55,9 +55,10 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
 
   const [_closeAction, setCloseAction] = React.useState<VoidFunction>();
   const afterClose = () => {
-    restProps.onClose();
-    _closeAction && _closeAction();
+    const closeAction = _closeAction;
     setCloseAction(undefined);
+    restProps.onClose();
+    closeAction && closeAction();
   };
 
   if (process.env.NODE_ENV === 'development' && !restProps.onClose) {
@@ -86,7 +87,7 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
     event.persist();
 
     if (autoclose) {
-      setCloseAction(() => action && action(event));
+      setCloseAction(() => () => action && action(event));
       setClosing(true);
     } else {
       action && action(event);
@@ -111,7 +112,6 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
       <ActionSheetContext.Provider value={contextValue}>
         <DropdownComponent
           closing={closing}
-          onTransitionEnd={closing && !isDesktop ? afterClose : null}
           timeout={timeout}
           {...restProps as Omit<SharedDropdownProps, 'closing'>}
           onClose={onClose}

--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -13,6 +13,7 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { warnOnce } from '../../lib/warnOnce';
 import { SharedDropdownProps, PopupDirection, ToggleRef } from './types';
+import { noop } from '@vkontakte/vkjs';
 import './ActionSheet.css';
 
 export interface ActionSheetProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -53,10 +54,10 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
   const [closing, setClosing] = React.useState(false);
   const onClose = () => setClosing(true);
 
-  const closeAction = React.useRef<VoidFunction>();
+  const closeAction = React.useRef<VoidFunction>(noop);
   const afterClose = () => {
     restProps.onClose();
-    closeAction.current && closeAction.current();
+    closeAction.current();
   };
 
   if (process.env.NODE_ENV === 'development' && !restProps.onClose) {


### PR DESCRIPTION
- Moved `closeAction` from state to ref
- Removed `onTransitionEnd` to prevent next `ActionSheet` closing. Otherwise, it initiates with truly `closing`

fixes #2033