### PR TITLE
supported custom platform

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ import {
   SizeType,
   withAdaptivity,
 } from "../../hoc/withAdaptivity";
-import { Platform, IOS, VKCOM } from "../../lib/platform";
+import { IOS, VKCOM, PlatformType } from "../../lib/platform";
 import Spinner from "../Spinner/Spinner";
 import "./Button.css";
 
@@ -45,7 +45,7 @@ export interface ButtonProps
 
 interface ButtonTypographyProps extends HasComponent {
   size: ButtonProps["size"];
-  platform: Platform | undefined;
+  platform: PlatformType | undefined;
   sizeY: AdaptivityProps["sizeY"];
   children?: ButtonProps["children"];
 }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -10,7 +10,11 @@ export const ANDROID = Platform.ANDROID;
 export const IOS = Platform.IOS;
 export const VKCOM = Platform.VKCOM;
 
-export type PlatformType = Platform.ANDROID | Platform.IOS | Platform.VKCOM;
+export type PlatformType =
+  | Platform.ANDROID
+  | Platform.IOS
+  | Platform.VKCOM
+  | string;
 
 export function platform(browserInfo?: BrowserInfo): PlatformType {
   if (!browserInfo) {


### PR DESCRIPTION
Теперь в `ConfigProvider.platform` можно передавать произвольную строку. Это сделано для того, чтобы VKUI могли использовать все юниты VK, у которых есть свой набор vkui-tokens.