### PR TITLE
Docs: PopoutWrapper in SplitLayout.popout

### DIFF
--- a/src/components/PopoutWrapper/Readme.md
+++ b/src/components/PopoutWrapper/Readme.md
@@ -9,4 +9,4 @@ import { PopoutWrapper } from "@vkontakte/vkui";
 </PopoutWrapper>;
 ```
 
-Все всплывающие окна передаются в свойство `popout` компонентов `View` или `Root`.
+Все всплывающие окна передаются в свойство `popout` компонента [`SplitLayout`](#/SplitLayout).


### PR DESCRIPTION
Свойство `popout` у компонентов `View` и `Root` устарело