### PR TITLE
fix(AdaptivityProvider): Consider landscape for computing `sizeY`

### DIFF
--- a/src/components/AdaptivityProvider/constants.ts
+++ b/src/components/AdaptivityProvider/constants.ts
@@ -1,0 +1,37 @@
+/**
+ * # Брейкпоинты
+ */
+export const DESKTOP_SIZE = 1280;
+
+export const TABLET_SIZE = 1024;
+
+export const SMALL_TABLET_SIZE = 768;
+
+export const MOBILE_SIZE = 320;
+
+export const MOBILE_LANDSCAPE_HEIGHT = 414;
+
+export const MEDIUM_HEIGHT = 720;
+
+/**
+ * # Медиа выражения
+ */
+export const MQ_DESKTOP_ONLY = `(min-width: ${DESKTOP_SIZE}px)`;
+
+export const MQ_TABLET_ONLY = `(min-width: ${TABLET_SIZE}px) and (max-width: ${
+  DESKTOP_SIZE - 1
+}px)`;
+
+export const MQ_SMALL_TABLET_ONLY = `(min-width: ${SMALL_TABLET_SIZE}px) and (max-width: ${
+  TABLET_SIZE - 1
+}px)`;
+
+export const MQ_MOBILE_ONLY = `(min-width: ${MOBILE_SIZE}px) and (max-width: ${
+  SMALL_TABLET_SIZE - 1
+}px)`;
+
+export const MQ_MEDIUM_HEIGHT = `(min-height: ${MEDIUM_HEIGHT}px)`;
+
+export const MQ_MOBILE_LANDSCAPE_HEIGHT = `(min-height: ${
+  MOBILE_LANDSCAPE_HEIGHT + 1
+}px) and (orientation: landscape)`;

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -42,3 +42,31 @@ export function computeBrowserInfo(userAgent = ""): BrowserInfo {
 
   return browserInfo;
 }
+
+/**
+ * Эмулярием функцию `window.matchMedia` для SSR.
+ */
+export function mediaQueryNull(query: string): MediaQueryList {
+  return {
+    matches: false,
+    media: query,
+    onchange() {
+      return void 0;
+    },
+    addListener() {
+      return void 0;
+    },
+    removeListener() {
+      return void 0;
+    },
+    addEventListener() {
+      return void 0;
+    },
+    removeEventListener() {
+      return void 0;
+    },
+    dispatchEvent() {
+      return false;
+    },
+  };
+}

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -190,3 +190,19 @@ Object.defineProperty(HTMLElement.prototype, "offsetParent", {
     return this.parentNode;
   },
 });
+
+// Не реализован в JSDOM.
+// Объявление скопировано с документации https://jestjs.io/ru/docs/26.x/manual-mocks
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // устарело
+    removeListener: jest.fn(), // устарело
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
## Проблема

Открытие клавиатуры, преимущественно в Android, вызывает событие `"resize"`, на которое подписан компонент, и значение `sizeY` из-за этого пересчитывается, т.к. высота начинает соответствовать константе [MOBILE_LANDSCAPE_HEIGHT](https://github.com/VKCOM/VKUI/blob/master/src/components/AdaptivityProvider/AdaptivityProvider.tsx#L17). Хотя, судя по названию, оно должно пересчитываться только для ландшафтной ориентации устройства.

https://user-images.githubusercontent.com/5850354/159764497-863d0b55-4767-4c81-839b-ac250fd0a347.mov

**Видео 1.** Визуализация проблемы в эмуляторе Android 11

## Решение

При проверке [MOBILE_LANDSCAPE_HEIGHT](https://github.com/VKCOM/VKUI/blob/master/src/components/AdaptivityProvider/AdaptivityProvider.tsx#L17), мы учитываем ориентацию экрана.

https://user-images.githubusercontent.com/5850354/159764521-d8cf2344-410d-4c30-90a6-cea6fe37d435.mov

**Видео 2.** Визуализация исправления в эмуляторе Android 11

## Реализация

Событие `"resize"` было заменено на браузерное API [matchMedia](https://developer.mozilla.org/ru/docs/Web/API/Window/matchMedia) для оптимизации и упрощения проверки на ландшафтную ориентацию.
