### PR TITLE
fix(Snackbar): fix multiplication by -1 in `calc()`

### DIFF
--- a/src/components/Snackbar/Snackbar.css
+++ b/src/components/Snackbar/Snackbar.css
@@ -66,7 +66,7 @@
 
 .Snackbar--l-horizontal .Snackbar__action {
   margin-right: calc(
-    (var(--vkui--size_button_tertiary_small_padding_horizontal--regular) * -1)
+    -1 * var(--vkui--size_button_tertiary_small_padding_horizontal--regular)
   );
   position: relative;
   top: 2px;
@@ -76,7 +76,7 @@
   margin-top: 2px;
   margin-bottom: -6px;
   margin-left: calc(
-    (var(--vkui--size_button_tertiary_small_padding_horizontal--regular) * -1)
+    -1 * var(--vkui--size_button_tertiary_small_padding_horizontal--regular)
   );
 }
 


### PR DESCRIPTION
Была проблема, что [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) версии `< 12` не могла распарсить минифицированнную запись умножения переменной на `-1`, где `-1` шла вторым операндом

Пример
```
calc(var(--value)*-1)
```

А вот так работает

```
calc(var(--value) * -1)
```

Упоминание о проблеме нашёл тут https://github.com/postcss/postcss-custom-properties/issues/179#issuecomment-497534247

Поэтому заменил на 

```diff
-calc(var(--value) * -1)
+calc(-1 * var(--value))
```

---

<!--- Ссылки на задачи --->

- Fix #2740
