### PR TITLE
 feat(Button): before and after role presentation

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -191,7 +191,11 @@ const ButtonComponent: React.FC<ButtonProps> = ({
     >
       {loading && <Spinner size="small" vkuiClass="Button__spinner" />}
       <span vkuiClass="Button__in">
-        {before && <span vkuiClass="Button__before">{before}</span>}
+        {before && (
+          <span vkuiClass="Button__before" role="presentation">
+            {before}
+          </span>
+        )}
         {children && (
           <ButtonTypography
             size={size}
@@ -203,7 +207,11 @@ const ButtonComponent: React.FC<ButtonProps> = ({
             {children}
           </ButtonTypography>
         )}
-        {after && <span vkuiClass="Button__after">{after}</span>}
+        {after && (
+          <span vkuiClass="Button__after" role="presentation">
+            {after}
+          </span>
+        )}
       </span>
     </Tappable>
   );

--- a/src/components/Button/Readme.md
+++ b/src/components/Button/Readme.md
@@ -21,18 +21,18 @@ const Example = () => {
   const buttonBefore =
     addBefore &&
     (size === "s" ? (
-      <Icon12Add />
+      <Icon12Add aria-hidden />
     ) : size === "m" ? (
-      <Icon16Add />
+      <Icon16Add aria-hidden />
     ) : (
-      <Icon24Add />
+      <Icon24Add aria-hidden />
     ));
   const buttonAfter =
     addAfter &&
     (size === "s" ? (
-      <Icon12Tag />
+      <Icon12Tag aria-hidden />
     ) : size === "m" ? (
-      <Icon24ChevronCompactRight />
+      <Icon24ChevronCompactRight aria-hidden />
     ) : (
       <Counter>16</Counter>
     ));


### PR DESCRIPTION
- убираем лишние узлы
- убираем в примере информацию о иконках

<details>
  <summary>До</summary>
  
<img width="897" alt="image" src="https://user-images.githubusercontent.com/14944123/169706657-4e76d9a1-0f7b-4a00-8e01-e52653c4174a.png">
  
</details>


<details>
  <summary>После</summary>
  
<img width="903" alt="image" src="https://user-images.githubusercontent.com/14944123/169706699-28823645-99cd-4163-9cd9-9f1e604e88b1.png">
  
</details>

