### PR TITLE
Optional Chaining для LinkRenderer

### DIFF
--- a/styleguide/Components/Link/LinkRenderer.js
+++ b/styleguide/Components/Link/LinkRenderer.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "@vkui";
 
 export const LinkRenderer = ({ href: _href, ...restProps }) => {
-  const href = _href.replace("https://vkcom.github.io/VKUI/", "");
+  const href = _href?.replace("https://vkcom.github.io/VKUI/", "");
 
   return <Link href={href} {...restProps} />;
 };


### PR DESCRIPTION
Если перейти на https://vkcom.github.io/VKUI/#/View, то рендер фейлится из-за наличия фейкового элемента для якорной ссылки