### PR TITLE
usePlatform: fix case with <ConfigProvider platform={undefined} />

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -5,28 +5,26 @@ import { ANDROID, VKCOM } from "../../lib/platform";
 import { baselineComponent } from "../../testing/utils";
 import { Scheme, Appearance } from "../../helpers/scheme";
 import ConfigProvider from "./ConfigProvider";
-import {
-  ConfigProviderContext,
-  ConfigProviderContextInterface,
-  WebviewType,
-  defaultConfigProviderProps,
-} from "./ConfigProviderContext";
+import { ConfigProviderContext, WebviewType } from "./ConfigProviderContext";
 
 describe("ConfigProvider", () => {
   baselineComponent<any>(ConfigProvider, { forward: false });
   it("provides config context", () => {
-    const config: ConfigProviderContextInterface = {
-      platform: ANDROID,
-      isWebView: true,
+    const config = {
+      platform: undefined,
       appearance: Appearance.LIGHT,
       webviewType: WebviewType.INTERNAL,
-      hasNewTokens: false,
+      hasNewTokens: undefined,
       transitionMotionEnabled: false,
     };
     const ConfigUser: FC = () => {
       expect(useContext(ConfigProviderContext)).toEqual({
-        ...defaultConfigProviderProps,
-        ...config,
+        platform: ANDROID,
+        isWebView: false,
+        appearance: Appearance.LIGHT,
+        webviewType: WebviewType.INTERNAL,
+        hasNewTokens: false,
+        transitionMotionEnabled: false,
       });
       return null;
     };

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -80,6 +80,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
     hasNewTokens,
     platform,
     scheme,
+    appearance,
   };
 
   const normalizedScheme = normalizeScheme({

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -73,16 +73,6 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
   appearance,
   scheme,
 }) => {
-  const config = {
-    webviewType,
-    isWebView,
-    transitionMotionEnabled,
-    hasNewTokens,
-    platform,
-    scheme,
-    appearance,
-  };
-
   const normalizedScheme = normalizeScheme({
     scheme,
     platform,
@@ -124,8 +114,13 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
   }, [platform, derivedAppearance]);
 
   const configContext = useObjectMemo({
-    appearance: derivedAppearance,
-    ...config,
+    webviewType,
+    isWebView,
+    transitionMotionEnabled,
+    hasNewTokens,
+    platform,
+    scheme,
+    appearance: appearance || derivedAppearance,
   });
 
   return (

--- a/src/components/ConfigProvider/ConfigProviderContext.tsx
+++ b/src/components/ConfigProvider/ConfigProviderContext.tsx
@@ -36,17 +36,13 @@ export interface ConfigProviderContextInterface {
   hasNewTokens: boolean;
 }
 
-export const defaultConfigProviderProps = {
-  webviewType: WebviewType.VKAPPS,
-  isWebView: vkBridge.isWebView(),
-  transitionMotionEnabled: true,
-  platform: platform(),
-  hasNewTokens: false,
-  // appearance is auto-detected by default
-  // appearance: Appearance.LIGHT,
-};
-
 export const ConfigProviderContext =
-  React.createContext<ConfigProviderContextInterface>(
-    defaultConfigProviderProps
-  );
+  React.createContext<ConfigProviderContextInterface>({
+    webviewType: WebviewType.VKAPPS,
+    isWebView: vkBridge.isWebView(),
+    transitionMotionEnabled: true,
+    platform: platform(),
+    hasNewTokens: false,
+    // appearance is auto-detected by default
+    // appearance: Appearance.LIGHT,
+  });

--- a/src/hooks/usePlatform.test.tsx
+++ b/src/hooks/usePlatform.test.tsx
@@ -1,0 +1,42 @@
+import { usePlatform } from "./usePlatform";
+import ConfigProvider from "../components/ConfigProvider/ConfigProvider";
+import { renderHook } from "@testing-library/react-hooks";
+import * as React from "react";
+
+describe(usePlatform, () => {
+  it("returns ConfigProvider's platform", () => {
+    const wrapper: React.FC = ({ children }) => (
+      <ConfigProvider platform="ios">{children}</ConfigProvider>
+    );
+
+    const { result } = renderHook(() => usePlatform(), { wrapper });
+
+    expect(result.current).toEqual("ios");
+  });
+
+  it("handles ConfigProvider's undefined platform", () => {
+    const wrapper: React.FC = ({ children }) => (
+      <ConfigProvider platform={undefined}>{children}</ConfigProvider>
+    );
+
+    const { result } = renderHook(() => usePlatform(), { wrapper });
+
+    expect(result.current).toEqual("android");
+  });
+
+  it("handles ConfigProvider's no platform", () => {
+    const wrapper: React.FC = ({ children }) => (
+      <ConfigProvider>{children}</ConfigProvider>
+    );
+
+    const { result } = renderHook(() => usePlatform(), { wrapper });
+
+    expect(result.current).toEqual("android");
+  });
+
+  it("handles no ConfigProvider", () => {
+    const { result } = renderHook(() => usePlatform());
+
+    expect(result.current).toEqual("android");
+  });
+});

--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { PlatformType, platform as resolvePlatform } from "../lib/platform";
+import { PlatformType } from "../lib/platform";
 import { SSRContext } from "../lib/SSR";
 import { ConfigProviderContext } from "../components/ConfigProvider/ConfigProviderContext";
 
 export function usePlatform(): PlatformType {
   const ssrContext = React.useContext(SSRContext);
   const { platform } = React.useContext(ConfigProviderContext);
-  return ssrContext.platform || platform || resolvePlatform();
+  return ssrContext.platform || platform;
 }

--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { PlatformType } from "../lib/platform";
+import { PlatformType, platform as resolvePlatform } from "../lib/platform";
 import { SSRContext } from "../lib/SSR";
 import { ConfigProviderContext } from "../components/ConfigProvider/ConfigProviderContext";
 
 export function usePlatform(): PlatformType {
   const ssrContext = React.useContext(SSRContext);
   const { platform } = React.useContext(ConfigProviderContext);
-  return ssrContext.platform || platform;
+  return ssrContext.platform || platform || resolvePlatform();
 }


### PR DESCRIPTION
Проблема: если явно передать в `<ConfigProvider platform={undefined} />`, то такое значение затрет дефолтный резолв через `platform()`, и `usePlatform` станет возвращать `undefined`. При этом `getClassName` всё равно будет использовать `platform()` в случае, если вторым аргументом передан `undefined`. То есть получился рассинхрон.