### PR TITLE
chore(build-deps): update @vkontakte/icons to 1.205.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser": "^4.0.0",
     "@vkontakte/appearance": "https://github.com/VKCOM/Appearance#v9.51.4",
     "@vkontakte/eslint-config": "3.1.0",
-    "@vkontakte/icons": "^1.184.0",
+    "@vkontakte/icons": "^1.205.0",
     "@vkontakte/vk-bridge": "^2.1.3",
     "@vkontakte/vkui-tokens": "4.17.0",
     "autoprefixer": "^10.4.2",

--- a/src/components/ChipsInput/__image_snapshots__/chipsinput-android-chromium-dark-1-snap.png
+++ b/src/components/ChipsInput/__image_snapshots__/chipsinput-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97d531a8628d1298c2eb94bb9e265b98a6eb9fafdf2159114d9d386a0e14918d
-size 282024
+oid sha256:fbd91b75bb91dba88b22c294f83df477e70396549c234c16884a3be1647270bc
+size 282007

--- a/src/components/ChipsInput/__image_snapshots__/chipsinput-android-chromium-light-1-snap.png
+++ b/src/components/ChipsInput/__image_snapshots__/chipsinput-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96056c87d87703c8bc33cf918a37d6f6496eca38173dfe5aaebe484f2d3cf54d
-size 272766
+oid sha256:10a36b83726eb796355dddfe5e15dae27d3f31bd2c4e26cc63c9ed571debab54
+size 272754

--- a/src/components/DateInput/__image_snapshots__/dateinput-android-chromium-dark-1-snap.png
+++ b/src/components/DateInput/__image_snapshots__/dateinput-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd154bfe9a2a3f00b0ea6fcc76a043c00ab5fae483ac5d2b8f88277dfaf502e2
-size 79626
+oid sha256:59dd6a67b9139a95e26d7c2d53d690cc3ff4bdddfe0ce197dc6a4cdfeb95e6ec
+size 79641

--- a/src/components/DateInput/__image_snapshots__/dateinput-android-chromium-light-1-snap.png
+++ b/src/components/DateInput/__image_snapshots__/dateinput-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77dc70bb0c6d5b43b5688abf5df88aa9d07d1993274fad78b45dfa364a40ae2a
-size 78162
+oid sha256:9b59ca4fcc182938129d19e276aba671e44f81dea6075a71406402bc42d8f710
+size 78184

--- a/src/components/DateRangeInput/__image_snapshots__/daterangeinput-android-chromium-dark-1-snap.png
+++ b/src/components/DateRangeInput/__image_snapshots__/daterangeinput-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b73bb79ddd2c628304e56b1291ec4e779f30252f6c206f3285ae639c38e5f7ee
-size 91630
+oid sha256:3184076023a517803775ef1142caba013a867b1591225f24baecfa26c9bfeea8
+size 91649

--- a/src/components/DateRangeInput/__image_snapshots__/daterangeinput-android-chromium-light-1-snap.png
+++ b/src/components/DateRangeInput/__image_snapshots__/daterangeinput-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa890f10feccec90520013d3e6f8dfac95e4263a48fcce2b884cea0ea202a6b4
-size 90948
+oid sha256:9a129eb19f3644eff3066b6c6991423220d2c5ab2d30cd20ed5fcef6b04375bc
+size 90973

--- a/src/components/Tabs/__image_snapshots__/tabs-android-chromium-dark-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e45729e2e905041c5d70a30d10981a0028e8f14ffd98602ee44ae3d7fb8ffb8b
-size 638781
+oid sha256:08c2465da27c27c2ae4447b2f9f4787af63910202c78b59e6eae0854268783b5
+size 635140

--- a/src/components/Tabs/__image_snapshots__/tabs-android-chromium-light-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7efba555a99286e69d9423d0ef06e75274f12b5422b14f620c9aeb60786221fa
-size 609321
+oid sha256:23dbb1928adda5be3e4e0fffb80ee7b256737e9396774f5ed30142e3b0464447
+size 605816

--- a/src/components/Tabs/__image_snapshots__/tabs-ios-webkit-dark-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:231330b2aa966bb04cc035fe52296adc47d676670dcf56ca14817cc4fc38325a
-size 668557
+oid sha256:173417d5fe4889a6b8decbd144c803bdf4481d99f26ed41e4d63fa2f4f341e78
+size 665763

--- a/src/components/Tabs/__image_snapshots__/tabs-ios-webkit-light-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b8429146c8e4634b80e985f89754679736ed2ac67eeb486d3bfdb28366e753c
-size 632940
+oid sha256:23f75b3db909780d2a8115933ae3a1dfdb01879bf01affa232cea0487211c02e
+size 630348

--- a/src/components/Tabs/__image_snapshots__/tabs-vkcom-chromium-dark-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:224173b91c3753aa32b8460960605f5600a165c769ad38788afc779d18aa088d
-size 241175
+oid sha256:790020a62fb45a913a09120bdbb39d027ffa8c363fdaa0bde9e1685cf13b10c6
+size 239758

--- a/src/components/Tabs/__image_snapshots__/tabs-vkcom-chromium-light-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:265fe442668d3c9b09a39cafb67fb5557be0ed5e8a27ec7919909072d2493c2d
-size 242804
+oid sha256:88cc7db5dded58043d806210c7a136efc5712953cdc343caae182105aed8ce45
+size 241541

--- a/src/components/Tabs/__image_snapshots__/tabs-vkcom-firefox-dark-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c345da3c8ae555f174ceba5f1274095db594c7a67e7657336e8c9ba30b30f38
-size 284403
+oid sha256:464de5f30408c01c6151713d4b12f4b3c5d49db1617288e4c2a0246de2aa099b
+size 283804

--- a/src/components/Tabs/__image_snapshots__/tabs-vkcom-firefox-light-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7d032ff51da6762f938deec45097ccb841674c74831c203007fcb2ef5eacfca
-size 285346
+oid sha256:60a2d3cc407775e63d56b420593f44a204a475e9af89706de526a1c1671d6e42
+size 284492

--- a/src/components/Tabs/__image_snapshots__/tabs-vkcom-webkit-dark-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8831b892261528cde192702fb6e96687ce7603a7dbec8badcf65d6d7450d7354
-size 514895
+oid sha256:2400d3bb72197c91995757bc7bbae1b5a44fd30618efdf61d4cfb9cfec3d89af
+size 513842

--- a/src/components/Tabs/__image_snapshots__/tabs-vkcom-webkit-light-1-snap.png
+++ b/src/components/Tabs/__image_snapshots__/tabs-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6d3ce02de3463db3f48761e3b3ab57173d71f3c5640f94aaa38ce4b09776e9e
-size 506700
+oid sha256:38edfc5e8944009a4307dcf5cbf2223271bc78508ac556ad9ed38da2a7a8cf42
+size 505826

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,10 +2060,10 @@
     "@typescript-eslint/parser" "^4.22.0"
     eslint-config-google "^0.9.1"
 
-"@vkontakte/icons@^1.184.0":
-  version "1.184.0"
-  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-1.184.0.tgz#826cff753581af31839e39c8224bd09015e8befd"
-  integrity sha512-0yLCt8S2pscE1DoIaTlS+2nYinwp45QQHNO9qORFexwRf4Z5R2ocEObESpwdMmuJfVnmRh3SkODbq6Fmb+HPvA==
+"@vkontakte/icons@^1.205.0":
+  version "1.205.0"
+  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-1.205.0.tgz#5e60df521e22b6527a8e388c1fc4ba8c422b5485"
+  integrity sha512-aUpuUrr2rjoDtzd9e92lr6cphCvxwq+gqZOagr5t/kJrsEYPZuZSWIPx/4ipFdVzROvypg9sPRuxNVqtrhmvYw==
   dependencies:
     svg-baker-runtime "1.4.7"
 


### PR DESCRIPTION
Часть иконок в репе `@vkontakte/icons` поменялась между минорами, поэтому развалилось столько скриншотов в https://github.com/VKCOM/VKUI/pull/3657 при попытке обновиться на `@vkontakte/icons@alpha`.

Соответственно — нужен бамп `@vkontakte/icons` в v4.