### PR TITLE
[Hotfix] Используем "files" в package.json, чтобы оставить в выходном пакете только нужное

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
     "CONTRIBUTING.md",
     "VKUI_TOKENS_MIGRATION_GUIDE.md"
   ],
-  "license": "MIT",
-  "description": "VKUI library",
-  "repository": "https://github.com/VKCOM/VKUI",
-  "homepage": "https://vkcom.github.io/VKUI/",
-  "defaultSchemeId": "bright_light",
   "sideEffects": [
     "./dist/lib/polyfills.js",
     "./dist/index.js",
@@ -23,6 +18,11 @@
     "./dist/cssm/index.js",
     "*.css"
   ],
+  "license": "MIT",
+  "description": "VKUI library",
+  "repository": "https://github.com/VKCOM/VKUI",
+  "homepage": "https://vkcom.github.io/VKUI/",
+  "defaultSchemeId": "bright_light",
   "devDependencies": {
     "@babel/cli": "^7.16.8",
     "@babel/core": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CONTRIBUTING.md",
+    "VKUI_TOKENS_MIGRATION_GUIDE.md"
+  ],
   "license": "MIT",
   "description": "VKUI library",
   "repository": "https://github.com/VKCOM/VKUI",


### PR DESCRIPTION
# Причина

Из-за того, что пакет в `npm` содержит практически все файлы из директории проекта, ломаются сборки пользователей, у которых `postcss-loader` прогоняет стили из `node_modules/`, т.к. `postcss-loader` начинает использовать `node_modules/@vkontakte/vkui/postcss.config.js`.

Выстрелило после [изменения конфига](https://github.com/VKCOM/VKUI/blob/v4.26.0/postcss.config.js#L13-L16) в версии `v4.26.0`.