### PR TITLE
fix(FormLayoutGroup): Remove margin left for offset element

### DIFF
--- a/src/components/FormLayoutGroup/FormLayoutGroup.css
+++ b/src/components/FormLayoutGroup/FormLayoutGroup.css
@@ -54,6 +54,7 @@
   flex: 1;
 }
 
-.FormLayoutGroup--segmented > *:not(:first-child) {
+.FormLayoutGroup--segmented
+  > *:not(:first-child):not(.FormLayoutGroup__offset) {
   margin-left: calc(-1 * var(--thin-border));
 }

--- a/src/components/Removable/Removable.css
+++ b/src/components/Removable/Removable.css
@@ -103,6 +103,10 @@
   align-items: flex-start;
 }
 
+.Removable__offset {
+  display: none;
+}
+
 .FormItem--withTop .FormItem__removable ~ .Removable__offset,
 .FormLayoutGroup--removable .FormItem--withTop ~ .Removable__offset {
   order: -1;


### PR DESCRIPTION
 (+hide offset element for removable items by default)

- fix #3436 