### PR TITLE
feat(MiniInfoCell): Tokenize

### DIFF
--- a/src/components/MiniInfoCell/MiniInfoCell.css
+++ b/src/components/MiniInfoCell/MiniInfoCell.css
@@ -1,19 +1,19 @@
 .MiniInfoCell {
   display: flex;
-  padding: 6px 12px;
+  padding: 6px var(--vkui--size_base_padding_horizontal--regular);
 }
 
 .MiniInfoCell--lvl-primary {
-  color: var(--text_primary);
+  color: var(--text_primary, var(--vkui--color_text_primary));
 }
 
 .MiniInfoCell--lvl-secondary {
-  color: var(--text_subhead);
+  color: var(--text_subhead, var(--vkui--color_text_subhead));
 }
 
 .MiniInfoCell__icon {
   margin-right: 12px;
-  color: var(--icon_outline_secondary);
+  color: var(--icon_outline_secondary, var(--vkui--color_icon_medium));
 }
 
 .MiniInfoCell__content {
@@ -45,23 +45,15 @@
 
 .MiniInfoCell--md-add,
 .MiniInfoCell--md-add .MiniInfoCell__icon {
-  color: var(--accent);
+  color: var(--accent, var(--vkui--color_icon_accent));
 }
 
 .MiniInfoCell--md-more,
 .MiniInfoCell--md-more .MiniInfoCell__icon {
-  color: var(--link_alternate);
+  color: var(--link_alternate, var(--vkui--color_icon_accent));
 }
 
 .MiniInfoCell--md-more {
   padding-top: 10px;
   padding-bottom: 10px;
-}
-
-/**
- * ANDROID
- */
-.MiniInfoCell--android {
-  padding-left: 16px;
-  padding-right: 16px;
 }

--- a/src/components/MiniInfoCell/MiniInfoCell.tsx
+++ b/src/components/MiniInfoCell/MiniInfoCell.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 import { classNames } from "../../lib/classNames";
-import { usePlatform } from "../../hooks/usePlatform";
-import { getClassName } from "../../helpers/getClassName";
 import { Text } from "../Typography/Text/Text";
-import { Tappable } from "../../components/Tappable/Tappable";
+import { Tappable } from "../Tappable/Tappable";
 import { hasReactNode } from "../../lib/utils";
 import "./MiniInfoCell.css";
 
@@ -52,13 +50,15 @@ export interface MiniInfoCellProps
 /**
  * @see https://vkcom.github.io/VKUI/#/MiniInfoCell
  */
-export const MiniInfoCell: React.FC<MiniInfoCellProps> = (
-  props: MiniInfoCellProps
-) => {
-  const platform = usePlatform();
-  const { before, after, mode, textWrap, textLevel, children, ...restProps } =
-    props;
-
+export const MiniInfoCell = ({
+  before,
+  after,
+  mode = "base",
+  textWrap = "nowrap",
+  textLevel = "secondary",
+  children,
+  ...restProps
+}: MiniInfoCellProps) => {
   const isClickable = !!restProps.onClick;
 
   return (
@@ -67,13 +67,10 @@ export const MiniInfoCell: React.FC<MiniInfoCellProps> = (
       disabled={!isClickable}
       role={isClickable ? "button" : undefined}
       {...restProps}
-      // eslint-disable-next-line vkui/no-object-expression-in-arguments
       vkuiClass={classNames(
-        getClassName("MiniInfoCell", platform),
-        {
-          [`MiniInfoCell--md-${mode}`]: mode !== "base",
-          [`MiniInfoCell--wr-${textWrap}`]: textWrap !== "nowrap",
-        },
+        "MiniInfoCell",
+        mode !== "base" && `MiniInfoCell--md-${mode}`,
+        textWrap !== "nowrap" && `MiniInfoCell--wr-${textWrap}`,
         `MiniInfoCell--lvl-${textLevel}`
       )}
     >
@@ -89,10 +86,4 @@ export const MiniInfoCell: React.FC<MiniInfoCellProps> = (
       )}
     </Tappable>
   );
-};
-
-MiniInfoCell.defaultProps = {
-  mode: "base",
-  textWrap: "nowrap",
-  textLevel: "secondary",
 };

--- a/src/components/MiniInfoCell/__image_snapshots__/miniinfocell-vkcom-light-1-snap.png
+++ b/src/components/MiniInfoCell/__image_snapshots__/miniinfocell-vkcom-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c912ec77b183005524131981997915cfd4c7adc2cd96bdedf2b4f777bc14d80f
-size 107357
+oid sha256:21e11d689a09284d5de65d0c90483fba86e2a8e860b38191fffced6a56aa3d75
+size 107409

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -10,6 +10,9 @@ export type { FormLayoutGroupProps } from "../components/FormLayoutGroup/FormLay
 export { Button } from "../components/Button/Button";
 export type { ButtonProps } from "../components/Button/Button";
 
+export { MiniInfoCell } from "../components/MiniInfoCell/MiniInfoCell";
+export type { MiniInfoCellProps } from "../components/MiniInfoCell/MiniInfoCell";
+
 export { Card } from "../components/Card/Card";
 export type { CardProps } from "../components/Card/Card";
 


### PR DESCRIPTION
## Чеклист перевода компонента на vkui-tokens
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647)) 
- [x] Исключаем проверки типа `platform === ANDROID` (пример такого PR [#2653](https://togithub.com/VKCOM/VKUI/pull/2653))
- [x] В стилях компонента не осталось платформенных селекторов (_осталось для обратной совместимости_)
- [x] В tsx компонента не осталось логики, которая зависит от платформы 

---

- resolve #2553 
