### PR TITLE
Move from date-fns to dayjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "@babel/runtime": "^7.14.6",
     "@popperjs/core": "^2.9.2",
     "@vkontakte/vkjs": "^0.22.2",
-    "date-fns": "^2.28.0",
+    "dayjs": "^1.11.0",
     "mitt": "^3.0.0",
     "react-popper": "^2.2.5"
   },

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { isSameMonth, isSameDay } from "date-fns";
+import { isSameMonth, isSameDay } from "../../lib/date";
 import {
   CalendarHeader,
   CalendarHeaderProps,

--- a/src/components/Calendar/Readme.md
+++ b/src/components/Calendar/Readme.md
@@ -1,7 +1,7 @@
 Компонент выбора даты.
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-import { format } from "date-fns";
+import { format } from "../../lib/date";
 
 const Example = () => {
   const [value, setValue] = useState(new Date());
@@ -17,7 +17,7 @@ const Example = () => {
     <FormLayout>
       <FormLayoutGroup mode="vertical">
         <FormItem top="Выбранная дата">
-          {format(value, "yyyy-MM-dd HH:mm:ss")}
+          {format(value, "YYYY-MM-DD HH:mm:ss")}
         </FormItem>
         <FormItem top="Выбор времени">
           <Checkbox

--- a/src/components/CalendarDays/CalendarDays.tsx
+++ b/src/components/CalendarDays/CalendarDays.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { isSameDay, isSameMonth } from "date-fns";
+import { isSameDay, isSameMonth } from "../../lib/date";
 import { CalendarDay } from "../CalendarDay/CalendarDay";
 import { getDaysNames, getWeeks } from "../../lib/calendar";
 import { LocaleProviderContext } from "../LocaleProviderContext/LocaleProviderContext";

--- a/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/src/components/CalendarHeader/CalendarHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { setMonth, setYear, subMonths, addMonths } from "date-fns";
+import { setMonth, setYear, subMonths, addMonths } from "../../lib/date";
 import {
   Icon20ChevronLeftOutline,
   Icon20ChevronRightOutline,

--- a/src/components/CalendarRange/CalendarRange.tsx
+++ b/src/components/CalendarRange/CalendarRange.tsx
@@ -8,7 +8,7 @@ import {
   startOfDay,
   endOfDay,
   isWithinInterval,
-} from "date-fns";
+} from "../../lib/date";
 import {
   CalendarHeader,
   CalendarHeaderProps,
@@ -51,10 +51,7 @@ const getIsDaySelected = (day: Date, value?: Array<Date | null>) => {
   }
 
   return Boolean(
-    isWithinInterval(day, {
-      start: startOfDay(value[0]),
-      end: endOfDay(value[1]),
-    })
+    isWithinInterval(day, startOfDay(value[0]), endOfDay(value[1]))
   );
 };
 

--- a/src/components/CalendarRange/Readme.md
+++ b/src/components/CalendarRange/Readme.md
@@ -1,7 +1,7 @@
 Компонент выбора диапазона дат.
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-import { addDays, format } from "date-fns";
+import { addDays, format } from "../../lib/date";
 
 const Example = () => {
   const [value, setValue] = useState([new Date(), addDays(new Date(), 10)]);
@@ -14,7 +14,7 @@ const Example = () => {
     <FormLayout>
       <FormLayoutGroup mode="vertical">
         <FormItem top="Выбранная дата">
-          {format(value[0], "yyyy-MM-dd")} - {format(value[1], "yyyy-MM-dd")}
+          {format(value[0], "YYYY-MM-DD")} - {format(value[1], "YYYY-MM-DD")}
         </FormItem>
         <FormItem top="Запрет выбора прошлых дат">
           <Checkbox

--- a/src/components/CalendarTime/CalendarTime.tsx
+++ b/src/components/CalendarTime/CalendarTime.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { setHours, setMinutes } from "date-fns";
+import { setHours, setMinutes } from "../../lib/date";
 import CustomSelect from "../CustomSelect/CustomSelect";
 import Button from "../Button/Button";
 import { SizeType } from "../../hoc/withAdaptivity";

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { format, isMatch, parse } from "date-fns";
+import { format, isMatch, parse } from "../../lib/date";
 import { Icon16Clear, Icon20CalendarOutline } from "@vkontakte/icons";
 import { Calendar, CalendarProps } from "../Calendar/Calendar";
 import { Popper, Placement } from "../Popper/Popper";
@@ -137,7 +137,7 @@ export const DateInput: React.FC<DateInputProps> = ({
       }
 
       let formattedValue = `${internalValue[0]}.${internalValue[1]}.${internalValue[2]}`;
-      let mask = "dd.MM.yyyy";
+      let mask = "DD.MM.YYYY";
       if (enableTime) {
         formattedValue += ` ${internalValue[3]}:${internalValue[4]}`;
         mask += " HH:mm";
@@ -226,7 +226,7 @@ export const DateInput: React.FC<DateInputProps> = ({
         name={name}
         value={
           value
-            ? format(value, enableTime ? "dd.MM.yyyy'T'HH:mm" : "dd.MM.yyyy")
+            ? format(value, enableTime ? "DD.MM.YYYYTHH:mm" : "DD.MM.YYYY")
             : ""
         }
       />

--- a/src/components/DateInput/Readme.md
+++ b/src/components/DateInput/Readme.md
@@ -3,7 +3,7 @@
 > ⚠️ Данный компонент предназначен для использования на desktop. При использовании на ios/android работа компонента не гарантируется
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-import { format } from "date-fns";
+import { format } from "../../lib/date";
 
 const Example = () => {
   const [value, setValue] = useState(new Date());

--- a/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { format, isMatch, parse, isAfter } from "date-fns";
+import { format, isMatch, parse, isAfter } from "../../lib/date";
 import { Icon16Clear, Icon20CalendarOutline } from "@vkontakte/icons";
 import {
   CalendarRange,
@@ -261,8 +261,8 @@ export const DateRangeInput: React.FC<DateRangeInputProps> = ({
         name={name}
         value={
           value
-            ? `${value[0] ? format(value[0], "dd.MM.yyyy") : ""} - ${
-                value[1] ? format(value[1], "dd.MM.yyyy") : ""
+            ? `${value[0] ? format(value[0], "DD.MM.YYYY") : ""} - ${
+                value[1] ? format(value[1], "DD.MM.YYYY") : ""
               }`
             : ""
         }

--- a/src/components/DateRangeInput/Readme.md
+++ b/src/components/DateRangeInput/Readme.md
@@ -3,7 +3,7 @@
 > ⚠️ Данный компонент предназначен для использования на desktop. При использовании на ios/android работа компонента не гарантируется
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-import { format, addDays } from "date-fns";
+import { format, addDays } from "../../lib/date";
 
 const Example = () => {
   const [value, setValue] = useState([new Date(), addDays(new Date(), 10)]);

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -7,7 +7,7 @@ import {
   endOfDay,
   isAfter,
   startOfDay,
-} from "date-fns";
+} from "../lib/date";
 
 export interface UseCalendarDependencies {
   value?: Array<Date | null> | Date;

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -11,7 +11,7 @@ import {
   isBefore,
   isFirstDayOfMonth,
   isLastDayOfMonth,
-} from "date-fns";
+} from "./date";
 
 export const getYears = (currentYear: number, range: number) => {
   const years: Array<{
@@ -53,10 +53,10 @@ export const getDaysNames = (
   const formatter = new Intl.DateTimeFormat(locale, {
     weekday: "short",
   });
-  return eachDayOfInterval({
-    start: startOfWeek(now, { weekStartsOn }),
-    end: endOfWeek(now, { weekStartsOn }),
-  }).map((day) => formatter.format(day));
+  return eachDayOfInterval(
+    startOfWeek(now, weekStartsOn),
+    endOfWeek(now, weekStartsOn)
+  ).map((day) => formatter.format(day));
 };
 
 export const navigateDate = (date?: Date | null, key?: string) => {
@@ -84,8 +84,8 @@ export const getWeeks = (
   viewDate: Date,
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
 ) => {
-  const start = startOfWeek(startOfMonth(viewDate), { weekStartsOn });
-  const end = endOfWeek(endOfMonth(viewDate), { weekStartsOn });
+  const start = startOfWeek(startOfMonth(viewDate), weekStartsOn);
+  const end = endOfWeek(endOfMonth(viewDate), weekStartsOn);
 
   let count = 0;
   let current = start;

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -20,17 +20,47 @@ describe(parse, () => {
     expect(format(result, "MM-DD-YYYY HH:mm")).toEqual("12-25-1995 20:34");
   });
 
-  it("It parses valid date and time", () => {
+  it("Parses valid date and time", () => {
     const result = parse("12-25-1995 16:36", "MM-DD-YYYY HH:mm");
     expect(format(result, "MM-DD-YYYY HH:mm")).toEqual("12-25-1995 16:36");
   });
 
-  it("It parses valid date and time with reference", () => {
+  it("Parses valid date and time with reference", () => {
     const reference = new Date(2022, 3, 4, 20, 34, 52);
     const result = parse("12-25-1995 16:36", "MM-DD-YYYY HH:mm", reference);
     expect(format(result, "MM-DD-YYYY HH:mm:ss")).toEqual(
       "12-25-1995 16:36:52"
     );
+  });
+
+  it("Validates identical non-formatting symbols", () => {
+    const result = parse("12 xxx 25 yyy 1995", "MM yyy DD xxx YYYY");
+    expect(result.toString()).toEqual("Invalid Date");
+  });
+
+  it("Fails if formatting not found", () => {
+    const result = parse("12 xxx 25 yyy 1995", "foo yyy bar xxx baz");
+    expect(result.toString()).toEqual("Invalid Date");
+  });
+
+  it("Fails with year month overflow", () => {
+    const result = parse("13-15-2022", "MM-DD-YYYY");
+    expect(result.toString()).toEqual("Invalid Date");
+  });
+
+  it("Fails with month day overflow", () => {
+    const result = parse("02-31-2022", "MM-DD-YYYY");
+    expect(result.toString()).toEqual("Invalid Date");
+  });
+
+  it("Fails with day hours overflow", () => {
+    const result = parse("04-04-2022 25:31", "MM-DD-YYYY HH:mm");
+    expect(result.toString()).toEqual("Invalid Date");
+  });
+
+  it("Fails with hours minutes overflow", () => {
+    const result = parse("04-04-2022 14:61", "MM-DD-YYYY HH:mm");
+    expect(result.toString()).toEqual("Invalid Date");
   });
 });
 

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -1,0 +1,149 @@
+import {
+  parse,
+  startOfWeek,
+  endOfWeek,
+  isLastDayOfMonth,
+  isWithinInterval,
+  eachDayOfInterval,
+  format,
+} from "./date";
+
+describe(parse, () => {
+  it("Parses valid date", () => {
+    const result = parse("12-25-1995", "MM-DD-YYYY");
+    expect(format(result, "MM-DD-YYYY")).toEqual("12-25-1995");
+  });
+
+  it("Parses valid date with reference", () => {
+    const reference = new Date(2022, 3, 4, 20, 34);
+    const result = parse("12-25-1995", "MM-DD-YYYY", reference);
+    expect(format(result, "MM-DD-YYYY HH:mm")).toEqual("12-25-1995 20:34");
+  });
+
+  it("It parses valid date and time", () => {
+    const result = parse("12-25-1995 16:36", "MM-DD-YYYY HH:mm");
+    expect(format(result, "MM-DD-YYYY HH:mm")).toEqual("12-25-1995 16:36");
+  });
+
+  it("It parses valid date and time with reference", () => {
+    const reference = new Date(2022, 3, 4, 20, 34, 52);
+    const result = parse("12-25-1995 16:36", "MM-DD-YYYY HH:mm", reference);
+    expect(format(result, "MM-DD-YYYY HH:mm:ss")).toEqual(
+      "12-25-1995 16:36:52"
+    );
+  });
+});
+
+describe(startOfWeek, () => {
+  it("Doesn't change start of the week", () => {
+    // 2022-04-04, Monday
+    const date = new Date(2022, 3, 4);
+    const result = startOfWeek(date, 1);
+    expect(format(result, "YYYY-MM-DD")).toEqual("2022-04-04");
+  });
+
+  it("Changes start of the week to Sunday", () => {
+    // 2022-04-04, Monday
+    const date = new Date(2022, 3, 4);
+    const result = startOfWeek(date, 0);
+    expect(format(result, "YYYY-MM-DD")).toEqual("2022-04-03");
+  });
+
+  it("Changes start of the week to Tuesday", () => {
+    // 2022-04-04, Monday
+    const date = new Date(2022, 3, 4);
+    const result = startOfWeek(date, 2);
+    expect(format(result, "YYYY-MM-DD")).toEqual("2022-03-29");
+  });
+});
+
+describe(endOfWeek, () => {
+  it("Doesn't change end of the week", () => {
+    // 2022-04-04, Monday
+    const date = new Date(2022, 3, 4);
+    const result = endOfWeek(date, 1);
+    expect(format(result, "YYYY-MM-DD")).toEqual("2022-04-10");
+  });
+
+  it("Changes end of the week to Saturday", () => {
+    // 2022-04-04, Monday
+    const date = new Date(2022, 3, 4);
+    const result = endOfWeek(date, 0);
+    expect(format(result, "YYYY-MM-DD")).toEqual("2022-04-09");
+  });
+
+  it("Changes start of the week to Monday", () => {
+    // 2022-04-04, Monday
+    const date = new Date(2022, 3, 4);
+    const result = endOfWeek(date, 2);
+    expect(format(result, "YYYY-MM-DD")).toEqual("2022-04-04");
+  });
+});
+
+describe(isLastDayOfMonth, () => {
+  it("is the last day of the month", () => {
+    const date = new Date(2022, 2, 31);
+    const result = isLastDayOfMonth(date);
+    expect(result).toEqual(true);
+  });
+
+  it("is NOT the last day of the month", () => {
+    const date = new Date(2022, 2, 30);
+    const result = isLastDayOfMonth(date);
+    expect(result).toEqual(false);
+  });
+
+  it("is NOT the last day of the month 2", () => {
+    const date = new Date(2022, 3, 1);
+    const result = isLastDayOfMonth(date);
+    expect(result).toEqual(false);
+  });
+});
+
+describe(isWithinInterval, () => {
+  it("is within interval", () => {
+    const date = new Date(2022, 3, 4);
+    const start = new Date(2022, 3, 3);
+    const end = new Date(2022, 3, 5);
+    const result = isWithinInterval(date, start, end);
+    expect(result).toEqual(true);
+  });
+
+  it("is within interval 2", () => {
+    const date = new Date(2022, 3, 4);
+    const start = new Date(2022, 3, 3, 23, 59, 59, 999);
+    const end = new Date(2022, 3, 5);
+    const result = isWithinInterval(date, start, end);
+    expect(result).toEqual(true);
+  });
+
+  it("is NOT within interval", () => {
+    const date = new Date(2022, 3, 4);
+    const start = new Date(2022, 3, 1);
+    const end = new Date(2022, 3, 3);
+    const result = isWithinInterval(date, start, end);
+    expect(result).toEqual(false);
+  });
+
+  it("is NOT within interval 2", () => {
+    const date = new Date(2022, 3, 4);
+    const start = new Date(2022, 3, 5);
+    const end = new Date(2022, 3, 3);
+    const result = isWithinInterval(date, start, end);
+    expect(result).toEqual(false);
+  });
+});
+
+describe(eachDayOfInterval, () => {
+  it("generates days within internal", () => {
+    const start = new Date(2022, 3, 1);
+    const end = new Date(2022, 3, 5);
+    const result = eachDayOfInterval(start, end).map((date: Date) => {
+      return format(date, "DD-MM-YYYY HH:mm");
+    });
+    expect(result.join()).toEqual(
+      "01-04-2022 00:00,02-04-2022 00:00," +
+        "03-04-2022 00:00,04-04-2022 00:00,05-04-2022 00:00"
+    );
+  });
+});

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,250 @@
+import dayjs from "dayjs";
+
+type DirtyDate = Date | number;
+
+export function startOfDay(date: DirtyDate) {
+  return dayjs(date).startOf("day").toDate();
+}
+
+export function endOfDay(date: DirtyDate) {
+  return dayjs(date).endOf("day").toDate();
+}
+
+export function startOfWeek(date: DirtyDate, weekStart = 0) {
+  // hacks
+  const day = dayjs(date);
+  // @ts-ignore
+  day.$locale().weekStart = weekStart;
+  return day.startOf("week").toDate();
+}
+
+export function endOfWeek(date: DirtyDate, weekStart = 0) {
+  // hacks
+  const day = dayjs(date);
+  // @ts-ignore
+  day.$locale().weekStart = weekStart;
+  return day.endOf("week").toDate();
+}
+
+export function startOfMonth(date: DirtyDate) {
+  return dayjs(date).startOf("month").toDate();
+}
+
+export function endOfMonth(date: DirtyDate) {
+  return dayjs(date).endOf("month").toDate();
+}
+
+export function isFirstDayOfMonth(date: DirtyDate) {
+  return dayjs(date).date() === 1;
+}
+
+export function isLastDayOfMonth(date: DirtyDate) {
+  // isSameDay -- shorter, but not exact with date-fns behavior
+  // return isSameDay(date, dayjs(date).endOf("month"));
+  return dayjs(date).endOf("day").isSame(dayjs(date).endOf("month"));
+}
+
+export function format(date: DirtyDate, format: string) {
+  return dayjs(date).format(format);
+}
+
+export function isBefore(date1: DirtyDate, date2: DirtyDate) {
+  // Exactly as date-fns does
+  // dayjs().isBefore() for slightly different approach
+  return dayjs(date1) < dayjs(date2);
+}
+
+export function isAfter(date1: DirtyDate, date2: DirtyDate) {
+  return dayjs(date1) > dayjs(date2);
+}
+
+export function isSameDay(date1: DirtyDate, date2: DirtyDate) {
+  return dayjs(date1).isSame(date2, "day");
+}
+
+export function isSameMonth(date1: DirtyDate, date2: DirtyDate) {
+  return dayjs(date1).isSame(date2, "month");
+}
+
+export function isWithinInterval(
+  date: DirtyDate,
+  start: DirtyDate,
+  end: DirtyDate
+) {
+  const day = dayjs(date);
+  return day >= dayjs(start) && day <= dayjs(end);
+}
+
+export function setMinutes(date: DirtyDate, minute: number) {
+  return dayjs(date).set("minute", minute).toDate();
+}
+
+export function setHours(date: DirtyDate, hour: number) {
+  return dayjs(date).set("hour", hour).toDate();
+}
+
+export function setMonth(date: DirtyDate, month: number) {
+  return dayjs(date).set("month", month).toDate();
+}
+
+export function setYear(date: DirtyDate, year: number) {
+  return dayjs(date).set("year", year).toDate();
+}
+
+export function addDays(date: DirtyDate, day: number) {
+  return dayjs(date).add(day, "day").toDate();
+}
+
+export function subDays(date: DirtyDate, day: number) {
+  return dayjs(date).subtract(day, "day").toDate();
+}
+
+export function addWeeks(date: DirtyDate, week: number) {
+  return dayjs(date).add(week, "week").toDate();
+}
+
+export function subWeeks(date: DirtyDate, week: number) {
+  return dayjs(date).subtract(week, "week").toDate();
+}
+
+export function addMonths(date: DirtyDate, month: number) {
+  return dayjs(date).add(month, "month").toDate();
+}
+
+export function subMonths(date: DirtyDate, month: number) {
+  return dayjs(date).subtract(month, "month").toDate();
+}
+
+// Rip off date-fns
+export function eachDayOfInterval(start: DirtyDate, end: DirtyDate) {
+  const dates: Date[] = [];
+  const startDate = dayjs(start).toDate();
+  const endDate = dayjs(end).toDate();
+
+  const endTime = endDate.getTime();
+  const currentDate = startDate;
+  currentDate.setHours(0, 0, 0, 0);
+
+  while (currentDate.getTime() <= endTime) {
+    dates.push(new Date(currentDate.getTime()));
+    currentDate.setDate(currentDate.getDate() + 1);
+    currentDate.setHours(0, 0, 0, 0);
+  }
+
+  return dates;
+}
+
+export function parse(input: string, format: string, referenceDate?: Date) {
+  const match2 = /^\d\d/; // 00 - 99
+  const match4 = /^\d{4}/; // 0000 - 9999
+
+  const date = referenceDate ? new Date(referenceDate) : new Date();
+
+  const entries: Array<
+    [string, RegExp, (val: string) => [string, number, boolean]]
+  > = [
+    ["YYYY", match4, (val) => ["Y", +val, true]],
+    // ['yyyy', match4, (val) => ['Y', +val, true]],
+    [
+      "MM",
+      match2,
+      (val) => {
+        const numVal = +val;
+        const okay = numVal > 0 && numVal <= 12;
+
+        return ["M", numVal - 1, okay];
+      },
+    ],
+    ["DD", match2, (val) => ["D", +val, true]],
+    // ['dd', match2, (val) => ['D', +val, true]],
+    [
+      "HH",
+      match2,
+      (val) => {
+        const numVal = parseInt(val, 10);
+        const okay = numVal >= 0 && numVal < 24;
+
+        return ["h", numVal, okay];
+      },
+    ],
+    [
+      "mm",
+      match2,
+      (val) => {
+        const numVal = parseInt(val, 10);
+        const okay = numVal >= 0 && numVal < 60;
+
+        return ["m", numVal, okay];
+      },
+    ],
+  ];
+
+  const superRegExp = new RegExp(entries.map((item) => item[0]).join("|"), "g");
+
+  const store: {
+    [key: string]: number;
+  } = {
+    Y: date.getFullYear(),
+    M: date.getMonth(),
+    D: date.getDate(),
+    h: date.getHours(),
+    m: date.getMinutes(),
+  };
+
+  let going = true;
+
+  // TODO:
+  // Если не было итераций, то считается валидной датой
+  // TODO:
+  // Как то обработать повторения, если нужно
+  while (going) {
+    const match = superRegExp.exec(format);
+
+    if (!match) {
+      going = false;
+      break;
+    }
+
+    const length = match[0].length;
+    const atIndex = superRegExp.lastIndex - length;
+
+    // TODO:
+    // Возможно нужна проверка что используются именно те разделитили что в формате
+    const item = entries.find((item) => item[0] === match[0]);
+
+    if (!item) {
+      return new Date("");
+    }
+
+    const value = input.slice(atIndex).match(item[1]);
+    const [key, newValue, okay] = item[2](value ? value[0] : "");
+
+    if (!okay) {
+      return new Date("");
+    }
+
+    store[key] = newValue;
+  }
+
+  date.setFullYear(store.Y);
+  date.setMonth(store.M);
+  date.setDate(store.D);
+  date.setHours(store.h);
+  date.setMinutes(store.m);
+
+  if (
+    date.getFullYear() === store.Y &&
+    date.getMonth() === store.M &&
+    date.getDate() === store.D &&
+    date.getHours() === store.h &&
+    date.getMinutes() === store.m
+  ) {
+    return date;
+  }
+
+  return new Date("");
+}
+
+export function isMatch(input: string, format: string) {
+  return !isNaN(+parse(input, format));
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -12,19 +12,19 @@ export function endOfDay(date: DirtyDate) {
 }
 
 export function startOfWeek(date: DirtyDate, weekStart = 0) {
-  // hacks
+  weekStart = weekStart % 7;
+
   const day = dayjs(date);
-  // @ts-ignore
-  day.$locale().weekStart = weekStart;
-  return day.startOf("week").toDate();
+  const weekDay = day.day();
+  const diff = (weekDay < weekStart ? 7 : 0) + weekDay - weekStart;
+
+  return day.date(day.date() - diff).toDate();
 }
 
 export function endOfWeek(date: DirtyDate, weekStart = 0) {
-  // hacks
-  const day = dayjs(date);
-  // @ts-ignore
-  day.$locale().weekStart = weekStart;
-  return day.endOf("week").toDate();
+  const day = dayjs(startOfWeek(date, weekStart));
+
+  return day.date(day.date() + 6).toDate();
 }
 
 export function startOfMonth(date: DirtyDate) {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -138,7 +138,7 @@ export function eachDayOfInterval(start: DirtyDate, end: DirtyDate) {
 export function parse(
   input: string,
   format: string,
-  referenceDate?: Date = new Date()
+  referenceDate: Date = new Date()
 ) {
   const match2 = /^\d\d/; // 00 - 99
   const match4 = /^\d{4}/; // 0000 - 9999

--- a/yarn.lock
+++ b/yarn.lock
@@ -4976,10 +4976,10 @@ date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
 
-date-fns@^2.28.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
-  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+dayjs@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
+  integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Переход на dayjs с date-fns что бы уменьшить размер компонента Calendar.

Было:
```
  JS
  Size: 83.66 kB with all dependencies, minified and gzipped
```

Стало:
```
  JS
  Size: 76.7 kB with all dependencies, minified and gzipped
```