### PR TITLE
feat(Banner): Tokenize

### DIFF
--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -1,7 +1,7 @@
 .Banner {
   margin: 12px 0;
-  padding: 0 16px;
-  color: var(--text_primary);
+  padding: 0 var(--vkui--size_base_padding_horizontal--regular);
+  color: var(--text_primary, var(--vkui--color_text_primary));
 }
 
 .Banner__in {
@@ -9,10 +9,12 @@
   display: flex;
   flex-flow: row nowrap;
   align-items: stretch;
-  padding: 12px;
-  padding-left: 16px;
-  background-color: var(--content_tint_background);
-  border-radius: 8px;
+  padding: 12px 12px 12px 16px;
+  background-color: var(
+    --content_tint_background,
+    var(--vkui--color_background_secondary)
+  );
+  border-radius: var(--vkui--size_border_radius--regular);
   overflow: hidden;
 }
 
@@ -24,7 +26,8 @@
   display: block;
   width: 100%;
   height: 100%;
-  border: var(--thin-border) solid var(--image_border);
+  border: var(--thin-border) solid
+    var(--image_border, var(--vkui--color_image_border_alpha));
   border-radius: inherit;
   pointer-events: none;
   box-sizing: border-box;
@@ -53,7 +56,11 @@
 
 .Banner__subheader {
   display: block;
-  color: var(--text_subhead);
+  color: var(--text_subhead, var(--vkui--color_text_subhead));
+}
+
+.Banner__text {
+  color: var(--vkui--color_text_subhead);
 }
 
 .Banner__bg {
@@ -76,7 +83,7 @@
   align-items: center;
   justify-content: flex-end;
   width: 28px;
-  color: var(--icon_tertiary);
+  color: var(--icon_tertiary, var(--vkui--color_icon_tertiary));
 }
 
 .Banner__dismiss {
@@ -88,7 +95,7 @@
   align-content: center;
   align-items: center;
   justify-content: center;
-  color: var(--icon_secondary);
+  color: var(--icon_secondary, var(--vkui--color_icon_secondary));
   z-index: 3;
 }
 
@@ -105,16 +112,19 @@
  * Mode "image"
  */
 .Banner--md-image .Banner__in {
-  background-color: var(--content_tint_background);
+  background-color: var(
+    --content_tint_background,
+    var(--vkui--color_background_secondary)
+  );
 }
 
 .Banner--md-image .Banner__dismiss,
 .Banner--inverted {
-  color: var(--white);
+  color: var(--white, var(--vkui--color_text_contrast));
 }
 
 .Banner--inverted .Banner__subheader {
-  color: var(--white);
+  color: var(--white, var(--vkui--color_text_contrast));
   opacity: 0.72;
 }
 
@@ -137,18 +147,7 @@
   margin-top: 4px;
 }
 
-/**
- * iOS
- */
-.Banner--ios {
-  padding: 0 12px;
-}
-
-.Banner--ios .Banner__in {
-  border-radius: 10px;
-}
-
 .Banner--ios .Banner__dismiss,
 .Banner--ios.Banner--md-image .Banner__dismiss {
-  color: var(--icon_tertiary);
+  color: var(--icon_tertiary, var(--vkui--color_icon_tertiary));
 }

--- a/src/components/Banner/Banner.e2e.tsx
+++ b/src/components/Banner/Banner.e2e.tsx
@@ -1,8 +1,8 @@
 import { Fragment } from "react";
 import { Avatar } from "../Avatar/Avatar";
-import Banner, { BannerProps } from "./Banner";
+import { Banner, BannerProps } from "./Banner";
 import { Button } from "../Button/Button";
-import { describeScreenshotFuzz } from "../../testing/e2e/utils";
+import { describeScreenshotFuzz } from "../../testing/e2e";
 
 describe("Banner", () => {
   describeScreenshotFuzz(

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -3,7 +3,7 @@ import { AdaptivityProps } from "../../hoc/withAdaptivity";
 import { baselineComponent } from "../../testing/utils";
 import { SizeType } from "../AdaptivityProvider/AdaptivityContext";
 import { AdaptivityProvider } from "../AdaptivityProvider/AdaptivityProvider";
-import Banner, { BannerProps } from "./Banner";
+import { Banner, BannerProps } from "./Banner";
 
 const BannerTest = ({
   sizeY = SizeType.REGULAR,

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { HasComponent } from "../../types";
-import { getClassName } from "../../helpers/getClassName";
 import { classNames } from "../../lib/classNames";
 import { usePlatform } from "../../hooks/usePlatform";
-import { ANDROID, IOS, VKCOM } from "../../lib/platform";
+import { IOS } from "../../lib/platform";
 import { hasReactNode } from "../../lib/utils";
 import {
   Icon24Chevron,
@@ -97,38 +96,35 @@ const BannerHeader: React.FC<BannerTypographyProps> = ({
 /**
  * @see https://vkcom.github.io/VKUI/#/Banner
  */
-const Banner: React.FC<BannerProps> = (props: BannerProps) => {
+export const Banner = ({
+  mode = "tint",
+  imageTheme = "dark",
+  size = "s",
+  before,
+  asideMode,
+  header,
+  subheader,
+  text,
+  children,
+  background,
+  actions,
+  onDismiss,
+  dismissLabel = "Скрыть",
+  ...restProps
+}: BannerProps) => {
   const platform = usePlatform();
-  const {
-    mode,
-    imageTheme,
-    size,
-    before,
-    asideMode,
-    header,
-    subheader,
-    text,
-    children,
-    background,
-    actions,
-    onDismiss,
-    dismissLabel,
-    ...restProps
-  } = props;
 
   const SubheaderTypography = size === "m" ? Text : Subhead;
 
   return (
     <section
       {...restProps}
-      // eslint-disable-next-line vkui/no-object-expression-in-arguments
       vkuiClass={classNames(
-        getClassName("Banner", platform),
+        "Banner",
+        platform === IOS && "Banner--ios",
         `Banner--md-${mode}`,
         `Banner--sz-${size}`,
-        {
-          "Banner--inverted": mode === "image" && imageTheme === "dark",
-        }
+        mode === "image" && imageTheme === "dark" && "Banner--inverted"
       )}
     >
       <Tappable
@@ -178,15 +174,15 @@ const Banner: React.FC<BannerProps> = (props: BannerProps) => {
                 hoverMode="opacity"
                 hasActive={false}
               >
-                {(platform === ANDROID || platform === VKCOM) && (
-                  <Icon24Cancel />
-                )}
-                {platform === IOS &&
-                  (mode === "image" ? (
+                {platform === IOS ? (
+                  mode === "image" ? (
                     <Icon24DismissDark />
                   ) : (
                     <Icon24DismissSubstract />
-                  ))}
+                  )
+                ) : (
+                  <Icon24Cancel />
+                )}
               </IconButton>
             )}
           </div>
@@ -195,13 +191,3 @@ const Banner: React.FC<BannerProps> = (props: BannerProps) => {
     </section>
   );
 };
-
-Banner.defaultProps = {
-  dismissLabel: "Скрыть",
-  mode: "tint",
-  size: "s",
-  imageTheme: "dark",
-};
-
-// eslint-disable-next-line import/no-default-export
-export default Banner;

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ export { Spacing } from "./components/Spacing/Spacing";
 export type { SpacingProps } from "./components/Spacing/Spacing";
 export { default as Placeholder } from "./components/Placeholder/Placeholder";
 export type { PlaceholderProps } from "./components/Placeholder/Placeholder";
-export { default as Banner } from "./components/Banner/Banner";
+export { Banner } from "./components/Banner/Banner";
 export type { BannerProps } from "./components/Banner/Banner";
 export { MiniInfoCell } from "./components/MiniInfoCell/MiniInfoCell";
 export type { MiniInfoCellProps } from "./components/MiniInfoCell/MiniInfoCell";

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -134,6 +134,9 @@ export type { HeadlineProps } from "../components/Typography/Headline/Headline";
 export { Div } from "../components/Div/Div";
 export type { DivProps } from "../components/Div/Div";
 
+export { Banner } from "../components/Banner/Banner";
+export type { BannerProps } from "../components/Banner/Banner";
+
 export { FixedLayout } from "../components/FixedLayout/FixedLayout";
 export type { FixedLayoutProps } from "../components/FixedLayout/FixedLayout";
 


### PR DESCRIPTION
## Чеклист перевода компонента на vkui-tokens
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647)) 
- [x] Исключаем проверки типа `platform === ANDROID` (пример такого PR [#2653](https://togithub.com/VKCOM/VKUI/pull/2653)) 
- [x] В стилях компонента не осталось платформенных селекторов (_прим.: осталось, для iOS свое скругление и цвет иконки закрытия_)
- [x] В tsx компонента не осталось логики, которая зависит от платформы (_прим.: осталась - нужна своя иконка для закрытия_)

---

- https://github.com/VKCOM/VKUI/issues/2191
- resolve #2509 
