### PR TITLE
fix(docs): Исправляем переход по `id` в `SectionSubheading` и `PlaygroundRenderer`

### DIFF
--- a/styleguide/Components/Playground/PlaygroundRenderer.js
+++ b/styleguide/Components/Playground/PlaygroundRenderer.js
@@ -23,7 +23,7 @@ class PlaygroundRenderer extends React.Component {
 
     return (
       <div className="Playground">
-        <SectionSubheading href={`#/${name}?id=example`}>
+        <SectionSubheading href={`#/${name}?id=example${exampleIndex}`}>
           Пример реализации
         </SectionSubheading>
         <Settings adaptivity={adaptivity} webviewType={webviewType} />
@@ -45,7 +45,7 @@ class PlaygroundRenderer extends React.Component {
         </div>
         {viewWidth > ViewWidth.MOBILE && (
           <>
-            <SectionSubheading href={`#/${name}?id=code`}>
+            <SectionSubheading href={`#/${name}?id=code${exampleIndex}`}>
               Редактируемый код
             </SectionSubheading>
             <div className="Playground__code">{tabBody}</div>

--- a/styleguide/Components/SectionSubheading/SectionSubheading.js
+++ b/styleguide/Components/SectionSubheading/SectionSubheading.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 import Heading from "../Heading/index";
 import { classNames } from "@vkui";
 import { Icon16Linked } from "@vkontakte/icons";
@@ -11,19 +11,21 @@ export const SectionSubheading = ({
   href,
   ...restProps
 }) => {
+  const id = href ? href.replace(/#?\/.+\?id=(.+)/g, "$1") : undefined;
+
   return (
     <Heading
       {...restProps}
       level={level}
       className={classNames("SectionSubheading", className)}
     >
-      {href && (
-        <a className="SectionSubheading__link" href={href}>
-          <Icon16Linked />
-        </a>
-      )}
-      {href && (
-        <a className="SectionSubheading__anchor" id={href.replace("#", "")}></a>
+      {href && id && (
+        <Fragment>
+          <a className="SectionSubheading__link" href={href}>
+            <Icon16Linked />
+          </a>
+          <a className="SectionSubheading__anchor" id={id} />
+        </Fragment>
       )}
       <span className="SectionSubheading__text">{children}</span>
     </Heading>


### PR DESCRIPTION
resolves #3000.