### PR TITLE
fix(CustomSelect): Use `onMouseOver` instead `onMouseEnter`

### DIFF
--- a/src/components/ChipsSelect/__image_snapshots__/chipsselect-scrolls-to-item-via-arrows-1-snap.png
+++ b/src/components/ChipsSelect/__image_snapshots__/chipsselect-scrolls-to-item-via-arrows-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88c2dae09d43536c703ac360fde0374dca4c7386332be55147c3f567a87aa4e1
-size 8572
+oid sha256:6bfde82674e49f62e8e94360231cbaf9cd603879cef44d37f38a1fc09c6c73d4
+size 9394

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -359,9 +359,14 @@ class CustomSelect extends React.Component<
 
     scrollTo && this.scrollToElement(index);
 
-    this.setState(() => ({
-      focusedOptionIndex: index,
-    }));
+    this.setState((prevState) =>
+      // Это оптимизация, прежде всего, под `onMouseOver`
+      prevState.focusedOptionIndex !== index
+        ? {
+            focusedOptionIndex: index,
+          }
+        : null
+    );
   };
 
   focusOption = (type: "next" | "prev") => {
@@ -600,7 +605,15 @@ class CustomSelect extends React.Component<
           disabled: option.disabled,
           onClick: this.handleOptionClick,
           onMouseDown: this.handleOptionDown,
-          onMouseEnter: this.handleOptionHover,
+          // Используем `onMouseOver` вместо `onMouseEnter`.
+          // При параметре `searchable`, обновляется "ребёнок", из-за чего `onMouseEnter` не срабатывает в следующих кейсах:
+          //  1. До загрузки выпадающего списка, курсор мышки находится над произвольным элементом этого списка.
+          //     > Лечение: только увод курсора мыши и возвращении его обратно вызывает событие `onMouseEnter` на этот элемент.
+          //  2. Если это тач-устройство.
+          //     > Лечение: нужно нажать на какой-нибудь произвольный элемент списка, после чего `onMouseEnter` будет работать на соседние элементы,
+          //     но не на тот, на который нажали в первый раз.
+          // Более подробно по ссылке https://github.com/facebook/react/issues/13956#issuecomment-1082055744
+          onMouseOver: this.handleOptionHover,
         })}
       </React.Fragment>
     );


### PR DESCRIPTION
## Компонент

[CustomSelect](https://vkcom.github.io/VKUI/#/CustomSelect)

## Какая была проблема?

При параметре `searchable`, обновляется "ребёнок", из-за чего `onMouseEnter` не срабатывает в следующих кейсах:
 1. До загрузки выпадающего списка, курсор мышки находится над произвольным элементом этого списка.
    > **Лечение:** только увод курсора мыши и возвращении его обратно вызывает событие `onMouseEnter` на этот элемент.
 2. Если это тач-устройство.
    > **Лечение:** нужно нажать на какой-нибудь произвольный элемент списка, после чего `onMouseEnter` будет работать на соседние элементы, но не на тот, на который нажали в первый раз.

Более подробно по ссылке https://github.com/facebook/react/issues/13956#issuecomment-1082055744

## Как починилось?

`onMouseEnter` был заменён на `onMouseOver`.

`onMouseOver` отличается тем, что он будет дополнительно вызываться, если мы указали на ребёнка элемента. Чтобы оптимизировать это, добавляем при проверку перед обновлением состояния в функции `focusOptionByIndex()` компонента

https://github.com/VKCOM/VKUI/blob/afc0481ea0442cdd47eec0ae3e25f4a444a7c57b/src/components/CustomSelect/CustomSelect.tsx#L362-L369