### PR TITLE
v5.0.0 Добавляем в доку по миграции переименованные пропсы

### DIFF
--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -166,52 +166,41 @@
 + <Button mode="outline" appearance="overlay">
 ```
 
-### ButtonGroup
+### Banner
 
-- В параметр `actions` компонентов `Banner` и `ModalCardBase` для группировки кнопок теперь нужно передавать `ButtonGroup` вместо `React.Fragment`
+- В параметр `actions` для группировки кнопок теперь передается `ButtonGroup` вместо `React.Fragment`
 
-  ```diff
-  - <Banner
-  -   actions={{
-  -     <React.Fragment>
-  -       <Button mode="primary">Подробнее</Button>
-  -       <Button mode="tertiary" hasHover={false}>Напомнить позже</Button>
-  -     </React.Fragment>
-  -   }}
-  - />
-  + <Banner
-  +   actions={{
-  +     <ButtonGroup mode="horizontal" gap="m">
-  +       <Button>Подробнее</Button>
-  +       <Button mode="secondary">Напомнить позже</Button>
-  +     </ButtonGroup>
-  +   }}
-  + />
-  ```
+```diff
+<Banner
+  actions={{
+-  <React.Fragment>
++  <ButtonGroup mode="horizontal" gap="m">
+    <Button>Подробнее</Button>
+    <Button mode="secondary">Напомнить позже</Button>
+-  </React.Fragment>
++  </ButtonGroup>
+  }}
+/>
+```
 
-  ```diff
-  - <ModalCardBase
-  -   actionsLayout="vertical"
-  -   actions={{
-  -     <React.Fragment key="buttons">
-  -       <Button size="l" mode="primary">Присоединиться</Button>
-  -       <Button size="l" mode="secondary">Скопировать приглашение</Button>
-  -     </React.Fragment>
-  -   }}
-  - />
-  + <ModalCardBase
-  +   actions={{
-  +     <ButtonGroup mode="vertical" gap="m" stretched>
-  +       <Button size="l" mode="primary" stretched>
-  +         Присоединиться
-  +       </Button>
-  +       <Button size="l" mode="secondary" stretched>
-  +         Скопировать приглашение
-  +       </Button>
-  +     </ButtonGroup>
-  +   }}
-  + />
-  ```
+### ModalCardBase
+
+- Устаревшее свойство `actionsLayout` удалено
+- В параметр `actions` для группировки кнопок теперь передается `ButtonGroup` вместо `React.Fragment`
+
+```diff
+<ModalCardBase
+-  actionsLayout="vertical"
+  actions={{
+-    <React.Fragment key="buttons">
++    <ButtonGroup mode="vertical" gap="m" stretched>
+      <Button size="l" mode="primary">Присоединиться</Button>
+      <Button size="l" mode="secondary">Скопировать приглашение</Button>
+-    </React.Fragment>
++    </ButtonGroup>
+  }}
+/>
+```
 
 ### SliderSwitch
 

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -119,6 +119,21 @@
 
 - Обновлено свойство `onInputChange`. Для фильтрации обновляйте `props.options` самостоятельно или используйте свойство `filterFn`
 
+### PanelHeader
+
+- Свойства `left` и `right` переименованы в `before` и `after`
+
+```diff
+ <PanelHeader
+-  left={<PanelHeaderClose />}
++  before={<PanelHeaderClose />}
+-  right={<Avatar size={36} />}
++  after={<Avatar size={36} />}
+ >
+   Стартовый экран
+ </PanelHeader>
+```
+
 ### Button
 
 - Удалены устаревшие значения свойства `mode` (`commerce`, `destructive`, `overlay_...`). Используйте свойства `mode` и `appearance`

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -245,4 +245,5 @@
 - Удалены константы `IS_PLATFORM_ANDROID` и `IS_PLATFORM_IOS`
 - Удален тип `Scheme`
 - Удалена css переменная `--font-tt`, используйте `--font-display`
+- Тип `VKUITouchEventHander` переименован в `VKUITouchEventHandler`
 - Удалены константы `ANDROID`, `IOS` и `VKCOM`, используйте `enum` `Platform.ANDROID / Platform.IOS, Platform.VKCOM`

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -59,6 +59,17 @@
  />
 ```
 
+### ActionSheetItem
+
+- Свойство `autoclose` типа _`ItemClickHandler`_ переименовано в `autoClose`
+
+```diff
+<ActionSheet>
+-  <ActionSheetItem autoclose>Сохранить в закладках</ActionSheetItem>
++  <ActionSheetItem autoClose>Сохранить в закладках</ActionSheetItem>
+</ActionSheet>
+```
+
 ### BannerData
 
 - Удалено свойство `ageRestriction`, добавленное по ошибке. Используйте свойство `ageRestrictions`

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -1,13 +1,15 @@
 Документацию по миграции c v3 на v4 можно найти [здесь](https://github.com/VKCOM/VKUI/releases/tag/v4.0.0).
 
+### &nbsp;
+
 ## Обновление React и Typescript
 
 - Минимальная поддерживаемая версия **React** увеличена до v17.0.0
 - Минимальная поддерживаемая версия **Typescript** увеличена до v4.4.4
 
-## Обратно несовместимые изменения
+### &nbsp;
 
-### ConfigProvider
+## [`ConfigProvider`](#/ConfigProvider)
 
 - По умолчанию `appearance` определяется автоматически — в зависимости от темы, указанной в VK, или настроек ОС
 - Удалено устаревшее свойство `scheme`. Для определения темы используйте свойство `appearance`
@@ -17,7 +19,9 @@
 + <ConfigProvider appearance={appearance}>...</ConfigProvider>
 ```
 
-### Root и View
+### &nbsp;
+
+## [`Root`](#/Root) и [`View`](#/View)
 
 - Удалены устаревшие свойства `popout` и `modal`. Используйте эти свойства в компоненте [`SplitLayout`](#/SplitLayout)
 
@@ -31,7 +35,9 @@
  </SplitLayout>
 ```
 
-### Alert
+### &nbsp;
+
+## [`Alert`](#/Alert)
 
 - Свойство `autoclose` типа _`AlertAction`_ переименовано в `autoClose`
 
@@ -56,7 +62,9 @@
  />
 ```
 
-### ActionSheetItem
+### &nbsp;
+
+## [`ActionSheetItem`](#/ActionSheetItem)
 
 - Свойство `autoclose` типа _`ItemClickHandler`_ переименовано в `autoClose`
 
@@ -67,15 +75,21 @@
 </ActionSheet>
 ```
 
-### PromoBanner
+### &nbsp;
+
+## [`PromoBanner`](#/PromoBanner)
 
 - Удалено свойство `ageRestriction` в типe _`BannerData`_, добавленное по ошибке. Используйте свойство `ageRestrictions`
 
-### ContentCard
+### &nbsp;
+
+## [`ContentCard`](#/ContentCard)
 
 - Удалено устаревшее свойство `image`. Используйте свойство `src`
 
-### IconButton
+### &nbsp;
+
+## [`IconButton`](#/IconButton)
 
 - Удалено устаревшее свойство `icon`. Передавайте иконки как `children`
 
@@ -86,7 +100,9 @@
 + </IconButton>
 ```
 
-### TabbarItem
+### &nbsp;
+
+## [`TabbarItem`](#/TabbarItem)
 
 - Удалено устаревшее свойство `label`. Используйте свойство `indicator`
 
@@ -103,7 +119,9 @@
  </TabbarItem>
 ```
 
-### Cell
+### &nbsp;
+
+## [`Cell`](#/Cell)
 
 - Удалены устаревшие свойства `removable` и `selectable`. Используйте свойства `mode="removable"` и `mode="selectable"`
 
@@ -114,7 +132,9 @@
 + <Cell mode="selectable">
 ```
 
-### AppRoot
+### &nbsp;
+
+## [`AppRoot`](#/AppRoot)
 
 - Удалено устаревшее свойство `embedded`. Используйте свойство `mode="embedded"`
 
@@ -123,11 +143,15 @@
 + <AppRoot mode="embedded">...</AppRoot>
 ```
 
-### CustomSelect
+### &nbsp;
+
+## [`CustomSelect`](#/CustomSelect)
 
 - Обновлено свойство `onInputChange`. Для фильтрации обновляйте `props.options` самостоятельно или используйте свойство `filterFn`
 
-### PanelHeader
+### &nbsp;
+
+## [`PanelHeader`](#/PanelHeader)
 
 - Свойства `left` и `right` переименованы в `before` и `after`
 
@@ -142,7 +166,9 @@
  </PanelHeader>
 ```
 
-### Button
+### &nbsp;
+
+## [`Button`](#/Button)
 
 - Удалены устаревшие значения свойства `mode` (`commerce`, `destructive`, `overlay_...`). Используйте свойства `mode` и `appearance`
 
@@ -163,7 +189,9 @@
 + <Button mode="outline" appearance="overlay">
 ```
 
-### Banner
+### &nbsp;
+
+## [`Banner`](#/Banner)
 
 - В параметр `actions` для группировки кнопок теперь передается `ButtonGroup` вместо `React.Fragment`
 
@@ -180,7 +208,9 @@
 />
 ```
 
-### ModalCardBase
+### &nbsp;
+
+## [`ModalCardBase`](#/ModalCardBase)
 
 - Устаревшее свойство `actionsLayout` удалено
 - В параметр `actions` для группировки кнопок теперь передается `ButtonGroup` вместо `React.Fragment`
@@ -199,7 +229,9 @@
 />
 ```
 
-### SliderSwitch
+### &nbsp;
+
+## [`SliderSwitch`](#/SliderSwitch)
 
 Устаревший компонент удален. Используйте [`SegmentedControl`](#/SegmentedControl)
 
@@ -221,12 +253,16 @@
  />
 ```
 
-### Gallery
+### &nbsp;
+
+## [`Gallery`](#/Gallery)
 
 - Вызов функции `onDragStart` теперь происходит только в начале drag event
 - Удалено свойство `onEnd`. Используйте свойство `onDragEnd`, которое теперь принимает индекс слайда вторым параметром
 
-### Импорты
+### &nbsp;
+
+## Типы и импорты
 
 - Удалены константы `IS_PLATFORM_ANDROID` и `IS_PLATFORM_IOS`
 - Удален тип `Scheme`

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -70,9 +70,9 @@
 </ActionSheet>
 ```
 
-### BannerData
+### PromoBanner
 
-- Удалено свойство `ageRestriction`, добавленное по ошибке. Используйте свойство `ageRestrictions`
+- Удалено свойство `ageRestriction` в типe _`BannerData`_, добавленное по ошибке. Используйте свойство `ageRestrictions`
 
 ### ContentCard
 

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -262,6 +262,13 @@
 
 <br/><br/>
 
+## [`Tabs`](#/Tabs)
+
+- `mode="buttons"` удалён. Используйте `mode="secondary"`.
+- `mode="segmented"` удалён. Используйте [`SegmentedControl`](#/SegmentedControl).
+
+<br/><br/>
+
 ## Типы и импорты
 
 - Удалены константы `IS_PLATFORM_ANDROID` и `IS_PLATFORM_IOS`

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -1,13 +1,13 @@
 Документацию по миграции c v3 на v4 можно найти [здесь](https://github.com/VKCOM/VKUI/releases/tag/v4.0.0).
 
-### &nbsp;
+<br/><br/>
 
 ## Обновление React и Typescript
 
 - Минимальная поддерживаемая версия **React** увеличена до v17.0.0
 - Минимальная поддерживаемая версия **Typescript** увеличена до v4.4.4
 
-### &nbsp;
+<br/><br/>
 
 ## [`ConfigProvider`](#/ConfigProvider)
 
@@ -19,7 +19,7 @@
 + <ConfigProvider appearance={appearance}>...</ConfigProvider>
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`Root`](#/Root) и [`View`](#/View)
 
@@ -35,11 +35,11 @@
  </SplitLayout>
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`Alert`](#/Alert)
 
-- Свойство `autoclose` типа _`AlertAction`_ переименовано в `autoClose`
+- Свойство `autoclose` типа `AlertAction` переименовано в `autoClose`
 
 ```diff
  <Alert
@@ -62,11 +62,11 @@
  />
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`ActionSheetItem`](#/ActionSheetItem)
 
-- Свойство `autoclose` типа _`ItemClickHandler`_ переименовано в `autoClose`
+- Свойство `autoclose` типа `ItemClickHandler` переименовано в `autoClose`
 
 ```diff
 <ActionSheet>
@@ -75,19 +75,19 @@
 </ActionSheet>
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`PromoBanner`](#/PromoBanner)
 
-- Удалено свойство `ageRestriction` в типe _`BannerData`_, добавленное по ошибке. Используйте свойство `ageRestrictions`
+- Удалено свойство `ageRestriction` в типe `BannerData`, добавленное по ошибке. Используйте свойство `ageRestrictions`
 
-### &nbsp;
+<br/><br/>
 
 ## [`ContentCard`](#/ContentCard)
 
 - Удалено устаревшее свойство `image`. Используйте свойство `src`
 
-### &nbsp;
+<br/><br/>
 
 ## [`IconButton`](#/IconButton)
 
@@ -100,7 +100,7 @@
 + </IconButton>
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`TabbarItem`](#/TabbarItem)
 
@@ -119,7 +119,7 @@
  </TabbarItem>
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`Cell`](#/Cell)
 
@@ -132,7 +132,7 @@
 + <Cell mode="selectable">
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`AppRoot`](#/AppRoot)
 
@@ -143,13 +143,13 @@
 + <AppRoot mode="embedded">...</AppRoot>
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`CustomSelect`](#/CustomSelect)
 
 - Обновлено свойство `onInputChange`. Для фильтрации обновляйте `props.options` самостоятельно или используйте свойство `filterFn`
 
-### &nbsp;
+<br/><br/>
 
 ## [`PanelHeader`](#/PanelHeader)
 
@@ -166,7 +166,7 @@
  </PanelHeader>
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`Button`](#/Button)
 
@@ -189,7 +189,7 @@
 + <Button mode="outline" appearance="overlay">
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`Banner`](#/Banner)
 
@@ -208,7 +208,7 @@
 />
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`ModalCardBase`](#/ModalCardBase)
 
@@ -229,7 +229,7 @@
 />
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`SliderSwitch`](#/SliderSwitch)
 
@@ -253,14 +253,14 @@
  />
 ```
 
-### &nbsp;
+<br/><br/>
 
 ## [`Gallery`](#/Gallery)
 
 - Вызов функции `onDragStart` теперь происходит только в начале drag event
 - Удалено свойство `onEnd`. Используйте свойство `onDragEnd`, которое теперь принимает индекс слайда вторым параметром
 
-### &nbsp;
+<br/><br/>
 
 ## Типы и импорты
 

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -24,14 +24,11 @@
 ```diff
 - <SplitLayout>
 -   <View popout={popout} modal={modal}>
--      ...
--   </View>
-- </SplitLayout>
 + <SplitLayout popout={popout} modal={modal}>
 +   <View>
-+      ...
-+   </View>
-+ </SplitLayout>
+     ...
+   </View>
+ </SplitLayout>
 ```
 
 ### Alert

--- a/styleguide/pages/migration_v5.md
+++ b/styleguide/pages/migration_v5.md
@@ -1,16 +1,16 @@
-Документацию по миграции c v3 на v4, можно найти [здесь](https://github.com/VKCOM/VKUI/releases/tag/v4.0.0).
+Документацию по миграции c v3 на v4 можно найти [здесь](https://github.com/VKCOM/VKUI/releases/tag/v4.0.0).
 
 ## Обновление React и Typescript
 
-- Минимальная поддерживаемая версия **React** была увеличена до v17.0.0
-- Минимальная поддерживаемая версия **Typescript** была увеличена до v4.4.4
+- Минимальная поддерживаемая версия **React** увеличена до v17.0.0
+- Минимальная поддерживаемая версия **Typescript** увеличена до v4.4.4
 
 ## Обратно несовместимые изменения
 
 ### ConfigProvider
 
-- По умолчанию `appearance` определяется автоматически, в зависимости от темы указанной в VK или настроек ОС.
-- Удалено устаревшее свойство `scheme`. Для определения темы используйте свойство `appearance`.
+- По умолчанию `appearance` определяется автоматически — в зависимости от темы, указанной в VK, или настроек ОС
+- Удалено устаревшее свойство `scheme`. Для определения темы используйте свойство `appearance`
 
 ```diff
 - <ConfigProvider scheme={scheme}>...</ConfigProvider>
@@ -19,7 +19,7 @@
 
 ### Root и View
 
-- Удалено устаревшее свойство `popout` и `modal`. Используйте эти свойства в компоненте [`SplitLayout`](#/SplitLayout)
+- Удалены устаревшие свойства `popout` и `modal`. Используйте эти свойства в компоненте [`SplitLayout`](#/SplitLayout)
 
 ```diff
 - <SplitLayout>
@@ -34,9 +34,9 @@
 + </SplitLayout>
 ```
 
-# Alert
+### Alert
 
-- Свойство `autoclose` типа AlertAction было переименовано в `autoClose`
+- Свойство `autoclose` типа _`AlertAction`_ переименовано в `autoClose`
 
 ```diff
  <Alert
@@ -61,7 +61,7 @@
 
 ### BannerData
 
-- Удалено свойство `ageRestriction` добавленное по ошибке. Используйте свойство `ageRestrictions`
+- Удалено свойство `ageRestriction`, добавленное по ошибке. Используйте свойство `ageRestrictions`
 
 ### ContentCard
 
@@ -69,7 +69,7 @@
 
 ### IconButton
 
-- Удалено устаревшее свойство `icon`. Необходимо сделать иконки дочерним элементом
+- Удалено устаревшее свойство `icon`. Передавайте иконки как `children`
 
 ```diff
 - <IconButton icon={<Icon16Clear />}/>
@@ -97,7 +97,7 @@
 
 ### Cell
 
-- Удалено устаревшие свойства `removable` и `selectable`. Используйте свойства `mode="removable"` и `mode="selectable"`
+- Удалены устаревшие свойства `removable` и `selectable`. Используйте свойства `mode="removable"` и `mode="selectable"`
 
 ```diff
 - <Cell removable>
@@ -117,11 +117,11 @@
 
 ### CustomSelect
 
-- Обновлено свойство onInputChange. Для фильтрации обновляйте props.options самостоятельно или используйте свойство filterFn.
+- Обновлено свойство `onInputChange`. Для фильтрации обновляйте `props.options` самостоятельно или используйте свойство `filterFn`
 
 ### Button
 
-- Удалены устаревшие значения свойства `mode` (`commerce`, `destructive`, `overlay_...`). Используйте свойства `mode` и `appearance`.
+- Удалены устаревшие значения свойства `mode` (`commerce`, `destructive`, `overlay_...`). Используйте свойства `mode` и `appearance`
 
 ```diff
 - <Button mode="commerce">
@@ -142,7 +142,7 @@
 
 ### ButtonGroup
 
-- В параметр `actions` компонентов `Banner` и `ModalCardBase` для группировки кнопок теперь нужно передавать `ButtonGroup` вместо `React.Fragment`.
+- В параметр `actions` компонентов `Banner` и `ModalCardBase` для группировки кнопок теперь нужно передавать `ButtonGroup` вместо `React.Fragment`
 
   ```diff
   - <Banner
@@ -189,7 +189,7 @@
 
 ### SliderSwitch
 
-Компонент устарел и был удален. Используйте [`SegmentedControl`](#/SegmentedControl).
+Устаревший компонент удален. Используйте [`SegmentedControl`](#/SegmentedControl)
 
 ```diff
 - <SliderSwitch
@@ -211,8 +211,8 @@
 
 ### Gallery
 
-- Вызов функции `onDragStart` теперь происходит только в начале drag event.
-- Удалено свойство `onEnd`. Используйте свойство `onDragEnd`, которое теперь принимает индекс слайда вторым параметром.
+- Вызов функции `onDragStart` теперь происходит только в начале drag event
+- Удалено свойство `onEnd`. Используйте свойство `onDragEnd`, которое теперь принимает индекс слайда вторым параметром
 
 ### Импорты
 


### PR DESCRIPTION
Добавленные в доку по миграции **компоненты**, которых не хватает.

#1522
- [x] `PanelHeader`
- [x] `ActionSheetItem`
- [x] `VKUITouchEventHandler`

#2584
- [x] `Tabs`

А также:
- [x] вычитала доку: привела в порядок времена, убрала лишние запятые и добавила отсутствующие, пофиксила опечатки и такое всякое %)

--------
resolves #1522
relates to #2351