### PR TITLE
Fix HorizontalCell example - showArrows

### DIFF
--- a/src/components/HorizontalCell/Readme.md
+++ b/src/components/HorizontalCell/Readme.md
@@ -183,7 +183,11 @@ const HorizontalCellExample = withPlatform(
           <Panel id="horizontalCell">
             <PanelHeader>HorizontalCell</PanelHeader>
             <Group header={<Header>Возможные друзья</Header>}>
-              <HorizontalScroll>
+              <HorizontalScroll
+                showArrows
+                getScrollToLeft={(i) => i - 80 * 3}
+                getScrollToRight={(i) => i + 80 * 3}
+              >
                 <div style={{ display: "flex" }}>{this.state.userItems}</div>
               </HorizontalScroll>
             </Group>
@@ -194,14 +198,22 @@ const HorizontalCellExample = withPlatform(
                 </Header>
               }
             >
-              <HorizontalScroll>
+              <HorizontalScroll
+                showArrows
+                getScrollToLeft={(i) => i - 80 * 3}
+                getScrollToRight={(i) => i + 80 * 3}
+              >
                 <div style={{ display: "flex" }}>{this.state.miniAppItems}</div>
               </HorizontalScroll>
             </Group>
             <Group
               header={<Header aside={<Link>Показать все</Link>}>Игры</Header>}
             >
-              <HorizontalScroll>
+              <HorizontalScroll
+                showArrows
+                getScrollToLeft={(i) => i - 100 * 2}
+                getScrollToRight={(i) => i + 100 * 2}
+              >
                 <div style={{ display: "flex" }}>{this.state.gamesItems}</div>
               </HorizontalScroll>
             </Group>
@@ -210,7 +222,11 @@ const HorizontalCellExample = withPlatform(
                 <Header aside={<Link>Показать все</Link>}>Плейлисты</Header>
               }
             >
-              <HorizontalScroll>
+              <HorizontalScroll
+                showArrows
+                getScrollToLeft={(i) => i - 140}
+                getScrollToRight={(i) => i + 140}
+              >
                 <div style={{ display: "flex" }}>
                   {this.state.playlistsItems}
                 </div>
@@ -221,7 +237,11 @@ const HorizontalCellExample = withPlatform(
                 <Header aside={<Link>Показать все</Link>}>Альбомы</Header>
               }
             >
-              <HorizontalScroll>
+              <HorizontalScroll
+                showArrows
+                getScrollToLeft={(i) => i - 234}
+                getScrollToRight={(i) => i + 234}
+              >
                 <div style={{ display: "flex" }}>{this.state.albumItems}</div>
               </HorizontalScroll>
             </Group>


### PR DESCRIPTION
### Проблема

В примере не работают стрелки в HorizontalScroll

### Бэкграунд

В `HorizontalScroll` появились стрелки, которые показываются по умолчанию, при наличии мыши. Данные стрелки кликабельны, но без `getScrollToLeft` или `getScrollToRight` ничего не происходит

### Текущее решение

Добавить `getScrollToLeft` и `getScrollToRight` на HorizontalScroll

### Предложения

В #2032 предлагается добавить getScrollToLeft и getScrollToRight по умолчанию.

Как вариант, можно просто не показывать стрелки, если нет `getScrollTo*` (но это плохо, с точки зрения дизайна)

```diff
-      {showArrows && hasMouse && canScrollLeft && (
+      {showArrows && hasMouse && canScrollLeft && getScrollToLeft && (
        <HorizontalScrollArrow
          direction="left"
          onClick={() => {
-            if (getScrollToLeft) {
              scrollTo(getScrollToLeft);
-            }
          }}
        />
      )}
```
