### PR TITLE
chore: add stylelint-bad-multiplication

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -6,6 +6,7 @@ module.exports = {
   plugins: [
     "stylelint-value-no-unknown-custom-properties",
     "./tasks/styleint-atomic",
+    "./tasks/stylelint-bad-multiplication",
   ],
   rules: {
     indentation: null,
@@ -42,5 +43,6 @@ module.exports = {
         severity: "warning",
       },
     ],
+    "vkui/bad-multiplication": true,
   },
 };

--- a/tasks/stylelint-bad-multiplication.js
+++ b/tasks/stylelint-bad-multiplication.js
@@ -1,0 +1,69 @@
+const stylelint = require("stylelint");
+const valueParser = require("postcss-value-parser");
+
+const MATCH_CALC = /((?:-(moz|webkit)-)?calc)/i;
+
+const ruleName = "vkui/bad-multiplication";
+const messages = stylelint.utils.ruleMessages(ruleName, {});
+const meta = {
+  url: "https://github.com/VKCOM/VKUI/pull/2741",
+};
+
+const searchBadMultiplication = (node) => {
+  let lastWord = "";
+
+  return node.nodes.some((nodeValue) => {
+    if (nodeValue.type === "function") {
+      if (searchBadMultiplication(nodeValue)) {
+        return true;
+      }
+    }
+
+    if (nodeValue.type === "word") {
+      if (lastWord.endsWith("*") && nodeValue.value.startsWith("-")) {
+        return true;
+      }
+    }
+
+    if (nodeValue.type !== "space") {
+      lastWord = nodeValue.value;
+    }
+  });
+};
+
+module.exports = stylelint.createPlugin(ruleName, function () {
+  /**
+   * @param {import('postcss').Root} root
+   */
+  function stylelintRule(root, result) {
+    root.walkRules((node) => {
+      node.each((childNode) => {
+        if (childNode.type === "decl") {
+          valueParser(childNode.value).walk((valueNode) => {
+            if (
+              valueNode.type !== "function" ||
+              !MATCH_CALC.test(valueNode.value)
+            ) {
+              return;
+            }
+
+            if (searchBadMultiplication(valueNode)) {
+              stylelint.utils.report({
+                ruleName,
+                node: childNode,
+                result,
+                message: `Bad multiplication, swap operands`,
+              });
+            }
+          });
+        }
+      });
+    });
+  }
+
+  return stylelintRule;
+});
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;
+module.exports.meta = meta;


### PR DESCRIPTION
### Проблема

Умножение в `calc` на отрицательное число ломает некоторые сборки

```css
calc(var(--some-variable) * -1)
```

- #1083
- #1057
- #2740

Проблема пропадает, если поменять местами операнды

```
calc(-1 * var(--some-variable))
```

Подробнее можно узнать в #2741

### Решение

Добавляем stylelint плагин который проверяет умножение на отрицательное число

<img width="658" alt="image" src="https://user-images.githubusercontent.com/14944123/175291933-ee356d8d-fdc1-4d04-bd1c-d1b4c9b80154.png">

