### PR TITLE
fix(Tappable): `activeMode=background` use stateLayer

### DIFF
--- a/src/components/Tappable/Tappable.module.css
+++ b/src/components/Tappable/Tappable.module.css
@@ -2,7 +2,7 @@
   position: relative;
   cursor: default;
   border-radius: var(--vkui--size_border_radius--regular);
-  transition: background-color 0.15s ease-out;
+  transition: background-color 0.15s ease-out, opacity 0.15s ease-out;
 }
 
 .Tappable--hover-has-not {
@@ -34,21 +34,9 @@
 }
 
 /**
- * active
- * increased specificity to override CellButton styles
+ * hover & active state
  */
-.Tappable--active-background.Tappable--active-background.Tappable--active-background {
-  background-color: var(--vkui--color_transparent--active);
-}
-
-.Tappable--active-opacity.Tappable--active-opacity.Tappable--active-opacity {
-  opacity: 0.7;
-}
-
-/**
- * hover
- */
-.Tappable__hoverShadow {
+.Tappable__stateLayer {
   position: absolute;
   top: 0;
   right: 0;
@@ -57,9 +45,10 @@
   pointer-events: none;
   overflow: hidden;
   border-radius: inherit;
+  transition: background-color 0.15s ease-out;
 }
 
-.Tappable--hover-background > .Tappable__hoverShadow {
+.Tappable--hover-background > .Tappable__stateLayer {
   background-color: var(--vkui--color_transparent--hover);
 }
 
@@ -67,15 +56,12 @@
   opacity: 0.8;
 }
 
-/**
- * mouse
- */
-.Tappable--mouse {
-  transition: opacity 0.15s ease-out;
+.Tappable--active-background > .Tappable__stateLayer {
+  background-color: var(--vkui--color_transparent--active);
 }
 
-.Tappable--mouse .Tappable__hoverShadow {
-  transition: background-color 0.15s ease-out;
+.Tappable--active-opacity {
+  opacity: 0.7;
 }
 
 /**
@@ -108,7 +94,7 @@
   opacity: 0;
   content: "";
   border-radius: 50%;
-  background: rgba(127, 127, 127, 0.1);
+  background: var(--vkui--color_transparent--active);
   animation: vkui-animation-wave 0.3s var(--vkui--animation_easing_platform);
 }
 

--- a/src/components/Tappable/Tappable.tsx
+++ b/src/components/Tappable/Tappable.tsx
@@ -314,7 +314,6 @@ export const Tappable = ({
     hasActive && active && !isPresetActiveMode && activeMode,
     focusVisible && !isPresetFocusVisibleMode && focusVisibleMode,
     hasActive && active && styles["Tappable--active"],
-    hasMouse && styles["Tappable--mouse"],
     hasHover &&
       hovered &&
       isPresetHoverMode &&
@@ -369,7 +368,7 @@ export const Tappable = ({
         </span>
       )}
       {hasHover && hoverMode === "background" && (
-        <span aria-hidden="true" className={styles.Tappable__hoverShadow} />
+        <span aria-hidden="true" className={styles.Tappable__stateLayer} />
       )}
       {!props.disabled && isPresetFocusVisibleMode && (
         <FocusVisible mode={focusVisibleMode as FocusVisibleMode} />


### PR DESCRIPTION
Изменяем поведение `activeMode=background`

- избавляемся от перебития специфичности
- избавляемся от `.Tappable--mouse`
- переименовываем `.Tappable__hoverShadow` в `.Tappable__stateLayer`

---

- fixes #3623