### PR TITLE
[Research]: Уменьшаем размер токенов

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -3,6 +3,7 @@ module.exports = {
   displayName: "unit",
   roots: [
     path.join(__dirname, "src"),
+    path.join(__dirname, "tasks"),
     path.join(__dirname, "postcss-plugin-vk-sans"),
     path.join(__dirname, "postcss-custom-properties-fallback"),
   ],

--- a/package.json
+++ b/package.json
@@ -130,6 +130,11 @@
       "path": "dist/index.js"
     },
     {
+      "name": "JS (brotli)",
+      "path": "dist/index.js",
+      "brotli": true
+    },
+    {
       "name": "JS, unstable",
       "path": "dist/unstable/index.js"
     },
@@ -137,6 +142,12 @@
       "name": "CSS",
       "path": "dist/vkui.css",
       "webpack": false
+    },
+    {
+      "name": "CSS (brotli)",
+      "path": "dist/vkui.css",
+      "webpack": false,
+      "brotli": true
     },
     {
       "name": "CSS, unstable",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const cssCustomProperties = require("postcss-custom-properties");
 const scopeRoot = require("./tasks/postcss-scope-root.js");
+const restructureVariable = require("./tasks/postcss-restructure-variable.js");
 const cssImport = require("postcss-import");
 const autoprefixer = require("autoprefixer");
 const cssModules = require("postcss-modules");
@@ -36,6 +37,20 @@ let plugins = [
       ),
     ],
   }),
+  restructureVariable(
+    [
+      "./src/styles/bright_light.css",
+      "./src/styles/space_gray.css",
+      "./src/styles/vkcom_light.css",
+      "./src/styles/vkcom_dark.css",
+      "./node_modules/@vkontakte/vkui-tokens/themes/vkBase/cssVars/declarations/onlyVariables.css",
+      "./node_modules/@vkontakte/vkui-tokens/themes/vkBaseDark/cssVars/declarations/onlyVariablesLocal.css",
+      "./node_modules/@vkontakte/vkui-tokens/themes/vkIOS/cssVars/declarations/onlyVariablesLocal.css",
+      "./node_modules/@vkontakte/vkui-tokens/themes/vkIOSDark/cssVars/declarations/onlyVariablesLocal.css",
+      "./node_modules/@vkontakte/vkui-tokens/themes/vkCom/cssVars/declarations/onlyVariablesLocal.css",
+      "./node_modules/@vkontakte/vkui-tokens/themes/vkComDark/cssVars/declarations/onlyVariablesLocal.css",
+    ].map((pathSegment) => path.resolve(pathSegment))
+  ),
   autoprefixer(),
   cssModules({
     generateScopedName: (name) =>

--- a/tasks/postcss-restructure-variable.js
+++ b/tasks/postcss-restructure-variable.js
@@ -1,0 +1,226 @@
+const { Rule } = require("postcss");
+
+function setEquals(a, b) {
+  return a.size === b.size && [...a].every((value) => b.has(value));
+}
+class Value {
+  constructor(prop, value) {
+    this.prop = prop;
+    this.value = value;
+    this.selectors = new Set();
+  }
+  addSelector(selector) {
+    this.selectors.add(selector.toString());
+  }
+  removeSelector(selector) {
+    return this.selectors.delete(selector.toString());
+  }
+  getSelectors() {
+    return this.selectors;
+  }
+  getProp() {
+    return this.prop;
+  }
+  toString() {
+    return this.value;
+  }
+}
+
+class Prop {
+  constructor(name) {
+    this.name = name;
+    this.values = new Map();
+  }
+  addValue(value) {
+    this.values.set(value.toString(), value);
+  }
+  getValue(value) {
+    return this.values.get(value);
+  }
+  toString() {
+    return this.name;
+  }
+}
+
+class Selector {
+  constructor(name) {
+    this.name = name;
+    this.props = new Map();
+  }
+  addProp(prop, value) {
+    const oldValue = this.props.get(prop);
+    if (oldValue) {
+      oldValue.removeSelector(this);
+    }
+    this.props.set(prop, value);
+  }
+  compare(b) {
+    if (this.name > b.name) {
+      return 1;
+    }
+    if (this.name < b.name) {
+      return -1;
+    }
+    return 0;
+  }
+  toString() {
+    return this.name;
+  }
+}
+
+class Graph {
+  constructor() {
+    this.selectors = new Map();
+    this.props = new Map();
+    this.values = new Set();
+  }
+  addEdge(selector, prop, value) {
+    value.addSelector(selector);
+    prop.addValue(value);
+    selector.addProp(prop, value);
+  }
+  add(selectors, prop, value) {
+    selectors.forEach((selector) => {
+      let _selector = this.selectors.get(selector);
+      if (!_selector) {
+        _selector = new Selector(selector);
+        this.selectors.set(selector, _selector);
+      }
+      let _prop = this.props.get(prop);
+      if (!_prop) {
+        _prop = new Prop(prop);
+        this.props.set(prop, _prop);
+      }
+      let _value = _prop.getValue(value);
+      if (!_value) {
+        _value = new Value(prop, value);
+        this.values.add(_value);
+      }
+      this.addEdge(_selector, _prop, _value);
+    });
+  }
+  restructure() {
+    const rules = [];
+    this.values.forEach((value) => {
+      const selectors = value.getSelectors();
+      if (selectors.size === 0) {
+        return;
+      }
+      const some = rules.some((rule) => {
+        if (setEquals(selectors, rule.selectors)) {
+          rule.decls.set(value.getProp(), value.toString());
+          return true;
+        }
+        return false;
+      });
+      if (!some) {
+        rules.push({
+          selectors: selectors,
+          decls: new Map([[value.getProp(), value.toString()]]),
+        });
+      }
+    });
+    return rules;
+  }
+}
+
+/**
+ * @type {import('postcss').PluginCreator}
+ * @param {string[]} onlySelectors
+ */
+module.exports = (importFrom = []) => {
+  return {
+    postcssPlugin: "postcss-restructure-variable",
+    Root(root) {
+      /**
+       * @type {string[]}
+       */
+      const ignoreValue = [];
+
+      const graph = new Graph();
+
+      /**
+       *
+       * @param {import('postcss').AtRule} node
+       */
+      const atRuleFind = (node) => {
+        node.each((atRuleNode) => {
+          switch (atRuleNode.type) {
+            case "rule":
+              atRuleNode.each((decl) => {
+                if (decl.type === "decl" && decl.variable) {
+                  ignoreValue.push(decl.prop);
+                }
+              });
+              break;
+            case "atrule":
+              atRuleFind(atRuleNode);
+              break;
+          }
+        });
+      };
+
+      root.each((node) => {
+        if (
+          !node.source ||
+          (node.source !== undefined &&
+            !importFrom.includes(node.source.input.file))
+        ) {
+          return;
+        }
+
+        switch (node.type) {
+          case "rule":
+            const beforeLength = node.nodes.length;
+
+            node.each((decl) => {
+              if (decl.type === "decl" && decl.variable) {
+                if (ignoreValue.includes(decl.prop)) {
+                  return;
+                }
+                graph.add(node.selectors, decl.prop, decl.value);
+                decl.remove();
+              }
+            });
+
+            // Удаляем если селектор оказался пустой, после наших действий
+            if (node.nodes.length === 0 && node.nodes.length !== beforeLength) {
+              node.remove();
+            }
+            break;
+          case "atrule":
+            atRuleFind(node);
+            break;
+        }
+      });
+
+      const rules = graph.restructure();
+
+      let lastRule = undefined;
+      rules.forEach(({ decls, selectors }) => {
+        const rule = new Rule({
+          selectors: Array.from(selectors),
+        });
+
+        decls.forEach((value, key) => {
+          rule.append({ prop: key, value: value });
+        });
+
+        if (lastRule) {
+          root.insertAfter(lastRule, rule);
+        } else {
+          // Вставляем первым
+          if (root.first) {
+            root.insertBefore(root.first, rule);
+          } else {
+            root.append(rule);
+          }
+        }
+
+        lastRule = rule;
+      });
+    },
+  };
+};
+
+module.exports.postcss = true;

--- a/tasks/postcss-restructure-variable.test.js
+++ b/tasks/postcss-restructure-variable.test.js
@@ -1,0 +1,174 @@
+const postcss = require("postcss");
+
+const plugin = require("./postcss-restructure-variable");
+
+async function run(input, output, opts = [undefined]) {
+  let result = await postcss([plugin(opts)]).process(input, {
+    from: undefined,
+  });
+  expect(result.css).toEqual(output);
+  expect(result.warnings()).toHaveLength(0);
+}
+
+it("rewrite custom property", async () => {
+  const input = `.a {
+    --color: #fff;
+}
+.a {
+    --color: #000;
+}
+.b {
+    --color: #fff;
+}
+.b {
+    --color: #000;
+}
+`;
+
+  const output = `
+.a, .b {
+    --color: #000
+}
+`;
+
+  await run(input, output);
+});
+
+it("merge one", async () => {
+  const input = `:root {
+    --color: #fff;
+}
+.b {
+    color: var(--color);
+}
+.b {
+    --color: #fff;
+}
+`;
+
+  const output = `
+:root, .b {
+    --color: #fff;
+}
+.b {
+    color: var(--color);
+}
+`;
+
+  await run(input, output);
+});
+
+it("merge three", async () => {
+  const input = `:root {
+    --color: #fff;
+    --size: 1px;
+}
+.b {
+    color: var(--color);
+}
+.b {
+    --color: #fff;
+    --size: 2px;
+}
+`;
+
+  const output = `
+:root, .b {
+    --color: #fff;
+}
+:root {
+    --size: 1px;
+}
+.b {
+    --size: 2px;
+}
+.b {
+    color: var(--color);
+}
+`;
+
+  await run(input, output);
+});
+
+// PS: по идеи @media в итоге не должно быть, но чтобы ничего не сломать оставлю так
+it("check cascading", async () => {
+  const input = `
+@media (min-resolution: 2dppx) {
+    :root {
+        --color: blue;
+        color: blue;
+    }
+}
+@media (min-resolution: 3dppx) {
+    :root {
+        --color: blue;
+    }
+}
+:root {
+    --color: blue;
+}`;
+
+  await run(input, input);
+});
+
+it("check deep cascading", async () => {
+  const input = `
+@supports (display: flex) {
+    @media screen and (min-width: 900px) {
+        :root {
+            --color: blue;
+        }
+    }
+}
+:root {
+    --color: blue;
+}`;
+
+  await run(input, input);
+});
+
+it("no custom properties", async () => {
+  const input = `
+.b {
+  color: var(--color);
+}`;
+
+  await run(input, input);
+});
+
+it("example", async () => {
+  const input = `
+.a {
+    --color1: #ff0000;
+    --color2: #ff0000;
+    --size: 2px;
+}
+.b {
+    --color1: #ff0000;
+    --color2: #ff0000;
+    --size: 1px;
+}
+.c {
+    --color: #0000ff;
+    --size: 1px;
+}
+`;
+
+  const output = `
+.a, .b {
+    --color1: #ff0000;
+    --color2: #ff0000
+}
+.a {
+    --size: 2px
+}
+.b, .c {
+    --size: 1px
+}
+.c {
+    --color: #0000ff
+}
+`;
+
+  await run(input, output);
+});

--- a/tasks/postcss-scope-root.js
+++ b/tasks/postcss-scope-root.js
@@ -1,7 +1,11 @@
 module.exports = ({ customPropRoot, except = [] }) => ({
   postcssPlugin: "postcss-scope-root",
   Rule: (rule) => {
-    if (rule.selector === ":root" && !except.includes(rule.source.input.file)) {
+    if (
+      rule.selector === ":root" &&
+      rule.source &&
+      !except.includes(rule.source.input.file)
+    ) {
       rule.selector = customPropRoot;
     }
   },


### PR DESCRIPTION
# Проблема

css переменные занимают большое количество места в нашей сборке.

![image](https://user-images.githubusercontent.com/14944123/163802215-6ca9c315-f633-4050-872a-bd8e9e5d6ed2.png)

При этом многие переменные имеют одинаковое значение, а разница между темами не большая

```diff
< .vkui--vkBase--light {
<       --vkui--theme_name: 'vkBase';
<       --vkui--theme_name_base: 'vkBase';
---
> .vkui--vkCom--light {
>       --vkui--theme_name: 'vkCom';
>       --vkui--theme_name_base: 'vkCom';

<       --vkui--size_border_radius--regular: 8px;
---
>       --vkui--size_border_radius--regular: 4px;

>       --vkui--theme_inherits_from: 'vkBase';
```

## Инкрементальная сборка [vkui-tokens](https://github.com/VKCOM/vkui-tokens)

В  [vkui-tokens](https://github.com/VKCOM/vkui-tokens) добавили инкрементальную сборку, которая в сгенерированных токенах убирает переменные с одинаковыми значениями. 

```diff
< [postcss] [postcss-bundle] asset vkui.css **358 KiB** [emitted] (name: vkui) (id hint: vkui) 1 related asset
---
> [postcss] [postcss-bundle] asset vkui.css **268 KiB** [emitted] (name: vkui) (id hint: vkui) 1 related asset

<   Size: **43.2 kB** with all dependencies, minified and gzipped
---
>   Size: **37.78 kB** with all dependencies, minified and gzipped
```

### Проблема №1

Текущее решение убирает не все одинаковые переменные.

![image](https://user-images.githubusercontent.com/14944123/163802705-17c46bdb-f55e-4b10-ad0b-b255e5953ccf.png)

### Проблема №2

Класс должен выглядеть так:

```html
<div class="vkui--vkBase--light vkui--vkBase--dark vkui--vkCom--dark">
...
</div>
```

Теперь если разработчик хочет что-то немного изменить в теме для **vkBase**, оно будет влиять на **vkCom**.

> ⚠️ Нужен еще один тип сборки токенов, где будут указаны селекторы зависимых тем. Так нам не нужно будет указывать много классов

### Проблема №3

VKUI требуется возможность подключения сразу двух видом но в vkui-tokens можно выбрать подключение или `:root` или `.vkui--vkBase--light`. Если подключать оба, увеличится размер выходного css.


> ⚠️ Нужен еще один тип сборки токенов...

### Проблема №4

Данное решение влияет только на [vkui-tokens](https://github.com/VKCOM/vkui-tokens). У нас еще есть [Appearance](https://github.com/VKCOM/Appearance)(хоть и устаревший, но все же).

## Идея

А что если сделать плагин для postcss, который будет искать одинаковые переменные для селекторов и объединять их

```css
:root {
  --vkui--theme_name: 'vkBase';
  --vkui--font_family_accent: "TT Commons", -apple-system, system-ui, Helvetica Neue, Roboto, sans-serif;
  --vkui--size_border_radius--regular: 8px;
}

.vkui--vkBase--light {
  --vkui--theme_name: 'vkBase';
  --vkui--font_family_accent: "TT Commons", -apple-system, system-ui, Helvetica Neue, Roboto, sans-serif;
  --vkui--size_border_radius--regular: 8px;
}]

.vkui--vkCom--light {
  --vkui--theme_name: 'vkCom';
  --vkui--font_family_accent: "TT Commons", -apple-system, system-ui, Helvetica Neue, Roboto, sans-serif;
  --vkui--size_border_radius--regular: 4px;
}
```

```css
:root,
  .vkui--vkBase--light,
  .vkui--vkCom--light {
  --vkui--font_family_accent: "TT Commons", -apple-system, system-ui, Helvetica Neue, Roboto, sans-serif;
}

:root,
  .vkui--vkBase--light {
  --vkui--theme_name: 'vkBase';
  --vkui--size_border_radius--regular: 8px;
}

.vkui--vkCom--light {
  --vkui--theme_name: 'vkCom';
  --vkui--size_border_radius--regular: 4px;
}
```

Теперь решаются многие проблемы с https://github.com/VKCOM/vkui-tokens

### Существующие решения

Нужно поискать (*плохо искал?*)

#### CSSO

В [csso](https://css.github.io/csso/csso.html) есть реструктуризация, но оно работает c учетом очередности селекторов.

## FAQ

### Q: Одинаковые переменные в одинаковых селекторах

Просто перезаписываем (если переменные не перезаписываются в медиазапросах)

```css
.light {
	--size: 10px;
}

.light {
	--size: 20px;
}
```

```css
.light {
	--size: 20px;
}
```

### Q: Что по очередности селекторов

Если переменные не перезаписываются в медиазапросах(и прочем) можем не соблюдать(с учетом предыдущего пункта).

...

## Итог

![image](https://user-images.githubusercontent.com/14944123/163804165-a1916506-c96b-421c-bc8c-1365b9c2dff8.png)
![image](https://user-images.githubusercontent.com/14944123/164384237-1f179d4b-4757-4000-a0c1-c2cb0f5c50e8.png)

- closed #2565