### PR TITLE
fix(Group): Add pointer-events: none to make events on children happy

### DIFF
--- a/src/components/Group/Group.css
+++ b/src/components/Group/Group.css
@@ -25,6 +25,7 @@
   height: 100%;
   position: absolute;
   border-radius: inherit;
+  pointer-events: none;
   box-shadow: inset 0 0 0 var(--thin-border) var(--input_border);
 }
 


### PR DESCRIPTION
Сейчас на дочерних компонентах, которые обернуты в `Group` (`mode=card`) не работают ивенты, проставляем 
`pointer-events: none;` для элемента `after`