### PR TITLE
fix(Root): Double View without animation

### DIFF
--- a/src/components/Root/Root.css
+++ b/src/components/Root/Root.css
@@ -174,11 +174,3 @@
     opacity: 1;
   }
 }
-
-/* iOS + Android */
-
-.Root--ios.Root--no-motion .Root__view,
-.Root--android.Root--no-motion .Root__view,
-.Root--vkcom.Root--no-motion .Root__view {
-  animation: none;
-}

--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -80,7 +80,7 @@ const Root: React.FC<RootProps> = ({
       _setState({
         activeView: panel,
         prevView: activeView,
-        transition: true,
+        transition: !disableAnimation,
         isBack,
       });
     }
@@ -107,7 +107,7 @@ const Root: React.FC<RootProps> = ({
           to: activeView,
         });
     }
-  }, [transition]);
+  }, [transition, prevView]);
 
   const fallbackTransition = useTimeout(
     finishTransition,
@@ -118,8 +118,8 @@ const Root: React.FC<RootProps> = ({
       fallbackTransition.clear();
       return;
     }
-    disableAnimation ? finishTransition() : fallbackTransition.set();
-  }, [disableAnimation, fallbackTransition, finishTransition, transition]);
+    fallbackTransition.set();
+  }, [fallbackTransition, transition]);
 
   const onAnimationEnd = (e: React.AnimationEvent) => {
     if (
@@ -150,8 +150,7 @@ const Root: React.FC<RootProps> = ({
       {...restProps}
       // eslint-disable-next-line vkui/no-object-expression-in-arguments
       vkuiClass={classNames(getClassName("Root", platform), {
-        "Root--transition": !disableAnimation && transition,
-        "Root--no-motion": disableAnimation,
+        "Root--transition": transition,
       })}
     >
       {views.map((view) => {


### PR DESCRIPTION
Fixes #2274, #1999

### Проблема

При переключении `activeView` в [Root](https://vkcom.github.io/VKUI/#/Root) без анимации(отключена разработчиком или большой размер экрана), в одном моменте рендерится текущий и предыдущий View. Из-за этого на несколько миллисекунд появляется скролл(заметно на windows, linux)

### Причины

Переход рендерится в три этапа

- `activeView="view1"` `transition=false` (переключилось свойство `_activeView`)
- `activeView="view2"` `transition=true` (начался переход, появляются новый View, происходит анимация)
- `activeView="view2"` `transition=false` (старый View убирается, выполняется onTransition...)

При отключенной анимации также рендерится в три этапа

- `activeView="view1"` `transition=false` (переключилось свойство `_activeView`)
- `activeView="view2"` `transition=true` (начался переход, **появляются новый View и скролл**, анимация отключена)
- `activeView="view2"` `transition=false` (старый View убирается, выполняется onTransition...)

### Решение

Рендер в два этапа

- `activeView="view1"` `transition=false` (переключилось свойство `_activeView`)
- `activeView="view2"` `transition=false` (старый View меняется на новый, выполняется onTransition...)

### Побочное

Класс `.Root--no-motion` теперь не имеет смысла, т.к. при `transition=false` не накладываются классы с анимацией
