### PR TITLE
Textarea: resize logic fixes

### DIFF
--- a/src/components/Textarea/Readme.md
+++ b/src/components/Textarea/Readme.md
@@ -10,6 +10,9 @@
         <FormItem top="Любимая музыка">
           <Textarea placeholder="Группы, исполнители, продюсеры" />
         </FormItem>
+        <FormItem top="Увлечения">
+          <Textarea cols={4} placeholder="Музыка, спорт" defaultValue="Музыка\nСпорт\nФотография\nПлавание\nПрограммирование" />
+        </FormItem>
         <FormItem top="Прикидываемся Input">
           <Textarea rows={1} placeholder="Once upon a time" />
         </FormItem>

--- a/src/components/Textarea/Textarea.test.tsx
+++ b/src/components/Textarea/Textarea.test.tsx
@@ -64,5 +64,12 @@ describe('Textarea', () => {
         .rerender(<Textarea value="\n\n\n\n" onResize={onResize} />);
       expect(onResize).toHaveBeenCalled();
     });
+    it('won\'t resize if parent is invisible', () => {
+      const onResize = jest.fn();
+      render(<div style={{ display: 'none' }}>
+        <Textarea onResize={onResize} />
+      </div>).rerender(<Textarea value="\n\n\n\n" onResize={onResize} />);
+      expect(onResize).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Textarea/Textarea.test.tsx
+++ b/src/components/Textarea/Textarea.test.tsx
@@ -66,9 +66,15 @@ describe('Textarea', () => {
     });
     it('won\'t resize if parent is invisible', () => {
       const onResize = jest.fn();
-      render(<div style={{ display: 'none' }}>
-        <Textarea onResize={onResize} />
-      </div>).rerender(<Textarea value="\n\n\n\n" onResize={onResize} />);
+      render(
+        <div style={{ display: 'none' }}>
+          <Textarea onResize={onResize} />
+        </div>,
+      ).rerender(
+        <div style={{ display: 'none' }}>
+          <Textarea value="\n\n\n\n" onResize={onResize} />
+        </div>,
+      );
       expect(onResize).not.toHaveBeenCalled();
     });
   });

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -7,7 +7,6 @@ import { getClassName } from '../../helpers/getClassName';
 import { useEnsuredControl } from '../../hooks/useEnsuredControl';
 import { useExternRef } from '../../hooks/useExternRef';
 import { usePlatform } from '../../hooks/usePlatform';
-import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import './Textarea.css';
 
 export interface TextareaProps extends
@@ -33,19 +32,24 @@ const Textarea: React.FC<TextareaProps> = React.memo(({
   ...restProps
 }: TextareaProps) => {
   const [value, onChange] = useEnsuredControl(restProps, { defaultValue });
+  const currentScrollHeight = React.useRef<number>();
   const elementRef = useExternRef(getRef);
   const platform = usePlatform();
 
   // autosize input
-  useIsomorphicLayoutEffect(() => {
+  React.useEffect(() => {
     const el = elementRef.current;
-    if (grow) {
+
+    if (grow && el.offsetParent) {
       el.style.height = null;
       el.style.height = `${el.scrollHeight}px`;
-      // TODO: call only when height changed?
-      onResize && onResize(el);
+
+      if (el.scrollHeight !== currentScrollHeight.current && onResize) {
+        onResize(el);
+        currentScrollHeight.current = el.scrollHeight;
+      }
     }
-  }, [grow, value]);
+  }, [grow, value, sizeY]);
 
   return (
     <FormField

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -125,3 +125,34 @@ export const mockScrollContext = (getY: () => number): [React.FC, jest.Mock] => 
     scrollTo,
   ];
 };
+
+const isNullOrUndefined = (val: any) => val === null || val === undefined;
+
+// Согласно спеке, offsetParent в ряде случаев будет null
+Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+  get() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let element: HTMLElement = this;
+    while (!isNullOrUndefined(element) &&
+    (isNullOrUndefined(element.style) ||
+      isNullOrUndefined(element.style.display) ||
+      element.style.display.toLowerCase() !== 'none')) {
+      // @ts-ignore
+      element = element.parentNode;
+    }
+
+    if (!isNullOrUndefined(element)) {
+      return null;
+    }
+
+    if (!isNullOrUndefined(this.style) && !isNullOrUndefined(this.style.position) && this.style.position.toLowerCase() === 'fixed') {
+      return null;
+    }
+
+    if (this.tagName.toLowerCase() === 'html' || this.tagName.toLowerCase() === 'body') {
+      return null;
+    }
+
+    return this.parentNode;
+  },
+});


### PR DESCRIPTION
- Не ресайзим, если `offsetParent === null`. Такое значение сигнализирует о том, что элемент или родитель скрыты с помощью стилей. Если запустить ресайз в таком случае, то `scrollHeight` вернет `0` и `textarea` схлопнется.
- Не вызываем `onResize`, если значение не поменялось.
- Ресайзим, если поменялся `sizeY` (fixes #1976)