### PR TITLE
updated @types/react and @types/react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "@types/jest": "^26.0.15",
     "@types/jest-image-snapshot": "^4.1.3",
     "@types/node": "^12.7.2",
-    "@types/react": "^16.9.2",
-    "@types/react-dom": "^16.8.5",
+    "@types/react": "^16.14.20",
+    "@types/react-dom": "^16.9.14",
     "@types/webpack-dev-server": "^3.11.1",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.0.0",
@@ -100,6 +100,10 @@
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^4.2.2",
     "yargs": "^15.4.1"
+  },
+  "resolutions": {
+    "@types/react": "^16.14.20",
+    "@types/react-dom": "^16.9.14"
   },
   "bin": {
     "generate_scheme": "./tasks/generate_scheme.js"

--- a/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/src/components/ActionSheet/ActionSheet.test.tsx
@@ -56,7 +56,9 @@ describe('ActionSheet', () => {
     ])('does not close on %s click', (_name, getNode) => {
       const onClose = jest.fn();
       render(<ActionSheet onClose={onClose}><div data-testid="xxx" /></ActionSheet>);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       userEvent.click(getNode());
       expect(onClose).not.toBeCalled();
     });

--- a/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/src/components/FocusTrap/FocusTrap.test.tsx
@@ -69,14 +69,18 @@ describe('FocusTrap', () => {
 
   const mountActionSheetViaClick = () => {
     userEvent.click(screen.getByTestId('toggle')); // mount ActionSheet
-    act(() => jest.runAllTimers());
+    act(() => {
+      jest.runAllTimers();
+    });
   };
 
   const mountAndUnmounntActionSheet = () => {
     mountActionSheetViaClick();
 
     userEvent.keyboard('{esc}');
-    act(() => jest.runAllTimers());
+    act(() => {
+      jest.runAllTimers();
+    });
   };
 
   it('renders with no focusable elements', () => {
@@ -121,7 +125,9 @@ describe('FocusTrap', () => {
     const mountViaKeyboard = () => {
       userEvent.tab(); // focus toggle via keyboard
       userEvent.keyboard('{enter}'); // mount ActionSheet via keyboard
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
     };
 
     it('focuses first element on keyboard navigation', () => {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -4,7 +4,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import Tappable, { TappableProps } from '../Tappable/Tappable';
 import './Link.css';
 
-export interface LinkProps extends React.AnchorHTMLAttributes<HTMLElement>, TappableProps {}
+export type LinkProps = TappableProps;
 
 const Link: React.FC<LinkProps> = ({
   children,

--- a/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
+++ b/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
@@ -62,7 +62,9 @@ describe('PanelHeaderContext', () => {
           <div data-testid="xxx" />
         </PanelHeaderContext>
       ));
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(screen.queryByTestId('xxx')).toBeNull();
     });
   });

--- a/src/components/PopoutWrapper/PopoutWrapper.test.tsx
+++ b/src/components/PopoutWrapper/PopoutWrapper.test.tsx
@@ -35,7 +35,9 @@ describe('PopoutWrapper', () => {
     it('after animation if mask', () => {
       render(<PopoutWrapper hasMask />);
       expect(isOpened()).toBe(false);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(isOpened()).toBe(true);
     });
   });

--- a/src/components/Root/Root.test.tsx
+++ b/src/components/Root/Root.test.tsx
@@ -28,7 +28,9 @@ describe('Root', () => {
     it('after prop update', () => {
       render(<Root activeView="v1">{views}</Root>)
         .rerender(<Root activeView="v2">{views}</Root>);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(document.getElementById('v1')).toBeNull();
       expect(document.getElementById('v2')).not.toBeNull();
     });
@@ -49,7 +51,9 @@ describe('Root', () => {
           <Root activeView="v2" onTransition={onTransition}>{views}</Root>
         </ConfigProvider>
       ));
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(onTransition).toBeCalledTimes(1);
       expect(onTransition).toBeCalledWith({ from: 'v1', to: 'v2', isBack: false });
     });
@@ -57,7 +61,9 @@ describe('Root', () => {
       const onTransition = jest.fn();
       render(<Root activeView="v2" onTransition={onTransition}>{views}</Root>)
         .rerender(<Root activeView="v1" onTransition={onTransition}>{views}</Root>);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(onTransition).toBeCalledWith({ from: 'v2', to: 'v1', isBack: true });
     });
     it('once on rapid transitions', () => {
@@ -65,7 +71,9 @@ describe('Root', () => {
       const h = render(<Root activeView="v2" onTransition={onTransition}>{views}</Root>);
       h.rerender(<Root activeView="v1" onTransition={onTransition}>{views}</Root>);
       h.rerender(<Root activeView="v3" onTransition={onTransition}>{views}</Root>);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(onTransition).toBeCalledTimes(1);
       expect(onTransition).toBeCalledWith({ from: 'v1', to: 'v3', isBack: false });
     });
@@ -74,7 +82,9 @@ describe('Root', () => {
       const h = render(<Root activeView="v1" onTransition={onTransition}>{views}</Root>);
       h.rerender(<Root activeView="v2" onTransition={onTransition}>{views}</Root>);
       h.rerender(<Root activeView="v1" onTransition={onTransition}>{views}</Root>);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(onTransition).toBeCalledTimes(1);
       expect(onTransition).toBeCalledWith({ from: 'v2', to: 'v1', isBack: true });
     });
@@ -105,7 +115,9 @@ describe('Root', () => {
       // trigger scroll save
       h.rerender(<MockScroll><Root activeView="v2">{views}</Root></MockScroll>);
       h.rerender(<MockScroll><Root activeView="v1">{views}</Root></MockScroll>);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(scrollTo).toBeCalledWith(0, y);
     });
     it('resets on forward navigation', () => {
@@ -115,7 +127,9 @@ describe('Root', () => {
       // trigger scroll save
       h.rerender(<MockScroll><Root activeView="v1">{views}</Root></MockScroll>);
       h.rerender(<MockScroll><Root activeView="v2">{views}</Root></MockScroll>);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(scrollTo.mock.calls[scrollTo.mock.calls.length - 1]).toEqual([0, 0]);
     });
   });

--- a/src/components/Tappable/Tappable.test.tsx
+++ b/src/components/Tappable/Tappable.test.tsx
@@ -170,7 +170,9 @@ describe('Tappable', () => {
       expect(waveCount()).toBe(1);
       userEvent.click(screen.getByTestId('x'));
       expect(waveCount()).toBe(2);
-      act(() => jest.runAllTimers());
+      act(() => {
+        jest.runAllTimers();
+      });
       // removes waves
       expect(waveCount()).toBe(0);
     });
@@ -179,14 +181,18 @@ describe('Tappable', () => {
       render(<TappableTest />);
       userEvent.click(tappable());
       expect(isActive()).toBe(true);
-      act(() => jest.runOnlyPendingTimers());
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
       expect(isActive()).toBe(false);
     });
     it('activates during longtap', () => {
       render(<TappableTest />);
       fireEvent.mouseDown(tappable());
       expect(isActive()).toBe(false);
-      act(() => jest.runOnlyPendingTimers());
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
       expect(isActive()).toBe(true);
       fireEvent.mouseUp(tappable());
       expect(isActive()).toBe(true);
@@ -202,7 +208,9 @@ describe('Tappable', () => {
       it('on slide', () => {
         render(<TappableTest />);
         fireEvent.mouseDown(tappable(), { clientX: 10 });
-        act(() => jest.runOnlyPendingTimers());
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
         fireEvent.mouseMove(tappable(), { clientX: 40 });
         expect(isActive()).toBe(false);
       });
@@ -210,28 +218,36 @@ describe('Tappable', () => {
         window.ontouchstart = null;
         render(<TappableTest />);
         fireEvent.touchStart(tappable(), { touches: [{}], changedTouches: [{}] });
-        act(() => jest.runOnlyPendingTimers());
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
         fireEvent.touchStart(tappable(), { touches: [{}, {}], changedTouches: [{}] });
         expect(isActive()).toBe(false);
       });
       it('on disable', () => {
         const h = render(<TappableTest />);
         fireEvent.mouseDown(tappable());
-        act(() => jest.runOnlyPendingTimers());
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
         h.rerender(<TappableTest disabled />);
         expect(isActive()).toBe(false);
       });
       it('on hasActive=false', () => {
         const h = render(<TappableTest />);
         fireEvent.mouseDown(tappable());
-        act(() => jest.runOnlyPendingTimers());
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
         h.rerender(<TappableTest hasActive={false} />);
         expect(isActive()).toBe(false);
       });
       it('on child hover', () => {
         render(<TappableTest><Tappable data-testid="c" /></TappableTest>);
         fireEvent.mouseDown(tappable());
-        act(() => jest.runOnlyPendingTimers());
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
         userEvent.hover(screen.getByTestId('c'));
         expect(isActive()).toBe(false);
       });

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -10,7 +10,9 @@ export function fakeTimers() {
   afterEach(() => jest.useRealTimers());
 }
 
-export const runAllTimers = () => act(() => jest.runAllTimers());
+export const runAllTimers = () => act(() => {
+  jest.runAllTimers();
+});
 
 export const imgOnlyAttributes: ImgOnlyAttributes = {
   alt: 'test',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,18 +2296,12 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@>=16.9.0":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
-  integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
+"@types/react-dom@>=16.9.0", "@types/react-dom@^16.9.14":
+  version "16.9.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
+  integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
   dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^16.8.5":
-  version "16.9.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.5.tgz#5de610b04a35d07ffd8f44edad93a71032d9aaa7"
-  dependencies:
-    "@types/react" "*"
+    "@types/react" "^16"
 
 "@types/react-test-renderer@>=16.9.0":
   version "17.0.1"
@@ -2316,10 +2310,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^16.9.2":
-  version "16.14.5"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.5.tgz#2c39b5cadefaf4829818f9219e5e093325979f4d"
-  integrity sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^16", "@types/react@^16.14.20":
+  version "16.14.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.20.tgz#ff6e932ad71d92c27590e4a8667c7a53a7d0baad"
+  integrity sha512-SV7TaVc8e9E/5Xuv6TIyJ5VhQpZoVFJqX6IZgj5HZoFCtIDCArE3qXkcHlc6O/Ud4UwcMoX+tlvDA95YrKdLgA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
В обновленной версии `@types/react` обновился тип `target` у `AnchorHTMLAttributes`. Учитывая, что `Link` использует `Tappable`, который наследуется от `AllHTMLAttributes`, я решил, что экстенд от `AnchorHTMLAttributes`, приводящий к конфликтам, можно убрать.

После обновления пришлось обновить типы у `act` в тестах.

fixes #2064 