### PR TITLE
fix(Firefox): placeholder opacity

### DIFF
--- a/src/components/ChipsInput/ChipsInput.css
+++ b/src/components/ChipsInput/ChipsInput.css
@@ -57,6 +57,8 @@
 
 .ChipsInput__el::placeholder {
   color: var(--field_text_placeholder, var(--vkui--color_text_secondary));
+  /* Для Firefox */
+  opacity: 1;
 }
 
 .ChipsInput__el:disabled::placeholder {

--- a/src/components/Input/Input.css
+++ b/src/components/Input/Input.css
@@ -54,6 +54,8 @@
 
 .Input__el::placeholder {
   color: var(--field_text_placeholder, var(--vkui--color_text_secondary));
+  /* Для Firefox */
+  opacity: 1;
 }
 
 .Input__el:disabled::placeholder {

--- a/src/components/Textarea/Textarea.css
+++ b/src/components/Textarea/Textarea.css
@@ -34,6 +34,8 @@
 
 .Textarea__el::placeholder {
   color: var(--field_text_placeholder, var(--vkui--color_text_secondary));
+  /* Для Firefox */
+  opacity: 1;
 }
 
 .Textarea__el:disabled {

--- a/src/components/WriteBar/WriteBar.css
+++ b/src/components/WriteBar/WriteBar.css
@@ -40,12 +40,8 @@
 
 .WriteBar__textarea::placeholder {
   color: var(--text_placeholder, var(--vkui--color_text_subhead));
-}
-
-/* stylelint-disable-next-line selector-no-vendor-prefix */
-.WriteBar__textarea::-moz-placeholder {
+  /* Для Firefox */
   opacity: 1;
-  color: var(--text_placeholder, var(--vkui--color_text_subhead));
 }
 
 .WriteBar__inlineAfter {


### PR DESCRIPTION
Для Firefox

|До|После|
|-|-|
|<img width="374" alt="image" src="https://user-images.githubusercontent.com/14944123/183467094-3a67f10f-27bc-4c5e-9cc8-dbc0d10825a4.png">|<img width="387" alt="image" src="https://user-images.githubusercontent.com/14944123/183467140-c9349860-4f22-44d1-ada7-d4d9f65bb68c.png">|
|<img width="317" alt="image" src="https://user-images.githubusercontent.com/14944123/183467349-c61b994e-a361-41af-820d-b2e5d7121d4b.png">|<img width="314" alt="image" src="https://user-images.githubusercontent.com/14944123/183467397-5599f467-e769-4725-b100-7e8521ad2ea0.png">|
|<img width="313" alt="image" src="https://user-images.githubusercontent.com/14944123/183467960-15ea767c-3dd3-4eaa-963c-b2f0f96662b7.png">|<img width="319" alt="image" src="https://user-images.githubusercontent.com/14944123/183467993-865e64a6-883e-4497-bdd2-8580b9d1ef9e.png">|

---

- Убрал `::-moz-placeholder` - [caniuse](https://caniuse.com/css-placeholder)