### PR TITLE
test(e2e): remove listen and close

### DIFF
--- a/e2e/jest/globalSetup.ts
+++ b/e2e/jest/globalSetup.ts
@@ -29,6 +29,8 @@ async function setupWebpack() {
 
   devServer = new WebpackDevServer(
     {
+      host: 'localhost',
+      port: 9000,
       allowedHosts: 'all',
       devMiddleware: {
         stats: 'minimal',
@@ -37,7 +39,7 @@ async function setupWebpack() {
     },
     compiler as any,
   );
-  devServer.listen(9000, 'localhost', console.error);
+  await devServer.start();
   (global as any)['__DEV_SERVER__'] = devServer;
 
   return compilerDone;

--- a/e2e/jest/globalTeardown.ts
+++ b/e2e/jest/globalTeardown.ts
@@ -7,7 +7,7 @@ module.exports = async function teardown(config: JestConfig.GlobalConfig) {
   await baseTeardown(config);
   // I don't know why, but devServer closes in watch mode, too
   if (!config.watch && !config.watchAll) {
-    (global as any)['__DEV_SERVER__'].close();
+    await (global as any)['__DEV_SERVER__'].stop();
     if (useDocker) {
       await stopDocker();
     }


### PR DESCRIPTION
- `listen` method is deprecated in favor async `start` or `startCallback` methods
- `close` method is deprecated in favor async `stop` or `stopCallback` methods