### PR TITLE
feat(WriteBar): Tokenize

### DIFF
--- a/src/components/SplitCol/SplitCol.css
+++ b/src/components/SplitCol/SplitCol.css
@@ -7,7 +7,7 @@
 }
 
 .SplitCol--spaced {
-  padding: 0 var(--vkui--size_split_col_padding_horizontal--regular);
+  margin: 0 var(--vkui--size_split_col_padding_horizontal--regular);
 }
 
 .SplitCol--fixed {

--- a/src/components/Typography/Headline/Headline.tsx
+++ b/src/components/Typography/Headline/Headline.tsx
@@ -1,13 +1,15 @@
 import * as React from "react";
-import { HasComponent } from "../../../types";
+import { HasComponent, HasRootRef } from "../../../types";
 import { usePlatform } from "../../../hooks/usePlatform";
 import { useAdaptivity } from "../../../hooks/useAdaptivity";
 import { classNames } from "../../../lib/classNames";
+import { warnOnce } from "../../../lib/warnOnce";
 import { getClassName } from "../../../helpers/getClassName";
 import "./Headline.css";
 
 export interface HeadlineProps
   extends React.AllHTMLAttributes<HTMLElement>,
+    HasRootRef<HTMLElement>,
     HasComponent {
   /**
    * Задаёт начертание шрифта отличное от стандартного.
@@ -18,6 +20,8 @@ export interface HeadlineProps
   level?: "1" | "2";
 }
 
+const warn = warnOnce("Headline");
+
 /**
  * @see https://vkcom.github.io/VKUI/#/Headline
  */
@@ -26,14 +30,24 @@ export const Headline = ({
   weight = "3",
   level = "1",
   Component = "h3", // TODO: v5 h4
+  getRootRef,
   ...restProps
 }: HeadlineProps) => {
   const platform = usePlatform();
   const { sizeY } = useAdaptivity();
 
+  if (
+    process.env.NODE_ENV === "development" &&
+    typeof Component !== "string" &&
+    getRootRef
+  ) {
+    warn("getRootRef может использоваться только с элементами DOM", "error");
+  }
+
   return (
     <Component
       {...restProps}
+      ref={getRootRef}
       vkuiClass={classNames(
         getClassName("Headline", platform), // TODO: v5 remove
         `Headline--sizeY-${sizeY}`, // TODO: новая адаптивность

--- a/src/components/WriteBar/WriteBar.css
+++ b/src/components/WriteBar/WriteBar.css
@@ -1,5 +1,9 @@
 .WriteBar {
-  background: var(--background_content);
+  background: var(--background_content, var(--vkui--color_background_modal));
+}
+
+.WriteBar--shadow {
+  box-shadow: var(--vkui--elevation3);
 }
 
 .WriteBar__before,
@@ -29,25 +33,37 @@
   background: transparent;
   border: none;
   resize: none;
-  line-height: 20px;
-  color: var(--text_primary);
+  color: var(--text_primary, var(--vkui--color_text_primary));
   -webkit-appearance: none;
   max-height: 120px;
 }
 
 .WriteBar__textarea::placeholder {
-  color: var(--text_placeholder);
+  color: var(--text_placeholder, var(--vkui--color_text_subhead));
 }
 
 /* stylelint-disable-next-line selector-no-vendor-prefix */
 .WriteBar__textarea::-moz-placeholder {
   opacity: 1;
-  color: var(--text_placeholder);
+  color: var(--text_placeholder, var(--vkui--color_text_subhead));
 }
 
 .WriteBar__inlineAfter {
   display: flex;
   align-items: flex-end;
+}
+
+.WriteBar__before {
+  padding-left: 4px;
+}
+
+.WriteBar__after {
+  padding-right: 4px;
+}
+
+.WriteBar__textarea {
+  height: 52px;
+  padding: 16px 12px;
 }
 
 /**
@@ -61,8 +77,12 @@
 
 .WriteBar--ios .WriteBar__formIn {
   box-sizing: border-box;
-  background-color: var(--input_background);
-  border: 1px solid var(--input_border);
+  background-color: var(
+    --input_background,
+    var(--vkui--color_field_background)
+  );
+  border: var(--thin-border) solid
+    var(--input_border, var(--vkui--color_field_border_alpha));
   border-radius: 18px;
   margin: 8px 0;
 }
@@ -82,26 +102,4 @@
   padding: 6px 11px;
   font-size: 17px;
   line-height: 22px;
-}
-
-/**
- * Android + vkcom
- */
-
-.WriteBar--android .WriteBar__before,
-.WriteBar--vkcom .WriteBar__before {
-  padding-left: 4px;
-}
-
-.WriteBar--android .WriteBar__after,
-.WriteBar--vkcom .WriteBar__after {
-  padding-right: 4px;
-}
-
-.WriteBar--android .WriteBar__textarea,
-.WriteBar--vkcom .WriteBar__textarea {
-  height: 52px;
-  padding: 16px 12px;
-  font-size: 16px;
-  line-height: 20px;
 }

--- a/src/components/WriteBar/WriteBar.tsx
+++ b/src/components/WriteBar/WriteBar.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
+import { Headline } from "../Typography/Headline/Headline";
 import { usePlatform } from "../../hooks/usePlatform";
 import { useExternRef } from "../../hooks/useExternRef";
 import { hasReactNode, isFunction } from "../../lib/utils";
-import { getClassName } from "../../helpers/getClassName";
+import { classNames } from "../../lib/classNames";
+import { IOS } from "../../lib/platform";
 import { HasRef, HasRootRef } from "../../types";
 import "./WriteBar.css";
 
@@ -26,6 +28,10 @@ export interface WriteBarProps
    * Вызывается при смене высоты поля ввода
    */
   onHeightChange?: VoidFunction;
+  /**
+   * Добавляет тень вокруг поля ввода
+   */
+  shadow?: boolean;
 
   children?: never;
 }
@@ -44,6 +50,7 @@ export const WriteBar = ({
   getRootRef,
   getRef,
   onHeightChange,
+  shadow = false,
   ...restProps
 }: WriteBarProps) => {
   const platform = usePlatform();
@@ -92,7 +99,11 @@ export const WriteBar = ({
   return (
     <div
       ref={getRootRef}
-      vkuiClass={getClassName("WriteBar", platform)}
+      vkuiClass={classNames(
+        "WriteBar",
+        platform === IOS && "WriteBar--ios",
+        shadow && "WriteBar--shadow"
+      )}
       className={className}
       style={style}
     >
@@ -102,14 +113,14 @@ export const WriteBar = ({
         )}
 
         <div vkuiClass="WriteBar__formIn">
-          <textarea
+          <Headline
             {...restProps}
+            Component="textarea"
             vkuiClass="WriteBar__textarea"
             onChange={onTextareaChange}
-            ref={textareaRef}
+            getRootRef={textareaRef}
             value={value}
           />
-
           {hasReactNode(inlineAfter) && (
             <div vkuiClass="WriteBar__inlineAfter">{inlineAfter}</div>
           )}

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -25,6 +25,9 @@ export type { CardScrollProps } from "../components/CardScroll/CardScroll";
 export { Group } from "../components/Group/Group";
 export type { GroupProps } from "../components/Group/Group";
 
+export { WriteBar } from "../components/WriteBar/WriteBar";
+export type { WriteBarProps } from "../components/WriteBar/WriteBar";
+
 export { Cell } from "../components/Cell/Cell";
 export type { CellProps } from "../components/Cell/Cell";
 


### PR DESCRIPTION
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647))
- [x] Исключаем проверки типа `platform === ANDROID` (пример такого PR [#2653](https://togithub.com/VKCOM/VKUI/pull/2653)) (осталось для iOS)
- [x] В стилях компонента не осталось платформенных селекторов (осталось для iOS)
- [x] В tsx компонента не осталось логики, которая зависит от платформы (осталось для iOS)

---

- resolve #2590 
