### PR TITLE
docs(Epic): TabbarItem.label is deprecated

### DIFF
--- a/src/components/Epic/Readme.md
+++ b/src/components/Epic/Readme.md
@@ -150,7 +150,11 @@ const Example = withAdaptivity(
                     onClick={onStoryChange}
                     selected={activeStory === "messages"}
                     data-story="messages"
-                    label="12"
+                    indicator={
+                      <Counter size="s" mode="prominent">
+                        12
+                      </Counter>
+                    }
                     text="Сообщения"
                   >
                     <Icon28MessageOutline />


### PR DESCRIPTION
> [VKUI/TabbarItem] Свойство label устарело и будет удалено в 5.0.0. Используйте indicator.