### PR TITLE
feat(Group): add `padding`

### DIFF
--- a/src/components/Group/Group.css
+++ b/src/components/Group/Group.css
@@ -7,9 +7,18 @@
   padding-bottom: 8px;
 }
 
-/* TODO v5.0.0 Новая адаптивность */
-.Group--sizeX-regular > .Group__inner {
+.Group--card.Group--padding-s > .Group__inner {
+  padding: 4px;
+}
+
+.Group--card.Group--padding-m > .Group__inner {
   padding: 8px;
+}
+
+/* TODO v5.0.0 Новая адаптивность */
+.Group--sizeX-compact > .Group__inner {
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .Group--card > .Group__inner {

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -34,6 +34,10 @@ export interface GroupProps
    * по умолчанию 'plain'.
    */
   mode?: "plain" | "card";
+  /**
+   * Отвечает за отступы вокруг контента в режиме 'card'.
+   */
+  padding?: "s" | "m";
   children?: React.ReactNode;
 }
 
@@ -44,6 +48,7 @@ const GroupComponent = ({
   separator = "auto",
   getRootRef,
   mode,
+  padding = "m",
   sizeX,
   ...restProps
 }: GroupProps) => {
@@ -81,7 +86,8 @@ const GroupComponent = ({
         platform === IOS && "Group--ios",
         // TODO v5.0.0 Новая адаптивность
         `Group--sizeX-${sizeX}`,
-        `Group--${computedMode}`
+        `Group--${computedMode}`,
+        `Group--padding-${padding}`
       )}
     >
       <div vkuiClass="Group__inner">


### PR DESCRIPTION
Добавляем свойство `padding`, которое отвечает за отступы вокруг контента для карточки

<img width="1880" alt="group-size" src="https://user-images.githubusercontent.com/91548592/185886774-1af35b9d-2bd3-472c-a895-07c5bfccb8a3.png">

- link #3018