### PR TITLE
chore: включает правило `@typescript-eslint/ban-ts-comment`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,7 +40,14 @@
   "plugins": ["import", "vkui"],
   "rules": {
     "no-shadow": "off", // Need using @typescript-eslint/no-shadow
-    "@typescript-eslint/prefer-ts-expect-error": "off", // Need typescript > 3.9
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+      {
+        "ts-expect-error": {
+          "descriptionFormat": "^: TS\\d+ .+$"
+        }
+      }
+    ],
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/no-unnecessary-condition": "off",
     "@typescript-eslint/no-magic-numbers": "off",

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -697,7 +697,7 @@ export function CustomSelect(props: SelectProps) {
           onChange={onInputChange}
           // TODO Ожидается, что клик поймает нативный select, но его перехватывает Input. К сожалению, это приводит к конфликтам типизации.
           // TODO Нужно перестать пытаться превратить CustomSelect в select. Тогда эта проблема уйдёт.
-          // @ts-ignore
+          // @ts-expect-error: TS2322 MouseEventHandler<HTMLSelectElement> !== MouseEventHandler<HTMLInputElement>
           onClick={props.onClick}
           before={before}
           after={icon}

--- a/src/components/ModalRoot/ModalRoot.tsx
+++ b/src/components/ModalRoot/ModalRoot.tsx
@@ -211,7 +211,7 @@ class ModalRootTouchComponent extends React.Component<
       // некоторые браузеры на странных вендорах типа Meizu не удаляют обработчик.
       // https://github.com/VKCOM/VKUI/issues/444
       this.window!.removeEventListener("touchmove", this.preventTouch, {
-        // @ts-expect-error (В интерфейсе EventListenerOptions нет поля passive)
+        // @ts-expect-error: TS2769 В интерфейсе EventListenerOptions нет поля passive
         passive: false,
       });
     } else {

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -164,7 +164,8 @@ export const mockScrollContext = (
   ];
 };
 
-const isNullOrUndefined = (val: any) => val === null || val === undefined;
+const isNullOrUndefined = (val: unknown): val is null | undefined =>
+  val === null || val === undefined;
 
 // Согласно спеке, offsetParent в ряде случаев будет null
 Object.defineProperty(HTMLElement.prototype, "offsetParent", {
@@ -177,7 +178,7 @@ Object.defineProperty(HTMLElement.prototype, "offsetParent", {
         isNullOrUndefined(element.style.display) ||
         element.style.display.toLowerCase() !== "none")
     ) {
-      // @ts-expect-error
+      // @ts-expect-error: TS2322 `parentNode: ParentNode | null`, а ожидается HTMLElement
       element = element.parentNode;
     }
 


### PR DESCRIPTION
`@typescript-eslint/prefer-ts-expect-error` было отключено. Мы обновили TS до версии 4, поэтому удалил отключение.

Также настроил `@typescript-eslint/ban-ts-comment`, которое разрешает использовать `// @ts-expect-error` только с комментарием формата `// @ts-expect-error: TS<номер_ошибки> <текст>`