### PR TITLE
feat: Radio and RadioGroup tokenized 

### DIFF
--- a/src/components/FormItem/FormItem.e2e.tsx
+++ b/src/components/FormItem/FormItem.e2e.tsx
@@ -3,7 +3,7 @@ import { FormItem } from "./FormItem";
 import { CellButton } from "../CellButton/CellButton";
 import Checkbox from "../Checkbox/Checkbox";
 import { Input } from "../Input/Input";
-import Radio from "../Radio/Radio";
+import { Radio } from "../Radio/Radio";
 import RichCell from "../RichCell/RichCell";
 import SimpleCell from "../SimpleCell/SimpleCell";
 import { Cell } from "../Cell/Cell";

--- a/src/components/FormItem/__image_snapshots__/formitem-android-light-1-snap.png
+++ b/src/components/FormItem/__image_snapshots__/formitem-android-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d32ee79ae47f1e10cea1400f142e3a25d6404347f729d978a965926fcec11ff
-size 96171
+oid sha256:ed509e80e8c397e443f7f8ebf891016016ab26b442afee85547e644528eae92b
+size 96117

--- a/src/components/FormItem/__image_snapshots__/formitem-ios-light-1-snap.png
+++ b/src/components/FormItem/__image_snapshots__/formitem-ios-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85dd38848b1eb9a17901ce3af21b979ae18228a2e4b9ca16b87c7cfd38ee7b8c
-size 99103
+oid sha256:19f1a2e72b7ec4daa07830982694a75245a858c97b1909f09bec23ebd01e8f4c
+size 99044

--- a/src/components/FormItem/__image_snapshots__/formitem-vkcom-light-1-snap.png
+++ b/src/components/FormItem/__image_snapshots__/formitem-vkcom-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57e3fe7ca6b58ba1432e0067e38b37a5712c3e9c79ae542227ae7b2b938dacef
-size 94095
+oid sha256:861550b4c013892252f4f343f6ccabdbffb426e69bd67083eeb0017890a31580
+size 94138

--- a/src/components/Radio/Radio.css
+++ b/src/components/Radio/Radio.css
@@ -1,15 +1,12 @@
 .Radio {
   display: block;
+  padding: 0 var(--vkui--size_base_padding_horizontal--regular);
 }
 
 .FormItem .Radio {
   width: 100%;
   box-sizing: content-box;
   margin: 0 calc(-1 * var(--vkui--size_base_padding_horizontal--regular));
-}
-
-.Radio__input {
-  display: none;
 }
 
 .Radio__container {
@@ -19,55 +16,42 @@
 }
 
 .Radio__input:disabled ~ .Radio__container {
-  opacity: 0.6;
+  opacity: var(--vkui--opacity_disable_accessibility);
 }
 
 .Radio__icon {
-  display: block;
   flex-shrink: 0;
-  box-sizing: border-box;
-  border-radius: 50%;
-  position: relative;
   width: 22px;
   height: 22px;
-  border: 2px solid var(--icon_tertiary);
   margin-right: 14px;
-  transition: border-color 0.15s var(--ios-easing);
+  color: var(--icon_tertiary, var(--vkui--color_icon_tertiary));
+  transition: color 0.15s var(--ios-easing);
 }
 
 .Radio__input:checked ~ .Radio__container .Radio__icon {
-  border-color: var(--accent);
+  color: var(--accent, var(--vkui--color_icon_accent));
 }
 
-.Radio__icon::after {
-  position: absolute;
-  content: "";
-  display: block;
-  border-radius: 50%;
-  box-sizing: border-box;
-  width: 14px;
-  height: 14px;
-  left: 2px;
-  top: 2px;
-  transform: scale(0.3);
+.Radio__icon .Radio__pin {
+  transform-origin: 12px 12px;
+  transform: scale(0);
   transition: transform 0.15s var(--ios-easing);
 }
 
-.Radio__input:checked ~ .Radio__container .Radio__icon::after {
-  background-color: var(--accent);
-  transform: scale(1);
+.Radio__input:checked ~ .Radio__container .Radio__icon .Radio__pin {
+  transform: none;
 }
 
 .Radio__content {
   display: block;
   flex-grow: 1;
   max-width: 100%;
-  color: var(--text_primary);
+  color: var(--text_primary, var(--vkui--color_text_primary));
 }
 
 .Radio__description {
   display: block;
-  color: var(--text_secondary);
+  color: var(--text_secondary, var(--vkui--color_text_secondary));
   margin-bottom: 12px;
   margin-top: 2px;
 }
@@ -78,22 +62,6 @@
 
 .Radio__children:last-child {
   margin-bottom: 12px;
-}
-
-/**
- * iOS
- */
-
-.Radio--ios {
-  padding: 0 12px;
-}
-
-/**
- * Android
- */
-
-.Radio--android {
-  padding: 0 16px;
 }
 
 /**
@@ -118,62 +86,8 @@
 }
 
 .Radio--sizeY-compact .Radio__icon::after {
-  top: 1px;
-  left: 1px;
   width: 12px;
   height: 12px;
-}
-
-/**
- * VKCOM
- */
-
-.Radio--vkcom {
-  padding: 0 16px;
-}
-
-.Radio--vkcom .Radio__icon {
-  width: 16px;
-  height: 16px;
-  margin: 2px 14px 2px 2px;
-  border: 1px solid var(--icon_secondary);
-  border-radius: 50%;
-  transition: border-color 0.5s var(--ios-easing);
-}
-
-.Radio--vkcom .Radio__icon::after {
-  width: 8px;
-  height: 8px;
-  left: 3px;
-  top: 3px;
-  transform: scale(0.3);
-  transition: transform 0.5s var(--ios-easing);
-}
-
-.Radio--vkcom .Radio__input:disabled ~ .Radio__container {
-  opacity: 0.4;
-}
-
-.Radio--vkcom .Radio__input:checked ~ .Radio__container .Radio__icon {
-  border-color: var(--accent);
-}
-
-.Radio--vkcom .Radio__input:checked ~ .Radio__container .Radio__icon::after {
-  background-color: var(--accent);
-  transform: scale(1);
-}
-
-.Radio--vkcom .Radio__children {
-  margin-top: 8px;
-}
-
-.Radio--vkcom .Radio__children:last-child {
-  margin-bottom: 8px;
-}
-
-.Radio--vkcom .Radio__description {
-  margin-top: 1px;
-  margin-bottom: 8px;
 }
 
 /**

--- a/src/components/Radio/Radio.e2e.tsx
+++ b/src/components/Radio/Radio.e2e.tsx
@@ -1,4 +1,4 @@
-import Radio, { RadioProps } from "./Radio";
+import { Radio, RadioProps } from "./Radio";
 import { describeScreenshotFuzz } from "../../testing/e2e/utils";
 import { SizeType } from "../AdaptivityProvider/AdaptivityContext";
 

--- a/src/components/Radio/Radio.test.tsx
+++ b/src/components/Radio/Radio.test.tsx
@@ -1,5 +1,5 @@
 import { baselineComponent } from "../../testing/utils";
-import Radio from "./Radio";
+import { Radio } from "./Radio";
 
 describe("Radio", () => {
   baselineComponent(Radio);

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import Tappable, { ACTIVE_EFFECT_DELAY } from "../Tappable/Tappable";
-import { getClassName } from "../../helpers/getClassName";
 import { classNames } from "../../lib/classNames";
 import { IOS, VKCOM } from "../../lib/platform";
 import { HasRef, HasRootRef } from "../../types";
@@ -11,10 +10,38 @@ import {
   SizeType,
 } from "../../hoc/withAdaptivity";
 import { hasReactNode } from "../../lib/utils";
+import { VisuallyHiddenInput } from "../VisuallyHiddenInput/VisuallyHiddenInput";
 import { Caption } from "../Typography/Caption/Caption";
 import { Headline } from "../Typography/Headline/Headline";
 import { Text } from "../Typography/Text/Text";
 import "./Radio.css";
+
+const RadioIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-hidden
+      {...props}
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="11"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r="7.5"
+        vkuiClass="Radio__pin"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
 
 export interface RadioProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
@@ -30,7 +57,6 @@ const RadioComponent: React.FC<RadioProps> = (props: RadioProps) => {
     description,
     style,
     className,
-    getRef,
     getRootRef,
     sizeY,
     ...restProps
@@ -45,22 +71,18 @@ const RadioComponent: React.FC<RadioProps> = (props: RadioProps) => {
       Component="label"
       style={style}
       className={className}
-      vkuiClass={classNames(
-        getClassName("Radio", platform),
-        `Radio--sizeY-${sizeY}`
-      )}
+      vkuiClass={classNames("Radio", `Radio--sizeY-${sizeY}`)}
       activeEffectDelay={platform === IOS ? 100 : ACTIVE_EFFECT_DELAY}
       disabled={restProps.disabled}
       getRootRef={getRootRef}
     >
-      <input
+      <VisuallyHiddenInput
         {...restProps}
-        type="radio"
         vkuiClass="Radio__input"
-        ref={getRef}
+        type="radio"
       />
       <div vkuiClass="Radio__container">
-        <i vkuiClass="Radio__icon" role="presentation" />
+        <RadioIcon vkuiClass="Radio__icon" />
         <RadioTypography vkuiClass="Radio__content" Component="div">
           <div vkuiClass="Radio__children">{children}</div>
           {hasReactNode(description) && (

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -24,10 +24,7 @@ export interface RadioProps
   description?: React.ReactNode;
 }
 
-/**
- * @see https://vkcom.github.io/VKUI/#/Radio
- */
-const Radio: React.FC<RadioProps> = (props: RadioProps) => {
+const RadioComponent: React.FC<RadioProps> = (props: RadioProps) => {
   const {
     children,
     description,
@@ -75,7 +72,9 @@ const Radio: React.FC<RadioProps> = (props: RadioProps) => {
   );
 };
 
-// eslint-disable-next-line import/no-default-export
-export default withAdaptivity(Radio, {
+/**
+ * @see https://vkcom.github.io/VKUI/#/Radio
+ */
+export const Radio = withAdaptivity(RadioComponent, {
   sizeY: true,
 });

--- a/src/components/Radio/__image_snapshots__/radio-android-light-1-snap.png
+++ b/src/components/Radio/__image_snapshots__/radio-android-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6845e6d6f150e1dfdfc7146acb6bab0bb91a80b962efab3afc4cdd441f819af2
-size 13865
+oid sha256:26bea753230270033025cc579fcdcd9077b50c1b3198c74900374a3100e54a2c
+size 13755

--- a/src/components/Radio/__image_snapshots__/radio-ios-light-1-snap.png
+++ b/src/components/Radio/__image_snapshots__/radio-ios-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b051b994f6af5596dbcbda09d74735bf5f4fa2bbf5ce1efafd7caa8b0d02994
-size 13856
+oid sha256:09d1a27256a17ed60240f6c5f567b80a8098c00e7d12ffa6b8b59e97571c0efc
+size 13747

--- a/src/components/Radio/__image_snapshots__/radio-sizes-and-description-android-light-1-snap.png
+++ b/src/components/Radio/__image_snapshots__/radio-sizes-and-description-android-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6fadc793df6d697e356d495ae7bca270d1b742ed7fabf3f6c26c50c150a6cab6
-size 19194
+oid sha256:655bfa3eee973e3834446847e754ec9f9460aecc3d33b75ec8ad6952f792cc4a
+size 19095

--- a/src/components/Radio/__image_snapshots__/radio-sizes-and-description-ios-light-1-snap.png
+++ b/src/components/Radio/__image_snapshots__/radio-sizes-and-description-ios-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89db37157f1b606a7d0beb7aedf85ef43b20950ef627856e8672180dba6201fe
-size 19210
+oid sha256:28295548c890e00a26bad9dbb9e377c5ae1594efe86545a066d5d43e38491723
+size 19103

--- a/src/components/Radio/__image_snapshots__/radio-sizes-and-description-vkcom-light-1-snap.png
+++ b/src/components/Radio/__image_snapshots__/radio-sizes-and-description-vkcom-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0ef010f4ec76859937a3068c24273c51c844551b4eeb9b896166b4359b237be
-size 5635
+oid sha256:f15d8274e5aa0368ecb4b639703ecdc194ee7e1e3373b4b363c26a5177f8e9ab
+size 5810

--- a/src/components/Radio/__image_snapshots__/radio-vkcom-light-1-snap.png
+++ b/src/components/Radio/__image_snapshots__/radio-vkcom-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b934d3c6c3d31f2241e899c4329ba8c678a2eb07e0ab44d3261a7c3b2afd3dc0
-size 10212
+oid sha256:9501969dfee216f83a59ede1dd2471d7d2c9e45be4301d860154d20ea42f12c6
+size 11452

--- a/src/components/RadioGroup/RadioGroup.e2e.tsx
+++ b/src/components/RadioGroup/RadioGroup.e2e.tsx
@@ -1,7 +1,7 @@
 import { ElementType, FC, Fragment } from "react";
 import { describeScreenshotFuzz } from "../../testing/e2e/utils";
 import { RadioGroup, RadioGroupProps } from "./RadioGroup";
-import Radio from "../Radio/Radio";
+import { Radio } from "../Radio/Radio";
 import { FormItem } from "../FormItem/FormItem";
 import FormLayout from "../FormLayout/FormLayout";
 

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,4 @@
 import * as React from "react";
-import { getClassName } from "../../helpers/getClassName";
-import { usePlatform } from "../../hooks/usePlatform";
 import { classNames } from "../../lib/classNames";
 import "./RadioGroup.css";
 
@@ -15,18 +13,11 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   mode = "vertical",
   children,
   ...restProps
-}) => {
-  const platform = usePlatform();
-
-  return (
-    <div
-      vkuiClass={classNames(
-        getClassName("RadioGroup", platform),
-        `RadioGroup--${mode}`
-      )}
-      {...restProps}
-    >
-      {children}
-    </div>
-  );
-};
+}) => (
+  <div
+    vkuiClass={classNames("RadioGroup", `RadioGroup--${mode}`)}
+    {...restProps}
+  >
+    {children}
+  </div>
+);

--- a/src/components/RadioGroup/__image_snapshots__/radiogroup-android-light-1-snap.png
+++ b/src/components/RadioGroup/__image_snapshots__/radiogroup-android-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fad76d6a0061c739e835c4d188b318b387c9974dee9962c2f4ab28e6c7330e51
-size 29960
+oid sha256:4cfe515a513bc2a1f315b454cf87a50ea3dfa4c2cb61423f26392309c00a2f92
+size 29696

--- a/src/components/RadioGroup/__image_snapshots__/radiogroup-ios-light-1-snap.png
+++ b/src/components/RadioGroup/__image_snapshots__/radiogroup-ios-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8eccc627ce781c88ca7fa9d5523b51bce9fc6e6c3a7e08ff26aca16a6c0bb8c0
-size 29996
+oid sha256:6906fe5ac93d314f45e0ca06a151f2fb035b145bccec5dd988679170b6b61f01
+size 29701

--- a/src/components/RadioGroup/__image_snapshots__/radiogroup-vkcom-light-1-snap.png
+++ b/src/components/RadioGroup/__image_snapshots__/radiogroup-vkcom-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86c945d7baff6526ea776cc4659d2241be4b85b54cd3eb5f292da8be39e20856
-size 28668
+oid sha256:0ad7ed9bc4e0ab16ef7c0e1f46b3c4762d619da581e476e9fb343b8a72c3681f
+size 28983

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -184,7 +184,10 @@ const Tappable: React.FC<TappableProps> = ({
   const hasActive = _hasActive && !childHover && !props.disabled;
   const hasHover = deviceHasHover && _hasHover && !childHover;
   const isCustomElement =
-    Component !== "a" && Component !== "button" && !props.contentEditable;
+    Component !== "a" &&
+    Component !== "button" &&
+    Component !== "label" &&
+    !props.contentEditable;
   const isPresetHoverMode = ["opacity", "background"].includes(hoverMode);
   const isPresetActiveMode = ["opacity", "background"].includes(activeMode);
   const isPresetFocusVisibleMode = ["inside", "outside"].includes(

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ export { default as RangeSlider } from "./components/RangeSlider/RangeSlider";
 export type { RangeSliderProps } from "./components/RangeSlider/RangeSlider";
 export { default as Textarea } from "./components/Textarea/Textarea";
 export type { TextareaProps } from "./components/Textarea/Textarea";
-export { default as Radio } from "./components/Radio/Radio";
+export { Radio } from "./components/Radio/Radio";
 export type { RadioProps } from "./components/Radio/Radio";
 export { RadioGroup } from "./components/RadioGroup/RadioGroup";
 export type { RadioGroupProps } from "./components/RadioGroup/RadioGroup";

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -16,6 +16,12 @@ export type { ButtonGroupProps } from "../components/ButtonGroup/ButtonGroup";
 export { Switch } from "../components/Switch/Switch";
 export type { SwitchProps } from "../components/Switch/Switch";
 
+export { Radio } from "../components/Radio/Radio";
+export type { RadioProps } from "../components/Radio/Radio";
+
+export { RadioGroup } from "../components/RadioGroup/RadioGroup";
+export type { RadioGroupProps } from "../components/RadioGroup/RadioGroup";
+
 export { SegmentedControl } from "../components/SegmentedControl/SegmentedControl";
 export type {
   SegmentedControlProps,

--- a/styleguide/tokenized.js
+++ b/styleguide/tokenized.js
@@ -9,6 +9,8 @@ export const tokenized = [
   "Subhead",
   "HorizontalScroll",
   "PanelSpinner",
+  "Radio",
+  "RadioGroup",
   "Pagination",
   "Calendar",
   "CalendarRange",


### PR DESCRIPTION
Перевод на токены Radio и RadioGroup

---

Чеклист перевода компонента на vkui-tokens

- [x] В стилях компонента не осталось платформенных селекторов
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens
- [x] В tsx компонента не осталось логики, которая зависит от платформы
- [x] Компонент добавлен в src/tokenized/index.ts (в src/index.ts он так же должен быть)
- [x] Имя компонента добавлено в массив из styleguide/tokenized.js

---

Документация компонентов

- [Radio](https://vkcom.github.io/VKUI/pull/2609/#/Radio)
- [RadioGroup](https://vkcom.github.io/VKUI/pull/2609/#/RadioGroup)

---

- Отказ от использование отдельных стилей в VKCOM
- #2191
- fixed #1960
- closed #2608
- closed #2561