### PR TITLE
fix(PanelHeader): fixed separator VKCOM

### DIFF
--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -44,25 +44,29 @@ const PanelHeaderIn: React.FC<PanelHeaderProps> = ({
   children,
   left,
   right,
+  separator,
 }) => {
   const { webviewType } = React.useContext(ConfigProviderContext);
   const { isInsideModal } = React.useContext(ModalRootContext);
   const platform = usePlatform();
 
   return (
-    <TooltipContainer fixed vkuiClass="PanelHeader__in">
-      <div vkuiClass="PanelHeader__left">{left}</div>
-      <div vkuiClass="PanelHeader__content">
-        {platform === VKCOM ? (
-          <Text weight="medium">{children}</Text>
-        ) : (
-          <span vkuiClass="PanelHeader__content-in">{children}</span>
-        )}
-      </div>
-      <div vkuiClass="PanelHeader__right">
-        {(webviewType === WebviewType.INTERNAL || isInsideModal) && right}
-      </div>
-    </TooltipContainer>
+    <React.Fragment>
+      <TooltipContainer fixed vkuiClass="PanelHeader__in">
+        <div vkuiClass="PanelHeader__left">{left}</div>
+        <div vkuiClass="PanelHeader__content">
+          {platform === VKCOM ? (
+            <Text weight="medium">{children}</Text>
+          ) : (
+            <span vkuiClass="PanelHeader__content-in">{children}</span>
+          )}
+        </div>
+        <div vkuiClass="PanelHeader__right">
+          {(webviewType === WebviewType.INTERNAL || isInsideModal) && right}
+        </div>
+      </TooltipContainer>
+      {separator && platform === VKCOM && <Separator wide />}
+    </React.Fragment>
   );
 };
 
@@ -120,11 +124,8 @@ const PanelHeader: React.FC<PanelHeaderProps> = (props: PanelHeaderProps) => {
       ) : (
         <PanelHeaderIn {...props} />
       )}
-      {separator && visor && (
-        <Separator
-          expanded={sizeX === SizeType.REGULAR && platform !== VKCOM}
-          wide={platform === VKCOM}
-        />
+      {separator && visor && platform !== VKCOM && (
+        <Separator expanded={sizeX === SizeType.REGULAR} />
       )}
     </div>
   );


### PR DESCRIPTION
**проблема:** На платформе VKCOM, в зафиксированном компоненте PanelHeader уезжает сепаратор 

```jsx
<PanelHeader fixed>More</PanelHeader>
```

До|После
-|-
![image](https://user-images.githubusercontent.com/14944123/168278287-90350d96-b7e8-4eee-9aee-4509a22cab6a.png)|![image](https://user-images.githubusercontent.com/14944123/168278350-ee7a71dc-fe5f-4632-95b7-8de8179b00df.png)

