### PR TITLE
Удалил исключения в поле `"files"` в `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
-    "!dist/*.hot-update.*",
-    "!dist/*.tmp",
-    "!dist/**/*.tmp",
     "dist"
   ],
   "sideEffects": [


### PR DESCRIPTION
Перенести исключения `*.tmp` из поля `"files"` в `.npmignore` не сработало.

Так или иначе не вижу смысла в исключении `*.tmp` файлов внутри `dist`.

## Как проверял?

Проверял через `yarn pack`, который генерирует архив пакета в том, в каком он будет лежать в пакетном менеджере.

---

- fix #3261 
