### PR TITLE
fix(FixedLayout): revert to 1364 PR number

### DIFF
--- a/src/components/FixedLayout/FixedLayout.css
+++ b/src/components/FixedLayout/FixedLayout.css
@@ -1,6 +1,16 @@
 .FixedLayout {
   position: fixed;
   box-sizing: border-box;
+  /**
+   * ⚠️ WARNING ⚠️
+   * `left: auto` решает следующие задачи:
+   * 1. При фиксированной ширине компонента позиционирует компонент по центру.
+   * 2. При использовании `SplitLayout` позиционирует компонент с права от `<SplitCol fixed />`.
+   *
+   * Подробности можно почитать здесь https://github.com/VKCOM/VKUI/pull/2472
+   *
+   * Единственное, есть проблема при срабатывании insets в landscape ориентации экрана (https://github.com/VKCOM/VKUI/issues/2422).
+   */
   left: auto;
   z-index: 3;
   padding-left: var(--safe-area-inset-left);

--- a/src/components/FixedLayout/FixedLayout.css
+++ b/src/components/FixedLayout/FixedLayout.css
@@ -1,11 +1,8 @@
 .FixedLayout {
   position: fixed;
   box-sizing: border-box;
-  left: 0;
-  right: 0;
+  left: auto;
   z-index: 3;
-  margin-left: auto;
-  margin-right: auto;
   padding-left: var(--safe-area-inset-left);
   padding-right: var(--safe-area-inset-right);
 }

--- a/src/components/FixedLayout/FixedLayout.css
+++ b/src/components/FixedLayout/FixedLayout.css
@@ -1,8 +1,11 @@
 .FixedLayout {
   position: fixed;
   box-sizing: border-box;
-  left: auto;
+  left: 0;
+  right: 0;
   z-index: 3;
+  margin-left: auto;
+  margin-right: auto;
   padding-left: var(--safe-area-inset-left);
   padding-right: var(--safe-area-inset-right);
 }
@@ -14,12 +17,10 @@
 .FixedLayout--top {
   width: 100%;
   top: 0;
-  left: 0;
 }
 
 .FixedLayout--bottom {
   width: 100%;
-  left: 0;
   bottom: 0;
   padding-bottom: var(--safe-area-inset-bottom);
 }


### PR DESCRIPTION
<details>
  <summary>Старое описание</summary>

  Поправил центровку при фиксированной ширине.
  
  Здесь #2414 (коммит https://github.com/VKCOM/VKUI/pull/2414/commits/230b4dceacd3b8aa0d66af4db767763cd0130f4e) не учёл это.
  
  Использовал старый добрый метод 😄 
  ```
  left: 0;
  right: 0;
  margin-left: auto;
  margin-right: auto;
  ```

</details>

**UPD**

После изменения https://github.com/VKCOM/VKUI/pull/2414 (коммит https://github.com/VKCOM/VKUI/commit/230b4dceacd3b8aa0d66af4db767763cd0130f4e) в `v4.29.1` сломалась:

1. центровка при фиксированной ширине
    <details>
      <summary>Демо</summary>        

      **Было**
      ![before](https://user-images.githubusercontent.com/5850354/167853306-fc4f704f-fa20-45b1-9ca1-0f7e2726b37f.jpeg)
      
      **Стало**
      ![after](https://user-images.githubusercontent.com/5850354/167853318-cd9335fa-2554-4d14-a8b9-1853b369c2f4.jpeg)
    
    </details>
2. #2475

поэтому ревертнул коммит https://github.com/VKCOM/VKUI/commit/230b4dceacd3b8aa0d66af4db767763cd0130f4e

---

fix #2475