### PR TITLE
Touch test: fixed emptyGesture duration

### DIFF
--- a/src/components/Touch/Touch.test.tsx
+++ b/src/components/Touch/Touch.test.tsx
@@ -101,7 +101,7 @@ describe('Touch', () => {
           startX: x,
           startY: y,
           startT: expect.any(Date),
-          duration: 0,
+          duration: expect.any(Number),
           isPressed: true,
           isY: false,
           isX: false,


### PR DESCRIPTION
Тест иногда валился из-за того, что `duration` был не 0, а 1 или 2