### PR TITLE
feat(SplitCol): Tokenize

### DIFF
--- a/src/components/SplitCol/SplitCol.css
+++ b/src/components/SplitCol/SplitCol.css
@@ -7,7 +7,7 @@
 }
 
 .SplitCol--spaced {
-  margin: 0 16px;
+  padding: 0 var(--vkui--size_split_col_padding_horizontal--regular);
 }
 
 .SplitCol--fixed {

--- a/src/components/SplitCol/SplitCol.tsx
+++ b/src/components/SplitCol/SplitCol.tsx
@@ -78,11 +78,11 @@ export const SplitCol: React.FC<SplitColProps> = (props: SplitColProps) => {
         minWidth: minWidth,
       }}
       ref={baseRef}
-      // eslint-disable-next-line vkui/no-object-expression-in-arguments
-      vkuiClass={classNames("SplitCol", {
-        "SplitCol--spaced": spaced,
-        "SplitCol--fixed": fixed,
-      })}
+      vkuiClass={classNames(
+        "SplitCol",
+        spaced && "SplitCol--spaced",
+        fixed && "SplitCol--fixed"
+      )}
     >
       <SplitColContext.Provider value={contextValue}>
         {fixed ? (

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -77,6 +77,9 @@ export type { ChipsInputProps } from "../components/ChipsInput/ChipsInput";
 export { ChipsSelect } from "../components/ChipsSelect/ChipsSelect";
 export type { ChipsSelectProps } from "../components/ChipsSelect/ChipsSelect";
 
+export { SplitCol } from "../components/SplitCol/SplitCol";
+export type { SplitColProps } from "../components/SplitCol/SplitCol";
+
 export { Headline } from "../components/Typography/Headline/Headline";
 export type { HeadlineProps } from "../components/Typography/Headline/Headline";
 

--- a/styleguide/tokenized.js
+++ b/styleguide/tokenized.js
@@ -23,6 +23,7 @@ export const tokenized = [
   "CustomSelectOption",
   "ChipsInput",
   "ChipsSelect",
+  "SplitCol",
   "Headline",
   "Progress",
   "DateInput",


### PR DESCRIPTION
Чеклист перевода компонента на vkui-tokens

- [x] В стилях компонента не осталось платформенных селекторов
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens
- [x] В tsx компонента не осталось логики, которая зависит от платформы
- [x] Компонент добавлен в src/tokenized/index.ts (в src/index.ts он так же должен быть)
- [x] Имя компонента добавлено в массив из styleguide/tokenized.js