### PR TITLE
Popper: observe targetRef resize

### DIFF
--- a/src/components/Popper/Popper.tsx
+++ b/src/components/Popper/Popper.tsx
@@ -105,6 +105,20 @@ export const Popper: React.FC<PopperProps> = ({
       {
         name: "flip",
       },
+      {
+        name: "observeTargetRefSize",
+        enabled: true,
+        phase: "main",
+        effect: ({ state, instance }) => {
+          const observer = new ResizeObserver(instance.update);
+
+          observer.observe(state.elements.reference as Element);
+
+          return () => {
+            observer.disconnect();
+          };
+        },
+      },
     ];
 
     if (arrow) {


### PR DESCRIPTION
День добрый, 

Решаемая проблема: В случаях когда кол-во Chip в ChipSelect занимает более одной строки, closeAfterSelect в false и  при открытом попапе удаляем Chip, в момент когда сам Select меняется в размерах, попап позиционируется по-прежнему размеру targetRef

<img width="231" alt="Снимок экрана 2022-06-24 в 15 15 43" src="https://user-images.githubusercontent.com/3533939/175532119-112ecd1f-5611-487e-9d8b-2a36126e43cc.png">

