### PR TITLE
feat(ModalCard, ModalCardBase): Tokenize

### DIFF
--- a/src/components/ModalCard/ModalCard.tsx
+++ b/src/components/ModalCard/ModalCard.tsx
@@ -58,10 +58,10 @@ const ModalCardComponent = ({
     <div
       {...restProps}
       id={id}
-      // eslint-disable-next-line vkui/no-object-expression-in-arguments
-      vkuiClass={classNames(getClassName("ModalCard", platform), {
-        "ModalCard--desktop": isDesktop,
-      })}
+      vkuiClass={classNames(
+        getClassName("ModalCard", platform),
+        isDesktop && "ModalCard--desktop"
+      )}
     >
       <ModalCardBase
         vkuiClass="ModalCard__in"

--- a/src/components/ModalCardBase/ModalCardBase.css
+++ b/src/components/ModalCardBase/ModalCardBase.css
@@ -4,7 +4,7 @@
 .ModalCardBase__container {
   box-sizing: border-box;
   position: relative;
-  background: var(--modal_card_background);
+  background: var(--modal_card_background, var(--vkui--color_background_modal));
   border-radius: 18px;
   padding: 16px;
   margin-bottom: var(--safe-area-inset-bottom);
@@ -12,6 +12,7 @@
   flex-direction: column;
   justify-content: center;
   pointer-events: initial;
+  box-shadow: var(--vkui--elevation3);
 }
 
 .ModalCardBase__container--softwareKeyboardOpened {
@@ -27,11 +28,11 @@
 }
 
 .ModalCardBase__header {
-  color: var(--text_primary);
+  color: var(--text_primary, var(--vkui--color_text_primary));
 }
 
 .ModalCardBase__subheader {
-  color: var(--text_secondary);
+  color: var(--text_secondary, var(--vkui--color_text_subhead));
 }
 
 .ModalCardBase__header + .ModalCardBase__subheader {
@@ -40,7 +41,7 @@
 
 .ModalCardBase__icon {
   margin: 8px auto 16px;
-  color: var(--accent);
+  color: var(--accent, var(--vkui--color_icon_accent));
 }
 
 .ModalCardBase__actions {
@@ -51,7 +52,7 @@
 }
 
 .ModalCardBase .UsersStack + .ModalCardBase__actions {
-  margin-top: 32px;
+  margin-top: 24px;
 }
 
 .ModalCardBase__header + .ModalCardBase__actions,
@@ -71,14 +72,19 @@
   right: 4px;
   width: 48px;
   height: 48px;
-  color: var(--placeholder_icon_foreground_primary);
+  color: var(
+    --placeholder_icon_foreground_primary,
+    var(--vkui--color_icon_secondary)
+  );
   justify-content: center;
 }
 
 /**
  * iOS
  */
-
+/*
+ * TODO v5.0.0: зачем этот стиль? Удалить?
+*/
 .ModalCardBase--ios .ModalCardBase__header:first-child {
   padding-left: 36px;
   padding-right: 36px;
@@ -91,7 +97,6 @@
 .ModalCardBase--android .ModalCardBase__container,
 .ModalCardBase--vkcom .ModalCardBase__container {
   border-radius: 12px;
-  box-shadow: 0 8px 8px 0 rgba(0, 0, 0, 0.16), 0 0 4px 0 rgba(0, 0, 0, 0.08);
 }
 
 /**
@@ -100,5 +105,4 @@
 
 .ModalCardBase--desktop .ModalCardBase__container {
   border-radius: 8px;
-  box-shadow: 0 16px 16px rgba(0, 0, 0, 0.16), 0 0 8px rgba(0, 0, 0, 0.12);
 }

--- a/src/components/ModalCardBase/ModalCardBase.tsx
+++ b/src/components/ModalCardBase/ModalCardBase.tsx
@@ -8,7 +8,7 @@ import { usePlatform } from "../../hooks/usePlatform";
 import { ViewWidth, withAdaptivity } from "../../hoc/withAdaptivity";
 import { HasRootRef } from "../../types";
 import { PanelHeaderButton } from "../PanelHeaderButton/PanelHeaderButton";
-import { ANDROID, IOS, Platform } from "../../lib/platform";
+import { IOS, Platform } from "../../lib/platform";
 import { ModalDismissButton } from "../ModalDismissButton/ModalDismissButton";
 import { Icon24Dismiss } from "@vkontakte/icons";
 import { useKeyboard } from "../../hooks/useKeyboard";
@@ -87,28 +87,24 @@ export const ModalCardBase = withAdaptivity<
     return (
       <div
         {...restProps}
-        // eslint-disable-next-line vkui/no-object-expression-in-arguments
-        vkuiClass={classNames(getClassName("ModalCardBase", platform), {
-          "ModalCardBase--desktop": isDesktop,
-        })}
+        vkuiClass={classNames(
+          getClassName("ModalCardBase", platform),
+          isDesktop && "ModalCardBase--desktop"
+        )}
         ref={getRootRef}
       >
         <div
-          // eslint-disable-next-line vkui/no-object-expression-in-arguments
-          vkuiClass={classNames("ModalCardBase__container", {
-            "ModalCardBase__container--softwareKeyboardOpened":
-              isSoftwareKeyboardOpened,
-          })}
+          vkuiClass={classNames(
+            "ModalCardBase__container",
+            isSoftwareKeyboardOpened &&
+              "ModalCardBase__container--softwareKeyboardOpened"
+          )}
         >
           {hasReactNode(icon) && (
             <div vkuiClass="ModalCardBase__icon">{icon}</div>
           )}
           {hasReactNode(header) && (
-            <Title
-              level="2"
-              weight={platform === ANDROID ? "2" : "1"}
-              vkuiClass="ModalCardBase__header"
-            >
+            <Title level="2" weight="2" vkuiClass="ModalCardBase__header">
               {header}
             </Title>
           )}
@@ -120,10 +116,10 @@ export const ModalCardBase = withAdaptivity<
 
           {hasReactNode(actions) && (
             <div
-              // eslint-disable-next-line vkui/no-object-expression-in-arguments
-              vkuiClass={classNames("ModalCardBase__actions", {
-                "ModalCardBase__actions--v": actionsLayout === "vertical",
-              })}
+              vkuiClass={classNames(
+                "ModalCardBase__actions",
+                actionsLayout === "vertical" && "ModalCardBase__actions--v"
+              )}
             >
               {actions}
             </div>

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -37,6 +37,12 @@ export type { InitialsAvatarProps } from "../components/InitialsAvatar/InitialsA
 export { InfoRow } from "../components/InfoRow/InfoRow";
 export type { InfoRowProps } from "../components/InfoRow/InfoRow";
 
+export { ModalCardBase } from "../components/ModalCardBase/ModalCardBase";
+export type { ModalCardBaseProps } from "../components/ModalCardBase/ModalCardBase";
+
+export { ModalCard } from "../components/ModalCard/ModalCard";
+export type { ModalCardProps } from "../components/ModalCard/ModalCard";
+
 export { Link } from "../components/Link/Link";
 export type { LinkProps } from "../components/Link/Link";
 


### PR DESCRIPTION
## Чеклист перевода компонента на vkui-tokens
- [ ] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [ ] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647)) 
- [ ] Исключаем проверки типа `platform === ANDROID` (пример такого PR [#2653](https://togithub.com/VKCOM/VKUI/pull/2653)) 
- [ ] В стилях компонента не осталось платформенных селекторов (остались, нет нужных токенов) 
- [ ] В tsx компонента не осталось логики, которая зависит от платформы 

---

- resolve #2554 

---

Как смотрите на то, чтобы выпилить в v5 вот эти строки из стилей:

```
.ModalCardBase .UsersStack + .ModalCardBase__actions {
  margin-top: 24px;
}

.ModalCardBase__header + .ModalCardBase__actions,
.ModalCardBase__subheader + .ModalCardBase__actions {
  margin-top: 32px;
}
```

На макетах в фигме используется для таких случаев `<Spacing />`, может, просто дать рекомендацию его и использовать с нужными отступами? 


