### PR TITLE
Fix double click with checkbox

### DIFF
--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { classNames } from "../../lib/classNames";
-import { noop } from "../../lib/utils";
+import { noop, stopPropagation } from "../../lib/utils";
 import { warnOnce } from "../../lib/warnOnce";
 import { getClassName } from "../../helpers/getClassName";
 import { ANDROID, IOS, VKCOM } from "../../lib/platform";
@@ -138,7 +138,13 @@ export const Cell: React.FC<CellProps> = ({
       checked,
       disabled,
     };
-    checkbox = <CellCheckbox vkuiClass="Cell__checkbox" {...checkboxProps} />;
+    checkbox = (
+      <CellCheckbox
+        vkuiClass="Cell__checkbox"
+        onClick={stopPropagation}
+        {...checkboxProps}
+      />
+    );
   }
 
   const simpleCellDisabled =

--- a/src/components/Switch/Readme.md
+++ b/src/components/Switch/Readme.md
@@ -5,51 +5,27 @@
   <Panel id="switch">
     <PanelHeader>Switch</PanelHeader>
     <Group>
-      <Cell
-        role={null}
-        disabled
-        after={<Switch aria-label="Комментарии к записям" />}
-      >
+      <SimpleCell Component="label" after={<Switch />}>
         Комментарии к записям
-      </Cell>
-      <Cell
-        role={null}
-        disabled
-        after={<Switch defaultChecked aria-label="Ссылки" />}
-      >
+      </SimpleCell>
+      <SimpleCell Component="label" after={<Switch defaultChecked />}>
         Ссылки
-      </Cell>
-      <Cell
-        role={null}
-        disabled
-        after={<Switch disabled aria-label="Фотоальбомы" />}
-      >
+      </SimpleCell>
+      <SimpleCell Component="label" after={<Switch disabled />}>
         Фотоальбомы
-      </Cell>
+      </SimpleCell>
     </Group>
     <Group header={<Header mode="secondary">Компактный вид</Header>}>
       <AdaptivityProvider sizeY="compact">
-        <Cell
-          role={null}
-          disabled
-          after={<Switch aria-label="Комментарии к записям" />}
-        >
+        <SimpleCell Component="label" after={<Switch />}>
           Комментарии к записям
-        </Cell>
-        <Cell
-          role={null}
-          disabled
-          after={<Switch defaultChecked aria-label="Ссылки" />}
-        >
+        </SimpleCell>
+        <SimpleCell Component="label" after={<Switch defaultChecked />}>
           Ссылки
-        </Cell>
-        <Cell
-          role={null}
-          disabled
-          after={<Switch disabled aria-label="Фотоальбомы" />}
-        >
+        </SimpleCell>
+        <SimpleCell Component="label" after={<Switch disabled />}>
           Фотоальбомы
-        </Cell>
+        </SimpleCell>
       </AdaptivityProvider>
     </Group>
   </Panel>

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { getClassName } from "../../helpers/getClassName";
 import { classNames } from "../../lib/classNames";
 import { callMultiple } from "../../lib/callMultiple";
+import { stopPropagation } from "../../lib/utils";
 import { usePlatform } from "../../hooks/usePlatform";
 import { HasRootRef } from "../../types";
 import { useAdaptivity } from "../../hooks/useAdaptivity";
@@ -21,6 +22,7 @@ export const Switch: React.FC<SwitchProps> = ({
   style,
   className,
   getRootRef,
+  onClick = stopPropagation,
   ...restProps
 }: SwitchProps) => {
   const platform = usePlatform();
@@ -45,6 +47,7 @@ export const Switch: React.FC<SwitchProps> = ({
     >
       <VisuallyHiddenInput
         {...restProps}
+        onClick={onClick}
         type="checkbox"
         vkuiClass="Switch__self"
         onBlur={callMultiple(onBlur, restProps.onBlur)}


### PR DESCRIPTION
Исправлено двойное срабатывание onClick:

- Switch по умолчанию `onClick=stopPropagation`
- Внутри Cell у компонента CellCheckbox `onClick={stopPropagation}`

This closed #2366

---

- Исправлен пример: 
  - чекбокс должен иметь [видимую текстовую метку](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Text_labels_and_names#form_elements_should_have_a_visible_text_label)
  - Cell заменен на SimpleCell
  - нажатие на SimpleCell переключает Switch
<img width="821" alt="image" src="https://user-images.githubusercontent.com/14944123/162750377-d843f03e-d495-4c40-9b07-7e8edae7a32a.png">
