### PR TITLE
feat(Link): tokenized

### DIFF
--- a/src/components/Link/Link.css
+++ b/src/components/Link/Link.css
@@ -1,5 +1,5 @@
 .Link {
-  color: var(--accent);
+  color: var(--accent, var(--vkui--color_text_link));
   text-decoration: none;
   border: 0;
   background: none;
@@ -9,6 +9,26 @@
   font-size: inherit;
   display: inline;
   border-radius: 0;
+}
+
+@media (hover: hover) {
+  .Link:hover {
+    text-decoration: underline;
+  }
+}
+
+.Link--focus-visible {
+  /**
+   * На момент v4.33.0, реализация <FocusVisible /> не подошла, т.к. текст может быть многострочным.
+   * Поэтому используем свой класс и применяем `outline`.
+   *
+   * `!important` – чтобы перебить глобальное обнуление `outline` на `:focus`.
+   */
+  outline: 2px solid var(--accent, var(--vkui--color_stroke_accent)) !important;
+}
+
+.Link--has-visited:visited {
+  color: var(--vkui--color_text_link_visited);
 }
 
 .Link .Icon {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,28 +1,26 @@
-import * as React from "react";
-import { getClassName } from "../../helpers/getClassName";
-import { usePlatform } from "../../hooks/usePlatform";
+import { classNames } from "../../lib/classNames";
 import { TappableProps, Tappable } from "../Tappable/Tappable";
 import "./Link.css";
 
-export type LinkProps = TappableProps;
+export interface LinkProps extends TappableProps {
+  /**
+   * Включает состояние `visited`, которое позволяет пользователю понять посещал ли он ссылку или нет
+   */
+  hasVisited?: boolean;
+}
 
 /**
  * @see https://vkcom.github.io/VKUI/#/Link
  */
-export const Link: React.FC<LinkProps> = ({
-  children,
-  ...restProps
-}: LinkProps) => {
-  const platform = usePlatform();
-
+export const Link = ({ hasVisited, children, ...restProps }: LinkProps) => {
   return (
     <Tappable
       Component={restProps.href ? "a" : "button"}
       {...restProps}
-      vkuiClass={getClassName("Link", platform)}
-      hasActive={false}
-      hoverMode="opacity"
-      focusVisibleMode="outside"
+      vkuiClass={classNames("Link", hasVisited && "Link--has-visited")}
+      hasHover={false}
+      activeMode="opacity"
+      focusVisibleMode="Link--focus-visible"
     >
       {children}
     </Tappable>

--- a/src/components/Link/Readme.md
+++ b/src/components/Link/Readme.md
@@ -1,8 +1,40 @@
 Надстройка над `<a />`. Компонент принимает все валидные для этого элемента свойства.
 
-```jsx static
-import { Link } from '@vkontakte/vkui';
+Все типографические свойства наследуются от родителя, а именно:
 
-<Link href="https://google.com" target="_blank">Google</Link>
-<Link href="/profile">Profile</Link>
+- семейство шрифта
+- размер шрифта
+- межстрочное расстояние
+- межбуквенное расстояние
+- вес шрифта
+
+```jsx { "props": { "layout": false, "iframe": false } }
+<div
+  style={{
+    padding: 24,
+  }}
+>
+  <Link href="#/About">О VKUI</Link>
+
+  <Spacing size={24} />
+
+  <Link href="https://google.com" target="_blank">
+    https://google.com <Icon24ExternalLinkOutline width={16} height={16} />
+  </Link>
+
+  <Spacing size={24} />
+
+  <div style={{ width: 304 }}>
+    Нажимая «Продолжить», вы принимаете{" "}
+    <Link href="#">пользовательское соглашение</Link> и{" "}
+    <Link href="#">политику конфиденциальности</Link>.
+  </div>
+
+  <Spacing size={24} />
+
+  <Link href="#/Link" hasVisited>
+    Если посетить эту ссылку, то она будет использовать состояние
+    <code>visited</code>
+  </Link>
+</div>
 ```

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -34,6 +34,9 @@ export type { InitialsAvatarProps } from "../components/InitialsAvatar/InitialsA
 export { InfoRow } from "../components/InfoRow/InfoRow";
 export type { InfoRowProps } from "../components/InfoRow/InfoRow";
 
+export { Link } from "../components/Link/Link";
+export type { LinkProps } from "../components/Link/Link";
+
 export { ButtonGroup } from "../components/ButtonGroup/ButtonGroup";
 export type { ButtonGroupProps } from "../components/ButtonGroup/ButtonGroup";
 


### PR DESCRIPTION
## Проблема с фокусом

Задал свой класс для фокуса `<Tappable focusVisibleMode="Link--focus-visible" />`, т.к. есть проблема с текущей реализацией `<FocusVisible />` (см. скриншоты)

<img width="140" src="https://user-images.githubusercontent.com/5850354/174833360-353d6ea0-02f3-457e-a2a6-560a1e1d3afe.png" /> <img width="140" src="https://user-images.githubusercontent.com/5850354/174833404-793f9a7a-3b4d-4197-9e9c-685740a1396b.png" />

Фокус задаю через `outline`

<img width="140" alt="image" src="https://user-images.githubusercontent.com/5850354/174833875-9a47b73d-87e0-41e4-9c88-bf82c7283029.png"> <img width="140" alt="image" src="https://user-images.githubusercontent.com/5850354/174833905-a1b7f2b3-b5e6-4fce-87dd-cf7349509322.png">

Также пришлось указать `!important` из-за глобального обнуления `outline` на фокус

https://github.com/VKCOM/VKUI/blob/8323f7aa9ce00ff28c17092ffc83f5146fca8a91/src/styles/common.css#L36-L39

## Чеклист перевода компонента на vkui-tokens
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647))
- [x] Дизайн ревью

---

<!--- Ссылки на задачи --->

- Close #2552 
