### PR TITLE
feat(ContentCard): Tokenize

### DIFF
--- a/src/components/ContentCard/ContentCard.css
+++ b/src/components/ContentCard/ContentCard.css
@@ -1,39 +1,31 @@
 .ContentCard--disabled {
-  opacity: 0.6;
+  opacity: var(--vkui--opacity_disable_accessibility);
 }
 
 .ContentCard__body {
-  padding: 12px 16px;
+  padding: var(--vkui--size_base_padding_vertical--regular)
+    var(--vkui--size_base_padding_horizontal--regular);
 }
 
 .ContentCard__tappable {
-  border-radius: 8px;
+  border-radius: var(--vkui--size_card_border_radius--regular);
   text-decoration: none;
-  color: var(--text_primary);
+  color: var(--text_primary, var(--vkui--color_text_primary));
   display: block;
 }
 
 .ContentCard__img {
   object-fit: cover;
   display: block;
-  border-radius: 8px 8px 0 0;
+  border-radius: var(--vkui--size_card_border_radius--regular)
+    var(--vkui--size_card_border_radius--regular) 0 0;
 }
 
 .ContentCard__text:not(:last-child) {
   margin-bottom: 4px;
 }
 
-.ContentCard__caption {
-  color: var(--text_secondary);
-}
-
-/*
- * iOS
- */
-.ContentCard--ios .ContentCard__tappable {
-  border-radius: 10px;
-}
-
-.ContentCard--ios .ContentCard__img {
-  border-radius: 10px 10px 0 0;
+.ContentCard__caption,
+.ContentCard__subtitle {
+  color: var(--text_secondary, var(--vkui--color_text_secondary));
 }

--- a/src/components/ContentCard/ContentCard.e2e.tsx
+++ b/src/components/ContentCard/ContentCard.e2e.tsx
@@ -1,0 +1,17 @@
+import { describeScreenshotFuzz } from "../../testing/e2e";
+import { ContentCard } from "./ContentCard";
+
+describe("ContentCard", () => {
+  describeScreenshotFuzz(ContentCard, [
+    {
+      subtitle: ["Album"],
+      header: ["Halsey – Badlands"],
+      text: [
+        "Badlands is the story about dreams and cruel reality, about opportunities and insurmountable obstacles, about love and broken hearts.",
+      ],
+      caption: ["Blue Vinyl · EU · 2015"],
+      mode: ["tint", "shadow", "outline", undefined],
+      $adaptivity: "y",
+    },
+  ]);
+});

--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import { Card, CardProps } from "../Card/Card";
 import { Caption } from "../Typography/Caption/Caption";
-import { Title } from "../Typography/Title/Title";
+import { Headline } from "../Typography/Headline/Headline";
 import { Text } from "../Typography/Text/Text";
 import { TappableProps, Tappable } from "../Tappable/Tappable";
-import { getClassName } from "../../helpers/getClassName";
-import { usePlatform } from "../../hooks/usePlatform";
 import { hasReactNode } from "../../lib/utils";
 import { warnOnce } from "../../lib/warnOnce";
 import { HasRef, HasRootRef } from "../../types";
@@ -52,38 +50,33 @@ const warn = warnOnce("ContentCard");
 /**
  * @see https://vkcom.github.io/VKUI/#/ContentCard
  */
-export const ContentCard: React.FC<ContentCardProps> = (
-  props: ContentCardProps
-) => {
-  const {
-    subtitle,
-    header,
-    text,
-    caption,
-    // card props
-    className,
-    mode = "shadow",
-    style,
-    getRootRef,
-    // img props
-    getRef,
-    maxHeight,
-    image,
-    src,
-    srcSet,
-    alt,
-    width,
-    height,
-    crossOrigin,
-    decoding,
-    loading,
-    referrerPolicy,
-    sizes,
-    useMap,
-    ...restProps
-  } = props;
-  const platform = usePlatform();
-
+export const ContentCard = ({
+  subtitle,
+  header,
+  text,
+  caption,
+  // card props
+  className,
+  mode = "shadow",
+  style,
+  getRootRef,
+  // img props
+  getRef,
+  maxHeight,
+  image,
+  src,
+  srcSet,
+  alt,
+  width,
+  height,
+  crossOrigin,
+  decoding,
+  loading,
+  referrerPolicy,
+  sizes,
+  useMap,
+  ...restProps
+}: ContentCardProps) => {
   const source = image || src;
 
   if (image && process.env.NODE_ENV === "development") {
@@ -94,10 +87,10 @@ export const ContentCard: React.FC<ContentCardProps> = (
     <Card
       mode={mode}
       getRootRef={getRootRef}
-      // eslint-disable-next-line vkui/no-object-expression-in-arguments
-      vkuiClass={classNames(getClassName("ContentCard", platform), {
-        "ContentCard--disabled": restProps.disabled,
-      })}
+      vkuiClass={classNames(
+        "ContentCard",
+        restProps.disabled && "ContentCard--disabled"
+      )}
       style={style}
       className={className}
     >
@@ -128,20 +121,27 @@ export const ContentCard: React.FC<ContentCardProps> = (
         )}
         <div vkuiClass="ContentCard__body">
           {hasReactNode(subtitle) && (
-            <Caption caps vkuiClass="ContentCard__text" weight="1" level="3">
+            <Caption
+              vkuiClass="ContentCard__text ContentCard__subtitle"
+              weight="1"
+              level="3"
+              caps
+            >
               {subtitle}
             </Caption>
           )}
           {hasReactNode(header) && (
-            <Title vkuiClass="ContentCard__text" weight="3" level="1">
+            <Headline vkuiClass="ContentCard__text" weight="2" level="1">
               {header}
-            </Title>
+            </Headline>
           )}
           {hasReactNode(text) && (
             <Text vkuiClass="ContentCard__text">{text}</Text>
           )}
           {hasReactNode(caption) && (
-            <Caption vkuiClass="ContentCard__text">{caption}</Caption>
+            <Caption vkuiClass="ContentCard__text ContentCard__caption">
+              {caption}
+            </Caption>
           )}
         </div>
       </Tappable>

--- a/src/components/ContentCard/Readme.md
+++ b/src/components/ContentCard/Readme.md
@@ -37,6 +37,12 @@ const Example = () => {
               caption="VKUI Styleguide > Blocks > ContentCard"
             />
             <ContentCard
+              subtitle="VKUI"
+              header="ContentCard example"
+              caption="VKUI Styleguide > Blocks > ContentCard"
+              mode="tint"
+            />
+            <ContentCard
               onClick={() => {}}
               src="https://images.unsplash.com/photo-1603988492906-4fb0fb251cf8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1600&q=80"
               subtitle="unsplash"

--- a/src/components/ContentCard/__image_snapshots__/contentcard-android-light-1-snap.png
+++ b/src/components/ContentCard/__image_snapshots__/contentcard-android-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09e569aa73ff81e49b44c4383ef2bc5ddf00311510634fa4c2fe43f587e07477
+size 182375

--- a/src/components/ContentCard/__image_snapshots__/contentcard-ios-light-1-snap.png
+++ b/src/components/ContentCard/__image_snapshots__/contentcard-ios-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:669d71c63bff2e7c9f480e70cca22d1da745535b66ee4d49b522e570ba2d1996
+size 182282

--- a/src/components/ContentCard/__image_snapshots__/contentcard-vkcom-light-1-snap.png
+++ b/src/components/ContentCard/__image_snapshots__/contentcard-vkcom-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:252e49509a0b7ac196817851b530fa1d43133e9c6631b2e25043859cc8c2071e
+size 91716

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -116,6 +116,9 @@ export type { ViewProps } from "../components/View/View";
 export { Spinner } from "../components/Spinner/Spinner";
 export type { SpinnerProps } from "../components/Spinner/Spinner";
 
+export { ContentCard } from "../components/ContentCard/ContentCard";
+export type { ContentCardProps } from "../components/ContentCard/ContentCard";
+
 export { CustomSelect } from "../components/CustomSelect/CustomSelect";
 export type { CustomSelectProps } from "../components/CustomSelect/CustomSelect";
 


### PR DESCRIPTION
## Чеклист перевода компонента на vkui-tokens
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647)) 
- [x] Исключаем проверки типа `platform === ANDROID` (пример такого PR [#2653](https://togithub.com/VKCOM/VKUI/pull/2653)) 
- [x] В стилях компонента не осталось платформенных селекторов
- [x] В tsx компонента не осталось логики, которая зависит от платформы 

---

- Resolve #2519 
