### PR TITLE
fix(Tappable): pointer-events: none for `disabled`

### DIFF
--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -13,6 +13,7 @@
 .Tappable[disabled],
 .Tappable[aria-disabled="true"] {
   cursor: default;
+  pointer-events: none;
 }
 
 .Tappable--focus-visible {


### PR DESCRIPTION
- Fixes #3446