### PR TITLE
ci: fix push protected branch

### DIFF
--- a/.github/gitflow/patch.js
+++ b/.github/gitflow/patch.js
@@ -1,6 +1,6 @@
 const { execSync } = require("child_process");
 const SemVer = require("semver/classes/semver");
-const { stableBranchName, GhApi } = require("./utils.js");
+const { stableBranchName, remoteRepository, GhApi } = require("./utils.js");
 const pkg = require("../../package.json");
 
 const semVer = new SemVer(pkg.version);
@@ -20,4 +20,4 @@ const patchRefs = patchCommits.map((commit) => commit.sha).join(" ");
 execSync(`git fetch origin ${stableBranchRef} ${patchRefs}`);
 execSync(`git checkout ${stableBranchRef}`);
 execSync(`git cherry-pick ${patchRefs}`);
-execSync(`git push origin ${stableBranchRef}`);
+execSync(`git push "${remoteRepository}" ${stableBranchRef}`);

--- a/.github/gitflow/stable_branch.js
+++ b/.github/gitflow/stable_branch.js
@@ -1,6 +1,6 @@
 const { execSync } = require("child_process");
 const SemVer = require("semver/classes/semver");
-const { stableBranchName } = require("./utils.js");
+const { stableBranchName, remoteRepository } = require("./utils.js");
 const pkg = require("../../package.json");
 
 const semVer = new SemVer(pkg.version);
@@ -11,4 +11,4 @@ if (semVer.patch !== 0) {
 const stableBranchRef = stableBranchName(semVer);
 
 execSync(`git branch ${stableBranchRef}`);
-execSync(`git push origin ${stableBranchRef}`);
+execSync(`git push "${remoteRepository}" ${stableBranchRef}`);

--- a/.github/gitflow/utils.js
+++ b/.github/gitflow/utils.js
@@ -6,6 +6,8 @@ module.exports.stableBranchName = (semVer) => {
   return `${semVer.major}.${semVer.minor}-stable`;
 };
 
+module.exports.remoteRepository = `https://${process.env.GITHUB_ACTOR}:${process.env.GITHUB_TOKEN}@github.com/VKCOM/VKUI.git`;
+
 module.exports.GhApi = class GhApi {
   constructor() {}
   /**

--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -1,4 +1,4 @@
-name: "Clear styleguide for closed PR"
+name: "Close PR"
 
 on:
   pull_request:
@@ -38,4 +38,4 @@ jobs:
       - run: node ./.github/gitflow/patch.js
         env:
           GITHUB_PULL_NUMBER: ${{ github.event.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Create stable branch
         run: node ./.github/gitflow/stable_branch.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
 
       - name: Publishing prerelase
         run: yarn publish --non-interactive --tag ${{ github.event.inputs.tag }}


### PR DESCRIPTION
> remote: error: GH006: Protected branch update failed for refs/heads/4.33-stable.        
> remote: error: You're not authorized to push to this branch. Visit https://docs.github.com/articles/about-protected-branches/ for more information.

[Упавший CI](https://github.com/VKCOM/VKUI/runs/7236771315?check_suite_focus=true)