### PR TITLE
Add support for nested ConfigProvider

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -5,7 +5,11 @@ import { ANDROID, VKCOM } from "../../lib/platform";
 import { baselineComponent } from "../../testing/utils";
 import { Scheme, Appearance } from "../../helpers/scheme";
 import { ConfigProvider } from "./ConfigProvider";
-import { ConfigProviderContext, WebviewType } from "./ConfigProviderContext";
+import {
+  ConfigProviderContext,
+  WebviewType,
+  ConfigProviderContextInterface,
+} from "./ConfigProviderContext";
 
 describe("ConfigProvider", () => {
   baselineComponent<any>(ConfigProvider, { forward: false });
@@ -103,6 +107,43 @@ describe("ConfigProvider", () => {
         </ConfigProvider>
       );
       expect(appearance).toBe(expectAppearance);
+    });
+  });
+  describe("inherits properties from parent ConfigProvider context", () => {
+    let config: ConfigProviderContextInterface | undefined;
+    const ReadConfig = () => {
+      config = useContext(ConfigProviderContext);
+      return null;
+    };
+
+    const defaultConfig: ConfigProviderContextInterface = {
+      platform: VKCOM,
+      appearance: Appearance.DARK,
+      webviewType: WebviewType.INTERNAL,
+      hasNewTokens: true,
+      transitionMotionEnabled: false,
+      isWebView: true,
+    };
+    it.each([
+      ["platform", ANDROID],
+      ["webviewType", WebviewType.VKAPPS],
+      ["hasNewTokens", false],
+      ["transitionMotionEnabled", true],
+      ["isWebView", false],
+      ["platform", Appearance.LIGHT],
+    ])("%s => %s", (prop, value) => {
+      const newConfig = { [prop]: value };
+      render(
+        <ConfigProvider {...defaultConfig}>
+          <ConfigProvider {...newConfig}>
+            <ReadConfig />
+          </ConfigProvider>
+        </ConfigProvider>
+      );
+
+      expect(config).toEqual(
+        expect.objectContaining({ ...defaultConfig, [prop]: value })
+      );
     });
   });
 });

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -83,7 +83,7 @@ export const ConfigProvider = (props: ConfigProviderProps) => {
     hasNewTokens = parentConfig.hasNewTokens,
     appearance = parentConfig.appearance,
     scheme,
-    locale = parentLocale,
+    locale = parentLocale ?? "ru",
   } = props;
 
   const normalizedScheme = normalizeScheme({

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
-import vkBridge, { AppearanceType } from "@vkontakte/vk-bridge";
+import { AppearanceType } from "@vkontakte/vk-bridge";
 import { canUseDOM, useDOM } from "../../lib/dom";
 import {
   ConfigProviderContext,
   ConfigProviderContextInterface,
-  WebviewType,
 } from "./ConfigProviderContext";
 import { useIsomorphicLayoutEffect } from "../../lib/useIsomorphicLayoutEffect";
 import { useObjectMemo } from "../../hooks/useObjectMemo";
@@ -20,7 +19,6 @@ import {
   generateVKUITokensClassName,
 } from "../AppearanceProvider/AppearanceProvider";
 import { LocaleProviderContext } from "../LocaleProviderContext/LocaleProviderContext";
-import { platform as resolvePlatform } from "../../lib/platform";
 
 export interface ConfigProviderProps
   extends Partial<ConfigProviderContextInterface> {
@@ -72,17 +70,22 @@ const deriveAppearance = (scheme: Scheme | undefined): AppearanceType =>
 /**
  * @see https://vkcom.github.io/VKUI/#/ConfigProvider
  */
-export const ConfigProvider = ({
-  children,
-  webviewType = WebviewType.VKAPPS,
-  isWebView = vkBridge.isWebView(),
-  transitionMotionEnabled = true,
-  platform = resolvePlatform(),
-  hasNewTokens = false,
-  appearance,
-  scheme,
-  locale = "ru",
-}: ConfigProviderProps) => {
+export const ConfigProvider = (props: ConfigProviderProps) => {
+  const parentLocale = React.useContext(LocaleProviderContext);
+  const parentConfig = React.useContext(ConfigProviderContext);
+
+  const {
+    children,
+    webviewType = parentConfig.webviewType,
+    isWebView = parentConfig.isWebView,
+    transitionMotionEnabled = parentConfig.transitionMotionEnabled,
+    platform = parentConfig.platform,
+    hasNewTokens = parentConfig.hasNewTokens,
+    appearance = parentConfig.appearance,
+    scheme,
+    locale = parentLocale,
+  } = props;
+
   const normalizedScheme = normalizeScheme({
     scheme,
     platform,
@@ -97,7 +100,8 @@ export const ConfigProvider = ({
     }
     if (
       process.env.NODE_ENV === "development" &&
-      target?.hasAttribute("scheme")
+      target?.hasAttribute("scheme") &&
+      parentConfig.appearance === undefined // appearance не была вычислена в родительском конфиге, @deprecated будет удалено в 5.0.0
     ) {
       warn(
         '<body scheme> был установлен перед монтированием VKUI - вы не забыли scheme="inherit"?'

--- a/src/components/LocaleProviderContext/LocaleProviderContext.tsx
+++ b/src/components/LocaleProviderContext/LocaleProviderContext.tsx
@@ -1,5 +1,3 @@
 import * as React from "react";
 
-export const LocaleProviderContext = React.createContext<string | undefined>(
-  undefined
-);
+export const LocaleProviderContext = React.createContext<string>("ru");

--- a/src/components/LocaleProviderContext/LocaleProviderContext.tsx
+++ b/src/components/LocaleProviderContext/LocaleProviderContext.tsx
@@ -1,3 +1,5 @@
 import * as React from "react";
 
-export const LocaleProviderContext = React.createContext<string>("ru");
+export const LocaleProviderContext = React.createContext<string | undefined>(
+  undefined
+);


### PR DESCRIPTION
Добавил поддержку вложенных `ConfigProvider`. Теперь `ConfigProvider` по умолчанию берет свойства из родительского.
close #2483 
