### PR TITLE
Dropdown and co: simplified types

### DIFF
--- a/src/components/ClickPopper/ClickPopper.tsx
+++ b/src/components/ClickPopper/ClickPopper.tsx
@@ -12,7 +12,7 @@ export interface ClickPopperProps extends PopperCommonProps {
    */
   content?: React.ReactNode;
   /**
-   * Если передан, то тултип будет показыван/скрыт в зависимости от значения свойства
+   * Если передан, то тултип будет показан/скрыт в зависимости от значения свойства
    */
   shown?: boolean;
   /**

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,55 +1,14 @@
 import * as React from "react";
 import { HoverPopper, HoverPopperProps } from "../HoverPopper/HoverPopper";
-import { ClickPopper } from "../ClickPopper/ClickPopper";
+import { ClickPopper, ClickPopperProps } from "../ClickPopper/ClickPopper";
 import { getClassName } from "../../helpers/getClassName";
 import { usePlatform } from "../../hooks/usePlatform";
-import { Placement } from "../Popper/Popper";
 import "./Dropdown.css";
 
-// Приходится избегать экстендов от HoverPopperProps, ClickPopperProps и PopperProps, потому что react-docgen не умеет в Omit.
-// Ждём либо фикса react-docgen (что вряд ли), либо переезда на react-docgen-typescript, где такой проблемы нет.
-export interface DropdownProps {
-  /**
-   * По умолчанию компонент выберет наилучшее расположение сам. Но его можно задать извне с помощью этого свойства
-   */
-  placement?: Placement;
-  /**
-   * Отступ по вспомогательной оси
-   */
-  offsetSkidding?: number;
-  /**
-   * Отступ по главной оси
-   */
-  offsetDistance?: number;
-  onPlacementChange?: (data: { placement?: Placement }) => void;
-  /**
-   * Содержимое тултипа
-   */
-  content?: React.ReactNode;
-  /**
-   * Если передан, то тултип будет показыван/скрыт в зависимости от значения свойства
-   */
-  shown?: boolean;
-  /**
-   * Вызывается при каждом изменении видимости тултипа
-   */
-  onShownChange?: (shown: boolean) => void;
-  /**
-   * Либо jsx-элемент (div, button, etc.), либо компонент со свойством `getRootRef`, которое применяется к корневому элементу компонента
-   */
-  children?: React.ReactElement;
-
+export interface DropdownProps
+  extends Omit<ClickPopperProps, "arrow" | "arrowClassName">,
+    Omit<HoverPopperProps, "arrow" | "arrowClassName"> {
   action?: "click" | "hover";
-  /**
-   * Актуально только для action="hover"
-   * Количество миллисекунд, после которых произойдет показ дропдауна
-   */
-  showDelay?: HoverPopperProps["showDelay"];
-  /**
-   * Актуально только для action="hover"
-   * Количество миллисекунд, после которых произойдет скрытие дропдауна
-   */
-  hideDelay?: HoverPopperProps["hideDelay"];
 }
 
 export const Dropdown: React.FC<DropdownProps> = ({

--- a/src/components/HoverPopper/HoverPopper.tsx
+++ b/src/components/HoverPopper/HoverPopper.tsx
@@ -11,7 +11,7 @@ export interface HoverPopperProps extends PopperCommonProps {
    */
   content?: React.ReactNode;
   /**
-   * Если передан, то тултип будет показыван/скрыт в зависимости от значения свойства
+   * Если передан, то тултип будет показан/скрыт в зависимости от значения свойства
    */
   shown?: boolean;
   /**

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -203,7 +203,7 @@
 }
 
 .SplitCol--spaced
-  .PanelHeader--android.PanelHeader--no-left
+  .PanelHeader--android.PanelHeader--no-left:not(.ModalPageHeader)
   .PanelHeader__content {
   padding-left: 0;
 }
@@ -218,7 +218,7 @@
 }
 
 .SplitCol--spaced
-  .PanelHeader--android.PanelHeader--no-right
+  .PanelHeader--android.PanelHeader--no-right:not(.ModalPageHeader)
   .PanelHeader__content {
   padding-right: 0;
 }

--- a/src/components/RichTooltip/RichTooltip.tsx
+++ b/src/components/RichTooltip/RichTooltip.tsx
@@ -1,55 +1,13 @@
 import * as React from "react";
-import { HoverPopper } from "../HoverPopper/HoverPopper";
+import { HoverPopper, HoverPopperProps } from "../HoverPopper/HoverPopper";
 import { getClassName } from "../../helpers/getClassName";
 import { usePlatform } from "../../hooks/usePlatform";
 import { useAppearance } from "../../hooks/useAppearance";
 import { classNames } from "../../lib/classNames";
 import { prefixClass } from "../../lib/prefixClass";
-import { Placement } from "../Popper/Popper";
 import "./RichTooltip.css";
 
-// Приходится избегать экстендов от HoverPopperProps и PopperProps, потому что react-docgen не умеет в Omit.
-// Ждём либо фикса react-docgen (что вряд ли), либо переезда на react-docgen-typescript, где такой проблемы нет.
-export interface RichTooltipProps {
-  /**
-   * Содержимое тултипа
-   */
-  content?: React.ReactNode;
-  /**
-   * Если передан, то тултип будет показыван/скрыт в зависимости от значения свойства
-   */
-  shown?: boolean;
-  /**
-   * Вызывается при каждом изменении видимости тултипа
-   */
-  onShownChange?: (shown: boolean) => void;
-  /**
-   * Количество миллисекунд, после которых произойдет показ дропдауна
-   */
-  showDelay?: number;
-  /**
-   * Количество миллисекунд, после которых произойдет скрытие дропдауна
-   */
-  hideDelay?: number;
-  /**
-   * Либо jsx-элемент (div, button, etc.), либо компонент со свойством `getRootRef`, которое применяется к корневому элементу компонента
-   */
-  children?: React.ReactElement;
-  /**
-   * По умолчанию компонент выберет наилучшее расположение сам. Но его можно задать извне с помощью этого свойства
-   */
-  placement?: Placement;
-  /**
-   * Отступ по вспомогательной оси
-   */
-  offsetSkidding?: number;
-  /**
-   * Отступ по главной оси
-   */
-  offsetDistance?: number;
-  onPlacementChange?: (data: { placement?: Placement }) => void;
-  arrow?: boolean;
-}
+export type RichTooltipProps = Omit<HoverPopperProps, "arrowClassName">;
 
 export const RichTooltip: React.FC<RichTooltipProps> = ({
   children,

--- a/src/components/TextTooltip/TextTooltip.tsx
+++ b/src/components/TextTooltip/TextTooltip.tsx
@@ -1,49 +1,14 @@
 import * as React from "react";
-import { HoverPopper } from "../HoverPopper/HoverPopper";
+import { HoverPopper, HoverPopperProps } from "../HoverPopper/HoverPopper";
 import { getClassName } from "../../helpers/getClassName";
 import { usePlatform } from "../../hooks/usePlatform";
 import { hasReactNode } from "../../lib/utils";
-import { Placement } from "../Popper/Popper";
 import Subhead from "../Typography/Subhead/Subhead";
 import { prefixClass } from "../../lib/prefixClass";
 import "./TextTooltip.css";
 
-// Приходится избегать экстендов от HoverPopperProps и PopperProps, потому что react-docgen не умеет в Omit.
-// Ждём либо фикса react-docgen (что вряд ли), либо переезда на react-docgen-typescript, где такой проблемы нет.
-export interface TextTooltipProps {
-  /**
-   * Если передан, то тултип будет показыван/скрыт в зависимости от значения свойства
-   */
-  shown?: boolean;
-  /**
-   * Вызывается при каждом изменении видимости тултипа
-   */
-  onShownChange?: (shown: boolean) => void;
-  /**
-   * Количество миллисекунд, после которых произойдет показ дропдауна
-   */
-  showDelay?: number;
-  /**
-   * Количество миллисекунд, после которых произойдет скрытие дропдауна
-   */
-  hideDelay?: number;
-  /**
-   * Либо jsx-элемент (div, button, etc.), либо компонент со свойством `getRootRef`, которое применяется к корневому элементу компонента
-   */
-  children?: React.ReactElement;
-  /**
-   * По умолчанию компонент выберет наилучшее расположение сам. Но его можно задать извне с помощью этого свойства
-   */
-  placement?: Placement;
-  /**
-   * Отступ по вспомогательной оси
-   */
-  offsetSkidding?: number;
-  /**
-   * Отступ по главной оси
-   */
-  offsetDistance?: number;
-  onPlacementChange?: (data: { placement?: Placement }) => void;
+export interface TextTooltipProps
+  extends Omit<HoverPopperProps, "arrow" | "arrowClassName" | "content"> {
   /**
    * Текст тултипа
    */


### PR DESCRIPTION
Сделал нормальный экстенд типов для выпадашек. Раньше он был невозможен из-за кривого отображения в стайлгайдисте.