### PR TITLE
fix(HorizontalCell): Add affection of Header paddings to HorizontalCell--s margins

### DIFF
--- a/src/components/HorizontalCell/HorizontalCell.module.css
+++ b/src/components/HorizontalCell/HorizontalCell.module.css
@@ -65,7 +65,7 @@
 
 .HorizontalCell--size-s:first-child::before,
 .HorizontalCell--size-s:last-child::after {
-  min-width: 8px;
+  min-width: calc(var(--vkui--size_base_padding_horizontal--regular) - 8px);
 }
 
 .HorizontalCell--size-s:first-child,


### PR DESCRIPTION
Имеем такую структуру:
```
<Group header={<Header>Шапка</Header>}>
  <HorizontalScroll>
    <div style={{ display: "flex" }}>
      {items.map((item) => {
        return (
          <HorizontalCell key={item.id} header="Бла-бла" size="s">
            <Avatar size={56} src="..." />
          </HorizontalCell>
        );
      })}
    </div>
  </HorizontalScroll>
</Group>
```
Когда хотим поменять `--vkui--size_base_padding_horizontal--regular`, чтобы уменьшить отступ – уменьшается только отступ у шапки.

PR делает привязку отступов `HorizontalCell--s` к токену горизонтальных отступов.