### PR TITLE
ci(patch): fix instructions about conflicts

### DIFF
--- a/.github/gitflow/patch.js
+++ b/.github/gitflow/patch.js
@@ -42,7 +42,7 @@ git checkout -b patch/pr${pullNumber} ${stableBranchRef}
 git cherry-pick ${patchRefs}
 \`\`\`
 
-2. Исправьте конфликты, пометьте файлы \`git add/rm <pathspec>\`, запустите \`git cherry-pick --continue\`
+2. Исправьте конфликты, следуя инструкциям из терминала
 3. Отправьте ветку на GitHub и создайте новый PR с последней стабильной веткой (метка patch не нужна)
 
 \`\`\`bash


### PR DESCRIPTION
Бывают разные сценарии при конфликтах. Например если коммит один, git будет требовать следующее

> hint: after resolving the conflicts, mark the corrected paths
> hint: with 'git add <paths>' or 'git rm <paths>'
> hint: and commit the result with 'git commit'