### PR TITLE
fix(ModalPage): Call updateModalHeight() after orientation change

### DIFF
--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -6,6 +6,7 @@ import {
   useModalRegistry,
 } from "../ModalRoot/ModalRootContext";
 import { usePlatform } from "../../hooks/usePlatform";
+import { useIsomorphicOrientationChange } from "../../hooks/useOrientationChange";
 import {
   withAdaptivity,
   ViewHeight,
@@ -46,8 +47,8 @@ const warn = warnOnce("ModalPage");
 const ModalPage: React.FC<ModalPageProps & AdaptivityContextInterface> = (
   props
 ) => {
-  const platform = usePlatform();
   const { updateModalHeight } = React.useContext(ModalRootContext);
+
   const {
     children,
     header,
@@ -63,9 +64,14 @@ const ModalPage: React.FC<ModalPageProps & AdaptivityContextInterface> = (
     ...restProps
   } = props;
 
-  React.useEffect(() => {
-    updateModalHeight();
-  }, [children, updateModalHeight]);
+  const platform = usePlatform();
+  const orientation = useIsomorphicOrientationChange();
+
+  React.useEffect(updateModalHeight, [
+    children,
+    orientation,
+    updateModalHeight,
+  ]);
 
   const isDesktop =
     viewWidth >= ViewWidth.SMALL_TABLET &&

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -6,7 +6,7 @@ import {
   useModalRegistry,
 } from "../ModalRoot/ModalRootContext";
 import { usePlatform } from "../../hooks/usePlatform";
-import { useIsomorphicOrientationChange } from "../../hooks/useOrientationChange";
+import { useOrientationChange } from "../../hooks/useOrientationChange";
 import {
   withAdaptivity,
   ViewHeight,
@@ -65,7 +65,7 @@ const ModalPage: React.FC<ModalPageProps & AdaptivityContextInterface> = (
   } = props;
 
   const platform = usePlatform();
-  const orientation = useIsomorphicOrientationChange();
+  const orientation = useOrientationChange();
 
   React.useEffect(updateModalHeight, [
     children,

--- a/src/hooks/useOrientationChange.ts
+++ b/src/hooks/useOrientationChange.ts
@@ -1,0 +1,71 @@
+import * as React from "react";
+import { useDOM } from "../lib/dom";
+import { Platform, platformName } from "../lib/platform";
+
+type Orientation = "portrait" | "landscape";
+
+/**
+ * Возвращает текущую ориентация экрана на человеском языке.
+ * Учитывает особенности API на разных платформах.
+ */
+function getOrientation(window: Window | undefined): Orientation {
+  if (typeof window === "undefined") {
+    return "portrait";
+  }
+
+  if (
+    window.screen &&
+    window.screen.orientation &&
+    window.screen.orientation.angle
+  ) {
+    return Math.abs(window.screen.orientation.angle) === 90
+      ? "landscape"
+      : "portrait";
+  }
+
+  // Support IOS safari
+  if (window.orientation) {
+    return Math.abs(Number(window.orientation)) === 90
+      ? "landscape"
+      : "portrait";
+  }
+
+  return "portrait";
+}
+
+export function useOrientationChange(): Orientation {
+  const { window } = useDOM();
+
+  const [orientation, setOrientation] = React.useState(() =>
+    getOrientation(window)
+  );
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleOrientationChange = () =>
+      setOrientation(getOrientation(window));
+
+    window.addEventListener("orientationchange", handleOrientationChange);
+
+    return () => {
+      window.removeEventListener("orientationchange", handleOrientationChange);
+    };
+  }, [window]);
+
+  return orientation;
+}
+
+function useNoopOrientationChange(): Orientation {
+  return "portrait";
+}
+
+/**
+ * Подписываемся на изменение только для мобильных устройств.
+ */
+export const useIsomorphicOrientationChange =
+  platformName === Platform.IOS || platformName === Platform.ANDROID
+    ? useOrientationChange
+    : useNoopOrientationChange;

--- a/src/hooks/useOrientationChange.ts
+++ b/src/hooks/useOrientationChange.ts
@@ -5,7 +5,7 @@ import { useGlobalEventListener } from "./useGlobalEventListener";
 type Orientation = "portrait" | "landscape";
 
 /**
- * Возвращает текущую ориентация экрана на человеском языке.
+ * Возвращает текущую ориентация экрана на человеческом языке.
  * Учитывает особенности API на разных платформах.
  */
 function getOrientation(window: Window | undefined): Orientation {
@@ -21,7 +21,8 @@ function getOrientation(window: Window | undefined): Orientation {
 }
 
 /**
- * Возвращает текущую ориентация экрана. Обновляется при её изменение.
+ * Возвращает текущую ориентация экрана на человеческом языке.
+ * Обновляется при изменении ориентации.
  */
 export function useOrientationChange(): Orientation {
   const { window } = useDOM();

--- a/src/hooks/useOrientationChange.ts
+++ b/src/hooks/useOrientationChange.ts
@@ -30,12 +30,9 @@ export function useOrientationChange(): Orientation {
     getOrientation(window)
   );
 
-  const handleOrientationChange = React.useCallback(
-    () => setOrientation(getOrientation(window)),
-    [window]
+  useGlobalEventListener(window, "orientationchange", () =>
+    setOrientation(getOrientation(window))
   );
-
-  useGlobalEventListener(window, "orientationchange", handleOrientationChange);
 
   return orientation;
 }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -24,7 +24,7 @@ export function platform(browserInfo?: BrowserInfo): PlatformType {
   return browserInfo.system === "ios" ? IOS : ANDROID;
 }
 
-export const platformName = platform();
+const platformName = platform();
 
 /**
  * @deprecated для определения платформы используйте withPlatform или usePlatform

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -24,7 +24,7 @@ export function platform(browserInfo?: BrowserInfo): PlatformType {
   return browserInfo.system === "ios" ? IOS : ANDROID;
 }
 
-const platformName = platform();
+export const platformName = platform();
 
 /**
  * @deprecated для определения платформы используйте withPlatform или usePlatform


### PR DESCRIPTION
## Проблема

Компонент [ModalPage](https://vkcom.github.io/VKUI/#/ModalPage), в режиме Action Sheet на iOS, при смене ориентации устройства не пересчитывает свои координаты.

Режим "portrait"

<img width="200" alt="image" src="https://user-images.githubusercontent.com/5850354/158842044-84eed5cb-b449-4096-a862-0bd77df7c40d.png">

Перевернули в режим "landscape"

<img width="200" alt="image" src="https://user-images.githubusercontent.com/5850354/158842178-69538a15-6184-4499-ac17-e08b04aa12cc.png">

🐛 часть контента обрезалась.

Приходится переоткрывать ActionSheet, чтобы поправить ситуацию.

## Решение

Внутри компонента [ModalPage](https://vkcom.github.io/VKUI/#/ModalPage) подписаться на событие изменение ориентации экрана и, при обработке события, вызывать `updateModalHeight()`.

## Демо с исправлением

Тестировал через симулятор в Xcode. 

- Приложение: VK (в WebView загрузил свою локальную dev сборку)
- Устройство: iPad Air (4th generation)
- Версия iOS: 14.4

https://user-images.githubusercontent.com/5850354/158841637-d4b26f58-693a-4652-a4f9-96ea28ebb1e2.mov

## Примечание

Добавил хук [useOrientationChange](https://github.com/VKCOM/VKUI/blob/bugfix/ModalPage-orientation-change/src/hooks/useOrientationChange.ts#L36).

Так как смена ориентации прежде всего касается мобильных устройств, решил не подписываться на событие в лишний раз на десктоп. Добился этого через хук [useIsomorphicOrientationChange](https://github.com/VKCOM/VKUI/blob/bugfix/ModalPage-orientation-change/src/hooks/useOrientationChange.ts#L68)

