### PR TITLE
Fix Touch.tsx unsubscribe listeners

### DIFF
--- a/src/components/Touch/Touch.tsx
+++ b/src/components/Touch/Touch.tsx
@@ -209,7 +209,7 @@ export const Touch: React.FC<TouchProps> = ({
     if (touchEnabled()) {
       onLeave && onLeave(e);
     }
-    subscribe(null);
+    unsubscribe();
   }
 
   const listenerParams = { capture: useCapture, passive: false };
@@ -222,6 +222,9 @@ export const Touch: React.FC<TouchProps> = ({
     if (el) {
       listeners.forEach((l) => l.add(el));
     }
+  }
+  function unsubscribe() {
+    listeners.forEach((l) => l.remove());
   }
 
   /**


### PR DESCRIPTION
### Проблема

В компоненте Touch после окончания касания (событие `touchend` или `mouseup`) не удаляются лишние обработчики событий.

![image](https://user-images.githubusercontent.com/14944123/159162604-ddebc1a3-5257-4ef2-8101-4102e2639375.png)
_Пример для [https://vkcom.github.io/VKUI/#/PullToRefresh](PullToRefresh), если начать тянуть все элементы_

### Бэкграунд

В #1988 было добавлено удаление обработчиков, вызывая `subscribe(null)`

https://github.com/VKCOM/VKUI/blob/4ffcb68f0619ab9b6cdb360bd6b1608938136c83/src/components/Touch/Touch.tsx#L182
https://github.com/VKCOM/VKUI/blob/4ffcb68f0619ab9b6cdb360bd6b1608938136c83/src/components/Touch/Touch.tsx#L191-L193
https://github.com/VKCOM/VKUI/blob/4ffcb68f0619ab9b6cdb360bd6b1608938136c83/src/hooks/useEventListener.ts#L29-L36

В #2195 функция `subscribe` изменилась

https://github.com/VKCOM/VKUI/blob/4566ee0ec11ab932b01c897fe3768c5a390ed028/src/components/Touch/Touch.tsx#L221-L225

Теперь выполнение `subscribe(null)` не имеет смысла

### Решение

Добавить функцию `unsubscribe`, которая удаляет все обработчики

![image](https://user-images.githubusercontent.com/14944123/159163480-81c2b4d0-1605-4e25-81fd-9b3b936c0d80.png)


### Прочее

Можно избавиться от `null` в функции `subscribe`...

```diff
-  function subscribe(el: HTMLElement | Document | null | undefined) {
+  function subscribe(el: HTMLElement | Document | undefined) {
```



