### PR TITLE
feat(Progress): tokenized

### DIFF
--- a/src/components/Progress/Progress.css
+++ b/src/components/Progress/Progress.css
@@ -1,6 +1,6 @@
 .Progress {
   border-radius: 1px;
-  background: var(--loader_track_fill);
+  background: var(--loader_track_fill, var(--vkui--color_track_background));
   height: 2px;
 }
 
@@ -8,5 +8,5 @@
   height: 100%;
   border-radius: inherit;
   transition: width 0.2s ease;
-  background: var(--accent);
+  background: var(--accent, var(--vkui--color_stroke_accent));
 }

--- a/src/components/Progress/Progress.test.tsx
+++ b/src/components/Progress/Progress.test.tsx
@@ -1,5 +1,5 @@
 import { baselineComponent } from "../../testing/utils";
-import Progress from "./Progress";
+import { Progress } from "./Progress";
 
 describe("Progress", () => {
   baselineComponent(Progress);

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-import { getClassName } from "../../helpers/getClassName";
 import { HasRootRef } from "../../types";
-import { usePlatform } from "../../hooks/usePlatform";
 import "./Progress.css";
 
 export interface ProgressProps
@@ -13,13 +11,11 @@ export interface ProgressProps
 const PROGRESS_MIN_VALUE = 0;
 const PROGRESS_MAX_VALUE = 100;
 
-const Progress: React.FC<ProgressProps> = ({
+export const Progress: React.FC<ProgressProps> = ({
   value = 0,
   getRootRef,
   ...restProps
 }: ProgressProps) => {
-  const platform = usePlatform();
-
   const progress = Math.max(
     PROGRESS_MIN_VALUE,
     Math.min(value, PROGRESS_MAX_VALUE)
@@ -33,17 +29,13 @@ const Progress: React.FC<ProgressProps> = ({
       aria-valuemin={PROGRESS_MIN_VALUE}
       aria-valuemax={PROGRESS_MAX_VALUE}
       ref={getRootRef}
-      vkuiClass={getClassName("Progress", platform)}
+      vkuiClass="Progress"
     >
-      <div vkuiClass="Progress__bg" aria-hidden="true" />
       <div
         vkuiClass="Progress__in"
         style={{ width: `${progress}%` }}
-        aria-hidden="true"
+        aria-hidden
       />
     </div>
   );
 };
-
-// eslint-disable-next-line import/no-default-export
-export default Progress;

--- a/src/components/Progress/Readme.md
+++ b/src/components/Progress/Readme.md
@@ -1,14 +1,12 @@
-```
-  <View activePanel="progress">
-    <Panel id="progress">
-      <PanelHeader>
-        Progress
-      </PanelHeader>
-      <Group>
-        <Div>
-          <Progress value={40} />
-        </Div>
-      </Group>
-    </Panel>
-  </View>
+```jsx
+<View activePanel="progress">
+  <Panel id="progress">
+    <PanelHeader>Progress</PanelHeader>
+    <Group>
+      <FormItem id="progresslabel" top="Прогресс">
+        <Progress aria-labelledby="progresslabel" value={40} />
+      </FormItem>
+    </Group>
+  </Panel>
+</View>
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export { GridAvatar } from "./components/GridAvatar/GridAvatar";
 export type { GridAvatarProps } from "./components/GridAvatar/GridAvatar";
 export { InitialsAvatar } from "./components/InitialsAvatar/InitialsAvatar";
 export type { InitialsAvatarProps } from "./components/InitialsAvatar/InitialsAvatar";
-export { default as Progress } from "./components/Progress/Progress";
+export { Progress } from "./components/Progress/Progress";
 export type { ProgressProps } from "./components/Progress/Progress";
 export { default as Search } from "./components/Search/Search";
 export type { SearchProps } from "./components/Search/Search";

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -70,3 +70,6 @@ export type { ChipsSelectProps } from "../components/ChipsSelect/ChipsSelect";
 
 export { Headline } from "../components/Typography/Headline/Headline";
 export type { HeadlineProps } from "../components/Typography/Headline/Headline";
+
+export { Progress } from "../components/Progress/Progress";
+export type { ProgressProps } from "../components/Progress/Progress";

--- a/styleguide/tokenized.js
+++ b/styleguide/tokenized.js
@@ -22,4 +22,5 @@ export const tokenized = [
   "ChipsInput",
   "ChipsSelect",
   "Headline",
+  "Progress",
 ];


### PR DESCRIPTION
Чеклист перевода компонента на vkui-tokens

- [x] В стилях компонента не осталось платформенных селекторов
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens
- [x] В tsx компонента не осталось логики, которая зависит от платформы
- [x] Компонент добавлен в src/tokenized/index.ts (в src/index.ts он так же должен быть)
- [x] Имя компонента добавлено в массив из styleguide/tokenized.js

---

[pull/2596/#/Progress](https://vkcom.github.io/VKUI/pull/2596/#/Progress)

- В пример добавлен label для a11y
- #2191
- closed #2560