### PR TITLE
feat(Avatar): add `object-fit: cover` for square images

### DIFF
--- a/src/components/Avatar/Avatar.css
+++ b/src/components/Avatar/Avatar.css
@@ -18,6 +18,7 @@
   height: 100%;
   border: none;
   border-radius: inherit;
+  object-fit: cover;
 }
 
 .Avatar__children,


### PR DESCRIPTION
- close #2780
