### PR TITLE
ci: JamesIves/github-pages-deploy-action@v4.3.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ github.event.inputs.tag }}
 
       - name: Publishing doc
-        uses: JamesIves/github-pages-deploy-action@e6d003d
+        uses: JamesIves/github-pages-deploy-action@v4.3.4
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           branch: gh-pages

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,7 +97,7 @@ jobs:
           name: styleguide
           path: tmp
       - name: Publishing styleguide to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@e6d003d
+        uses: JamesIves/github-pages-deploy-action@v4.3.4
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           commit-message: "Publish PR ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
> Unable to resolve action `JamesIves/github-pages-deploy-action@e6d003d`, the provided ref `e6d003d` is the shortened version of a commit SHA, which is not supported