### PR TITLE
[CustomSelect] added custom trigger for select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ PUBLISHING.md
 .idea/tasks.xml
 .idea/markdown-navigator-enh.xml
 .idea/markdown-navigator.xml
+.idea/jsLinters/
 docs/
 .vscode/
 test-results.json

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -101,11 +101,7 @@ export interface CustomSelectProps
     e: React.ChangeEvent,
     options: CustomSelectOptionInterface[]
   ) => void | CustomSelectOptionInterface[];
-  options: Array<{
-    value: SelectValue;
-    label: string;
-    [index: string]: any;
-  }>;
+  options: CustomSelectOptionInterface[];
   /**
    * Функция для кастомной фильтрации. По-умолчанию поиск производится по option.label.
    */
@@ -133,6 +129,14 @@ export interface CustomSelectProps
   }: {
     defaultDropdownContent: React.ReactNode;
   }) => React.ReactNode;
+  /**
+   * Рендер-проп для кастомного рендера триггера.
+   * В selectedOption содержится выбранная опция из options.
+   * По умолчанию будет рендериться option.label
+   */
+  renderTrigger?: (
+    selectedOption: CustomSelectOptionInterface
+  ) => React.ReactNode;
   /**
    * Если true, то в дропдауне вместо списка опций рисуется спиннер. При переданных renderDropdown и fetching: true,
    * "победит" renderDropdown
@@ -632,6 +636,19 @@ class CustomSelect extends React.Component<
     }));
   };
 
+  renderTrigger = () => {
+    const { renderTrigger } = this.props;
+    const selected = this.getSelectedItem();
+
+    if (!selected) {
+      return undefined;
+    }
+
+    return typeof renderTrigger === "function"
+      ? renderTrigger(selected)
+      : selected.label;
+  };
+
   render() {
     const { opened, nativeSelectValue, options: stateOptions } = this.state;
     const {
@@ -662,11 +679,9 @@ class CustomSelect extends React.Component<
       dropdownOffsetDistance,
       fixDropdownWidth,
       forceDropdownPortal,
+      renderTrigger,
       ...restProps
     } = this.props;
-    const selected = this.getSelectedItem();
-    const label = selected ? selected.label : undefined;
-
     const defaultDropdownContent =
       stateOptions !== undefined && stateOptions.length > 0 ? (
         stateOptions.map(this.renderOption)
@@ -732,7 +747,7 @@ class CustomSelect extends React.Component<
             })}
             after={icon}
           >
-            {label}
+            {this.renderTrigger()}
           </SelectMimicry>
         )}
         <select

--- a/src/components/CustomSelect/Readme.md
+++ b/src/components/CustomSelect/Readme.md
@@ -86,6 +86,37 @@ class Example extends React.Component {
                 )}
               />
             </FormItem>
+            <FormItem top="Администратор" bottom="Кастомный дизайн триггера">
+              <CustomSelect
+                placeholder="Не выбран"
+                options={this.users}
+                renderOption={({ option, ...restProps }) => (
+                  <CustomSelectOption
+                    {...restProps}
+                    before={<Avatar size={24} src={option.avatar} />}
+                    description={option.description}
+                  />
+                )}
+                renderTrigger={(selectedOption) => (
+                  <div style={{ display: "flex", alignItems: "center" }}>
+                    <Avatar
+                      style={{ marginRight: "8px" }}
+                      size={20}
+                      src={selectedOption.avatar}
+                    />
+                    <span>{selectedOption.label}</span>
+                    <span
+                      style={{
+                        color: "var(--text_secondary)",
+                        marginLeft: "auto",
+                      }}
+                    >
+                      {selectedOption.description}
+                    </span>
+                  </div>
+                )}
+              />
+            </FormItem>
             <Header>Поиск</Header>
             <FormItem top="Администратор" bottom="Поиск по списку">
               <CustomSelect
@@ -107,6 +138,19 @@ class Example extends React.Component {
                     {...restProps}
                     description={option.description}
                   />
+                )}
+                renderTrigger={(selectedOption) => (
+                  <div style={{ display: "flex", alignItems: "center" }}>
+                    <span>{selectedOption.label}</span>
+                    <span
+                      style={{
+                        color: "var(--text_secondary)",
+                        marginLeft: "8px",
+                      }}
+                    >
+                      ({selectedOption.description})
+                    </span>
+                  </div>
                 )}
                 options={this.cities}
               />

--- a/src/components/Select/Readme.md
+++ b/src/components/Select/Readme.md
@@ -19,6 +19,16 @@
               before={<Avatar size={24} src={option.avatar} />}
             />
           )}
+          renderTrigger={(option) => (
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <Avatar
+                style={{ marginRight: "8px" }}
+                size={20}
+                src={option.avatar}
+              />
+              {option.label}
+            </div>
+          )}
         />
       </FormItem>
     </Group>


### PR DESCRIPTION
Добавил возможность рендерить кастомный триггер в селекте. Например, если нужно показывать какую-то иконку слева от текста

похожее, например, есть в [semantic-ui](https://react.semantic-ui.com/modules/dropdown/#usage-trigger) и в [material](https://mui.com/components/selects/#UnstyledSelectCustomRenderValue.tsx) (renderValue)