### PR TITLE
feat(CardGrid): Tokenize

### DIFF
--- a/src/components/CardGrid/CardGrid.css
+++ b/src/components/CardGrid/CardGrid.css
@@ -5,12 +5,13 @@
   flex-wrap: wrap;
 }
 
-.CardGrid + .CardGrid {
-  margin-top: 16px;
+.CardGrid--spaced {
+  padding: var(--vkui--size_base_padding_vertical--regular)
+    var(--vkui--size_base_padding_horizontal--regular);
 }
 
 .CardGrid .Card {
-  margin-right: 8px;
+  margin-right: var(--vkui--size_cardgrid_padding--regular);
 }
 
 .CardGrid--l .Card {
@@ -19,7 +20,7 @@
 }
 
 .CardGrid--l .Card:not(:first-child) {
-  margin-top: 8px;
+  margin-top: var(--vkui--size_cardgrid_padding--regular);
 }
 
 .CardGrid--m .Card {
@@ -27,7 +28,7 @@
 }
 
 .CardGrid--m .Card:nth-child(n + 3) {
-  margin-top: 8px;
+  margin-top: var(--vkui--size_cardgrid_padding--regular);
 }
 
 .CardGrid--m .Card:nth-child(2n) {
@@ -39,29 +40,20 @@
 }
 
 .CardGrid--s .Card:nth-child(n + 4) {
-  margin-top: 8px;
+  margin-top: var(--vkui--size_cardgrid_padding--regular);
 }
 
 .CardGrid--s .Card:nth-child(3n) {
   margin-right: 0;
 }
 
-/**
- * iOS
- */
-
-.CardGrid--ios.CardGrid--sizeX-compact {
-  padding-left: 12px;
-  padding-right: 12px;
+.CardGrid--sizeX-compact {
+  padding-left: var(--vkui--size_base_padding_horizontal--regular);
+  padding-right: var(--vkui--size_base_padding_horizontal--regular);
 }
 
-/**
- * Android & VKCOM
- */
-
-.CardGrid--android.CardGrid--sizeX-compact {
-  padding-left: 16px;
-  padding-right: 16px;
+.CardGrid + .CardGrid {
+  margin-top: 16px;
 }
 
 /**

--- a/src/components/CardGrid/CardGrid.test.tsx
+++ b/src/components/CardGrid/CardGrid.test.tsx
@@ -1,5 +1,5 @@
 import { baselineComponent } from "../../testing/utils";
-import CardGrid from "./CardGrid";
+import { CardGrid } from "./CardGrid";
 
 describe("CardGrid", () => {
   baselineComponent(CardGrid);

--- a/src/components/CardGrid/CardGrid.tsx
+++ b/src/components/CardGrid/CardGrid.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
 import { classNames } from "../../lib/classNames";
-import { getClassName } from "../../helpers/getClassName";
-import { usePlatform } from "../../hooks/usePlatform";
 import { withAdaptivity, AdaptivityProps } from "../../hoc/withAdaptivity";
 import "./CardGrid.css";
 
@@ -9,26 +7,27 @@ export interface CardGridProps
   extends React.HTMLAttributes<HTMLDivElement>,
     AdaptivityProps {
   size: "s" | "m" | "l";
+  /**
+   * Если true, то вокруг компонента присутствуют стандартные отсупы сверху/снизу и слева/справа
+   */
+  spaced?: boolean;
 }
 
-/**
- * @see https://vkcom.github.io/VKUI/#/CardGrid
- */
-const CardGrid = ({
+const CardGridComponent = ({
   children,
   size = "s",
+  spaced = false,
   sizeX,
   ...restProps
 }: CardGridProps) => {
-  const platform = usePlatform();
-
   return (
     <div
       {...restProps}
       vkuiClass={classNames(
-        getClassName("CardGrid", platform),
+        "CardGrid",
+        spaced && "CardGrid--spaced",
         `CardGrid--${size}`,
-        `CardGrid--sizeX-${sizeX}`
+        `CardGrid--sizeX-${sizeX}` // TODO: v5 новая адаптивность
       )}
     >
       {children}
@@ -36,5 +35,9 @@ const CardGrid = ({
   );
 };
 
-// eslint-disable-next-line import/no-default-export
-export default withAdaptivity(CardGrid, { sizeX: true });
+/**
+ * @see https://vkcom.github.io/VKUI/#/CardGrid
+ */
+export const CardGrid = withAdaptivity(CardGridComponent, { sizeX: true });
+
+CardGrid.displayName = "CardGrid"; // TODO: v5 remove

--- a/src/components/CardGrid/Readme.md
+++ b/src/components/CardGrid/Readme.md
@@ -35,6 +35,11 @@
         <div style={{ paddingBottom: "30%" }} />
       </Card>
     </CardGrid>
+    <CardGrid size="l" spaced>
+      <Card>
+        <div style={{ paddingBottom: "30%" }} />
+      </Card>
+    </CardGrid>
     <Spacing size={16} />
   </Panel>
 </View>

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export { IconButton } from "./components/IconButton/IconButton";
 export type { IconButtonProps } from "./components/IconButton/IconButton";
 export { Card } from "./components/Card/Card";
 export type { CardProps } from "./components/Card/Card";
-export { default as CardGrid } from "./components/CardGrid/CardGrid";
+export { CardGrid } from "./components/CardGrid/CardGrid";
 export type { CardGridProps } from "./components/CardGrid/CardGrid";
 export { CardScroll } from "./components/CardScroll/CardScroll";
 export type { CardScrollProps } from "./components/CardScroll/CardScroll";

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -119,6 +119,9 @@ export type { InputProps } from "../components/Input/Input";
 export { File } from "../components/File/File";
 export type { FileProps } from "../components/File/File";
 
+export { CardGrid } from "../components/CardGrid/CardGrid";
+export type { CardGridProps } from "../components/CardGrid/CardGrid";
+
 export { FocusVisible } from "../components/FocusVisible/FocusVisible";
 export type { FocusVisibleProps } from "../components/FocusVisible/FocusVisible";
 


### PR DESCRIPTION
## Чеклист перевода компонента на vkui-tokens
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647)) 
- [x] Исключаем проверки типа `platform === ANDROID` (пример такого PR [#2653](https://togithub.com/VKCOM/VKUI/pull/2653)) 
- [x] В стилях компонента не осталось платформенных селекторов 
- [x] В tsx компонента не осталось логики, которая зависит от платформы 

---

- close #2191
- resolve #2511 
