### PR TITLE
[Infra] Skip `deploy_styleguide` job for "dependabot[bot]"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -91,8 +91,8 @@ jobs:
   deploy_styleguide:
     runs-on: ubuntu-latest
     needs: styleguide
-    # Skip deploy from forked repo
-    if: github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
+    # Skip deploy from forked repo or from dependabot
+    if: ${{ (github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id) && (github.actor != 'dependabot[bot]') }}
     steps:
       - uses: actions/checkout@v2
       - name: Download styleguide artifact


### PR DESCRIPTION
Пропускаем запуск джобы `deploy_styleguide` в PR от `@dependabot`. Во-первых, у бота нет прав на деплой (надо настраивать), во-вторых, экономим ресурсы, т.к. песочницу собирать кажется нет смысла.

![image](https://user-images.githubusercontent.com/5850354/161943891-e7c71936-dcb1-4b5a-bad4-a947b8373539.png)

**Пример.** Упавшая джоба `deploy_styleguide` в PR [#2327](https://togithub.com/VKCOM/VKUI/pull/2327)
