### PR TITLE
fix(ActionSheet): fix overflow for adroid and ios

### DIFF
--- a/src/components/ActionSheet/ActionSheet.css
+++ b/src/components/ActionSheet/ActionSheet.css
@@ -1,6 +1,6 @@
 .ActionSheet {
   position: relative;
-  overflow: hidden;
+  overflow: auto;
   box-shadow: var(--vkui--elevation3);
   width: calc(100% - 20px);
   align-items: stretch;

--- a/src/components/PopoutWrapper/PopoutWrapper.css
+++ b/src/components/PopoutWrapper/PopoutWrapper.css
@@ -55,6 +55,7 @@
   display: flex;
   justify-content: center;
   width: 100%;
+  max-height: 100%;
   z-index: 2;
   pointer-events: none;
 }


### PR DESCRIPTION
- Добавил max-height: 100% для **PopoutWrapper** , а так же overflow:auto для **ActionSheet**, тем самым, получили скролл в ActionSheet на мобильных IOS и Android