### PR TITLE
[Security] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 *          @VKCOM/vkui-core
-yarn.lock  @VKCOM/vkui-core @VKCOM/vk-sec
-.yarnrc    @VKCOM/vkui-core @VKCOM/vk-sec
+yarn.lock  @VKCOM/vk-sec
+.yarnrc    @VKCOM/vk-sec


### PR DESCRIPTION
CODEOWNERS в GitHub не дают возможности затребовать аппрув у всех указанных групп перед мерджем реквеста. Поэтому — оставляем `yarn.lock` и `.yarnrc` в ведении @VKCOM/vk-sec.