### PR TITLE
feat: Create ButtonGroup component

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -12,6 +12,26 @@
   max-width: 100%;
 }
 
+.Button--in-group {
+  flex-basis: 100%;
+}
+
+.Button--in-group-horizontal-medium:not(:last-child) {
+  margin-right: var(--vkui--size_button_group--padding-medium);
+}
+
+.Button--in-group-horizontal-small:not(:last-child) {
+  margin-right: var(--vkui--size_button_group--padding-small);
+}
+
+.Button--in-group-vertical-medium:not(:first-child) {
+  margin-top: var(--vkui--size_button_group--padding-medium);
+}
+
+.Button--in-group-vertical-small:not(:first-child) {
+  margin-top: var(--vkui--size_button_group--padding-small);
+}
+
 .Button--stretched {
   display: block;
   width: 100%;
@@ -77,6 +97,12 @@
 .Button--singleIcon .Button__before:only-child,
 .Button--singleIcon .Button__after:only-child {
   margin: 0;
+}
+
+.Button--singleIcon.Button--in-group {
+  flex-shrink: 1;
+  flex-grow: 0;
+  flex-basis: content;
 }
 
 .Button__content {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,6 +16,7 @@ import {
 import { PlatformType, IOS, VKCOM, ANDROID } from "../../lib/platform";
 import Spinner from "../Spinner/Spinner";
 import Headline from "../Typography/Headline/Headline";
+import { ButtonGroupContext } from "../ButtonGroup/ButtonGroup";
 import "./Button.css";
 
 export interface VKUIButtonProps extends HasAlign {
@@ -145,6 +146,7 @@ function resolveButtonAppearance(
 }
 
 const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
+  const buttonGroupContext = React.useContext(ButtonGroupContext);
   const platform = usePlatform();
   const {
     size,
@@ -182,8 +184,11 @@ const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
         `Button--clr-${resolvedAppearance}`,
         `Button--aln-${align}`,
         `Button--sizeY-${sizeY}`,
+        buttonGroupContext &&
+          `Button--in-group Button--in-group-${buttonGroupContext.mode}-${buttonGroupContext.padding}`,
         {
-          ["Button--stretched"]: stretched,
+          // Контекст ButtonGroup в приоритете
+          ["Button--stretched"]: buttonGroupContext?.stretched || stretched,
           ["Button--with-icon"]: hasIcons,
           ["Button--singleIcon"]: Boolean(
             (!children && !after && before) || (!children && after && !before)

--- a/src/components/ButtonGroup/ButtonGroup.css
+++ b/src/components/ButtonGroup/ButtonGroup.css
@@ -1,0 +1,23 @@
+.ButtonGroup {
+  display: inline-flex;
+}
+
+.ButtonGroup--mode-vertical {
+  flex-direction: column;
+}
+
+.ButtonGroup--mode-horizontal {
+  flex-direction: row;
+}
+
+.ButtonGroup--vertical-padding-medium:not(:first-child) {
+  margin-top: var(--vkui--size_button_group--padding-medium);
+}
+
+.ButtonGroup--vertical-padding-small:not(:first-child) {
+  margin-top: var(--vkui--size_button_group--padding-small);
+}
+
+.ButtonGroup--stretched {
+  display: flex;
+}

--- a/src/components/ButtonGroup/ButtonGroup.e2e.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.e2e.tsx
@@ -1,0 +1,33 @@
+import Button from "../Button/Button";
+import ButtonGroup, { ButtonGroupProps } from "./ButtonGroup";
+import { describeScreenshotFuzz } from "../../testing/e2e/utils";
+
+describe("ButtonGroup", () => {
+  describeScreenshotFuzz(
+    (props: ButtonGroupProps) => (
+      <ButtonGroup {...props}>
+        <Button size="l" appearance="accent">
+          Разрешить
+        </Button>
+        <Button size="l" appearance="accent">
+          Завершить
+        </Button>
+        <ButtonGroup mode="horizontal">
+          <Button size="l" appearance="negative">
+            Не сейчас
+          </Button>
+          <Button size="l" appearance="positive">
+            Продолжить
+          </Button>
+        </ButtonGroup>
+      </ButtonGroup>
+    ),
+    [
+      {
+        mode: ["horizontal", "vertical"],
+        padding: ["medium", "small"],
+        stretched: [undefined, true],
+      },
+    ]
+  );
+});

--- a/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -1,0 +1,6 @@
+import { baselineComponent } from "../../testing/utils";
+import ButtonGroup from "./ButtonGroup";
+
+describe("ButtonGroup", () => {
+  baselineComponent(ButtonGroup);
+});

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { classNames } from "../../lib/classNames";
+import type { HasRootRef } from "../../types";
+import "./ButtonGroup.css";
+
+export interface ButtonGroupProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    HasRootRef<HTMLDivElement> {
+  mode?: "vertical" | "horizontal";
+  padding?: "medium" | "small"; // number
+  stretched?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+export type ButtonGroupContextProps = Pick<
+  ButtonGroupProps,
+  "mode" | "padding" | "stretched"
+> | null;
+
+export const ButtonGroupContext =
+  React.createContext<ButtonGroupContextProps>(null);
+
+const ButtonGroup: React.FC<ButtonGroupProps> = ({
+  mode: modeProp,
+  padding: paddingProp,
+  stretched: stretchedProp,
+  getRootRef,
+  ...restProps
+}: ButtonGroupProps) => {
+  const context = React.useContext(ButtonGroupContext);
+  const isNested = context !== null;
+
+  const mode = modeProp || context?.mode || "horizontal";
+  const padding = paddingProp || context?.padding || "medium";
+  const stretched = stretchedProp || context?.stretched || false;
+
+  return (
+    <ButtonGroupContext.Provider value={{ mode, padding, stretched }}>
+      <div
+        vkuiClass={classNames(
+          "ButtonGroup",
+          `ButtonGroup--mode-${mode}`,
+          stretched && "ButtonGroup--stretched",
+          isNested && `ButtonGroup--vertical-padding-${padding}`
+        )}
+        role="group"
+        ref={getRootRef}
+        {...restProps}
+      />
+    </ButtonGroupContext.Provider>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default ButtonGroup;

--- a/src/components/ButtonGroup/Readme.md
+++ b/src/components/ButtonGroup/Readme.md
@@ -1,0 +1,118 @@
+Группирует компонент [Button](#!/Button).
+
+Позволяет вкладывать внутрь себя же. Если вложенному [ButtonGroup](#!/ButtonGroup) не передать параметры `mode`, `padding` и `stretched`, то значения для этих параметров будут унаследованы из контекста выше стоящего [ButtonGroup](#!/ButtonGroup).
+
+```jsx { "props": { "layout": false, "iframe": false } }
+const containerStyles = {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  width: "100%",
+};
+
+const Example = () => {
+  const [sizeY, setSizeY] = useState("compact");
+
+  const [padding, setPadding] = useState("medium");
+  const [stretched, setStretched] = useState(false);
+  const buttonText = "Button";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "row-reverse" }}>
+      <AdaptivityProvider sizeY={sizeY}>
+        <div style={containerStyles}>
+          <Div>
+            <ButtonGroup
+              mode="vertical"
+              padding={padding}
+              stretched={stretched}
+            >
+              <Button size="l" appearance="accent">
+                Разрешить
+              </Button>
+              <Button size="l" appearance="accent">
+                Завершить
+              </Button>
+              <ButtonGroup mode="horizontal">
+                <Button size="l" appearance="negative">
+                  Не сейчас
+                </Button>
+                <Button size="l" appearance="positive">
+                  Продолжить
+                </Button>
+              </ButtonGroup>
+            </ButtonGroup>
+          </Div>
+          <Div>
+            <ButtonGroup
+              mode="vertical"
+              padding={padding}
+              stretched={stretched}
+            >
+              <ButtonGroup mode="horizontal">
+                <Button size="l" appearance="accent">
+                  Button
+                </Button>
+                <Button size="l" appearance="accent" before={<Icon24Add />} />
+              </ButtonGroup>
+              <ButtonGroup mode="vertical">
+                <Button size="l" appearance="accent">
+                  Button
+                </Button>
+                <Button size="l" appearance="accent" before={<Icon24Add />} />
+                <ButtonGroup mode="horizontal">
+                  <Button size="l" appearance="accent" before={<Icon24Add />} />
+                  <Button size="l" appearance="accent">
+                    Button
+                  </Button>
+                </ButtonGroup>
+              </ButtonGroup>
+              <Button size="l" appearance="accent">
+                Button
+              </Button>
+              <ButtonGroup mode="horizontal">
+                <Button size="l" appearance="accent">
+                  Button
+                </Button>
+                <Button size="l" appearance="accent">
+                  Button
+                </Button>
+                <Button size="l" appearance="accent">
+                  Button
+                </Button>
+              </ButtonGroup>
+            </ButtonGroup>
+          </Div>
+        </div>
+      </AdaptivityProvider>
+      <div style={{ minWidth: 200 }}>
+        <FormItem top="sizeY">
+          <Select
+            value={sizeY}
+            onChange={(e) => setSizeY(e.target.value)}
+            options={[
+              { label: "compact", value: "compact" },
+              { label: "regular", value: "regular" },
+            ]}
+          />
+        </FormItem>
+        <FormItem top="props">
+          <Select
+            value={padding}
+            onChange={(e) => setPadding(e.target.value)}
+            options={[
+              { label: "medium", value: "medium" },
+              { label: "small", value: "small" },
+            ]}
+          />
+          <Checkbox onChange={(e) => setStretched(e.target.checked)}>
+            stretched
+          </Checkbox>
+        </FormItem>
+      </div>
+    </div>
+  );
+};
+
+<Example />;
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,14 @@ export type { ModalDismissButtonProps } from "./components/ModalDismissButton/Mo
  */
 export { Badge } from "./components/Badge/Badge";
 export type { BadgeProps } from "./components/Badge/Badge";
+export {
+  default as ButtonGroup,
+  ButtonGroupContext,
+} from "./components/ButtonGroup/ButtonGroup";
+export type {
+  ButtonGroupProps,
+  ButtonGroupContextProps,
+} from "./components/ButtonGroup/ButtonGroup";
 export { default as Button } from "./components/Button/Button";
 export type { ButtonProps } from "./components/Button/Button";
 export { default as IconButton } from "./components/IconButton/IconButton";

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -58,6 +58,7 @@
 @import "../components/ModalPageHeader/ModalPageHeader.css";
 
 /* Blocks */
+@import "../components/ButtonGroup/ButtonGroup.css";
 @import "../components/Badge/Badge.css";
 @import "../components/IconButton/IconButton.css";
 @import "../components/Card/Card.css";

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -39,6 +39,10 @@
 
   /* animations */
   --duration: 0.7s;
+
+  /* FIXME Для теста зашил токены тут. Надо добавить их в `@vkontakte/vkui-tokens` и брать оттуда */
+  --vkui--size_button_group--padding-medium: 12px;
+  --vkui--size_button_group--padding-small: 8px;
 }
 
 @media (min-resolution: 2dppx) {

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -196,6 +196,7 @@ const baseConfig = {
           name: "Blocks",
           components: () => [
             "../src/components/Badge/Badge.tsx",
+            "../src/components/ButtonGroup/ButtonGroup.tsx",
             "../src/components/Button/Button.tsx",
             "../src/components/CellButton/CellButton.tsx",
             "../src/components/IconButton/IconButton.tsx",


### PR DESCRIPTION
## Описание решения

Реализовал с помощью реактовского контекста.

1. При оборачивании в `ButtonGroup`, создается контекст `ButtonGroupContext`, в котором хранится `mode`, `padding` и `stretched`. 
2. `Button` из контекста понимает находится он сейчас в группе или нет и выставляет соответсвующие классы.
    1. `stretched` из контекста приоритетнее чем `stretched` в компоненте `Button` ([ссылка на код](https://github.com/inomdzhon/VKUI/blob/feature/ButtonGroup-v1/src/components/Button/Button.tsx#L191))
    2. В случае, если у нас кнопка-иконка, то выставляем ей несколько св-в ([ссылка на код](https://github.com/inomdzhon/VKUI/blob/feature/ButtonGroup-v1/src/components/Button/Button.css#L102-L106))

## Какие ещё были варианты?

1. Изначально была идею использовать `display: flex` со св-ом `gap`, но это решение не будет совместимо с поддерживаемыми нами браузерами (ссылка на поддержку https://caniuse.com/flexbox-gap).
2. Добавлять падинги через каскад `.ButtonGroup .Button`, но ввиду того, что мы идём к CSS Modules, будет сложно подогнать под него такой каскад...пока даже не представляю как 😰

## Нюансы

1. Надо завести докены `sizeButtonGroupPaddingMedium` и `sizeButtonGroupPaddingSmall` в репе с токенами. Сейчас пока зашил их в [src/styles/constants.css](https://github.com/inomdzhon/VKUI/blob/feature/ButtonGroup-v1/src/styles/constants.css#L44-L45)
2. Надо доделать, чтобы `padding` принимал произвольное число. Сейчас принимает только `enum`. Пока идея оперировать атрибутом `style`
    1. либо меняем св-во `margin` напрямую
    2. либо в рут элементе `ButtonGroup` перебиваем токены
        ```jsx
        <div style={{ '--vkui--size_button_group--padding-medium': padding }}>...</div>
        ```
    3. либо на уровне дизайн-системы договариваемся использовать только `enum`
3. Пока не проверял в связке с компонентами `Banner`, `ModalCardBase` и `RichCell`. Вижу, что в [Button.css](https://github.com/VKCOM/VKUI/blob/master/src/components/Button/Button.css) ими 
    перебиваются отступы, которые я задаю если `Button` внутри `ButtonGroup`. Предполагаю в них может всё поломаться. Проверю позже. Сейчас хочу саму идею с контекстом показать. Вот ссылки на строчки:
    - [Banner](https://github.com/VKCOM/VKUI/blob/master/src/components/Button/Button.css#L511-L542)
    - [ModalCardBase](https://github.com/VKCOM/VKUI/blob/master/src/components/Button/Button.css#L544-L561)
    - [RichCell](https://github.com/VKCOM/VKUI/blob/master/src/components/Button/Button.css#L563-L566)