### PR TITLE
[Draft] fix(HorizontalScroll): fix problem with shadow cut

### DIFF
--- a/src/components/HorizontalScroll/HorizontalScroll.css
+++ b/src/components/HorizontalScroll/HorizontalScroll.css
@@ -1,11 +1,26 @@
 .HorizontalScroll {
   position: relative;
+}
 
-  /**
-   * ⚠️ WARNING ⚠️
-   * `overflow-y` мы не трогаем, т.к. из-за `hidden` могут обрезаться тени у потомков.
-   */
-  overflow-x: hidden;
+/**
+ * Перекрываем интерактивную область элемента со скроллом и отрицательным отступом.
+ */
+.HorizontalScroll--overflowVisible::before,
+.HorizontalScroll--overflowVisible::after {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  left: 0;
+  width: 100%;
+  height: var(--horizonalscroll-invisible-gap);
+}
+
+.HorizontalScroll--overflowVisible::before {
+  top: 0;
+}
+
+.HorizontalScroll--overflowVisible::after {
+  bottom: 0;
 }
 
 .HorizontalScroll__in {
@@ -14,7 +29,7 @@
 
   /**
    * Для удаление скролла в Firefox.
-   * В версии ниже 64 будет виден скролл, но это не ломает функциональность.
+   * В версии 63 и ниже будет виден скролл, но это не ломает функциональность.
    */
   scrollbar-width: none;
 }
@@ -23,18 +38,31 @@
   display: none;
 }
 
+.HorizontalScroll--overflowVisible .HorizontalScroll__in {
+  /**
+   * (см. подробности в описании используемой переменной)
+   */
+  margin-top: calc(-1 * var(--horizonalscroll-invisible-gap));
+  padding-top: var(--horizonalscroll-invisible-gap);
+  margin-bottom: calc(-1 * var(--horizonalscroll-invisible-gap));
+  padding-bottom: var(--horizonalscroll-invisible-gap);
+}
+
 .HorizontalScroll__in-wrapper {
-  transition: transform 0.2s;
+  transition: transform 0.2s ease-in-out;
 }
 
-.HorizontalScroll__arrowLeft:hover
-  ~ .HorizontalScroll__in
-  .HorizontalScroll__in-wrapper {
-  transform: translateX(8px);
+.HorizontalScroll--overflowVisible .HorizontalScroll__arrow {
+  top: var(--horizonalscroll-invisible-gap);
+  bottom: var(--horizonalscroll-invisible-gap);
 }
 
-.HorizontalScroll__arrowRight:hover
-  ~ .HorizontalScroll__in
-  .HorizontalScroll__in-wrapper {
-  transform: translateX(-8px);
+@media (hover: hover) {
+  .HorizontalScroll__arrow--left:hover + * + .HorizontalScroll__in-wrapper {
+    transform: translateX(8px);
+  }
+
+  .HorizontalScroll__arrow--right:hover + .HorizontalScroll__in-wrapper {
+    transform: translateX(-8px);
+  }
 }

--- a/src/components/HorizontalScroll/HorizontalScroll.e2e.tsx
+++ b/src/components/HorizontalScroll/HorizontalScroll.e2e.tsx
@@ -11,11 +11,26 @@ import { ConfigProvider } from "../ConfigProvider/ConfigProvider";
 import { Scheme } from "../../helpers/scheme";
 
 describe("HorizontalScroll", () => {
-  const items = new Array(20).fill(0).map((_, i) => (
-    <HorizontalCell key={i} header={`item ${i}`}>
-      <Avatar size={56} />
-    </HorizontalCell>
-  ));
+  const getItem = (i: number, withShadow?: boolean) => {
+    return (
+      <HorizontalCell
+        key={i}
+        header={`item ${i}`}
+        style={
+          withShadow
+            ? {
+                boxShadow:
+                  "0px 0px 8px rgba(0, 0, 0, 0.12), 0px 16px 16px rgba(0, 0, 0, 0.16)",
+              }
+            : undefined
+        }
+      >
+        <Avatar size={56} />
+      </HorizontalCell>
+    );
+  };
+
+  const items = new Array(20).fill(0).map((_, i) => getItem(i));
 
   describeScreenshotFuzz(
     HorizontalScroll,
@@ -23,6 +38,7 @@ describe("HorizontalScroll", () => {
       {
         showArrows: ["always"],
         arrowSize: ["m", "l"],
+        overflowVisible: [undefined, true],
         children: [
           <div key="0" style={{ display: "flex" }}>
             {items}
@@ -34,7 +50,7 @@ describe("HorizontalScroll", () => {
       platforms: [ANDROID],
       adaptivity: {
         viewWidth: ViewWidth.MOBILE,
-        hasMouse: false,
+        hasMouse: true,
       },
     }
   );
@@ -55,6 +71,29 @@ describe("HorizontalScroll", () => {
       adaptivity: {
         viewWidth: ViewWidth.SMALL_TABLET,
         hasMouse: true,
+      },
+    }
+  );
+
+  const itemsWithShadow = new Array(20).fill(0).map((_, i) => getItem(i, true));
+
+  describeScreenshotFuzz(
+    HorizontalScroll,
+    [
+      {
+        overflowVisible: [true],
+        children: [
+          <div key="0" style={{ display: "flex" }}>
+            {itemsWithShadow}
+          </div>,
+        ],
+      },
+    ],
+    {
+      platforms: [ANDROID],
+      adaptivity: {
+        viewWidth: ViewWidth.MOBILE,
+        hasMouse: false,
       },
     }
   );

--- a/src/components/HorizontalScroll/Readme.md
+++ b/src/components/HorizontalScroll/Readme.md
@@ -1,63 +1,87 @@
 Компонент для отрисовки "длинного" содержимого, которое можно скроллить по горизонтали.
 
 ```jsx
-import { useEffect, useState, Fragment } from "react";
+const buttonWrapperStyles = {
+  display: "flex",
+  gap: 8,
+  justifyContent: "center",
+};
 
 const HorizontalScrollExample = () => {
-  const [recentFriends] = useState(getRandomUsers(20));
-  const [commonFriends, setCommonFriends] = useState([]);
+  const [recentFriends] = React.useState(getRandomUsers(20));
+  const [commonFriends, setCommonFriends] = React.useState([]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     // Эмуляция загрузки
-    setTimeout(() => {
+    window.setTimeout(() => {
       setCommonFriends(getRandomUsers(20));
-    }, 500);
+    }, 700);
   }, []);
 
   return (
     <View activePanel="horizontal">
       <Panel id="horizontal">
         <PanelHeader>HorizontalScroll</PanelHeader>
-        <Group header={<Header mode="secondary">Недавние</Header>}>
+        <Group header={<Header mode="secondary">Стандартный пример</Header>}>
           <HorizontalScroll
-            showArrows
             getScrollToLeft={(i) => i - 120}
             getScrollToRight={(i) => i + 120}
           >
             <div style={{ display: "flex" }}>
-              {recentFriends.map((item) => {
-                return (
-                  <HorizontalCell key={item.id} header={item.first_name}>
-                    <Avatar size={56} src={item.photo_200} />
-                  </HorizontalCell>
-                );
-              })}
+              {recentFriends.map((item) => (
+                <HorizontalCell key={item.id} header={item.first_name}>
+                  <Avatar size={56} src={item.photo_200} />
+                </HorizontalCell>
+              ))}
             </div>
           </HorizontalScroll>
         </Group>
 
-        <Group header={<Header mode="secondary">Общие друзья</Header>}>
+        <Group header={<Header mode="secondary">Пример посложнее</Header>}>
+          <div style={buttonWrapperStyles}>
+            <button style={{ position: "relative", zIndex: 2 }}>
+              Клибально
+            </button>
+            <button>Не клибально</button>
+          </div>
+          <Spacing size={8} />
           <HorizontalScroll
-            showArrows
+            showArrows="always"
             arrowSize="m"
+            overflowVisible // ⚠️ см. описание параметра в "Свойства и методы"
             getScrollToLeft={(i) => i - 120}
             getScrollToRight={(i) => i + 120}
           >
-            <div style={{ display: "flex" }}>
+            <div
+              style={{
+                display: "flex",
+                gap: 16,
+              }}
+            >
               {commonFriends.length === 0 && <PanelSpinner />}
               {commonFriends.length > 0 && (
-                <Fragment>
-                  {commonFriends.map((item) => {
-                    return (
-                      <HorizontalCell key={item.id} header={item.first_name}>
-                        <Avatar size={56} src={item.photo_200} />
-                      </HorizontalCell>
-                    );
-                  })}
-                </Fragment>
+                <React.Fragment>
+                  <div style={{ width: 1, flexShrink: 0 }} />
+                  {commonFriends.map((item) => (
+                    <Avatar
+                      key={item.id}
+                      size={56}
+                      src={item.photo_200}
+                      style={{
+                        boxShadow: "var(--vkui--elevation4)",
+                      }}
+                    />
+                  ))}
+                  <div style={{ width: 1, flexShrink: 0 }} />
+                </React.Fragment>
               )}
             </div>
           </HorizontalScroll>
+          <Spacing size={8} />
+          <div style={buttonWrapperStyles}>
+            <button style={{ position: "relative" }}>Клибально</button>
+            <button>Не клибально</button>
+          </div>
         </Group>
       </Panel>
     </View>

--- a/src/components/HorizontalScrollArrow/HorizontalScrollArrow.css
+++ b/src/components/HorizontalScrollArrow/HorizontalScrollArrow.css
@@ -3,17 +3,30 @@
   cursor: pointer;
   user-select: auto;
   top: 0;
-  height: 100%;
+  bottom: 0;
   padding: 0;
   opacity: 0;
+  visibility: hidden;
   z-index: 3;
   border: none;
   background-color: transparent;
-  transition: opacity 0.15s;
+  transition: opacity 0.15s, visibility 0.15s 0.15s;
   transition-timing-function: var(--android-easing);
   display: flex;
   flex-direction: column;
   justify-content: center;
+}
+
+.HorizontalScrollArrow--visible {
+  opacity: var(--vkui--opacity_disable_accessibility);
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+.HorizontalScrollArrow--hover {
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0s;
 }
 
 .HorizontalScrollArrow__icon {
@@ -55,19 +68,4 @@
  */
 .HorizontalScrollArrow--ios .HorizontalScrollArrow {
   transition-timing-function: var(--ios-easing);
-}
-
-/**
- * CMP: Gallery, HorizontalScroll
- */
-.Gallery:hover .HorizontalScrollArrow,
-.HorizontalScroll:hover .HorizontalScrollArrow {
-  opacity: var(--vkui--opacity_disable_accessibility);
-}
-
-.Gallery:hover .HorizontalScrollArrow:hover,
-.HorizontalScroll:hover .HorizontalScrollArrow:hover,
-.HorizontalScroll--withConstArrows .HorizontalScrollArrow,
-.HorizontalScroll--withConstArrows:hover .HorizontalScrollArrow {
-  opacity: 1;
 }

--- a/src/components/HorizontalScrollArrow/HorizontalScrollArrow.tsx
+++ b/src/components/HorizontalScrollArrow/HorizontalScrollArrow.tsx
@@ -11,19 +11,50 @@ import { IOS } from "../../lib/platform";
 import { Tappable } from "../Tappable/Tappable";
 import "./HorizontalScrollArrow.css";
 
+export interface HorizontalScrollArrowController {
+  setAvailable(value: boolean): void;
+  setVisible(value: boolean): void;
+}
+
 export interface HorizontalScrollArrowProps {
   direction: "left" | "right";
   size?: "m" | "l";
+  visilble?: boolean;
+  controller?: React.Ref<HorizontalScrollArrowController>;
   onClick(): void;
 }
 
+/**
+ * Внутренний компонент.
+ *
+ * По умолчанию невидим и недоступен. Для изменения этого, надо использовать `controller`.
+ *
+ * Чтобы компонент был всегда виден при доступности, передайте `visible={true}`.
+ */
 export const HorizontalScrollArrow = ({
   size = "l",
   direction,
+  visilble: visilbleProp = false,
+  controller,
   onClick,
   ...restProps
 }: HorizontalScrollArrowProps) => {
   const platform = usePlatform();
+
+  const [available, setAvailable] = React.useState(false);
+  const [visible, setVisible] = React.useState(false);
+
+  React.useImperativeHandle(
+    controller,
+    () => {
+      return {
+        setAvailable,
+        setVisible,
+      };
+    },
+    []
+  );
+
   let ArrowIcon: React.ComponentType<unknown>;
 
   if (size === "m") {
@@ -36,12 +67,16 @@ export const HorizontalScrollArrow = ({
     <Tappable
       {...restProps}
       Component="button"
-      hasHover={false}
+      hasHover={available}
       hasActive={false}
+      hoverMode="HorizontalScrollArrow--hover"
       vkuiClass={classNames(
         "HorizontalScrollArrow",
         `HorizontalScrollArrow--${size}`,
         `HorizontalScrollArrow--${direction}`,
+        available &&
+          (visilbleProp || visible) &&
+          "HorizontalScrollArrow--visible",
         platform === IOS && "HorizontalScrollArrow--ios"
       )}
       onClick={onClick}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -40,8 +40,8 @@
 @import "../components/Epic/Epic.css";
 @import "../components/Tabbar/Tabbar.css";
 @import "../components/TabbarItem/TabbarItem.css";
+@import "../components/HorizontalScrollArrow/HorizontalScrollArrow.css";
 @import "../components/HorizontalScroll/HorizontalScroll.css";
-@import "../components/HorizontalScroll/HorizontalScrollArrow.css";
 
 /* Popouts */
 @import "../components/PopoutWrapper/PopoutWrapper.css";

--- a/src/styles/constants.css
+++ b/src/styles/constants.css
@@ -28,6 +28,21 @@
   --panelheader_height_vkcom: 48px;
   --search_default_height: 36px;
   --thin-border: 1px;
+  /**
+   * Параметр для увелечения видимой области контейнера, чтобы не обрезались тени, если они есть у внутренних элементов.
+   *
+   * Пример:
+   * ```
+   * margin-top: calc(-1 * var(--horizonalscroll-fake-gap));
+   * padding-top: var(--horizonalscroll-fake-gap);
+   * margin-bottom: calc(-1 * var(--horizonalscroll-fake-gap));
+   * padding-bottom: var(--horizonalscroll-fake-gap);
+   * ```
+   *
+   * ⚠️ WARNING ⚠️
+   * На хост-элементе не должно быть `overflow: hidden`.
+   */
+  --horizonalscroll-invisible-gap: 32px;
 
   /* paddings */
   /* TODO: v5 удалить */


### PR DESCRIPTION
PR #2862 не решил проблему обрезания теней.

В этом PR применил иной подход, который решает проблему, но при этом имеет недостаток. Написал о нём в комментарии к параметру `overflowVisible`.

## Допонительно

Избавился от обращения от одного блока к другому в `HorizontalScrollArrow`.

---

- fix #2860
