### PR TITLE
Повсеместное использование `--safe-area-inset-top`

### DIFF
--- a/src/components/FixedLayout/FixedLayout.css
+++ b/src/components/FixedLayout/FixedLayout.css
@@ -14,10 +14,12 @@
 .FixedLayout--top {
   width: 100%;
   top: 0;
+  left: 0;
 }
 
 .FixedLayout--bottom {
   width: 100%;
+  left: 0;
   bottom: 0;
   padding-bottom: var(--safe-area-inset-bottom);
 }

--- a/src/components/ModalRoot/ModalRoot.css
+++ b/src/components/ModalRoot/ModalRoot.css
@@ -34,13 +34,14 @@
   pointer-events: none;
 }
 
-:not(.ModalRoot--desktop).ModalRoot--ios .ModalRoot__viewport {
+:not(.ModalRoot--desktop).ModalRoot--ios .ModalRoot__viewport,
+:not(.ModalRoot--desktop).ModalRoot--android .ModalRoot__viewport {
   top: var(--safe-area-inset-top);
 }
 
 :not(.ModalRoot--desktop).ModalRoot--vkapps.ModalRoot--android
   .ModalRoot__viewport {
-  top: var(--panelheader_height_android);
+  top: calc(var(--safe-area-inset-top) + var(--panelheader_height_android));
 }
 
 :not(.ModalRoot--desktop).ModalRoot--vkapps.ModalRoot--ios

--- a/src/components/PanelHeader/PanelHeader.css
+++ b/src/components/PanelHeader/PanelHeader.css
@@ -151,14 +151,6 @@
 /**
  * Android
  */
-
-@supports not (padding-top: env(safe-area-inset-top)) {
-  .PanelHeader--android,
-  .PanelHeader--vkcom {
-    --safe-area-inset-top: 0px;
-  }
-}
-
 .PanelHeader--android ~ .FixedLayout--top,
 .PanelHeader--android ~ * .FixedLayout--top:not(.PanelHeader__fixed) {
   top: calc(var(--panelheader_height_android) + var(--safe-area-inset-top));

--- a/src/components/SplitLayout/SplitLayout.css
+++ b/src/components/SplitLayout/SplitLayout.css
@@ -26,7 +26,9 @@
 
 .SplitLayout--android .SplitLayout__inner--header,
 .SplitLayout--vkcom .SplitLayout__inner--header {
-  margin-top: calc(-1 * var(--panelheader_height_android));
+  margin-top: calc(
+    -1 * calc(var(--panelheader_height_android) + var(--safe-area-inset-top))
+  );
 }
 
 .SplitLayout__popout {

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -60,21 +60,6 @@
   }
 }
 
-/**
- * Проверка на iOS.
- *
- * > Не стандартное св-во. Если так и не стандартизируют, то потребуется иначе определять платформу.
- *
- * Ссылки:
- * - https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout
- * - https://stackoverflow.com/questions/30102792/css-media-query-to-target-only-ios-devices
- */
-@supports (-webkit-touch-callout: none) {
-  :root {
-    --safe-area-inset-top: 20px;
-  }
-}
-
 @supports (padding-top: constant(safe-area-inset-top)) {
   :root {
     --safe-area-inset-top: constant(safe-area-inset-top);

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -38,8 +38,8 @@
   --white: #fff;
   --blue_200: #5c9ce6;
 
-  /* iOS insets */
-  --safe-area-inset-top: 20px;
+  /* insets */
+  --safe-area-inset-top: 0px;
   --safe-area-inset-right: 0px;
   --safe-area-inset-bottom: 0px;
   --safe-area-inset-left: 0px;
@@ -57,6 +57,21 @@
 @media (min-resolution: 3dppx) {
   :root {
     --thin-border: 0.33px;
+  }
+}
+
+/**
+ * Проверка на iOS.
+ *
+ * > Не стандартное св-во. Если так и не стандартизируют, то потребуется иначе определять платформу.
+ *
+ * Ссылки:
+ * - https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout
+ * - https://stackoverflow.com/questions/30102792/css-media-query-to-target-only-ios-devices
+ */
+@supports (-webkit-touch-callout: none) {
+  :root {
+    --safe-area-inset-top: 20px;
   }
 }
 


### PR DESCRIPTION
В частности поправил, что на Android игнорировалось использование `--safe-area-inset-top` в следующих компонентах:

- [ModalPage](https://vkcom.github.io/VKUI/#!/ModalPage)
- [SplitLayout](https://vkcom.github.io/VKUI/#!/SplitLayout)

Проверил на эмуляторе

<img width="200" alt="safari" src="https://user-images.githubusercontent.com/5850354/163995134-a3dba802-a628-4521-82b8-43e16506568e.jpg">

## О значении по умолчанию для iOS

Для iOS в `--safe-area-inset-top` в `:root` выставлялось значение по умолчанию в `20px` (прикрепляю код ниже)

https://github.com/VKCOM/VKUI/blob/ca0a2dab093152b55907e748de46529bb06213b7/src/styles/constants.css#L34-L35

Из-за этого для других платформ приходилось обнулять это значение точечно (прикрепляю пример ниже)

https://github.com/VKCOM/VKUI/blob/ca0a2dab093152b55907e748de46529bb06213b7/src/components/PanelHeader/PanelHeader.css#L155-L160

Чтобы избежать этого, сделал так, что значение по умолчанию выставлялось только для iOS ([ссылка на коммит](https://github.com/VKCOM/VKUI/commit/d355e3539244a5dde2a899e11330768771fa91eb#diff-637cffb7aeb0f93d290dbc37db8d46644c0eee4073dd0adbfc7568709bf94cdcR56-R70))

**DevTools Safari**

<img width="528" alt="safari" src="https://user-images.githubusercontent.com/5850354/163968631-2f8e6ca2-7c3b-4ac9-8fe5-a531bc980a5d.png">

**DevTools Android**

<img width="420" alt="android" src="https://user-images.githubusercontent.com/5850354/163968799-69c192e5-b19e-449f-bab6-130f8b2e20be.png">

---

fix https://github.com/VKCOM/VKUI/issues/2183

**UPD**
В рамках этого PR, также поправил следующие issues:
fix https://github.com/VKCOM/VKUI/issues/2422