### PR TITLE
test(postcss-restructure-variable): to snapshot

### DIFF
--- a/packages/postcss-restructure-variable/__snapshots__/postcss-restructure-variable.test.js.snap
+++ b/packages/postcss-restructure-variable/__snapshots__/postcss-restructure-variable.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`check cascading 1`] = `
+"
+@media (min-resolution: 2dppx) {
+    :root {
+        --color: blue;
+        color: blue;
+    }
+}
+@media (min-resolution: 3dppx) {
+    :root {
+        --color: blue;
+    }
+}
+:root {
+    --color: blue;
+}"
+`;
+
+exports[`check deep cascading 1`] = `
+"
+@supports (display: flex) {
+    @media screen and (min-width: 900px) {
+        :root {
+            --color: blue;
+        }
+    }
+}
+:root {
+    --color: blue;
+}"
+`;
+
+exports[`example 1`] = `
+".a, .b {
+    --color1: #ff0000;
+    --color2: #ff0000
+}
+.a {
+    --size: 2px
+}
+.b, .c {
+    --size: 1px
+}
+.c {
+    --color: #0000ff
+}
+"
+`;
+
+exports[`merge one 1`] = `
+":root, .b {
+    --color: #fff;
+}.b {
+    color: var(--color);
+}
+"
+`;
+
+exports[`merge three 1`] = `
+":root, .b {
+    --color: #fff;
+}:root {
+    --size: 1px;
+}.b {
+    --size: 2px;
+}.b {
+    color: var(--color);
+}
+"
+`;
+
+exports[`no custom properties 1`] = `
+"
+.b {
+  color: var(--color);
+}"
+`;
+
+exports[`rewrite custom property 1`] = `
+".a, .b {
+    --color: #000
+}
+"
+`;

--- a/packages/postcss-restructure-variable/postcss-restructure-variable.test.js
+++ b/packages/postcss-restructure-variable/postcss-restructure-variable.test.js
@@ -2,12 +2,13 @@ const postcss = require("postcss");
 
 const plugin = require(".");
 
-async function run(input, output, opts = [undefined]) {
+async function run(input, opts = [undefined]) {
   let result = await postcss([plugin(opts)]).process(input, {
     from: undefined,
   });
-  expect(result.css).toEqual(output);
   expect(result.warnings()).toHaveLength(0);
+
+  return result.css;
 }
 
 it("rewrite custom property", async () => {
@@ -25,12 +26,7 @@ it("rewrite custom property", async () => {
 }
 `;
 
-  const output = `.a, .b {
-    --color: #000
-}
-`;
-
-  await run(input, output);
+  expect(await run(input)).toMatchSnapshot();
 });
 
 it("merge one", async () => {
@@ -45,15 +41,7 @@ it("merge one", async () => {
 }
 `;
 
-  const output = `:root, .b {
-    --color: #fff;
-}
-.b {
-    color: var(--color);
-}
-`;
-
-  await run(input, output);
+  expect(await run(input)).toMatchSnapshot();
 });
 
 it("merge three", async () => {
@@ -70,21 +58,7 @@ it("merge three", async () => {
 }
 `;
 
-  const output = `:root, .b {
-    --color: #fff;
-}
-:root {
-    --size: 1px;
-}
-.b {
-    --size: 2px;
-}
-.b {
-    color: var(--color);
-}
-`;
-
-  await run(input, output);
+  expect(await run(input)).toMatchSnapshot();
 });
 
 // PS: по идеи @media в итоге не должно быть, но чтобы ничего не сломать оставлю так
@@ -105,7 +79,7 @@ it("check cascading", async () => {
     --color: blue;
 }`;
 
-  await run(input, input);
+  expect(await run(input)).toMatchSnapshot();
 });
 
 it("check deep cascading", async () => {
@@ -121,7 +95,7 @@ it("check deep cascading", async () => {
     --color: blue;
 }`;
 
-  await run(input, input);
+  expect(await run(input)).toMatchSnapshot();
 });
 
 it("no custom properties", async () => {
@@ -130,7 +104,7 @@ it("no custom properties", async () => {
   color: var(--color);
 }`;
 
-  await run(input, input);
+  expect(await run(input)).toMatchSnapshot();
 });
 
 it("example", async () => {
@@ -166,5 +140,5 @@ it("example", async () => {
 }
 `;
 
-  await run(input, output);
+  expect(await run(input)).toMatchSnapshot();
 });


### PR DESCRIPTION
Переписываем тест на снапшот. postcss при обновлении иногда удаляет или добавлят переносы строк