### PR TITLE
feat(SplitLayout): Tokenize

### DIFF
--- a/src/components/SplitLayout/SplitLayout.css
+++ b/src/components/SplitLayout/SplitLayout.css
@@ -16,18 +16,14 @@
 .SplitLayout__inner--header {
   position: relative;
   z-index: 11;
+  margin-top: calc(
+    -1 * (var(--panelheader_height) + var(--safe-area-inset-top))
+  );
 }
 
 .SplitLayout--ios .SplitLayout__inner--header {
   margin-top: calc(
     -1 * (var(--panelheader_height_ios) + var(--safe-area-inset-top))
-  );
-}
-
-.SplitLayout--android .SplitLayout__inner--header,
-.SplitLayout--vkcom .SplitLayout__inner--header {
-  margin-top: calc(
-    -1 * (var(--panelheader_height) + var(--safe-area-inset-top))
   );
 }
 

--- a/src/components/SplitLayout/SplitLayout.tsx
+++ b/src/components/SplitLayout/SplitLayout.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { getClassName } from "../../helpers/getClassName";
 import { classNames } from "../../lib/classNames";
+import { IOS } from "../../lib/platform";
 import { HasRef, HasRootRef } from "../../types";
 import { PopoutRoot } from "../PopoutRoot/PopoutRoot";
 import { usePlatform } from "../../hooks/usePlatform";
@@ -37,7 +37,10 @@ export const SplitLayout = ({
 
   return (
     <PopoutRoot
-      vkuiClass={getClassName("SplitLayout", platform)}
+      vkuiClass={classNames(
+        "SplitLayout",
+        platform === IOS && "SplitLayout--ios"
+      )}
       popout={popout}
       modal={modal}
       getRootRef={getRootRef}
@@ -46,10 +49,10 @@ export const SplitLayout = ({
       <div
         {...restProps}
         ref={getRef}
-        // eslint-disable-next-line vkui/no-object-expression-in-arguments
-        vkuiClass={classNames("SplitLayout__inner", {
-          "SplitLayout__inner--header": !!header,
-        })}
+        vkuiClass={classNames(
+          "SplitLayout__inner",
+          !!header && "SplitLayout__inner--header"
+        )}
       >
         {children}
       </div>

--- a/src/tokenized/index.ts
+++ b/src/tokenized/index.ts
@@ -215,6 +215,9 @@ export type { ChipsSelectProps } from "../components/ChipsSelect/ChipsSelect";
 export { Spacing } from "../components/Spacing/Spacing";
 export type { SpacingProps } from "../components/Spacing/Spacing";
 
+export { SplitLayout } from "../components/SplitLayout/SplitLayout";
+export type { SplitLayoutProps } from "../components/SplitLayout/SplitLayout";
+
 export { SplitCol } from "../components/SplitCol/SplitCol";
 export type { SplitColProps } from "../components/SplitCol/SplitCol";
 


### PR DESCRIPTION
## Чеклист перевода компонента на vkui-tokens
- [x] Компонент добавлен в `src/tokenized/index.ts` (в `src/index.ts` он так же должен быть)
- [x] Если в стилях встречаются токены из Appearance, то их нужно не удалять, а дополнять фоллбэком на соответствующий токен из vkui-tokens (пример такого PR [#2647](https://togithub.com/VKCOM/VKUI/pull/2647))
- [x] Исключаем проверки типа `platform === ANDROID` (пример такого PR [#2653](https://togithub.com/VKCOM/VKUI/pull/2653)) (_осталось для iOS_)
- [x] В стилях компонента не осталось платформенных селекторов (_осталось для iOS_)
- [x] В tsx компонента не осталось логики, которая зависит от платформы (_осталось для iOS_)

---

- resolve #2579 
