### PR TITLE
build(deps_v4): support @vkontakte/icons v2 alongside v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "generate_scheme": "./tasks/generate_scheme.js"
   },
   "peerDependencies": {
-    "@vkontakte/icons": "^1.184.0",
+    "@vkontakte/icons": "^1.184.0 || ^2.1.1",
     "@vkontakte/vk-bridge": "^2.0.2",
     "react": "^16.8.6 || ^17.0.0 || ^18.1.0",
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.1.0"

--- a/src/components/Cell/CellCheckbox/CellCheckbox.tsx
+++ b/src/components/Cell/CellCheckbox/CellCheckbox.tsx
@@ -34,8 +34,12 @@ export const CellCheckbox = ({
       style={style}
     >
       <input vkuiClass="CellCheckbox__input" type="checkbox" {...restProps} />
-      <IconOff vkuiClass="CellCheckbox__icon CellCheckbox__icon--off" />
-      <IconOn vkuiClass="CellCheckbox__icon CellCheckbox__icon--on" />
+      <span vkuiClass="CellCheckbox__icon CellCheckbox__icon--off">
+        <IconOff />
+      </span>
+      <span vkuiClass="CellCheckbox__icon CellCheckbox__icon--on">
+        <IconOn />
+      </span>
     </div>
   );
 };

--- a/src/components/DropdownIcon/DropdownIcon.tsx
+++ b/src/components/DropdownIcon/DropdownIcon.tsx
@@ -5,12 +5,13 @@ import {
   Icon24ChevronUp,
   Icon20ChevronUp,
 } from "@vkontakte/icons";
+import { VKontakteIconsBackwardsCompatibleElement } from "../../types";
 import { classNames } from "../../lib/classNames";
 import { SizeType } from "../AdaptivityProvider/AdaptivityContext";
 import { useAdaptivity } from "../../hooks/useAdaptivity";
 
 export interface DropdownIconProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+  extends React.HTMLAttributes<VKontakteIconsBackwardsCompatibleElement> {
   opened?: boolean;
 }
 

--- a/src/components/WriteBarIcon/WriteBarIcon.css
+++ b/src/components/WriteBarIcon/WriteBarIcon.css
@@ -49,6 +49,8 @@
 .WriteBarIcon--ios.WriteBarIcon--send,
 .WriteBarIcon--ios.WriteBarIcon--done {
   width: 48px;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .WriteBarIcon--ios.WriteBarIcon--send:first-child,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,3 +45,12 @@ export interface Version {
   minor?: number;
   patch?: number;
 }
+
+/**
+ * В зависимости от версии `getRootRef`
+ * иконок `@vkontakte/icons` возвращает
+ * `HTMLDivElement` (v1) или `SVGSVGElement` (v2)
+ */
+export type VKontakteIconsBackwardsCompatibleElement =
+  | HTMLDivElement
+  | SVGSVGElement;


### PR DESCRIPTION
- closes #3748.

Что сделала:

- [x] перенесла фиксы проблем, возникших при апдейте на v2
- [x] проверила, что все ок с v1
- [x] проверила, что все ок при обновлении на v2
- [x] добавила v2 в peer dependencies