### PR TITLE
ci: правит падающий `yarn test:ci` в ветке `v5`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -142,7 +142,7 @@
       }
     ],
     "compat/compat": "error",
-    "react/no-unknown-property": ["error", { "ignore": ["vkuiClass"] }]
+    "react/no-unknown-property": ["error"]
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-plugin-react": "7.31.8",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-vkui": "file:./packages/eslint-plugin-vkui",
-    "expect-playwright": "^0.8.0",
     "husky": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",

--- a/src/components/AppearanceProvider/AppearanceProvider.tsx
+++ b/src/components/AppearanceProvider/AppearanceProvider.tsx
@@ -44,7 +44,7 @@ export const AppearanceProvider = ({
   return (
     <AppearanceProviderContext.Provider value={appearance}>
       {React.Children.map(children, (child) => {
-        if (React.isValidElement(child)) {
+        if (React.isValidElement<{ className?: string }>(child)) {
           return React.cloneElement(child, {
             className: classNamesString(
               child.props.className,

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -26,7 +26,7 @@ export interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
   after?: React.ReactNode;
 }
 
-export interface RenderChip<T> extends ChipProps {
+export interface RenderChip<T extends ChipOption> extends ChipProps {
   label: string;
   option: T;
   disabled: boolean;

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -11,6 +11,5 @@
     "src/**/*.e2e.ts",
     "src/**/*.e2e.tsx",
     "src/testing/"
-  ],
-  "files": ["types/global.d.ts", "types/env.d.ts"]
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,10 +41,5 @@
     "*.js"
   ],
   "exclude": ["packages/token-translator/**/*"],
-  "files": [
-    "node_modules/jest-playwright-preset/types/global.d.ts",
-    "node_modules/expect-playwright/global.d.ts",
-    "types/global.d.ts",
-    "types/env.d.ts"
-  ]
+  "files": ["types/global.d.ts", "types/env.d.ts"]
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,7 +1,0 @@
-import "react";
-
-declare module "react" {
-  interface Attributes {
-    vkuiClass?: string | string[];
-  }
-}


### PR DESCRIPTION
- Поправил `yarn lint:es`
- Поправил `yarn typecheck`
- **Дополнительно.** Удалил оставшиеся упомнинания `vkuiClass` (забыл сделать здесь #3318)

## Почему падал `yarn lint:es`?

### Проблема

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/194612355-b5e9a34c-35c8-40f6-b652-dee66e9bf345.png">

**Рис. 1** ESLint жалуется, что матчеры jest'а возвращают `promise`, хотя это не так

Есть два момента:
1. В `master` обновили зависимость `expect-playwright` с `0.2.6` до `0.8.0` ([`3cecda`](https://github.com/VKCOM/VKUI/pull/3326/commits/3cecda31c89866069ef3a938938983c5da71cf70#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R73)). А с версии `0.6.0` ([release note](https://github.com/playwright-community/expect-playwright/releases/tag/v0.6.0)) расширили кол-во матчеров.
  Подключается здесь:
  https://github.com/VKCOM/VKUI/blob/c32efca6750bde879ca068429b017a08697eca58/tsconfig.json#L45-L46
2. При слиянии `master` в `v5` (https://github.com/VKCOM/VKUI/pull/3135/commits/e4cdaa006dfd7435746af9cb45bd927ecab4b3fe) версия `@types/testing-library__jest-dom`, зависимость `@testing-library/jest-dom` в `yarn.lock`, поменялась с `5.9.5` на `5.14.5`. В новой версии изменили способ расширения `@types/jest` дополнительными типами ([DefinitelyTyped/DefinitelyTyped#59030](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59030/files#diff-86bd4219f0aeb8cd212b2b6394f469cc62313b7fc4b38d8fe7568c8432aa34fbR16)).

В итоге в `v5` ситуация, что `expect-playwright@0.8.0` перебивает матчеры, которые задаёт `@types/testing-library__jest-dom`. Пример на **Рис. 3**.

<img width="320" alt="v4" src="https://user-images.githubusercontent.com/5850354/194614035-0feff4af-ea15-415c-b05e-7131017010d9.png">

**Рис. 2** `expect-playwright@0.8.0` НЕ перебивает `@types/testing-library__jest-dom@5.9.5`

<img width="320" alt="v5" src="https://user-images.githubusercontent.com/5850354/194614056-6f860c32-6b0c-480b-bd0d-bd19fa76026f.png">

**Рис. 3** `expect-playwright@0.8.0` перебивает `@types/testing-library__jest-dom@5.14.5`

### Решение

~Задать в `package.json` в поле `"resolutions"` версию `5.9.5` зависимости `@types/testing-library__jest-dom`~

Всё оказалось проще! Подключение `jest-playwright-preset/types/global.d.ts` и `expect-playwright/global.d.ts` в `tsconfig.json` лишнее

https://github.com/VKCOM/VKUI/blob/c32efca6750bde879ca068429b017a08697eca58/tsconfig.json#L45-L46

Удалил их из `tsconfig.json`, также удалил `expect-playwright` из `package.json`, т.к. он и так тянется как зависимость в `jest-playwright-preset` и не используются в нашем репозитории.