### PR TITLE
fix: prevent modal touch events only on touchstart

### DIFF
--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -214,12 +214,12 @@ class ModalRootTouchComponent extends React.Component<
       // некоторые браузеры на странных вендорах типа Meizu не удаляют обработчик.
       // https://github.com/VKCOM/VKUI/issues/444
       this.window!.removeEventListener("touchmove", this.preventTouch, {
-        // @ts-expect-error (В интерфейсе EventListenerOptions нет поля passive)
+        // @ts-ignore (В интерфейсе EventListenerOptions нет поля passive)
         passive: true,
       });
 
       this.window!.removeEventListener("touchstart", this.preventTouch, {
-        // @ts-expect-error (В интерфейсе EventListenerOptions нет поля passive)
+        // @ts-ignore (В интерфейсе EventListenerOptions нет поля passive)
         passive: false,
       });
     } else {

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -215,7 +215,7 @@ class ModalRootTouchComponent extends React.Component<
       // https://github.com/VKCOM/VKUI/issues/444
       this.window!.removeEventListener("touchmove", this.preventTouch, {
         // @ts-ignore (В интерфейсе EventListenerOptions нет поля passive)
-        passive: true,
+        passive: false,
       });
 
       this.window!.removeEventListener("touchstart", this.preventTouch, {
@@ -224,7 +224,7 @@ class ModalRootTouchComponent extends React.Component<
       });
     } else {
       this.window!.addEventListener("touchmove", this.preventTouch, {
-        passive: true,
+        passive: false,
       });
 
       this.window!.addEventListener("touchstart", this.preventTouch, {

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -214,11 +214,20 @@ class ModalRootTouchComponent extends React.Component<
       // некоторые браузеры на странных вендорах типа Meizu не удаляют обработчик.
       // https://github.com/VKCOM/VKUI/issues/444
       this.window!.removeEventListener("touchmove", this.preventTouch, {
-        // @ts-ignore (В интерфейсе EventListenerOptions нет поля passive)
+        // @ts-expect-error (В интерфейсе EventListenerOptions нет поля passive)
+        passive: true,
+      });
+
+      this.window!.removeEventListener("touchstart", this.preventTouch, {
+        // @ts-expect-error (В интерфейсе EventListenerOptions нет поля passive)
         passive: false,
       });
     } else {
       this.window!.addEventListener("touchmove", this.preventTouch, {
+        passive: true,
+      });
+
+      this.window!.addEventListener("touchstart", this.preventTouch, {
         passive: false,
       });
     }


### PR DESCRIPTION
Исправил отмену touch событий при перемещении модалки.
На iOS нужно отменять событие во время touchstart, иначе страница может продолжить двигаться