### PR TITLE
docs: remove ComponentType

### DIFF
--- a/src/hoc/withAdaptivity.tsx
+++ b/src/hoc/withAdaptivity.tsx
@@ -24,10 +24,10 @@ interface Config {
 export function withAdaptivity<T extends AdaptivityProps>(
   TargetComponent: React.ComponentType<T>,
   config: Config
-): React.ComponentType<Omit<T, keyof AdaptivityContextInterface> & SizeProps> {
-  const AdaptivityConsumer: React.ComponentType<
-    Omit<T, keyof AdaptivityContextInterface> & SizeProps
-  > = (props: Omit<T, keyof AdaptivityContextInterface> & SizeProps) => {
+): React.FC<Omit<T, keyof AdaptivityContextInterface> & SizeProps> {
+  const AdaptivityConsumer = (
+    props: Omit<T, keyof AdaptivityContextInterface> & SizeProps
+  ) => {
     const context = React.useContext(AdaptivityContext);
     let update = false;
 

--- a/src/hoc/withContext.tsx
+++ b/src/hoc/withContext.tsx
@@ -4,7 +4,7 @@ export function withContext<T, X>(
   Component: React.ComponentType<T>,
   Ctx: React.Context<X>,
   prop: string
-): React.ComponentType<T> {
+): React.FC<T> {
   function WithContext(props: T) {
     const context = React.useContext<X>(Ctx);
 

--- a/src/hoc/withPlatform.tsx
+++ b/src/hoc/withPlatform.tsx
@@ -5,7 +5,7 @@ import { ConfigProviderContext } from "../components/ConfigProvider/ConfigProvid
 
 export function withPlatform<T extends HasPlatform>(
   Component: React.ComponentType<T>
-): React.ComponentType<Omit<T, keyof HasPlatform>> {
+): React.FC<Omit<T, keyof HasPlatform>> {
   function WithPlatform(props: Omit<T, keyof HasPlatform>) {
     const ssrContext = React.useContext(SSRContext);
     const { platform } = React.useContext(ConfigProviderContext);


### PR DESCRIPTION
react-docgen-typescript не поддерживает `ComponentType`. Из-за этого не загружались свойства компонентов