### PR TITLE
[Enhancement, a11y] PanelHeaderButton

### DIFF
--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -2,8 +2,9 @@ import * as React from "react";
 import Tappable, { TappableProps } from "../Tappable/Tappable";
 import { getClassName } from "../../helpers/getClassName";
 import { classNames } from "../../lib/classNames";
+import { warnOnce } from "../../lib/warnOnce";
 import { usePlatform } from "../../hooks/usePlatform";
-import { isPrimitiveReactNode } from "../../lib/utils";
+import { getTitleFromChildren, isPrimitiveReactNode } from "../../lib/utils";
 import { IOS, VKCOM, ANDROID } from "../../lib/platform";
 import Text from "../Typography/Text/Text";
 import Title from "../Typography/Title/Title";
@@ -41,6 +42,7 @@ const ButtonTypography: React.FC<ButtonTypographyProps> = ({
   );
 };
 
+const warn = warnOnce("PanelHeaderButton");
 export const PanelHeaderButton: React.FC<PanelHeaderButtonProps> = ({
   children,
   primary = false,
@@ -66,6 +68,19 @@ export const PanelHeaderButton: React.FC<PanelHeaderButtonProps> = ({
     case VKCOM:
       hoverMode = "PanelHeaderButton--hover";
       activeMode = "PanelHeaderButton--active";
+  }
+
+  const hasAccessibleName = Boolean(
+    getTitleFromChildren(children) ||
+      getTitleFromChildren(label) ||
+      restProps["aria-label"] ||
+      restProps["aria-labelledby"]
+  );
+
+  if (process.env.NODE_ENV === "development" && !hasAccessibleName) {
+    warn(
+      "a11y: У кнопки нет названия, которое может прочитать скринридер, и она недоступна для части пользователей. Замените содержимое на текст или добавьте описание действия с помощью пропа aria-label."
+    );
   }
 
   return (

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -43,7 +43,7 @@ const ButtonTypography: React.FC<ButtonTypographyProps> = ({
 
 export const PanelHeaderButton: React.FC<PanelHeaderButtonProps> = ({
   children,
-  primary,
+  primary = false,
   label,
   ...restProps
 }: PanelHeaderButtonProps) => {
@@ -93,9 +93,4 @@ export const PanelHeaderButton: React.FC<PanelHeaderButtonProps> = ({
       )}
     </Tappable>
   );
-};
-
-PanelHeaderButton.defaultProps = {
-  primary: false,
-  "aria-label": "Закрыть",
 };

--- a/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -70,17 +70,19 @@ export const PanelHeaderButton: React.FC<PanelHeaderButtonProps> = ({
       activeMode = "PanelHeaderButton--active";
   }
 
-  const hasAccessibleName = Boolean(
-    getTitleFromChildren(children) ||
-      getTitleFromChildren(label) ||
-      restProps["aria-label"] ||
-      restProps["aria-labelledby"]
-  );
-
-  if (process.env.NODE_ENV === "development" && !hasAccessibleName) {
-    warn(
-      "a11y: У кнопки нет названия, которое может прочитать скринридер, и она недоступна для части пользователей. Замените содержимое на текст или добавьте описание действия с помощью пропа aria-label."
+  if (process.env.NODE_ENV === "development") {
+    const hasAccessibleName = Boolean(
+      getTitleFromChildren(children) ||
+        getTitleFromChildren(label) ||
+        restProps["aria-label"] ||
+        restProps["aria-labelledby"]
     );
+
+    if (!hasAccessibleName) {
+      warn(
+        "a11y: У кнопки нет названия, которое может прочитать скринридер, и она недоступна для части пользователей. Замените содержимое на текст или добавьте описание действия с помощью пропа aria-label."
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
Fixes #2235.

Из https://github.com/VKCOM/VKUI/issues/2235#issuecomment-1031598727:

> Мы не можем предсказать, какое действие будет осуществляться по кнопке, но если внутри только иконка, то для того, чтобы кнопка вообще была доступной, ей нужен `aria-label`. Поэтому мы со своей стороны задаем только дефолт; сейчас он — "Закрыть". Разработчикам нужно прокинуть свое значение `aria-label`, чтобы все заработало как надо.

> Другое дело, что это может быть не самый уместный дефолт для конкретной кнопки (учитывая, что есть отдельный `PanelHeaderClose`). Возможно, лучше будет чекать, что кнопка не озвучивается, и кидать варнинг в dev-сборке. 

- [x] убрала дефолтный `aria-label`,
- [x] добавила проверку на доступность и варнинг в dev-сборке в случае, если у кнопки нет [доступного имени](https://www.w3.org/TR/accname-1.1/#mapping_additional_nd),
- [x] в качестве бонуса выкинула `defaultProps`. 🤗 