### PR TITLE
docs: fix Adaptivity section

### DIFF
--- a/docs/ADAPTIVITY_GUIDE.md
+++ b/docs/ADAPTIVITY_GUIDE.md
@@ -159,7 +159,7 @@ const App = () => {
 const App = () => {
   const [mounted, setMounted] = React.useState(false);
 
-  React.useEffect(function componentDidMount() {
+  React.useEffect(() => {
     setMounted(true);
   }, []);
 

--- a/styleguide/pages/adaptivity.md
+++ b/styleguide/pages/adaptivity.md
@@ -116,7 +116,7 @@ function App() {
 
 Вот небольшой и наглядный пример:
 
-```tsx
+```jsx static
 // ❌ bad for SSR
 const App = () => {
   return (
@@ -130,7 +130,7 @@ const App = () => {
 const App = () => {
   const [mounted, setMounted] = React.useState(false);
 
-  React.useEffect(function componentDidMount() {
+  React.useEffect(() => {
     setMounted(true);
   }, []);
 


### PR DESCRIPTION
Исправил ошибку с отображением примера кода как "редактируемого" (closes #3567)

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/36604233/200125422-5a841a0c-2346-4318-8d20-b14167ff9dc6.png">

> Также переписал функцию в useEffect на стрелочную (более распространенный вариант)