### PR TITLE
chore: tune .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ PUBLISHING.md
 .idea/tasks.xml
 .idea/markdown-navigator-enh.xml
 .idea/markdown-navigator.xml
+docs/
+!docs/*.md
 .vscode/
 test-results.json
 lint-results.json


### PR DESCRIPTION
Микрофикс вдогонку к https://github.com/VKCOM/VKUI/pull/2788: исключаем всё в `docs/`, кроме `markdown`-файлов.