### PR TITLE
fix: Remove "files" and ignore `postcss.config.js` in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,7 @@ dist/**/*.tmp
 .gitignore
 package-lock.json
 .github
+postcss.config.js
 
 __image_snapshots__
 *.e2e.*

--- a/package.json
+++ b/package.json
@@ -4,11 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "CONTRIBUTING.md",
-    "VKUI_TOKENS_MIGRATION_GUIDE.md"
-  ],
   "sideEffects": [
     "./dist/lib/polyfills.js",
     "./dist/index.js",


### PR DESCRIPTION
В PR https://github.com/VKCOM/VKUI/pull/2282 мы исключили `postcss.config.js` посредством поля "files" в `package.json`.

Но тем самым из пакета пропала директория `tasks/`, что теперь вызывает следующую ошибку при попытке установки версии [v4.28.0](https://github.com/VKCOM/VKUI/releases/tag/v4.28.0):
```
npm ERR! enoent ENOENT: no such file or directory, chmod '/node_modules/@vkontakte/vkui/tasks/generate_scheme.js'
npm ERR! enoent This is related to npm not being able to find a file.
```

## Решение

Удаляем `"files"`, а `postcss.config.js` игнорируем в файле `.npmignore`.