### PR TITLE
[Feature][FormField] Добавление параметра `before`

### DIFF
--- a/src/components/ChipsInput/ChipsInput.tsx
+++ b/src/components/ChipsInput/ChipsInput.tsx
@@ -96,6 +96,7 @@ export const ChipsInput = <Option extends ChipsInputOption>(
     getOptionLabel,
     getNewOptionData,
     renderChip,
+    before,
     after,
     inputAriaLabel,
     ...restProps
@@ -186,6 +187,7 @@ export const ChipsInput = <Option extends ChipsInputOption>(
       className={className}
       style={style}
       disabled={restProps.disabled}
+      before={before}
       after={after}
       onClick={handleClick}
       role="application"

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -637,6 +637,7 @@ class CustomSelectComponent extends React.Component<
   render() {
     const { opened, nativeSelectValue, options: stateOptions } = this.state;
     const {
+      before,
       searchable,
       name,
       className,
@@ -715,6 +716,7 @@ class CustomSelectComponent extends React.Component<
             // TODO Нужно перестать пытаться превратить CustomSelect в select. Тогда эта проблема уйдёт.
             // @ts-ignore
             onClick={onClick}
+            before={before}
             after={icon}
             placeholder={restProps.placeholder}
           />
@@ -733,6 +735,7 @@ class CustomSelectComponent extends React.Component<
               (dropdownOffsetDistance as number) > 0 &&
                 "CustomSelect__open--not-adjacent"
             )}
+            before={before}
             after={icon}
             selectType={selectType}
           >

--- a/src/components/FormField/FormField.css
+++ b/src/components/FormField/FormField.css
@@ -11,6 +11,7 @@
   border-radius: inherit;
 }
 
+.FormField__before,
 .FormField__after {
   flex-shrink: 0;
   position: relative;
@@ -23,6 +24,14 @@
   margin: -1px;
   color: var(--icon_secondary, var(--vkui--color_icon_secondary));
   z-index: 2;
+}
+
+.FormField__before {
+  color: var(--vkui--color_icon_accent);
+}
+
+.FormField__after {
+  color: var(--icon_secondary, var(--vkui--color_icon_secondary));
 }
 
 .ChipsInput .FormField__after {
@@ -79,6 +88,7 @@
 /**
  * sizeY COMPACT
  */
+.FormField--sizeY-compact .FormField__before,
 .FormField--sizeY-compact .FormField__after {
   min-width: 36px;
   height: 36px;

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -9,7 +9,21 @@ import "./FormField.css";
 
 export interface FormFieldProps {
   /**
-   * Иконка 12|16|20|24|28 или `IconButton`.
+   * Добавляет иконку слева.
+   *
+   * Рекомендации:
+   *
+   * - Используйте следующие размеры иконок `12` | `16` | `20` | `24` | `28`.
+   * - Используйте [IconButton](#/IconButton), если вам нужна кликабельная иконка.
+   */
+  before?: React.ReactNode;
+  /**
+   * Добавляет иконку справа.
+   *
+   * Рекомендации:
+   *
+   * - Используйте следующие размеры иконок `12` | `16` | `20` | `24` | `28`.
+   * - Используйте [IconButton](#/IconButton), если вам нужна кликабельная иконка.
    */
   after?: React.ReactNode;
 }
@@ -26,6 +40,7 @@ export const FormField: React.FC<FormFieldOwnProps> = ({
   Component = "div",
   children,
   getRootRef,
+  before,
   after,
   disabled,
   ...restProps
@@ -57,6 +72,11 @@ export const FormField: React.FC<FormFieldOwnProps> = ({
         disabled && "FormField--disabled"
       )}
     >
+      {hasReactNode(before) && (
+        <div role="presentation" vkuiClass="FormField__before">
+          {before}
+        </div>
+      )}
       {children}
       {hasReactNode(after) && (
         <div role="presentation" vkuiClass="FormField__after">

--- a/src/components/FormField/Readme.md
+++ b/src/components/FormField/Readme.md
@@ -1,6 +1,90 @@
 Компонент-оболочка для элементов форм ([Input](#/Input), [Select](#/Select), [Textarea](#/Textarea) и другие).
 
-```jsx
+```jsx { "props": { "layout": false, "iframe": false } }
+const Example = () => {
+  const [sizeY, setSizeY] = useState("regular");
+  const [before, setBefore] = useState(<Icon24WalletOutline />);
+  const [after, setAfter] = useState(<Icon24ChevronUp />);
+  const [disabled, setDisabled] = useState(false);
+
+  return (
+    <div style={rootContainerStyles}>
+      <div style={demoContainerStyles}>
+        <AdaptivityProvider sizeY={sizeY}>
+          <FormLayout>
+            <FormItem>
+              <FormField before={before} after={after} disabled={disabled}>
+                <CustomInput />
+              </FormField>
+            </FormItem>
+          </FormLayout>
+        </AdaptivityProvider>
+      </div>
+      <div style={propsContainerStyles}>
+        <FormItem top="sizeY">
+          <Select
+            value={sizeY}
+            onChange={(e) => setSizeY(e.target.value)}
+            options={[
+              { label: "compact", value: "compact" },
+              { label: "regular", value: "regular" },
+            ]}
+          />
+        </FormItem>
+        <FormItem top="prop[before]">
+          <Checkbox
+            description="Icon24WalletOutline for example"
+            checked={!!before}
+            onChange={(e) =>
+              e.target.checked
+                ? setBefore(<Icon24WalletOutline />)
+                : setBefore(undefined)
+            }
+          >
+            before
+          </Checkbox>
+        </FormItem>
+        <FormItem top="prop[after]">
+          <Checkbox
+            description="Icon24ChevronUp for example"
+            checked={!!after}
+            onChange={(e) =>
+              e.target.checked
+                ? setAfter(<Icon24ChevronUp />)
+                : setAfter(undefined)
+            }
+          >
+            after
+          </Checkbox>
+        </FormItem>
+        <FormItem top="prop[disabled]">
+          <Checkbox
+            checked={disabled}
+            onChange={(e) => setDisabled(e.target.checked)}
+          >
+            disabled
+          </Checkbox>
+        </FormItem>
+      </div>
+    </div>
+  );
+};
+
+const rootContainerStyles = {
+  display: "flex",
+  flexDirection: "row-reverse",
+  flexWrap: "wrap",
+  justifyContent: "center",
+};
+
+const demoContainerStyles = {
+  flexGrow: 2,
+  paddingTop: 24,
+  paddingBottom: 24,
+};
+
+const propsContainerStyles = { minWidth: 200 };
+
 const CustomInput = () => {
   const style = {
     position: "relative",
@@ -19,24 +103,6 @@ const CustomInput = () => {
 
   return <input type="text" style={style} placeholder="Кастомный инпут" />;
 };
-
-const Example = () => (
-  <View activePanel="custom-field">
-    <Panel id="custom-field">
-      <PanelHeader>FormField</PanelHeader>
-
-      <Group>
-        <FormLayout>
-          <FormItem>
-            <FormField>
-              <CustomInput />
-            </FormField>
-          </FormItem>
-        </FormLayout>
-      </Group>
-    </Panel>
-  </View>
-);
 
 <Example />;
 ```

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -23,6 +23,7 @@ const InputComponent: React.FunctionComponent<InputProps> = ({
   getRootRef,
   sizeY,
   style,
+  before,
   after,
   ...restProps
 }: InputProps) => {
@@ -37,6 +38,7 @@ const InputComponent: React.FunctionComponent<InputProps> = ({
       style={style}
       className={className}
       getRootRef={getRootRef}
+      before={before}
       after={after}
       disabled={restProps.disabled}
     >

--- a/src/components/SelectMimicry/SelectMimicry.tsx
+++ b/src/components/SelectMimicry/SelectMimicry.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { classNames } from "../../lib/classNames";
 import { DropdownIcon } from "../DropdownIcon/DropdownIcon";
-import { FormField } from "../FormField/FormField";
+import { FormField, FormFieldProps } from "../FormField/FormField";
 import { HasAlign, HasRootRef } from "../../types";
 import {
   withAdaptivity,
@@ -21,10 +21,10 @@ export interface SelectMimicryProps
   extends React.HTMLAttributes<HTMLElement>,
     HasAlign,
     HasRootRef<HTMLElement>,
-    AdaptivityProps {
+    AdaptivityProps,
+    Pick<FormFieldProps, "before" | "after"> {
   multiline?: boolean;
   disabled?: boolean;
-  after?: React.ReactNode;
   selectType?: SelectType;
 }
 
@@ -39,6 +39,7 @@ const SelectMimicry: React.FunctionComponent<SelectMimicryProps> = ({
   onClick,
   sizeX,
   sizeY,
+  before,
   after = <DropdownIcon />,
   selectType = SelectType.Default,
   ...restProps
@@ -68,6 +69,7 @@ const SelectMimicry: React.FunctionComponent<SelectMimicryProps> = ({
       getRootRef={getRootRef}
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
+      before={before}
       after={after}
     >
       <TypographyComponent


### PR DESCRIPTION
- Поправил jsdoc у `before` и `after`.
- Добавил передачу `before` в `FormField` в следующих компонентах:
  - [ChipsInput](https://vkcom.github.io/VKUI/#/ChipsInput)
  - [CustomSelect](https://vkcom.github.io/VKUI/#/CustomSelect)
    > ⚠️ тут не консистентное название
    > `icon` вместо `after`
  - [Input](https://vkcom.github.io/VKUI/#/Input)
  - [SelectMimicry](https://vkcom.github.io/VKUI/#/SelectMimicry) + наследуем `before` и `after` от `FormFieldProps`

---

resolve https://github.com/VKCOM/VKUI/issues/2374
resolve https://github.com/VKCOM/VKUI/issues/529
resolve https://github.com/VKCOM/VKUI/issues/975