### PR TITLE
docs: add component issues link and rename source link

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "description": "VKUI library",
   "repository": "https://github.com/VKCOM/VKUI",
   "homepage": "https://vkcom.github.io/VKUI/",
+  "bugs": "https://github.com/VKCOM/VKUI/issues",
   "defaultSchemeId": "bright_light",
   "devDependencies": {
     "@babel/cli": "^7.16.8",

--- a/styleguide/Components/ReactComponent/ReactComponent.css
+++ b/styleguide/Components/ReactComponent/ReactComponent.css
@@ -1,4 +1,5 @@
 .ReactComponent__src {
+  margin-right: 6px;
   margin-top: 24px;
   color: var(--vkui--color_text_secondary);
   display: inline-block;

--- a/styleguide/Components/ReactComponent/ReactComponent.css
+++ b/styleguide/Components/ReactComponent/ReactComponent.css
@@ -1,9 +1,18 @@
 .ReactComponent__src {
-  margin-right: 6px;
+  margin: 0 6px;
   margin-top: 24px;
   color: var(--vkui--color_text_secondary);
   display: inline-block;
   font-size: 0;
+}
+
+.ReactComponent__src:first-child {
+  margin-left: 0;
+}
+
+.ReactComponent__divider {
+  display: inline-block;
+  color: var(--vkui--color_text_secondary);
 }
 
 .ReactComponent__name {

--- a/styleguide/Components/ReactComponent/ReactComponent.js
+++ b/styleguide/Components/ReactComponent/ReactComponent.js
@@ -42,7 +42,7 @@ const ReactComponent = ({ component, exampleMode }) => {
       <Link
         target="_blank"
         className="ReactComponent__src"
-        href={`${pkg.repository}/issues?q=${encodeURIComponent(issuesQuery)}`}
+        href={`${pkg.bugs}?q=${encodeURIComponent(issuesQuery)}`}
       >
         <Caption>Issues</Caption>
       </Link>

--- a/styleguide/Components/ReactComponent/ReactComponent.js
+++ b/styleguide/Components/ReactComponent/ReactComponent.js
@@ -9,6 +9,11 @@ import { deprecated } from "../../deprecated";
 import pkg from "../../../package.json";
 import "./ReactComponent.css";
 
+const toKebabCase = (str) =>
+  str
+    .replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)
+    .replace(/^-/, "");
+
 const ReactComponent = ({ component, exampleMode }) => {
   const { name, visibleName, pathLine } = component;
   const { description = "", examples = [] } = component.props || {};
@@ -17,6 +22,9 @@ const ReactComponent = ({ component, exampleMode }) => {
   const showPropsPlaceholder =
     process.env.NODE_ENV === "development" &&
     process.env.VKUI_STYLEGUIDE_PROPSPARSER !== 1;
+
+  const githubTag = `cmp:${toKebabCase(visibleName)}`;
+  const issuesQuery = `is:open is:issue label:${githubTag}`;
 
   return (
     <div className="ReactComponent">
@@ -28,7 +36,14 @@ const ReactComponent = ({ component, exampleMode }) => {
           ""
         )}`}
       >
-        <Caption>Github</Caption>
+        <Caption>Source</Caption>
+      </Link>
+      <Link
+        target="_blank"
+        className="ReactComponent__src"
+        href={`${pkg.repository}/issues?q=${encodeURIComponent(issuesQuery)}`}
+      >
+        <Caption>Issues</Caption>
       </Link>
       <Heading
         level={1}

--- a/styleguide/Components/ReactComponent/ReactComponent.js
+++ b/styleguide/Components/ReactComponent/ReactComponent.js
@@ -38,6 +38,7 @@ const ReactComponent = ({ component, exampleMode }) => {
       >
         <Caption>Source</Caption>
       </Link>
+      <div className="ReactComponent__divider">•</div>
       <Link
         target="_blank"
         className="ReactComponent__src"


### PR DESCRIPTION
Предлагаю добавить ссылку на Issues компонента, чтобы было проще найти известную проблему, прежде чем заводить баг.
Также, переименовываю Github на Source, чтобы было понятнее, куда ведет ссылка, так как в шапке был элемент с таким же текстом.

<img width="302" alt="image" src="https://user-images.githubusercontent.com/17943083/198947856-6258ba4c-343c-4a6b-9ec7-df2698275cc4.png">
