### PR TITLE
[Docs, Bug] Именованные экспорты в доке

### DIFF
--- a/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -46,7 +46,7 @@ export interface ActionSheetItemProps
   onImmediateClick?: React.MouseEventHandler<HTMLElement>;
 }
 
-const ActionSheetItem: React.FC<ActionSheetItemProps> = ({
+const ActionSheetItemComponent: React.FC<ActionSheetItemProps> = ({
   children,
   autoclose,
   mode = "default",
@@ -185,8 +185,6 @@ const ActionSheetItem: React.FC<ActionSheetItemProps> = ({
   );
 };
 
-const ActionSheetItemWithAdaptivity = withAdaptivity(ActionSheetItem, {
+export const ActionSheetItem = withAdaptivity(ActionSheetItemComponent, {
   sizeY: true,
 });
-
-export { ActionSheetItemWithAdaptivity as ActionSheetItem };

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -52,7 +52,7 @@ type TransitionEndHandler = (e?: TransitionEvent) => void;
 
 type ItemClickHander = (item: AlertActionInterface) => () => void;
 
-class Alert extends React.Component<TAlertProps, AlertState> {
+class AlertComponent extends React.Component<TAlertProps, AlertState> {
   constructor(props: TAlertProps) {
     super(props);
     this.element = React.createRef();
@@ -285,10 +285,8 @@ class Alert extends React.Component<TAlertProps, AlertState> {
   }
 }
 
-const AlertWithPlatformAndAdaptivity = withPlatform(
-  withAdaptivity(Alert, {
+export const Alert = withPlatform(
+  withAdaptivity(AlertComponent, {
     viewWidth: true,
   })
 );
-
-export { AlertWithPlatformAndAdaptivity as Alert };


### PR DESCRIPTION
Fixes #2246.

`react-docgen-typescript` или игнорирует `export { CmpName as AnotherName }`, или как-то по-своему его обрабатывает, потому что при запуске `yarn styleguide` проблема не повторяется. 🤦🏻‍♀️ 

Пофиксила:
- [x] Alert
- [x] ActionSheet