### PR TITLE
chore: add `yarn.lock` to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src/**/__image_snapshots__/*.png filter=lfs diff=lfs merge=lfs -text
+yarn.lock linguist-vendored merge=ours -diff


### PR DESCRIPTION
- `linguist-vendored` исключает из статистики
- `merge=ours` решение конфликтов с использованием стратегии ours
- `-diff` не будет пытаться объединить  эти файлы