### PR TITLE
refactor(PanelHeader): Переименовать `left`/`right` в `before`/`after`

### DIFF
--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -124,7 +124,7 @@
 /**
  * .PanelHeader
  */
-.PanelHeader__left .Avatar {
+.PanelHeader__before .Avatar {
   margin-left: 8px;
 }
 

--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -128,7 +128,7 @@
   margin-left: 8px;
 }
 
-.PanelHeader__right .Avatar {
+.PanelHeader__after .Avatar {
   margin-right: 8px;
 }
 

--- a/src/components/Epic/Readme.md
+++ b/src/components/Epic/Readme.md
@@ -182,7 +182,7 @@ const Example = withAdaptivity(
           >
             <View id="feed" activePanel="feed">
               <Panel id="feed">
-                <PanelHeader left={<PanelHeaderBack />}>Новости</PanelHeader>
+                <PanelHeader before={<PanelHeaderBack />}>Новости</PanelHeader>
                 <Group style={{ height: "1000px" }}>
                   <Placeholder
                     icon={<Icon56NewsfeedOutline width={56} height={56} />}
@@ -192,7 +192,7 @@ const Example = withAdaptivity(
             </View>
             <View id="services" activePanel="services">
               <Panel id="services">
-                <PanelHeader left={<PanelHeaderBack />}>Сервисы</PanelHeader>
+                <PanelHeader before={<PanelHeaderBack />}>Сервисы</PanelHeader>
                 <Group style={{ height: "1000px" }}>
                   <Placeholder
                     icon={<Icon28ServicesOutline width={56} height={56} />}
@@ -202,7 +202,9 @@ const Example = withAdaptivity(
             </View>
             <View id="messages" activePanel="messages">
               <Panel id="messages">
-                <PanelHeader left={<PanelHeaderBack />}>Сообщения</PanelHeader>
+                <PanelHeader before={<PanelHeaderBack />}>
+                  Сообщения
+                </PanelHeader>
                 <Group style={{ height: "1000px" }}>
                   <Placeholder
                     icon={<Icon28MessageOutline width={56} height={56} />}
@@ -212,7 +214,7 @@ const Example = withAdaptivity(
             </View>
             <View id="clips" activePanel="clips">
               <Panel id="clips">
-                <PanelHeader left={<PanelHeaderBack />}>Клипы</PanelHeader>
+                <PanelHeader before={<PanelHeaderBack />}>Клипы</PanelHeader>
                 <Group style={{ height: "1000px" }}>
                   <Placeholder
                     icon={<Icon28ClipOutline width={56} height={56} />}
@@ -222,7 +224,7 @@ const Example = withAdaptivity(
             </View>
             <View id="profile" activePanel="profile">
               <Panel id="profile">
-                <PanelHeader left={<PanelHeaderBack />}>Профиль</PanelHeader>
+                <PanelHeader before={<PanelHeaderBack />}>Профиль</PanelHeader>
                 <Group style={{ height: "1000px" }}>
                   <Placeholder
                     icon={<Icon28UserCircleOutline width={56} height={56} />}

--- a/src/components/FixedLayout/FixedLayout.css
+++ b/src/components/FixedLayout/FixedLayout.css
@@ -32,6 +32,19 @@
   padding-bottom: var(--safe-area-inset-bottom);
 }
 
+/**
+ * CMP:
+ * Epic
+ */
 .Epic .FixedLayout--bottom {
   padding-bottom: calc(var(--tabbar_height) + var(--safe-area-inset-bottom));
+}
+
+/**
+ * CMP:
+ * PanelHeader
+ */
+.PanelHeader ~ .FixedLayout--top,
+.PanelHeader ~ * .FixedLayout--top:not(.PanelHeader__fixed) {
+  top: calc(var(--panelheader_height) + var(--safe-area-inset-top));
 }

--- a/src/components/Group/Readme.md
+++ b/src/components/Group/Readme.md
@@ -96,14 +96,14 @@ class App extends React.Component {
           onClose={() => this.setState({ isModalOpened: false })}
           header={
             <ModalPageHeader
-              left={
+              before={
                 this.props.platform !== IOS && (
                   <PanelHeaderClose
                     onClick={() => this.setState({ isModalOpened: false })}
                   />
                 )
               }
-              right={
+              after={
                 this.props.platform === IOS && (
                   <PanelHeaderButton
                     onClick={() => this.setState({ isModalOpened: false })}

--- a/src/components/MiniInfoCell/Readme.md
+++ b/src/components/MiniInfoCell/Readme.md
@@ -16,14 +16,14 @@ function MiniInfoCellExample() {
       <ModalPage
         header={
           <ModalPageHeader
-            left={
+            before={
               (platform === ANDROID || platform === VKCOM) && (
                 <PanelHeaderButton onClick={closeModal}>
                   <Icon24Cancel />
                 </PanelHeaderButton>
               )
             }
-            right={
+            after={
               platform === IOS && (
                 <PanelHeaderButton onClick={closeModal}>
                   <Icon24Dismiss />

--- a/src/components/ModalPageHeader/ModalPageHeader.e2e.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.e2e.tsx
@@ -1,4 +1,4 @@
-import ModalPageHeader, { ModalPageHeaderProps } from "./ModalPageHeader";
+import { ModalPageHeader, ModalPageHeaderProps } from "./ModalPageHeader";
 import { describeScreenshotFuzz } from "../../testing/e2e/utils";
 import { PanelHeaderButton } from "../PanelHeaderButton/PanelHeaderButton";
 import { Icon24Cancel, Icon24Dismiss, Icon24Done } from "@vkontakte/icons";

--- a/src/components/ModalPageHeader/ModalPageHeader.e2e.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.e2e.tsx
@@ -7,7 +7,7 @@ import { ViewWidth } from "../../hoc/withAdaptivity";
 import ModalRootContext from "../ModalRoot/ModalRootContext";
 import { noop } from "../../lib/utils";
 
-const BaseModalPageHeader = (p: ModalPageHeaderProps) => (
+const BaseModalPageHeader = (props: ModalPageHeaderProps) => (
   <ModalRootContext.Provider
     value={{
       isInsideModal: true,
@@ -15,7 +15,7 @@ const BaseModalPageHeader = (p: ModalPageHeaderProps) => (
       registerModal: noop,
     }}
   >
-    <ModalPageHeader {...p} />
+    <ModalPageHeader {...props} />
   </ModalRootContext.Provider>
 );
 
@@ -45,8 +45,8 @@ describe("ModalPageHeader", () => {
     [
       {
         children,
-        left: [null, cancel],
-        right: [null, done],
+        before: [null, cancel],
+        after: [null, done],
       },
     ],
     {
@@ -61,8 +61,8 @@ describe("ModalPageHeader", () => {
     [
       {
         children,
-        left: [null, cancel],
-        right: [null, done],
+        before: [null, cancel],
+        after: [null, done],
       },
     ],
     {
@@ -77,8 +77,8 @@ describe("ModalPageHeader", () => {
     [
       {
         children,
-        right: [dismiss, dismissText],
-        left: [null, cancel],
+        before: [null, cancel],
+        after: [dismiss, dismissText],
       },
     ],
     {
@@ -93,8 +93,8 @@ describe("ModalPageHeader", () => {
     [
       {
         children,
-        right: [dismiss, dismissText],
-        left: [null, cancel],
+        before: [null, cancel],
+        after: [dismiss, dismissText],
       },
     ],
     {

--- a/src/components/ModalPageHeader/ModalPageHeader.test.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.test.tsx
@@ -1,5 +1,5 @@
 import { baselineComponent } from "../../testing/utils";
-import ModalPageHeader from "./ModalPageHeader";
+import { ModalPageHeader } from "./ModalPageHeader";
 
 describe("ModalPageHeader", () => {
   baselineComponent(ModalPageHeader);

--- a/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { usePlatform } from "../../hooks/usePlatform";
+import { useAdaptivityIsDesktop } from "../../hooks/useAdaptivity";
 import { HasRef } from "../../types";
 import { VKCOM } from "../../lib/platform";
-import PanelHeader, { PanelHeaderProps } from "../PanelHeader/PanelHeader";
 import { Separator } from "../Separator/Separator";
-import { useAdaptivityIsDesktop } from "../../hooks/useAdaptivity";
+import { PanelHeader, PanelHeaderProps } from "../PanelHeader/PanelHeader";
 import { classNames } from "../../lib/classNames";
 import { getClassName } from "../../helpers/getClassName";
 import "./ModalPageHeader.css";

--- a/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -17,7 +17,7 @@ export interface ModalPageHeaderProps
 /**
  * @see https://vkcom.github.io/VKUI/#/ModalPageHeader
  */
-const ModalPageHeader: React.FunctionComponent<ModalPageHeaderProps> = ({
+const ModalPageHeader = ({
   children,
   separator,
   getRef,

--- a/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -19,7 +19,7 @@ export interface ModalPageHeaderProps
  */
 const ModalPageHeader = ({
   children,
-  separator,
+  separator = true,
   getRef,
   ...restProps
 }: ModalPageHeaderProps) => {
@@ -47,10 +47,6 @@ const ModalPageHeader = ({
       {hasSeparator && <Separator wide />}
     </div>
   );
-};
-
-ModalPageHeader.defaultProps = {
-  separator: true,
 };
 
 // eslint-disable-next-line import/no-default-export

--- a/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -29,10 +29,10 @@ export const ModalPageHeader = ({
 
   return (
     <div
-      // eslint-disable-next-line vkui/no-object-expression-in-arguments
-      vkuiClass={classNames(getClassName("ModalPageHeader", platform), {
-        "ModalPageHeader--desktop": isDesktop,
-      })}
+      vkuiClass={classNames(
+        getClassName("ModalPageHeader", platform),
+        isDesktop && "ModalPageHeader--desktop"
+      )}
       ref={getRef}
     >
       <PanelHeader

--- a/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -17,7 +17,7 @@ export interface ModalPageHeaderProps
 /**
  * @see https://vkcom.github.io/VKUI/#/ModalPageHeader
  */
-const ModalPageHeader = ({
+export const ModalPageHeader = ({
   children,
   separator = true,
   getRef,
@@ -48,6 +48,3 @@ const ModalPageHeader = ({
     </div>
   );
 };
-
-// eslint-disable-next-line import/no-default-export
-export default ModalPageHeader;

--- a/src/components/ModalPageHeader/Readme.md
+++ b/src/components/ModalPageHeader/Readme.md
@@ -16,7 +16,7 @@ const platform = usePlatform();
 
 return (
   <ModalPageHeader
-    left={
+    before={
       <Fragment>
         {(platform === ANDROID || platform === VKCOM) && (
           <PanelHeaderButton onClick={this.backModal}>
@@ -25,7 +25,7 @@ return (
         )}
       </Fragment>
     }
-    right={
+    after={
       <Fragment>
         {(platform === ANDROID || platform === VKCOM) && (
           <PanelHeaderButton onClick={this.backModal}>

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-android-light-w_2-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-android-light-w_2-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a64425d70d0252332674c086f36b3565f81d960d903962376facfaf6d2ccca2
-size 65189
+oid sha256:f44bc969844c5a9b0f29fdc24fbb30066d825fd6e565c29a642660396b9d1aac
+size 66421

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-android-light-w_5-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-android-light-w_5-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbf7876b0853e41aa47c4b6c461e81fd75e8c6aad4f44b6df44e1f1286904df4
-size 80535
+oid sha256:f67038b9b36b3087f77b7d4548b809a77c1932d3bfff0fb5d419c5c0d7f5e14f
+size 80610

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-light-w_2-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-light-w_2-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:307e2878ea30ac60b824d15a7925b0c9c4017bb9fe4d71cbf7087ba2c980b25f
-size 67742
+oid sha256:a134955f86d78d62d4633f1baa83e75266fcb9dfe70abfcc32796b6786969a14
+size 69337

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-light-w_5-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-ios-light-w_5-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b586635f13eec08d7a5dd49929ff22a8b02ecb335930e1028b2710528f286f63
-size 82246
+oid sha256:ef6d2831b7dd32a1f87a8520a3ae636f897b6f0c2c542f8d93df652a637a29f5
+size 82344

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-vkcom-light-w_2-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-vkcom-light-w_2-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3982976a1e79ee7dd8c3838afc87443e4f1bb3b1b2837163ae2c182b5bab1e9e
-size 60089
+oid sha256:033ba24f4cb6aa0584db7aa7e3f67cae8809e5331da2cde2a740c31dd59342cd
+size 61318

--- a/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-vkcom-light-w_5-1-snap.png
+++ b/src/components/ModalPageHeader/__image_snapshots__/modalpageheader-vkcom-light-w_5-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0da240819f41ca54857d82b6e333d2aac2d3267c19cda96f273064b57d3a74f1
-size 65723
+oid sha256:8dad10a8d2b118eb8c6ee92c4287c90cf91548b906a5f3257df486eaf4d6cdc6
+size 65882

--- a/src/components/ModalRoot/ModalRoot.css
+++ b/src/components/ModalRoot/ModalRoot.css
@@ -41,7 +41,7 @@
 
 :not(.ModalRoot--desktop).ModalRoot--vkapps.ModalRoot--android
   .ModalRoot__viewport {
-  top: calc(var(--safe-area-inset-top) + var(--panelheader_height_android));
+  top: calc(var(--safe-area-inset-top) + var(--panelheader_height));
 }
 
 :not(.ModalRoot--desktop).ModalRoot--vkapps.ModalRoot--ios

--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -65,17 +65,17 @@ const DynamicModalPage = ({ updateModalHeight, onClose, ...props }) => {
       {...props}
       header={
         <ModalPageHeader
-          right={
+          before={
+            isMobile &&
+            platform === ANDROID && <PanelHeaderClose onClick={onClose} />
+          }
+          after={
             isMobile &&
             platform === IOS && (
               <PanelHeaderButton onClick={onClose}>
                 <Icon24Dismiss />
               </PanelHeaderButton>
             )
-          }
-          left={
-            isMobile &&
-            platform === ANDROID && <PanelHeaderClose onClick={onClose} />
           }
         >
           Dynamic modal
@@ -157,17 +157,17 @@ const App = withPlatform(
               settlingHeight={100}
               header={
                 <ModalPageHeader
-                  right={
+                  before={
+                    isMobile &&
+                    platform === ANDROID && (
+                      <PanelHeaderClose onClick={this.modalBack} />
+                    )
+                  }
+                  after={
                     platform === IOS && (
                       <PanelHeaderButton onClick={this.modalBack}>
                         <Icon24Dismiss />
                       </PanelHeaderButton>
-                    )
-                  }
-                  left={
-                    isMobile &&
-                    platform === ANDROID && (
-                      <PanelHeaderClose onClick={this.modalBack} />
                     )
                   }
                 >
@@ -225,10 +225,10 @@ const App = withPlatform(
               onClose={this.modalBack}
               header={
                 <ModalPageHeader
-                  left={
+                  before={
                     isMobile && <PanelHeaderClose onClick={this.modalBack} />
                   }
-                  right={<PanelHeaderSubmit onClick={this.modalBack} />}
+                  after={<PanelHeaderSubmit onClick={this.modalBack} />}
                 >
                   Фильтры
                 </ModalPageHeader>
@@ -309,7 +309,7 @@ const App = withPlatform(
               onClose={this.modalBack}
               header={
                 <ModalPageHeader
-                  left={
+                  before={
                     <PanelHeaderBack label="Назад" onClick={this.modalBack} />
                   }
                 >
@@ -342,7 +342,7 @@ const App = withPlatform(
               onClose={this.modalBack}
               header={
                 <ModalPageHeader
-                  left={
+                  before={
                     <PanelHeaderBack label="Назад" onClick={this.modalBack} />
                   }
                 >
@@ -370,7 +370,7 @@ const App = withPlatform(
               onClose={this.modalBack}
               header={
                 <ModalPageHeader
-                  left={
+                  before={
                     <PanelHeaderBack label="Назад" onClick={this.modalBack} />
                   }
                 >

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -46,7 +46,7 @@
 
 .Panel__centered .PanelHeader--android.PanelHeader--vis + *,
 .Panel__centered .PanelHeader--vkcom.PanelHeader--vis + * {
-  margin-top: var(--panelheader_height_android);
+  margin-top: var(--panelheader_height);
 }
 
 .Panel--sizeX-compact .Panel__centered .PanelHeader--ios.PanelHeader--sep + * {
@@ -57,7 +57,7 @@
   .Panel__centered
   .PanelHeader--android.PanelHeader--sep
   + * {
-  margin-top: calc(var(--panelheader_height_android) + 5px);
+  margin-top: calc(var(--panelheader_height) + 5px);
 }
 
 .Panel--sizeX-compact
@@ -75,7 +75,7 @@
   .Panel__centered
   .PanelHeader--android.PanelHeader--sep
   + * {
-  margin-top: calc(var(--panelheader_height_android) + 16px);
+  margin-top: calc(var(--panelheader_height) + 16px);
 }
 
 .Panel--sizeX-regular

--- a/src/components/Panel/Panel.e2e.tsx
+++ b/src/components/Panel/Panel.e2e.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { Panel, PanelProps } from "./Panel";
 import { describeScreenshotFuzz } from "../../testing/e2e/utils";
-import PanelHeader from "../PanelHeader/PanelHeader";
+import { PanelHeader } from "../PanelHeader/PanelHeader";
 import Group from "../Group/Group";
 import { AppRoot } from "../AppRoot/AppRoot";
 

--- a/src/components/Panel/Readme.md
+++ b/src/components/Panel/Readme.md
@@ -42,7 +42,7 @@ class Example extends React.Component {
         <Panel id="panel2">
           <PanelHeader
             separator={false}
-            left={
+            before={
               <PanelHeaderBack
                 onClick={() => this.setState({ activePanel: "panel1" })}
               />
@@ -77,7 +77,7 @@ class Example extends React.Component {
         </Panel>
         <Panel id="panel3" centered>
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack
                 onClick={() => this.setState({ activePanel: "panel2" })}
               />

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -32,7 +32,7 @@
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.08);
 }
 
-.PanelHeader__left {
+.PanelHeader__before {
   box-sizing: border-box;
   color: var(--header_tint);
   display: flex;
@@ -81,7 +81,7 @@
   padding-top: var(--safe-area-inset-top);
 }
 
-.PanelHeader--ios .PanelHeader__left {
+.PanelHeader--ios .PanelHeader__before {
   flex-basis: 0;
   flex-shrink: 0;
   flex-grow: 1;
@@ -91,7 +91,7 @@
 }
 
 .PanelHeader--ios
-  .PanelHeader__left
+  .PanelHeader__before
   .PanelHeaderButton
   + .PanelHeaderButton--primitive {
   margin-left: -6px;
@@ -113,11 +113,11 @@
   padding: 0 4px;
 }
 
-.PanelHeader--ios.PanelHeader--no-left .PanelHeader__content > * {
+.PanelHeader--ios.PanelHeader--no-before .PanelHeader__content > * {
   padding-left: 0;
 }
 
-.PanelHeader--ios.PanelHeader--no-left .PanelHeader__content {
+.PanelHeader--ios.PanelHeader--no-before .PanelHeader__content {
   padding-left: 8px;
 }
 
@@ -138,7 +138,7 @@
   padding: 4px 4px 4px 0;
 }
 
-.View--ios .View__panel--prev .PanelHeader__left,
+.View--ios .View__panel--prev .PanelHeader__before,
 .View--ios .View__panel--prev .PanelHeader__after,
 .View--ios .View__panel--prev .PanelHeader__content {
   opacity: 0;
@@ -158,7 +158,7 @@
   padding-top: var(--safe-area-inset-top);
 }
 
-.PanelHeader--android .PanelHeader__left:not(:empty) {
+.PanelHeader--android .PanelHeader__before:not(:empty) {
   padding: 4px 0 4px 4px;
 }
 
@@ -181,17 +181,17 @@
   padding: 0 4px;
 }
 
-.PanelHeader--android.PanelHeader--no-left .PanelHeader__content > *,
-.PanelHeader--vkcom.PanelHeader--no-left .PanelHeader__content > * {
+.PanelHeader--android.PanelHeader--no-before .PanelHeader__content > *,
+.PanelHeader--vkcom.PanelHeader--no-before .PanelHeader__content > * {
   padding-left: 0;
 }
 
-.PanelHeader--android.PanelHeader--no-left .PanelHeader__content {
+.PanelHeader--android.PanelHeader--no-before .PanelHeader__content {
   padding-left: 16px;
 }
 
 .SplitCol--spaced
-  .PanelHeader--android.PanelHeader--no-left:not(.ModalPageHeader__in)
+  .PanelHeader--android.PanelHeader--no-before:not(.ModalPageHeader__in)
   .PanelHeader__content {
   padding-left: 0;
 }
@@ -259,11 +259,11 @@
   padding-top: var(--safe-area-inset-top);
 }
 
-.PanelHeader--vkcom .PanelHeader__left:not(:empty) {
+.PanelHeader--vkcom .PanelHeader__before:not(:empty) {
   padding: 0 0 0 4px;
 }
 
-.PanelHeader--vkcom .PanelHeader__left,
+.PanelHeader--vkcom .PanelHeader__before,
 .PanelHeader--vkcom .PanelHeader__after {
   flex-basis: 0;
   flex-shrink: 0;

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -55,6 +55,12 @@
   font-family: var(--font-display);
 }
 
+.PanelHeader::before,
+.PanelHeader__in {
+  height: var(--panelheader_height);
+  padding-top: var(--safe-area-inset-top);
+}
+
 .PanelHeader__after {
   display: flex;
   justify-content: flex-end;
@@ -69,16 +75,8 @@
 /**
  * iOS
  */
-
-.PanelHeader--ios ~ .FixedLayout--top,
-.PanelHeader--ios ~ * .FixedLayout--top:not(.PanelHeader__fixed) {
-  top: calc(var(--panelheader_height_ios) + var(--safe-area-inset-top));
-}
-
-.PanelHeader--ios::before,
-.PanelHeader--ios .PanelHeader__in {
-  height: var(--panelheader_height_ios);
-  padding-top: var(--safe-area-inset-top);
+.PanelHeader--ios {
+  --panelheader_height: var(--panelheader_height_ios);
 }
 
 .PanelHeader--ios .PanelHeader__before {
@@ -106,7 +104,6 @@
 
 .PanelHeader--ios .PanelHeader__content-in {
   font-size: 21px;
-  line-height: var(--panelheader_height_ios);
 }
 
 .PanelHeader--ios .PanelHeader__content > * {
@@ -147,17 +144,6 @@
 /**
  * Android
  */
-.PanelHeader--android ~ .FixedLayout--top,
-.PanelHeader--android ~ * .FixedLayout--top:not(.PanelHeader__fixed) {
-  top: calc(var(--panelheader_height_android) + var(--safe-area-inset-top));
-}
-
-.PanelHeader--android::before,
-.PanelHeader--android .PanelHeader__in {
-  height: var(--panelheader_height_android);
-  padding-top: var(--safe-area-inset-top);
-}
-
 .PanelHeader--android .PanelHeader__before:not(:empty) {
   padding: 4px 0 4px 4px;
 }
@@ -219,26 +205,14 @@
 /**
  * VKCOM
  */
-
 .PanelHeader--vkcom {
+  --panelheader_height: var(--panelheader_height_vkcom);
+
   position: relative;
   z-index: 10;
 }
 
-.PanelHeader--vkcom ~ .FixedLayout--top,
-.PanelHeader--vkcom ~ * .FixedLayout--top:not(.PanelHeader__fixed) {
-  top: calc(var(--panelheader_height_vkcom) + var(--safe-area-inset-top));
-}
-
 /* TODO: v5.0.0 новая адаптивность */
-.PanelHeader--vkcom.PanelHeader--sizeX-regular:not(.ModalPageHeader__in)
-  .PanelHeader__in {
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-  box-shadow: 0 0 0 var(--thin-border) var(--input_border) inset;
-  border-bottom: none;
-}
-
 .PanelHeader--vkcom.PanelHeader--sizeX-regular:not(.ModalPageHeader__in)::after {
   position: absolute;
   left: var(--thin-border);
@@ -251,12 +225,6 @@
 
 .PanelHeader--vkcom .PanelHeader__content {
   text-align: center;
-}
-
-.PanelHeader--vkcom::before,
-.PanelHeader--vkcom .PanelHeader__in {
-  height: var(--panelheader_height_vkcom);
-  padding-top: var(--safe-area-inset-top);
 }
 
 .PanelHeader--vkcom .PanelHeader__before:not(:empty) {

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -55,14 +55,14 @@
   font-family: var(--font-display);
 }
 
-.PanelHeader__right {
+.PanelHeader__after {
   display: flex;
   justify-content: flex-end;
   box-sizing: border-box;
   color: var(--header_tint);
 }
 
-.PanelHeader--vkapps .PanelHeader__right {
+.PanelHeader--vkapps .PanelHeader__after {
   min-width: 90px;
 }
 
@@ -121,15 +121,15 @@
   padding-left: 8px;
 }
 
-.PanelHeader--ios.PanelHeader--no-right .PanelHeader__content > * {
+.PanelHeader--ios.PanelHeader--no-after .PanelHeader__content > * {
   padding-right: 0;
 }
 
-.PanelHeader--ios.PanelHeader--no-right .PanelHeader__content {
+.PanelHeader--ios.PanelHeader--no-after .PanelHeader__content {
   padding-right: 8px;
 }
 
-.PanelHeader--ios .PanelHeader__right {
+.PanelHeader--ios .PanelHeader__after {
   flex-basis: 0;
   flex-shrink: 0;
   flex-grow: 1;
@@ -139,7 +139,7 @@
 }
 
 .View--ios .View__panel--prev .PanelHeader__left,
-.View--ios .View__panel--prev .PanelHeader__right,
+.View--ios .View__panel--prev .PanelHeader__after,
 .View--ios .View__panel--prev .PanelHeader__content {
   opacity: 0;
 }
@@ -196,23 +196,23 @@
   padding-left: 0;
 }
 
-.PanelHeader--android.PanelHeader--no-right .PanelHeader__content > *,
-.PanelHeader--vkcom.PanelHeader--no-right .PanelHeader__content > * {
+.PanelHeader--android.PanelHeader--no-after .PanelHeader__content > *,
+.PanelHeader--vkcom.PanelHeader--no-after .PanelHeader__content > * {
   padding-right: 0;
 }
 
-.PanelHeader--android.PanelHeader--no-right .PanelHeader__content {
+.PanelHeader--android.PanelHeader--no-after .PanelHeader__content {
   padding-right: 16px;
 }
 
 .SplitCol--spaced
-  .PanelHeader--android.PanelHeader--no-right:not(.ModalPageHeader__in)
+  .PanelHeader--android.PanelHeader--no-after:not(.ModalPageHeader__in)
   .PanelHeader__content {
   padding-right: 0;
 }
 
-.PanelHeader--android .PanelHeader__right:not(:empty),
-.PanelHeader--vkcom .PanelHeader__right:not(:empty) {
+.PanelHeader--android .PanelHeader__after:not(:empty),
+.PanelHeader--vkcom .PanelHeader__after:not(:empty) {
   padding: 4px 4px 4px 0;
 }
 
@@ -264,7 +264,7 @@
 }
 
 .PanelHeader--vkcom .PanelHeader__left,
-.PanelHeader--vkcom .PanelHeader__right {
+.PanelHeader--vkcom .PanelHeader__after {
   flex-basis: 0;
   flex-shrink: 0;
   flex-grow: 1;

--- a/src/components/PanelHeader/PanelHeader.test.tsx
+++ b/src/components/PanelHeader/PanelHeader.test.tsx
@@ -1,6 +1,6 @@
 import { baselineComponent } from "../../testing/utils";
 import { render } from "@testing-library/react";
-import PanelHeader from "./PanelHeader";
+import { PanelHeader } from "./PanelHeader";
 import ConfigProvider from "../ConfigProvider/ConfigProvider";
 import { Platform } from "../../lib/platform";
 

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -81,7 +81,7 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
 };
 
 const warn = warnOnce("PanelHeader");
-const PanelHeaderComponent: React.FC<PanelHeaderProps> = ({
+const PanelHeaderComponent = ({
   // TODO: поправить перед 5.0.0
   before: propsBefore,
   left,
@@ -99,7 +99,7 @@ const PanelHeaderComponent: React.FC<PanelHeaderProps> = ({
   sizeY,
   fixed,
   ...restProps
-}) => {
+}: PanelHeaderProps) => {
   const platform = usePlatform();
   const { webviewType } = React.useContext(ConfigProviderContext);
   const { isInsideModal } = React.useContext(ModalRootContext);

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -81,10 +81,7 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
 };
 
 const warn = warnOnce("PanelHeader");
-/**
- * @see https://vkcom.github.io/VKUI/#/PanelHeader
- */
-const PanelHeader: React.FC<PanelHeaderProps> = ({
+const PanelHeaderComponent: React.FC<PanelHeaderProps> = ({
   // TODO: поправить перед 5.0.0
   before: propsBefore,
   left,
@@ -167,8 +164,10 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export
-export default withAdaptivity(PanelHeader, {
+/**
+ * @see https://vkcom.github.io/VKUI/#/PanelHeader
+ */
+export const PanelHeader = withAdaptivity(PanelHeaderComponent, {
   sizeX: true,
   sizeY: true,
 });

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -26,6 +26,10 @@ export interface PanelHeaderProps
     HasRef<HTMLDivElement>,
     HasRootRef<HTMLDivElement>,
     AdaptivityProps {
+  before?: React.ReactNode;
+  /**
+   * @deprecated Будет удалено в 5.0.0. Используйте `before`
+   */
   left?: React.ReactNode;
   after?: React.ReactNode;
   /**
@@ -47,7 +51,7 @@ export interface PanelHeaderProps
 
 const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
   children,
-  left,
+  before,
   after,
   separator,
 }) => {
@@ -58,7 +62,7 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
   return (
     <React.Fragment>
       <TooltipContainer fixed vkuiClass="PanelHeader__in">
-        <div vkuiClass="PanelHeader__left">{left}</div>
+        <div vkuiClass="PanelHeader__before">{before}</div>
         <div vkuiClass="PanelHeader__content">
           {platform === VKCOM ? (
             <Text weight="2">{children}</Text>
@@ -79,6 +83,7 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
  * @see https://vkcom.github.io/VKUI/#/PanelHeader
  */
 const PanelHeader: React.FC<PanelHeaderProps> = ({
+  before: propsBefore,
   left,
   children,
   after: propsAfter,
@@ -100,9 +105,10 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
   const needShadow = shadow && sizeX === SizeType.REGULAR;
   let isFixed = fixed !== undefined ? fixed : platform !== Platform.VKCOM;
 
+  const before = propsBefore ?? left;
   const after = propsAfter ?? right;
 
-  const innerProps = { children, left, after, separator };
+  const innerProps = { children, before, after, separator };
 
   return (
     <div
@@ -117,7 +123,7 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
           "PanelHeader--sep": separator && visor,
           "PanelHeader--vkapps":
             webviewType === WebviewType.VKAPPS && !isInsideModal,
-          "PanelHeader--no-left": !left,
+          "PanelHeader--no-before": !before,
           "PanelHeader--no-after": !after,
           "PanelHeader--fixed": isFixed,
         },

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -51,10 +51,10 @@ export interface PanelHeaderProps
 }
 
 const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
-  children,
   before,
   after,
   separator,
+  children,
 }) => {
   const { webviewType } = React.useContext(ConfigProviderContext);
   const { isInsideModal } = React.useContext(ModalRootContext);
@@ -85,11 +85,13 @@ const warn = warnOnce("PanelHeader");
  * @see https://vkcom.github.io/VKUI/#/PanelHeader
  */
 const PanelHeader: React.FC<PanelHeaderProps> = ({
+  // TODO: поправить перед 5.0.0
   before: propsBefore,
   left,
-  children,
   after: propsAfter,
   right,
+  // /end TODO
+  children,
   separator = true,
   visor = true,
   transparent = false,
@@ -123,7 +125,7 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
   }
   // /end TODO
 
-  const innerProps = { children, before, after, separator };
+  const innerProps = { before, after, separator, children };
 
   return (
     <div

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -74,27 +74,28 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
 /**
  * @see https://vkcom.github.io/VKUI/#/PanelHeader
  */
-const PanelHeader: React.FC<PanelHeaderProps> = (props: PanelHeaderProps) => {
-  const {
-    left,
-    children,
-    right,
-    separator,
-    visor,
-    transparent,
-    shadow,
-    getRef,
-    getRootRef,
-    sizeX,
-    sizeY,
-    fixed,
-    ...restProps
-  } = props;
+const PanelHeader: React.FC<PanelHeaderProps> = ({
+  left,
+  children,
+  right,
+  separator = true,
+  visor = true,
+  transparent = false,
+  shadow,
+  getRef,
+  getRootRef,
+  sizeX,
+  sizeY,
+  fixed,
+  ...restProps
+}) => {
   const platform = usePlatform();
   const { webviewType } = React.useContext(ConfigProviderContext);
   const { isInsideModal } = React.useContext(ModalRootContext);
   const needShadow = shadow && sizeX === SizeType.REGULAR;
   let isFixed = fixed !== undefined ? fixed : platform !== Platform.VKCOM;
+
+  const innerProps = { children, left, right, separator };
 
   return (
     <div
@@ -123,10 +124,10 @@ const PanelHeader: React.FC<PanelHeaderProps> = (props: PanelHeaderProps) => {
           vertical="top"
           getRootRef={getRef}
         >
-          <PanelHeaderIn {...props} />
+          <PanelHeaderIn {...innerProps} />
         </FixedLayout>
       ) : (
-        <PanelHeaderIn {...props} />
+        <PanelHeaderIn {...innerProps} />
       )}
       {separator &&
         visor &&
@@ -134,12 +135,6 @@ const PanelHeader: React.FC<PanelHeaderProps> = (props: PanelHeaderProps) => {
         (sizeX === SizeType.REGULAR ? <Spacing size={16} /> : <Separator />)}
     </div>
   );
-};
-
-PanelHeader.defaultProps = {
-  separator: true,
-  transparent: false,
-  visor: true,
 };
 
 // eslint-disable-next-line import/no-default-export

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { usePlatform } from "../../hooks/usePlatform";
 import { getClassName } from "../../helpers/getClassName";
 import { classNames } from "../../lib/classNames";
+import { warnOnce } from "../../lib/warnOnce";
 import FixedLayout from "../FixedLayout/FixedLayout";
 import { Separator } from "../Separator/Separator";
 import { Platform, VKCOM } from "../../lib/platform";
@@ -79,6 +80,7 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
   );
 };
 
+const warn = warnOnce("PanelHeader");
 /**
  * @see https://vkcom.github.io/VKUI/#/PanelHeader
  */
@@ -107,6 +109,17 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
 
   const before = propsBefore ?? left;
   const after = propsAfter ?? right;
+
+  if (process.env.NODE_ENV === "development") {
+    right &&
+      warn(
+        "Свойство right устарелo и будет удалено в 5.0.0. Используйте after."
+      );
+    left &&
+      warn(
+        "Свойство left устарелo и будет удалено в 5.0.0. Используйте before."
+      );
+  }
 
   const innerProps = { children, before, after, separator };
 

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -27,6 +27,10 @@ export interface PanelHeaderProps
     HasRootRef<HTMLDivElement>,
     AdaptivityProps {
   left?: React.ReactNode;
+  after?: React.ReactNode;
+  /**
+   * @deprecated Будет удалено в 5.0.0. Используйте `after`
+   */
   right?: React.ReactNode;
   separator?: boolean;
   transparent?: boolean;
@@ -44,7 +48,7 @@ export interface PanelHeaderProps
 const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
   children,
   left,
-  right,
+  after,
   separator,
 }) => {
   const { webviewType } = React.useContext(ConfigProviderContext);
@@ -62,8 +66,8 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
             <span vkuiClass="PanelHeader__content-in">{children}</span>
           )}
         </div>
-        <div vkuiClass="PanelHeader__right">
-          {(webviewType === WebviewType.INTERNAL || isInsideModal) && right}
+        <div vkuiClass="PanelHeader__after">
+          {(webviewType === WebviewType.INTERNAL || isInsideModal) && after}
         </div>
       </TooltipContainer>
       {separator && platform === VKCOM && <Separator wide />}
@@ -77,6 +81,7 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
 const PanelHeader: React.FC<PanelHeaderProps> = ({
   left,
   children,
+  after: propsAfter,
   right,
   separator = true,
   visor = true,
@@ -95,7 +100,9 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
   const needShadow = shadow && sizeX === SizeType.REGULAR;
   let isFixed = fixed !== undefined ? fixed : platform !== Platform.VKCOM;
 
-  const innerProps = { children, left, right, separator };
+  const after = propsAfter ?? right;
+
+  const innerProps = { children, left, after, separator };
 
   return (
     <div
@@ -111,7 +118,7 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
           "PanelHeader--vkapps":
             webviewType === WebviewType.VKAPPS && !isInsideModal,
           "PanelHeader--no-left": !left,
-          "PanelHeader--no-right": !right,
+          "PanelHeader--no-after": !after,
           "PanelHeader--fixed": isFixed,
         },
         `PanelHeader--sizeX-${sizeX}`

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -107,6 +107,7 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
   const needShadow = shadow && sizeX === SizeType.REGULAR;
   let isFixed = fixed !== undefined ? fixed : platform !== Platform.VKCOM;
 
+  // TODO: удалить перед 5.0.0
   const before = propsBefore ?? left;
   const after = propsAfter ?? right;
 
@@ -120,6 +121,7 @@ const PanelHeader: React.FC<PanelHeaderProps> = ({
         "Свойство left устарелo и будет удалено в 5.0.0. Используйте before."
       );
   }
+  // /end TODO
 
   const innerProps = { children, before, after, separator };
 

--- a/src/components/PanelHeader/Readme.md
+++ b/src/components/PanelHeader/Readme.md
@@ -32,8 +32,8 @@ class Example extends React.Component {
         <View id="main" activePanel={this.state.mainPanel}>
           <Panel id="panel1">
             <PanelHeader
-              left={<PanelHeaderClose />}
-              right={<Avatar size={36} />}
+              before={<PanelHeaderClose />}
+              after={<Avatar size={36} />}
             >
               Стартовый экран
             </PanelHeader>
@@ -47,13 +47,13 @@ class Example extends React.Component {
           </Panel>
           <Panel id="panel2">
             <PanelHeader
-              left={
+              before={
                 <PanelHeaderBack
                   onClick={() => this.setState({ mainPanel: "panel1" })}
                   label={platform === VKCOM ? "Назад" : undefined}
                 />
               }
-              right={
+              after={
                 <PanelHeaderButton
                   aria-label="Изображения"
                   label={
@@ -82,12 +82,12 @@ class Example extends React.Component {
           </Panel>
           <Panel id="panel3">
             <PanelHeader
-              left={
+              before={
                 <PanelHeaderBack
                   onClick={() => this.setState({ mainPanel: "panel2" })}
                 />
               }
-              right={
+              after={
                 <React.Fragment>
                   <PanelHeaderButton
                     aria-label="Настройки"
@@ -134,14 +134,14 @@ class Example extends React.Component {
         <View id="modal" activePanel={this.state.modalPanel}>
           <Panel id="modal-panel1">
             <PanelHeader
-              left={
+              before={
                 <PanelHeaderButton
                   onClick={() => this.setState({ activeView: "main" })}
                 >
                   Отмена
                 </PanelHeaderButton>
               }
-              right={
+              after={
                 <PanelHeaderButton
                   disabled
                   primary
@@ -163,7 +163,7 @@ class Example extends React.Component {
           </Panel>
           <Panel id="modal-panel2">
             <PanelHeader
-              left={
+              before={
                 <PanelHeaderBack
                   onClick={() => this.setState({ modalPanel: "modal-panel1" })}
                   label={platform === VKCOM ? "Назад" : undefined}
@@ -188,7 +188,7 @@ class Example extends React.Component {
           <Panel id="modal-panel3">
             <PanelHeader
               separator={platform === VKCOM || sizeX === SizeType.REGULAR}
-              left={
+              before={
                 platform !== VKCOM && (
                   <PanelHeaderBack
                     onClick={() =>
@@ -218,7 +218,7 @@ class Example extends React.Component {
           <Panel id="modal-panel4">
             <PanelHeader
               separator={platform === VKCOM || sizeX === SizeType.REGULAR}
-              left={
+              before={
                 <PanelHeaderBack
                   onClick={() => this.setState({ modalPanel: "modal-panel3" })}
                 />

--- a/src/components/PanelHeaderBack/Readme.md
+++ b/src/components/PanelHeaderBack/Readme.md
@@ -3,7 +3,7 @@
 ```jsx static
 import { PanelHeaderBack } from "@vkontakte/vkui";
 
-<PanelHeader left={<PanelHeaderBack onClick={this.props.onBackClick} />}>
+<PanelHeader before={<PanelHeaderBack onClick={this.props.onBackClick} />}>
   Заголовок панели
 </PanelHeader>;
 ```

--- a/src/components/PanelHeaderButton/Readme.md
+++ b/src/components/PanelHeaderButton/Readme.md
@@ -8,12 +8,12 @@ import { PanelHeader, PanelHeaderButton } from "@vkontakte/vkui";
 import { Icon28Notifications, Icon28SettingsOutline } from "@vkontakte/icons";
 
 <PanelHeader
-  left={
+  before={
     <PanelHeaderButton>
       <Icon28Notifications />
     </PanelHeaderButton>
   }
-  right={
+  after={
     <PanelHeaderButton>
       <Icon28SettingsOutline />
     </PanelHeaderButton>
@@ -28,7 +28,7 @@ import { PanelHeader, PanelHeaderButton } from "@vkontakte/vkui";
 import { Icon28SettingsOutline, Icon28Notifications } from "@vkontakte/icons";
 
 <PanelHeader
-  right={
+  after={
     <React.Fragment>
       <PanelHeaderButton>
         <Icon28SettingsOutline />

--- a/src/components/PanelHeaderClose/Readme.md
+++ b/src/components/PanelHeaderClose/Readme.md
@@ -3,7 +3,7 @@
 ```jsx static
 import { PanelHeaderClose } from "@vkontakte/vkui";
 
-<PanelHeader left={<PanelHeaderClose onClick={this.props.onCloseClick} />}>
+<PanelHeader before={<PanelHeaderClose onClick={this.props.onCloseClick} />}>
   Заголовок модального окна
 </PanelHeader>;
 ```

--- a/src/components/PanelHeaderContent/PanelHeaderContent.css
+++ b/src/components/PanelHeaderContent/PanelHeaderContent.css
@@ -89,7 +89,7 @@
   font-size: 23px;
   font-family: var(--font-display);
   font-weight: 500;
-  line-height: var(--panelheader_height_android);
+  line-height: var(--panelheader_height);
 }
 
 /**

--- a/src/components/PanelHeaderContent/Readme.md
+++ b/src/components/PanelHeaderContent/Readme.md
@@ -7,8 +7,8 @@ const Example = () => {
     <View activePanel="brand">
       <Panel id="brand">
         <PanelHeader
-          left={<PanelHeaderBack label="Назад" />}
-          right={
+          before={<PanelHeaderBack label="Назад" />}
+          after={
             <PanelHeaderButton>
               <Icon28MessageOutline
                 width={platform === VKCOM ? 24 : 28}

--- a/src/components/PanelHeaderContext/Readme.md
+++ b/src/components/PanelHeaderContext/Readme.md
@@ -39,8 +39,8 @@ const Example = withPlatform(
               <View activePanel="context2">
                 <Panel id="context2">
                   <PanelHeader
-                    left={<PanelHeaderBack />}
-                    right={
+                    before={<PanelHeaderBack />}
+                    after={
                       <PanelHeaderButton>
                         <Icon28AddOutline />
                       </PanelHeaderButton>

--- a/src/components/PanelHeaderSubmit/Readme.md
+++ b/src/components/PanelHeaderSubmit/Readme.md
@@ -4,7 +4,7 @@
 import { PanelHeaderSubmit } from "@vkontakte/vkui";
 
 <PanelHeader
-  right={
+  after={
     <PanelHeaderSubmit onClick={this.props.onSubmit}>Готово</PanelHeaderSubmit>
   }
 >

--- a/src/components/PanelSpinner/Readme.md
+++ b/src/components/PanelSpinner/Readme.md
@@ -4,7 +4,7 @@
 import { PanelSpinner } from "@vkontakte/vkui";
 
 <Panel>
-  <PanelHeader left={<PanelHeaderBack />}>Заголовок панели</PanelHeader>
+  <PanelHeader before={<PanelHeaderBack />}>Заголовок панели</PanelHeader>
 
   {loading ? (
     <PanelSpinner />

--- a/src/components/Placeholder/Readme.md
+++ b/src/components/Placeholder/Readme.md
@@ -49,7 +49,7 @@ class PlaceholderExample extends React.Component {
 
         <Panel id="example-2">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack onClick={this.onNavClick} data-to="example-1" />
             }
           >
@@ -74,7 +74,7 @@ class PlaceholderExample extends React.Component {
 
         <Panel id="example-3">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack onClick={this.onNavClick} data-to="example-1" />
             }
           >

--- a/src/components/Search/Readme.md
+++ b/src/components/Search/Readme.md
@@ -53,7 +53,7 @@ class SimpleSearch extends React.Component {
     return (
       <React.Fragment>
         <PanelHeader
-          right={
+          after={
             <PanelHeaderButton onClick={this.props.goHeaderSearch}>
               <Icon28AddOutline />
             </PanelHeaderButton>
@@ -103,7 +103,7 @@ class HeaderSearch extends React.Component {
     return (
       <React.Fragment>
         <PanelHeader
-          left={platform !== VKCOM && <PanelHeaderBack onClick={goSearch} />}
+          before={platform !== VKCOM && <PanelHeaderBack onClick={goSearch} />}
           separator={sizeX === SizeType.REGULAR}
         >
           <Search
@@ -167,14 +167,14 @@ class SearchExample extends React.Component {
               onClose={this.hideModal}
               header={
                 <ModalPageHeader
-                  left={
+                  before={
                     platform === ANDROID && (
                       <PanelHeaderButton onClick={this.hideModal}>
                         <Icon24Cancel />
                       </PanelHeaderButton>
                     )
                   }
-                  right={
+                  after={
                     <PanelHeaderButton onClick={this.hideModal}>
                       {platform === IOS ? "Готово" : <Icon24Done />}
                     </PanelHeaderButton>

--- a/src/components/SimpleCell/Readme.md
+++ b/src/components/SimpleCell/Readme.md
@@ -117,7 +117,7 @@ class Example extends React.Component {
         </Panel>
         <Panel id="nothing">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack
                 onClick={() => this.setState({ activePanel: "list" })}
               />

--- a/src/components/SplitLayout/Readme.md
+++ b/src/components/SplitLayout/Readme.md
@@ -92,7 +92,7 @@ const Example = withAdaptivity(
         >
           <View activePanel={panel}>
             <Panel id={panels[0]}>
-              <PanelHeader right={<Avatar size={36} />}>Panel 1</PanelHeader>
+              <PanelHeader after={<Avatar size={36} />}>Panel 1</PanelHeader>
               <Group>
                 <Placeholder
                   icon={<Icon56UsersOutline />}
@@ -110,7 +110,7 @@ const Example = withAdaptivity(
             </Panel>
 
             <Panel id={panels[1]}>
-              <PanelHeader right={<Avatar size={36} />}>Panel 2</PanelHeader>
+              <PanelHeader after={<Avatar size={36} />}>Panel 2</PanelHeader>
               <Group>
                 <Placeholder>Доступ запрещён</Placeholder>
                 <Separator />
@@ -124,7 +124,7 @@ const Example = withAdaptivity(
             </Panel>
 
             <Panel id={panels[2]}>
-              <PanelHeader right={<Avatar size={36} />}>Panel 3</PanelHeader>
+              <PanelHeader after={<Avatar size={36} />}>Panel 3</PanelHeader>
               <Group>
                 <Placeholder
                   icon={<Icon56MessageReadOutline />}

--- a/src/components/SplitLayout/SplitLayout.css
+++ b/src/components/SplitLayout/SplitLayout.css
@@ -20,14 +20,14 @@
 
 .SplitLayout--ios .SplitLayout__inner--header {
   margin-top: calc(
-    -1 * calc(var(--panelheader_height_ios) + var(--safe-area-inset-top))
+    -1 * (var(--panelheader_height_ios) + var(--safe-area-inset-top))
   );
 }
 
 .SplitLayout--android .SplitLayout__inner--header,
 .SplitLayout--vkcom .SplitLayout__inner--header {
   margin-top: calc(
-    -1 * calc(var(--panelheader_height_android) + var(--safe-area-inset-top))
+    -1 * (var(--panelheader_height) + var(--safe-area-inset-top))
   );
 }
 

--- a/src/components/SubnavigationBar/Readme.md
+++ b/src/components/SubnavigationBar/Readme.md
@@ -81,8 +81,10 @@ const SubnavigationBarExample = () => {
         id={MODAL_NAME}
         header={
           <ModalPageHeader
-            left={platform !== IOS && <PanelHeaderClose onClick={closeModal} />}
-            right={
+            before={
+              platform !== IOS && <PanelHeaderClose onClick={closeModal} />
+            }
+            after={
               platform === IOS && (
                 <PanelHeaderButton onClick={closeModal}>
                   <Icon24Dismiss />
@@ -229,7 +231,7 @@ const SubnavigationBarExample = () => {
           </Panel>
           <Panel id="add_friend">
             <PanelHeader
-              left={
+              before={
                 <PanelHeaderBack onClick={() => setActivePanel("example")} />
               }
             >

--- a/src/components/Tabs/Readme.md
+++ b/src/components/Tabs/Readme.md
@@ -27,12 +27,12 @@ class Example extends React.Component {
       <View activePanel={this.state.activePanel}>
         <Panel id="panel1">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderButton>
                 <Icon28CameraOutline />
               </PanelHeaderButton>
             }
-            right={
+            after={
               <PanelHeaderButton>
                 <Icon28AddOutline />
               </PanelHeaderButton>
@@ -116,7 +116,7 @@ class Example extends React.Component {
         </Panel>
         <Panel id="panel2">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack
                 onClick={() => this.setState({ activePanel: "panel1" })}
               />
@@ -149,7 +149,7 @@ class Example extends React.Component {
         </Panel>
         <Panel id="panel3">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack
                 onClick={() => this.setState({ activePanel: "panel2" })}
               />
@@ -204,7 +204,7 @@ class Example extends React.Component {
         </Panel>
         <Panel id="panel4">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack
                 onClick={() => this.setState({ activePanel: "panel2" })}
               />
@@ -236,7 +236,7 @@ class Example extends React.Component {
         </Panel>
         <Panel id="panel5">
           <PanelHeader
-            left={
+            before={
               <PanelHeaderBack
                 onClick={() => this.setState({ activePanel: "panel4" })}
               />

--- a/src/components/Tooltip/Readme.md
+++ b/src/components/Tooltip/Readme.md
@@ -75,14 +75,14 @@ class Example extends React.Component {
 
         <Panel id="tooltip2">
           <PanelHeader
-            left={
+            before={
               <Tooltip
                 isShown={this.state.tooltip2}
                 onClose={() =>
                   this.setState({ tooltip2: false, tooltip3: true })
                 }
                 text="Нажмите на кнопку, если хотите вернуться"
-                header="Возвратиться"
+                header="Назад"
               >
                 <PanelHeaderBack
                   onClick={() => this.setState({ activePanel: "tooltip" })}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export { Panel } from "./components/Panel/Panel";
 export type { PanelProps } from "./components/Panel/Panel";
 export { PanelHeaderButton } from "./components/PanelHeaderButton/PanelHeaderButton";
 export type { PanelHeaderButtonProps } from "./components/PanelHeaderButton/PanelHeaderButton";
-export { default as PanelHeader } from "./components/PanelHeader/PanelHeader";
+export { PanelHeader } from "./components/PanelHeader/PanelHeader";
 export type { PanelHeaderProps } from "./components/PanelHeader/PanelHeader";
 export { default as PanelHeaderContent } from "./components/PanelHeaderContent/PanelHeaderContent";
 export type { PanelHeaderContentProps } from "./components/PanelHeaderContent/PanelHeaderContent";

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export { withModalRootContext } from "./components/ModalRoot/withModalRootContex
 export { default as ModalRootContext } from "./components/ModalRoot/ModalRootContext";
 export { default as ModalPage } from "./components/ModalPage/ModalPage";
 export type { ModalPageProps } from "./components/ModalPage/ModalPage";
-export { default as ModalPageHeader } from "./components/ModalPageHeader/ModalPageHeader";
+export { ModalPageHeader } from "./components/ModalPageHeader/ModalPageHeader";
 export type { ModalPageHeaderProps } from "./components/ModalPageHeader/ModalPageHeader";
 export { default as ModalCard } from "./components/ModalCard/ModalCard";
 export type { ModalCardProps } from "./components/ModalCard/ModalCard";

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -23,11 +23,9 @@
 
   /* sizes */
   --tabbar_height: 48px;
+  --panelheader_height: 56px;
   --panelheader_height_ios: 52px;
-  --panelheader_height_android: 56px;
   --panelheader_height_vkcom: 48px;
-  --modalheader_height_ios: 52px;
-  --modalheader_height_android: 56px;
   --search_default_height: 36px;
   --thin-border: 1px;
 

--- a/styleguide/Components/StyleGuide/StyleGuideMobile.js
+++ b/styleguide/Components/StyleGuide/StyleGuideMobile.js
@@ -15,13 +15,13 @@ import {
 import { Logo } from "../Logo/Logo";
 import "./StyleGuideMobile.css";
 
-const StyleGuideMobileHeader = ({ left, switchStyleGuideAppearance }) => {
+const StyleGuideMobileHeader = ({ before, switchStyleGuideAppearance }) => {
   const appearance = useAppearance();
 
   return (
     <PanelHeader
-      left={left}
-      right={
+      before={before}
+      after={
         <PanelHeaderButton
           onClick={switchStyleGuideAppearance}
           aria-label="Сменить тему"
@@ -59,7 +59,7 @@ export const StyleGuideMobile = (props) => {
           <Panel id="content">
             <StyleGuideMobileHeader
               switchStyleGuideAppearance={props.switchStyleGuideAppearance}
-              left={
+              before={
                 <PanelHeaderButton
                   aria-label="Показать меню"
                   onClick={() => setActivePanel("menu")}
@@ -73,7 +73,7 @@ export const StyleGuideMobile = (props) => {
           <Panel id="menu">
             <StyleGuideMobileHeader
               switchStyleGuideAppearance={props.switchStyleGuideAppearance}
-              left={
+              before={
                 <PanelHeaderClose
                   aria-label="Скрыть меню"
                   onClick={() => setActivePanel("content")}

--- a/styleguide/pages/helpers.md
+++ b/styleguide/pages/helpers.md
@@ -63,7 +63,7 @@ class Example extends React.Component {
         <View id={HOME_VIEW} activePanel={activePanels[HOME_VIEW]}>
           <Panel id={MAIN_PANEL}>
             <PanelHeader
-              left={<PanelHeaderBack onClick={() => this.closeApp()} />}
+              before={<PanelHeaderBack onClick={() => this.closeApp()} />}
             >
               Приложение
             </PanelHeader>
@@ -77,12 +77,12 @@ class Example extends React.Component {
 
           <Panel id={LIST_PANEL}>
             <PanelHeader
-              left={
+              before={
                 <PanelHeaderBack
                   onClick={() => this.go(HOME_VIEW, MAIN_PANEL)}
                 />
               }
-              right={
+              after={
                 <PanelHeaderEdit
                   isActive={editing}
                   editLabel="Изменить"
@@ -143,8 +143,8 @@ class Example extends React.Component {
         <View id={CREATE_VIEW} activePanel={activePanels[CREATE_VIEW]}>
           <Panel id={CREATE_PANEL} theme="white">
             <PanelHeader
-              left={<PanelHeaderClose onClick={() => this.go(HOME_VIEW)} />}
-              right={<PanelHeaderSubmit onClick={() => this.go(HOME_VIEW)} />}
+              before={<PanelHeaderClose onClick={() => this.go(HOME_VIEW)} />}
+              after={<PanelHeaderSubmit onClick={() => this.go(HOME_VIEW)} />}
             >
               Добавить
             </PanelHeader>


### PR DESCRIPTION
Fixes #1519.

Поскольку `ModalPageHeader` и `StyleGuideMobileHeader` используют в своей основе `PanelHeader`, им тоже прилетело.

## `PanelHeader` и `ModalPageHeader`
- [x] переехали на именованные экспорты #2191
  - fixes #2616
  - fixes #2617
- [x] переехали с `defaultProps` на спреды #1586
  - fixes #2648
  - fixes #2649  
- [x] `left` => `before`
- [x] `right` => `after`
- [x] поправила тесты
- [x] поправила примеры в документации

## `StyleGuideMobileHeader`
- [x] `left` => `before`