### PR TITLE
feat(ModalRoot,ModalPage): Add onOpen() to ModalRoot and ModalPage

### DIFF
--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -32,15 +32,21 @@ export interface ModalPageProps
    */
   header?: React.ReactNode;
   /**
-   * Будет вызвано при открытии модалки.
-   *
-   * > Может дожидаться окончания анимации, если она есть.
+   * Будет вызвано при начале открытия модалки.
    */
   onOpen?: VoidFunction;
   /**
-   * Будет вызвано при закрытии модалки.
+   * Будет вызвано при окончательном открытии модалки.
+   */
+  onOpened?: VoidFunction;
+  /**
+   * Будет вызвано при начале закрытия модалки.
    */
   onClose?: VoidFunction;
+  /**
+   * Будет вызвано при окончательном закрытии модалки.
+   */
+  onClosed?: VoidFunction;
   /**
    * Процент, на который изначально будет открыта модальная страница. При `settlingHeight={100}` модальная страница раскрывается на всю высоту.
    */
@@ -66,7 +72,9 @@ const ModalPage: React.FC<ModalPageProps & AdaptivityContextInterface> = (
     sizeX,
     hasMouse,
     onOpen,
+    onOpened,
     onClose,
+    onClosed,
     settlingHeight,
     dynamicContentHeight,
     getModalContentRef,

--- a/src/components/ModalPage/ModalPage.tsx
+++ b/src/components/ModalPage/ModalPage.tsx
@@ -31,6 +31,15 @@ export interface ModalPageProps
    * Шапка модальной страницы, `<ModalPageHeader />`
    */
   header?: React.ReactNode;
+  /**
+   * Будет вызвано при открытии модалки.
+   *
+   * > Может дожидаться окончания анимации, если она есть.
+   */
+  onOpen?: VoidFunction;
+  /**
+   * Будет вызвано при закрытии модалки.
+   */
   onClose?: VoidFunction;
   /**
    * Процент, на который изначально будет открыта модальная страница. При `settlingHeight={100}` модальная страница раскрывается на всю высоту.
@@ -56,6 +65,7 @@ const ModalPage: React.FC<ModalPageProps & AdaptivityContextInterface> = (
     viewHeight,
     sizeX,
     hasMouse,
+    onOpen,
     onClose,
     settlingHeight,
     dynamicContentHeight,

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -45,6 +45,13 @@ export interface ModalRootProps extends HasPlatform {
   activeModal?: string | null;
 
   /**
+   * Будет вызвано при открытии активной модалки с её id
+   *
+   * > Может дожидаться окончания анимации, если она есть.
+   */
+  onOpen?(modalId: string): void;
+
+  /**
    * Будет вызвано при закрытии активной модалки с её id
    */
   onClose?(modalId: string): void;

--- a/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -15,16 +15,24 @@ export interface ModalRootProps extends AdaptivityProps {
   activeModal?: string | null;
 
   /**
-   * Будет вызвано при открытии активной модалки с её id
-   *
-   * > Может дожидаться окончания анимации, если она есть.
+   * Будет вызвано при начале открытия активной модалки с её id
    */
   onOpen?(modalId: string): void;
 
   /**
-   * Будет вызвано при закрытии активной модалки с её id
+   * Будет вызвано при окончательном открытии активной модалки с её id
    */
-  onClose?: (modalId: string) => void;
+  onOpened?(modalId: string): void;
+
+  /**
+   * Будет вызвано при начале закрытия активной модалки с её id
+   */
+  onClose?(modalId: string): void;
+
+  /**
+   * Будет вызвано при окончательном закрытии активной модалки с её id
+   */
+  onClosed?(modalId: string): void;
 }
 
 const ModalRootComponent: React.FC<

--- a/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -15,6 +15,13 @@ export interface ModalRootProps extends AdaptivityProps {
   activeModal?: string | null;
 
   /**
+   * Будет вызвано при открытии активной модалки с её id
+   *
+   * > Может дожидаться окончания анимации, если она есть.
+   */
+  onOpen?(modalId: string): void;
+
+  /**
    * Будет вызвано при закрытии активной модалки с её id
    */
   onClose?: (modalId: string) => void;

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -32,16 +32,24 @@ export interface ModalRootProps extends HasPlatform {
   configProvider?: ConfigProviderContextInterface;
 
   /**
-   * Будет вызвано при открытии активной модалки с её id
-   *
-   * > Может дожидаться окончания анимации, если она есть.
+   * Будет вызвано при начале открытия активной модалки с её id
    */
   onOpen?(modalId: string): void;
 
   /**
-   * Будет вызвано при закрытии активной модалки с её id
+   * Будет вызвано при окончательном открытии активной модалки с её id
+   */
+  onOpened?(modalId: string): void;
+
+  /**
+   * Будет вызвано при начале закрытия активной модалки с её id
    */
   onClose?(modalId: string): void;
+
+  /**
+   * Будет вызвано при окончательном закрытии активной модалки с её id
+   */
+  onClosed?(modalId: string): void;
 }
 
 class ModalRootDesktopComponent extends React.Component<
@@ -56,7 +64,7 @@ class ModalRootDesktopComponent extends React.Component<
       updateModalHeight: () => undefined,
       registerModal: ({ id, ...data }) =>
         Object.assign(this.getModalState(id), data),
-      onClose: () => this.props.closeActiveModal(),
+      onClose: () => this.props.onExit(),
       isInsideModal: true,
     };
   }
@@ -99,10 +107,11 @@ class ModalRootDesktopComponent extends React.Component<
     ) {
       const { enteringModal } = this.props;
       const enteringState = this.getModalState(enteringModal);
+      this.props.onEnter();
       requestAnimationFrame(() => {
         if (this.props.enteringModal === enteringModal) {
           this.waitTransitionFinish(enteringState, () =>
-            this.props.onEnter(enteringModal)
+            this.props.onEntered(enteringModal)
           );
           this.animateModalOpacity(enteringState, true);
         }
@@ -130,7 +139,7 @@ class ModalRootDesktopComponent extends React.Component<
       return;
     }
 
-    this.waitTransitionFinish(prevModalState, () => this.props.onExit(id));
+    this.waitTransitionFinish(prevModalState, () => this.props.onExited(id));
     this.animateModalOpacity(prevModalState, false);
     if (!this.props.activeModal) {
       this.setMaskOpacity(prevModalState, 0);
@@ -222,7 +231,7 @@ class ModalRootDesktopComponent extends React.Component<
           <div
             vkuiClass="ModalRoot__mask"
             ref={this.maskElementRef}
-            onClick={this.props.closeActiveModal}
+            onClick={this.props.onExit}
           />
           <div vkuiClass="ModalRoot__viewport">
             {this.modals.map((Modal: React.ReactElement) => {
@@ -236,7 +245,7 @@ class ModalRootDesktopComponent extends React.Component<
               return (
                 <FocusTrap
                   restoreFocus={false}
-                  onClose={this.props.closeActiveModal}
+                  onClose={this.props.onExit}
                   timeout={this.timeout}
                   key={key}
                   // eslint-disable-next-line vkui/no-object-expression-in-arguments

--- a/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -32,6 +32,13 @@ export interface ModalRootProps extends HasPlatform {
   configProvider?: ConfigProviderContextInterface;
 
   /**
+   * Будет вызвано при открытии активной модалки с её id
+   *
+   * > Может дожидаться окончания анимации, если она есть.
+   */
+  onOpen?(modalId: string): void;
+
+  /**
    * Будет вызвано при закрытии активной модалки с её id
    */
   onClose?(modalId: string): void;

--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -661,14 +661,14 @@ class SelectModal extends Component {
 export default withModalRootContext(SelectModal);
 ```
 
-#### В мобильной версии при парамтре `autoFocus` у контрола ломается поведение карточки
+#### В мобильной версии при параметре `autoFocus` у контрола ломается поведение карточки
 
 К сожалению, из-за особенностей React, `autoFocus` ломает CSS анимацию.
 
-Чтобы исправить проблему, следует отказаться от `autoFocus` и выставлять фокус в ручную при событии `onOpen`.
-Подписываться на `onOpen` можно двумя разными способами.
+Чтобы исправить проблему, следует отказаться от `autoFocus` и выставлять фокус в ручную при событии `onOpened`.
+Подписываться на `onOpened` можно двумя разными способами.
 
-1️⃣ `<ModalRoot onOpen={(id) => ...} />`
+1️⃣ `<ModalRoot onOpened={(id) => ...} />`
 
 ```jsx static
 const App = () => {
@@ -681,7 +681,7 @@ const App = () => {
   }, []);
 
   const modal = (
-    <ModalRoot activeModal="modal-with-auto-focus" onOpen={handleOpen}>
+    <ModalRoot activeModal="modal-with-auto-focus" onOpened={handleOpen}>
       <ModalPage id="modal-with-auto-focus">
         <Input getRootRef={inputRef} />
       </ModalPage>
@@ -691,10 +691,10 @@ const App = () => {
 };
 ```
 
-2️⃣ `<ModalPage onOpen={() => ...} />`
+2️⃣ `<ModalPage onOpened={() => ...} />`
 
 > ⚠️ в этом случае `ModalPage` нельзя заворачивать в другой компонент
-> иначе `ModalRoot` не сможет получить доступ к `onOpen`.
+> иначе `ModalRoot` не сможет получить доступ к `onOpened`.
 
 ```jsx static
 const App = () => {
@@ -708,7 +708,7 @@ const App = () => {
 
   const modal = (
     <ModalRoot activeModal="modal-with-auto-focus">
-      <ModalPage id="modal-with-auto-focus" onOpen={handleOpen}>
+      <ModalPage id="modal-with-auto-focus" onOpened={handleOpen}>
         <Input getRootRef={inputRef} />
       </ModalPage>
     </ModalRoot>
@@ -734,7 +734,7 @@ const Example = () => {
   }, []);
 
   const modal = (
-    <ModalRoot activeModal={activeModal} onOpen={handleOpenOfModalRoot}>
+    <ModalRoot activeModal={activeModal} onOpened={handleOpenOfModalRoot}>
       <ModalPage id="modal-1" onClose={() => setActiveModal(null)}>
         <Div>
           <input type="text" ref={firstInputRef} />
@@ -742,7 +742,7 @@ const Example = () => {
       </ModalPage>
       <ModalPage
         id="modal-2"
-        onOpen={handleOpenOfModalPage}
+        onOpened={handleOpenOfModalPage}
         onClose={() => setActiveModal(null)}
       >
         <Div>
@@ -758,10 +758,10 @@ const Example = () => {
         <View activePanel="main">
           <Panel id="main">
             <CellButton multiline onClick={() => setActiveModal("modal-1")}>
-              Пример с onOpen() на ModalRoot
+              Пример с onOpened() на ModalRoot
             </CellButton>
             <CellButton multiline onClick={() => setActiveModal("modal-2")}>
-              Пример с onOpen() на ModalPage
+              Пример с onOpened() на ModalPage
             </CellButton>
           </Panel>
         </View>

--- a/src/components/ModalRoot/Readme.md
+++ b/src/components/ModalRoot/Readme.md
@@ -660,3 +660,115 @@ class SelectModal extends Component {
 
 export default withModalRootContext(SelectModal);
 ```
+
+#### В мобильной версии при парамтре `autoFocus` у контрола ломается поведение карточки
+
+К сожалению, из-за особенностей React, `autoFocus` ломает CSS анимацию.
+
+Чтобы исправить проблему, следует отказаться от `autoFocus` и выставлять фокус в ручную при событии `onOpen`.
+Подписываться на `onOpen` можно двумя разными способами.
+
+1️⃣ `<ModalRoot onOpen={(id) => ...} />`
+
+```jsx static
+const App = () => {
+  const inputRef = useRef(null);
+
+  const handleOpen = React.useCallback((id) => {
+    if (id === "modal-with-auto-focus" && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  const modal = (
+    <ModalRoot activeModal="modal-with-auto-focus" onOpen={handleOpen}>
+      <ModalPage id="modal-with-auto-focus">
+        <Input getRootRef={inputRef} />
+      </ModalPage>
+    </ModalRoot>
+  );
+  // ...
+};
+```
+
+2️⃣ `<ModalPage onOpen={() => ...} />`
+
+> ⚠️ в этом случае `ModalPage` нельзя заворачивать в другой компонент
+> иначе `ModalRoot` не сможет получить доступ к `onOpen`.
+
+```jsx static
+const App = () => {
+  const inputRef = useRef(null);
+
+  const handleOpen = React.useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  const modal = (
+    <ModalRoot activeModal="modal-with-auto-focus">
+      <ModalPage id="modal-with-auto-focus" onOpen={handleOpen}>
+        <Input getRootRef={inputRef} />
+      </ModalPage>
+    </ModalRoot>
+  );
+  // ...
+};
+```
+
+```jsx { "props": { "layout": false, "adaptivity": true } }
+const Example = () => {
+  const firstInputRef = useRef(null);
+  const secondInputRef = useRef(null);
+  const [activeModal, setActiveModal] = React.useState(false);
+
+  const handleOpenOfModalRoot = React.useCallback((id) => {
+    if (id === "modal-1") {
+      firstInputRef.current.focus();
+    }
+  }, []);
+
+  const handleOpenOfModalPage = React.useCallback(() => {
+    secondInputRef.current.focus();
+  }, []);
+
+  const modal = (
+    <ModalRoot activeModal={activeModal} onOpen={handleOpenOfModalRoot}>
+      <ModalPage id="modal-1" onClose={() => setActiveModal(null)}>
+        <Div>
+          <input type="text" ref={firstInputRef} />
+        </Div>
+      </ModalPage>
+      <ModalPage
+        id="modal-2"
+        onOpen={handleOpenOfModalPage}
+        onClose={() => setActiveModal(null)}
+      >
+        <Div>
+          <input type="text" ref={secondInputRef} />
+        </Div>
+      </ModalPage>
+    </ModalRoot>
+  );
+
+  return (
+    <SplitLayout modal={modal}>
+      <SplitCol>
+        <View activePanel="main">
+          <Panel id="main">
+            <CellButton multiline onClick={() => setActiveModal("modal-1")}>
+              Пример с onOpen() на ModalRoot
+            </CellButton>
+            <CellButton multiline onClick={() => setActiveModal("modal-2")}>
+              Пример с onOpen() на ModalPage
+            </CellButton>
+          </Panel>
+        </View>
+      </SplitCol>
+    </SplitLayout>
+  );
+};
+
+Example();
+```

--- a/src/components/ModalRoot/types.ts
+++ b/src/components/ModalRoot/types.ts
@@ -17,10 +17,21 @@ export interface ModalElements {
 export interface ModalsStateEntry extends ModalElements {
   id: string | null;
   /**
+   * Событие начала открытия модалки.
+   */
+  onOpen?: VoidFunction;
+  /**
    * Событие открытия модалки.
    */
-  onOpen?: () => any;
-  onClose?: () => any;
+  onOpened?: VoidFunction;
+  /**
+   * Событие начала закрытия модалки.
+   */
+  onClose?: VoidFunction;
+  /**
+   * Событие закрытия модалки.
+   */
+  onClosed?: VoidFunction;
   type?: ModalType;
 
   settlingHeight?: number;

--- a/src/components/ModalRoot/types.ts
+++ b/src/components/ModalRoot/types.ts
@@ -16,6 +16,10 @@ export interface ModalElements {
 
 export interface ModalsStateEntry extends ModalElements {
   id: string | null;
+  /**
+   * Событие открытия модалки.
+   */
+  onOpen?: () => any;
   onClose?: () => any;
   type?: ModalType;
 


### PR DESCRIPTION
Расширил API у `ModalRoot` и `ModalPage`:

* `onOpen` – начало открытия
* `onOpened` – окончательно открытие (имеется ввиду завершилась анимация)
* `onClosed`– окончательно открытие (имеется ввиду завершилась анимация)

`onClose` уже есть и работает как `onOpen` – начало закрытия

---

resolve #2340
resolve #680
resolve #1935