### PR TITLE
fix(View): правим проблему со свайпом при открытой клавиатуре в iOS

### DIFF
--- a/src/components/AppRoot/ScrollContext.tsx
+++ b/src/components/AppRoot/ScrollContext.tsx
@@ -15,6 +15,15 @@ const clearDisableScrollStyle = (node: HTMLElement) => {
   });
 };
 
+const getPageYOffsetWithoutKeyboardHeight = (window: Window) => {
+  // Note: здесь расчёт на то, что `clientHeight` равен `window.innerHeight`.
+  //  Это достигается тем, что тегу `html` задали`height: 100%` и у него нет отступов сверху и снизу. Если есть отступы,
+  //  то надо задать `box-sizing: border-box`, чтобы они не учитывались.
+  const diffOfClientHeightAndViewportHeight =
+    window.document.documentElement.clientHeight - window.innerHeight;
+  return window.pageYOffset - diffOfClientHeightAndViewportHeight;
+};
+
 export interface ScrollContextInterface {
   getScroll(this: void): { x: number; y: number };
   scrollTo(this: void, x?: number, y?: number): void;
@@ -45,7 +54,10 @@ export const GlobalScrollController = ({ children }: ScrollControllerProps) => {
   const beforeScrollLockFnSetRef = React.useRef<Set<() => void>>(new Set());
 
   const getScroll = React.useCallback<ScrollContextInterface["getScroll"]>(
-    () => ({ x: window!.pageXOffset, y: window!.pageYOffset }),
+    () => ({
+      x: window!.pageXOffset,
+      y: getPageYOffsetWithoutKeyboardHeight(window!),
+    }),
     [window]
   );
   const scrollTo = React.useCallback<ScrollContextInterface["scrollTo"]>(

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -301,6 +301,8 @@ export const View = ({
 
       if (e.startX <= 70 && !swipingBack && history && history.length > 1) {
         if (activePanel !== null) {
+          // Note: вызываем закрытие клавиатуры. В iOS это нативное поведение при свайпе.
+          blurActiveElement(document);
           scrolls.current[activePanel] = scroll?.getScroll().y;
         }
 


### PR DESCRIPTION
При открытии клавиатуры в iOS весь контент сдвигается вверх на высоту клавиатуры. В `window.pageYOffset` этот сдвиг учитывается, из-за чего мы получаем не верное значение для `marginTop`,

https://github.com/VKCOM/VKUI/blob/ba7991a35e0c0b84acda8ba59959427e646400c1/src/components/View/View.tsx#L581-L588

который служит для исправления бага с `overflow: hidden` в iOS.

## Решение

1. Во-первых, мы в любом случае закрываем клавиатуру, т.к. это нативное поведение при свайпе в iOS.
2. Во-вторых, в [`GlobalScrollController`](https://github.com/VKCOM/VKUI/blob/v4.37.0/src/components/AppRoot/ScrollContext.tsx#L42-L120) в [`getScroll()`](https://github.com/VKCOM/VKUI/blob/v4.37.0/src/components/AppRoot/ScrollContext.tsx#L47-L50) мы вычитаем высоту клавиатуры из `window.pageYOffset` для `y`. Чтобы получить высоту клавиатуры, я смотрю на разницу между `document.documentElement.clientHeight` и `window.innerHeight`.

## Чеклист

<details>
<summary>Проверил GlobalScrollController</summary>

https://user-images.githubusercontent.com/5850354/190402525-8ed6972d-1c60-4a87-aaf3-a1fefd606721.MP4
</details>

<details>
<summary>Убедился, что нет такой баги при оборачивании в ElementScrollController</summary>

https://user-images.githubusercontent.com/5850354/190402546-685bf979-8521-441a-a2b0-a62d8b61fae5.MP4
</details>

<details>
<summary>Код, используемый для проверки</summary>

Использовал `create-react-app`. У него из под капота настроен PWA – использовал, чтобы убрать меню и поисковую строку Safari.

```tsx
// @ts-nocheck
import React from "react";
import ReactDOM from "react-dom";
import { PullToRefresh, View, Panel, PanelHeader, AppRoot, AdaptivityProvider, ConfigProvider, Group, CellButton, Placeholder, Div, useAdaptivity, FormItem, Input } from "@vkontakte/vkui";
import "@vkontakte/vkui/dist/vkui.css";

function App() {
  const [history, setHistory] = React.useState(["main"]);
  const activePanel = history[history.length - 1];

  const goBack = () => setHistory(history.slice(0, -1));
  const go = (panel) => setHistory([...history, panel]);

  return (
    <View onSwipeBack={goBack} history={history} activePanel={activePanel}>
      <Panel id="main">
        <PanelHeader>Main</PanelHeader>

        <PullToRefresh>
          <Group>
            <CellButton onClick={() => go("profile")}>profile</CellButton>
          </Group>
        </PullToRefresh>
      </Panel>
      <Panel id="profile">
        <PanelHeader>Профиль</PanelHeader>
        <Group>
          <Placeholder>
            Теперь свайпните от левого края направо, чтобы вернуться
          </Placeholder>
          <Div
            style={{ height: 50, background: "#eee" }}
            data-vkui-swipe-back={false}
          >
            Здесь свайпбек отключен
          </Div>
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <br />
          <FormItem>
            <Input />
          </FormItem>
          <FormItem>
            <Input />
          </FormItem>
          <FormItem>
            <Input />
          </FormItem>
        </Group>
      </Panel>
    </View>
  );
}

ReactDOM.render(
  <ConfigProvider isWebView>
    <AdaptivityProvider>
      <AppRoot>
        <App />,
      </AppRoot>
    </AdaptivityProvider>
  </ConfigProvider>,
  document.getElementById("root")
);
```
</details>

---

- fix #3268 