### PR TITLE
fix(View): fix view blinking after transition to prev view

### DIFF
--- a/src/components/Root/Root.css
+++ b/src/components/Root/Root.css
@@ -79,7 +79,7 @@
 }
 
 .Root--ios .Root__view--show-back::after {
-  animation: vkui-root-ios-animation-show-back 0.6s var(--ios-easing);
+  animation: vkui-root-ios-animation-show-back 0.6s var(--ios-easing) forwards;
 }
 
 .Root--ios .Root__view--hide-forward::after {
@@ -91,7 +91,7 @@
 }
 
 .Root--ios .Root__view--hide-back {
-  animation: vkui-root-ios-animation-hide-back 0.6s var(--ios-easing);
+  animation: vkui-root-ios-animation-hide-back 0.6s var(--ios-easing) forwards;
 }
 
 @keyframes vkui-root-ios-animation-show-back {
@@ -148,7 +148,8 @@
 
 .Root--android .Root__view--hide-back,
 .Root--vkcom .Root__view--hide-back {
-  animation: vkui-root-android-animation-hide-back 0.3s var(--android-easing);
+  animation: vkui-root-android-animation-hide-back 0.3s var(--android-easing)
+    forwards;
 }
 
 @keyframes vkui-root-android-animation-hide-back {

--- a/src/components/View/View.css
+++ b/src/components/View/View.css
@@ -89,7 +89,7 @@
  * Panel transition
  */
 .View__panel--next ~ .View__panel--prev {
-  animation: vkui-animation-view-prev-back 0.3s var(--android-easing);
+  animation: vkui-animation-view-prev-back 0.3s var(--android-easing) forwards;
 }
 
 .View__panel--prev ~ .View__panel--next {

--- a/src/components/View/ViewIOS.css
+++ b/src/components/View/ViewIOS.css
@@ -54,7 +54,7 @@
 }
 
 .View--ios .View__panel--next ~ .View__panel--prev {
-  animation: vkui-animation-ios-prev-back 0.6s var(--ios-easing);
+  animation: vkui-animation-ios-prev-back 0.6s var(--ios-easing) forwards;
 }
 
 .View--ios .View__panel--prev .Panel__fade,
@@ -74,7 +74,7 @@
 }
 
 .View--ios .View__panel--next .Panel__fade {
-  animation: vkui-animation-ios-fade-out 0.6s var(--ios-easing);
+  animation: vkui-animation-ios-fade-out 0.6s var(--ios-easing) forwards;
 }
 
 .View--ios .View__panel--prev ~ .View__panel--next .Panel__fade,


### PR DESCRIPTION
Использовал `create-react-app`

- `@vkontakte/vkui@4.28.1`
- `react@18.0.0`
- `react-dom@18.0.0`

<details>
  <summary>Тестируемый код</summary>

  ```tsx
// @ts-nocheck
import * as React from "react";
import { createRoot } from "react-dom/client";

import { ConfigProvider, AdaptivityProvider, AppRoot, View, Panel, CellButton, PanelHeader, Group } from "@vkontakte/vkui";

import "@vkontakte/vkui/dist/vkui.css";

function App() {
  const [history, setHistory] = React.useState(["main"]);
  const activePanel = history[history.length - 1];

  const goBack = () => setHistory(history.slice(0, -1));
  const go = (panel) => setHistory([...history, panel]);

  return (
    <View onSwipeBack={goBack} history={history} activePanel={activePanel}>
      <Panel id="main">
        <PanelHeader>Main</PanelHeader>
        <Group>
          <CellButton onClick={() => go("profile")}>profile</CellButton>
        </Group>
      </Panel>
      <Panel id="profile">
        <PanelHeader>Профиль</PanelHeader>
        <Group>
          <CellButton onClick={() => goBack()}>main</CellButton>
        </Group>
      </Panel>
    </View>
  );
}

const container = document.getElementById('root');
const root = createRoot(container);

root.render(
  <ConfigProvider>
    <AdaptivityProvider>
      <AppRoot>
        <App />
      </AppRoot>
    </AdaptivityProvider>
  </ConfigProvider>
);

   ```
</details>

**До**

https://user-images.githubusercontent.com/5850354/163793993-3f25e8dd-2e69-4340-a76d-767ee1b896ae.mov

**После**

https://user-images.githubusercontent.com/5850354/163794000-500cce6d-bb8b-4e38-83fa-b31d39b4d53d.mov

---

fix https://github.com/VKCOM/VKUI/issues/2043
related to https://github.com/VKCOM/VKUI/pull/2088 (спасибо @worldwidebaby 🙏 )