### PR TITLE
ci: GH_TOKEN for GitHub CLI

### DIFF
--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -39,3 +39,4 @@ jobs:
         env:
           INPUT_GITHUB_PULL_NUMBER: ${{ github.event.number }}
           INPUT_GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> To use GitHub CLI in a GitHub Actions workflow,
set the GH_TOKEN environment variable.

[Close PR #55](https://github.com/VKCOM/VKUI/runs/7496269102?check_suite_focus=true)