### PR TITLE
Revert "fix(Tappable): `pointer-events: none` for `disabled`"

### DIFF
--- a/src/components/Tappable/Tappable.css
+++ b/src/components/Tappable/Tappable.css
@@ -13,7 +13,6 @@
 .Tappable[disabled],
 .Tappable[aria-disabled="true"] {
   cursor: default;
-  pointer-events: none;
 }
 
 .Tappable--focus-visible {


### PR DESCRIPTION
Многие для отключения анимации наведения передают disabled(так было в примерах и сам параметр так описан)

Но на деле это была плохая идея, поскольку ломает семантику кнопок в after и before

```html
<SimpleCell
  disabled
  after={
    <Button>Эта кнопка не доступна для скринридера</Button>
  }
>
  Статичный текст
</SimpleCell>
```

Код в #3447 правильный, но к сожалению ломает кучу текущего кода, в котором disabled используют только для отключения анимации компонента `SimpleCell`.

Сейчас это откачу, но в будущем(v6) нужно переделать логику отключения анимации наведения

- Reverts VKCOM/VKUI#3447