### PR TITLE
Action sheet fix

### DIFF
--- a/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/src/components/ActionSheet/ActionSheet.test.tsx
@@ -70,6 +70,7 @@ describe('ActionSheet', () => {
       render(<ActionSheetDesktop onClose={onClose} />);
       jest.runAllTimers();
       userEvent.click(document.body);
+      jest.runAllTimers();
       expect(onClose).toBeCalledTimes(1);
     });
     it('calls popupDirection with element', () => {

--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -82,7 +82,9 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
     }
   }, [closing]);
 
-  const onItemClick = React.useCallback<ItemClickHandler>((action, autoclose) => (event) => {
+  const onItemClick = React.useCallback<ItemClickHandler>((action, immediateAction, autoclose) => (event) => {
+    event.persist();
+    immediateAction && immediateAction(event);
     if (autoclose) {
       _action.current = () => action && action(event);
       setClosing(true);

--- a/src/components/ActionSheet/ActionSheet.tsx
+++ b/src/components/ActionSheet/ActionSheet.tsx
@@ -4,7 +4,7 @@ import { ViewWidth, ViewHeight } from '../../hoc/withAdaptivity';
 import { IOS } from '../../lib/platform';
 import { ActionSheetDropdownDesktop } from './ActionSheetDropdownDesktop';
 import { ActionSheetDropdown } from './ActionSheetDropdown';
-import { hasReactNode } from '../../lib/utils';
+import { hasReactNode, noop } from '../../lib/utils';
 import { ActionSheetContext, ItemClickHandler } from './ActionSheetContext';
 import Caption from '../Typography/Caption/Caption';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -52,9 +52,12 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
   const platform = usePlatform();
   const [closing, setClosing] = React.useState(false);
   const onClose = () => setClosing(true);
+  const _action = React.useRef(noop);
 
   const afterClose = () => {
     restProps.onClose();
+    _action.current();
+    _action.current = noop;
   };
 
   if (process.env.NODE_ENV === 'development' && !restProps.onClose) {
@@ -64,25 +67,27 @@ export const ActionSheet: React.FC<ActionSheetProps> = ({
   const { viewWidth, viewHeight, hasMouse } = useAdaptivity();
   const isDesktop = viewWidth >= ViewWidth.SMALL_TABLET && (hasMouse || viewHeight >= ViewHeight.MEDIUM);
 
-  const timeout = platform === IOS ? 300 : 200;
+  let timeout = platform === IOS ? 300 : 200;
+
+  if (isDesktop) {
+    timeout = 0;
+  }
 
   const fallbackTransitionFinish = useTimeout(afterClose, timeout);
   React.useEffect(() => {
     if (closing) {
-      if (isDesktop) {
-        afterClose();
-      } else {
-        fallbackTransitionFinish.set();
-      }
+      fallbackTransitionFinish.set();
     } else {
       fallbackTransitionFinish.clear();
     }
   }, [closing]);
 
   const onItemClick = React.useCallback<ItemClickHandler>((action, autoclose) => (event) => {
-    action && action(event);
     if (autoclose) {
+      _action.current = () => action && action(event);
       setClosing(true);
+    } else {
+      action && action(event);
     }
   }, []);
   const contextValue = useObjectMemo({ onItemClick, isDesktop });

--- a/src/components/ActionSheet/ActionSheetContext.ts
+++ b/src/components/ActionSheet/ActionSheetContext.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export type ActionType = (event: React.MouseEvent) => void;
 
-export type ItemClickHandler = (action: ActionType, autoclose: boolean) => (event: React.MouseEvent) => void;
+export type ItemClickHandler = (action: ActionType, immediateAction: ActionType, autoclose: boolean) => (event: React.MouseEvent) => void;
 
 export const ActionSheetContext = React.createContext<{
   onItemClick?: ItemClickHandler;

--- a/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
+++ b/src/components/ActionSheet/ActionSheetDropdownDesktop.tsx
@@ -76,9 +76,7 @@ export const ActionSheetDropdownDesktop: React.FC<SharedDropdownProps> = ({
       getRootRef={elementRef}
       onClick={onClick}
       style={dropdownStyles}
-      vkuiClass={classNames(getClassName('ActionSheet', platform), 'ActionSheet--desktop', {
-        'ActionSheet--closing': closing,
-      }, `ActionSheet--sizeY-${sizeY}`)}
+      vkuiClass={classNames(getClassName('ActionSheet', platform), 'ActionSheet--desktop', `ActionSheet--sizeY-${sizeY}`)}
     >
       {children}
     </FocusTrap>

--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -26,6 +26,13 @@ export interface ActionSheetItemProps extends
   autoclose?: boolean;
   selectable?: boolean;
   disabled?: boolean;
+  /**
+   * Если autoclose === true, onClick будет вызван после завершения анимации скрытия и после вызова onClose.
+   * Из этого следует, что в объекте события значения полей типа `currentTarget` будут не определены.
+   * Если вам нужен объект события именно на момент клика, используйте `onImmediateClick`.
+   */
+  onClick?: React.MouseEventHandler<HTMLElement>;
+  onImmediateClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 const ActionSheetItem: React.FC<ActionSheetItemProps> = ({
@@ -43,6 +50,7 @@ const ActionSheetItem: React.FC<ActionSheetItemProps> = ({
   onChange,
   onClick,
   sizeY,
+  onImmediateClick,
   ...restProps
 }: ActionSheetItemProps) => {
   const platform = usePlatform();
@@ -59,7 +67,7 @@ const ActionSheetItem: React.FC<ActionSheetItemProps> = ({
   return (
     <Tappable
       {...restProps}
-      onClick={selectable ? onClick : onItemClick(onClick, autoclose)}
+      onClick={selectable ? onClick : onItemClick(onClick, onImmediateClick, autoclose)}
       activeMode="ActionSheetItem--active"
       vkuiClass={
         classNames(
@@ -130,7 +138,7 @@ const ActionSheetItem: React.FC<ActionSheetItemProps> = ({
             name={name}
             value={value}
             onChange={onChange}
-            onClick={onItemClick(noop, autoclose)}
+            onClick={onItemClick(noop, noop, autoclose)}
             defaultChecked={defaultChecked}
             checked={checked}
             disabled={restProps.disabled}


### PR DESCRIPTION
Недоразумения с ActionSheet продолжаются

Мной была выпилена логика отложенного вызова `onClick` в режиме `autoclose`. Сейчас я понимаю, что такой апдейт может сломать кейсы, когда по клику происходит переход: анимация закрытия шита наслоится на анимацию перехода. Такой апдейт мог сломать бог знает что ещё. Поэтому:

1. Вернули отложенность вызова `onClick`. Так работало до переписывания компонента на функциональный и мы не должны это поведение менять. Если `autoclose === true`, `onClick` будет вызван после завершения анимации скрытия и после вызова `onClose`. Из этого следует, что в объекте события значения полей типа `currentTarget` будут не определены. Если вам нужен объект события именно на момент клика, используйте `onImmediateClick`.
2. С десктопом, где нет анимации скрытия, всё ещё веселее. В случае, когда один шит открывал другой, не происходило анмаунта первого, что приводило к лютым багам. Поэтому теперь в любом случае ставится таймаут вызова `afterClose`.