### PR TITLE
default `noop` for `onRemove`

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { classNames } from "../../lib/classNames";
+import { noop } from "../../lib/utils";
 import { warnOnce } from "../../lib/warnOnce";
 import { getClassName } from "../../helpers/getClassName";
 import { ANDROID, IOS, VKCOM } from "../../lib/platform";
@@ -58,7 +59,7 @@ export interface CellProps
 const warn = warnOnce("Cell");
 export const Cell: React.FC<CellProps> = ({
   mode: propsMode, // TODO: убрать переименование в propsMode перед 5.0.0
-  onRemove,
+  onRemove = noop,
   removePlaceholder = "Удалить",
   onDragFinish,
   before,

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -4,7 +4,7 @@ import { classNames } from "../../lib/classNames";
 import { useExternRef } from "../../hooks/useExternRef";
 import { usePlatform } from "../../hooks/usePlatform";
 import { getClassName } from "../../helpers/getClassName";
-import { hasReactNode } from "../../lib/utils";
+import { hasReactNode, noop } from "../../lib/utils";
 import Subhead from "../Typography/Subhead/Subhead";
 import Caption from "../Typography/Caption/Caption";
 import { useAdaptivity } from "../../hooks/useAdaptivity";
@@ -32,7 +32,7 @@ export const FormItem: React.FC<FormItemProps> = ({
   status = "default",
   Component = "div",
   removable,
-  onRemove,
+  onRemove = noop,
   removePlaceholder = "Удалить",
   getRootRef,
   ...restProps

--- a/src/components/FormLayoutGroup/FormLayoutGroup.tsx
+++ b/src/components/FormLayoutGroup/FormLayoutGroup.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { HasRootRef } from "../../types";
 import { getClassName } from "../../helpers/getClassName";
 import { classNames } from "../../lib/classNames";
+import { noop } from "../../lib/utils";
 import { useExternRef } from "../../hooks/useExternRef";
 import { usePlatform } from "../../hooks/usePlatform";
 import { Removable, RemovableProps } from "../Removable/Removable";
@@ -24,7 +25,7 @@ const FormLayoutGroup: React.FC<FormLayoutGroupProps> = ({
   mode = "vertical",
   removable,
   removePlaceholder = "Удалить",
-  onRemove,
+  onRemove = noop,
   getRootRef,
   ...restProps
 }: FormLayoutGroupProps) => {


### PR DESCRIPTION
Чтобы `onRemove` не выстреливал неожиданной ошибкой, когда в доке пытаешься посмотреть, как выглядит какой-нибудь компонент, у которого доступен `removable`.

- [x] Cell
- [x] FormItem
- [x] FormLayoutGroup