### PR TITLE
feat(FocusVisible): tokenized

### DIFF
--- a/src/components/FocusVisible/FocusVisible.css
+++ b/src/components/FocusVisible/FocusVisible.css
@@ -5,7 +5,7 @@
   right: 2px;
   bottom: 2px;
   border-radius: inherit;
-  box-shadow: 0 0 0 2px var(--accent);
+  box-shadow: 0 0 0 2px var(--accent, var(--vkui--color_stroke_accent));
   user-select: none;
   pointer-events: none;
   overflow: hidden;

--- a/src/components/FocusVisible/FocusVisible.tsx
+++ b/src/components/FocusVisible/FocusVisible.tsx
@@ -1,19 +1,16 @@
-import * as React from "react";
 import { classNames } from "../../lib/classNames";
 import "./FocusVisible.css";
 
 export type FocusVisibleMode = "inside" | "outside";
 
-interface FocusVisibleProps {
+export interface FocusVisibleProps {
   mode: FocusVisibleMode;
 }
 
 /**
  * @see https://vkcom.github.io/VKUI/#/FocusVisible
  */
-export const FocusVisible: React.FC<FocusVisibleProps> = ({
-  mode,
-}: FocusVisibleProps) => (
+export const FocusVisible = ({ mode }: FocusVisibleProps) => (
   <span
     aria-hidden="true"
     vkuiClass={classNames("FocusVisible", `FocusVisible--${mode}`)}

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -80,6 +80,9 @@ export type { InputProps } from "../components/Input/Input";
 export { File } from "../components/File/File";
 export type { FileProps } from "../components/File/File";
 
+export { FocusVisible } from "../components/FocusVisible/FocusVisible";
+export type { FocusVisibleProps } from "../components/FocusVisible/FocusVisible";
+
 export { FormField } from "../components/FormField/FormField";
 export type { FormFieldProps } from "../components/FormField/FormField";
 


### PR DESCRIPTION
## Чеклист перевода компонента на vkui-tokens
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Имя компонента добавлено в массив из `styleguide/tokenized.js`
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647))

---

<!--- Ссылки на задачи --->

- Fix #2540
