### PR TITLE
fix(TabsItem): заменил `header_tint_alternate` на `button_secondary_foreground` для `after` при `mode="accent"`

### DIFF
--- a/src/components/Tabs/__image_snapshots__/tabs-vkcom-light-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-vkcom-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a485b7801c8ae7db14d7d9dcdefc75f9c97ca7f899adccb6806b0cb92f35bd04
-size 241393
+oid sha256:265fe442668d3c9b09a39cafb67fb5557be0ed5e8a27ec7919909072d2493c2d
+size 242804

--- a/src/components/TabsItem/TabsItem.css
+++ b/src/components/TabsItem/TabsItem.css
@@ -157,6 +157,14 @@
   color: var(--header_tint_alternate, var(--vkui--color_icon_accent_themed));
 }
 
+/* TODO удалить блок в v5.0.0 */
+.TabsItem--selected.TabsItem--accent .TabsItem__after {
+  color: var(
+    --button_secondary_foreground,
+    var(--vkui--color_icon_accent_themed)
+  );
+}
+
 /* Элемент */
 .TabsItem__underline {
   position: absolute;


### PR DESCRIPTION
## Чеклист

- [x] Дизайн ревью
- [x] Обновить скриншоты
- [x] Добавить в **release notes**

---

- fix #3304 