### PR TITLE
ci(pull_request): запускает все джобы для PR из форкнутной репы

### DIFF
--- a/.github/gitflow/messages.js
+++ b/.github/gitflow/messages.js
@@ -1,0 +1,34 @@
+/**
+ * @param {string} header
+ * @param {string} description
+ * @param {{ stableBranchRef: string, patchRefs: string, pullNumber: string  }} patch
+ * @returns string
+ */
+module.exports.getPatchInstructions = (header, description, patch) => {
+  const { stableBranchRef, patchRefs, pullNumber } = patch;
+  return `
+## ${header}
+
+${description}
+
+> Дальнейшие действия выполняют контрибьютеры из группы @VKCOM/vkui-core
+
+Чтобы исправление попало в стабильную ветку, выполните следующие действия:
+
+1. Создайте новую ветку от стабильной и примените исправления используя cherry-pick
+
+\`\`\`bash
+git fetch origin ${stableBranchRef}
+git checkout -b patch/pr${pullNumber} origin/${stableBranchRef}
+git cherry-pick ${patchRefs}
+\`\`\`
+
+2. Исправьте конфликты, следуя инструкциям из терминала
+3. Отправьте ветку на GitHub и создайте новый PR с последней стабильной веткой (метка patch не нужна)
+
+\`\`\`bash
+git push --set-upstream origin patch/pr${pullNumber}
+gh pr create --base ${stableBranchRef}
+\`\`\`
+`;
+};

--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -1,7 +1,7 @@
 name: "Close PR"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:
@@ -25,7 +25,12 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'patch')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: actions/checkout@v3 for forked
+        uses: actions/checkout@v3
+        if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+      - name: actions/checkout@v3 for base
+        uses: actions/checkout@v3
+        if: github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
@@ -37,6 +42,7 @@ jobs:
           git config --local user.name "GitHub Action"
       - run: node ./.github/gitflow/patch.js
         env:
+          FORKED: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
           INPUT_GITHUB_PULL_NUMBER: ${{ github.event.number }}
           INPUT_GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 name: "Pull Request"
 
-on: ["pull_request"]
+on: ["pull_request_target"]
 
 concurrency:
   group: pr-${{ github.ref }}
@@ -111,8 +111,8 @@ jobs:
     concurrency: ci-gh-pages
     runs-on: ubuntu-latest
     needs: styleguide
-    # Skip deploy from forked repo or from dependabot
-    if: ${{ (github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id) && (github.actor != 'dependabot[bot]') }}
+    # Skip deploy from dependabot
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v3
       - name: Download styleguide artifact


### PR DESCRIPTION
Чинится заменой события `["pull_request"]` на `["pull_request_target"]` ([ссылка на документацию pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)).

- в воркфлоу `pull_request.yml`
  -  [x] `deploy_styleguide` – проверили с @SevereCloud в сторонней репе
  -  [ ] `report_tests` – простестируем при открытии PR из форк репы
- в воркфлоу `pr_close.yml`
  - [x] `clear_styleguide` – проверили с @SevereCloud в сторонней репе
  - [x] `patch` – показываем сообщение, что необходимо черри-пикнуть изменение (нам самим, а не контрибьютеру). Автоматического закрытия не добился, т.к. в `actions/checkout@v3` не передается `DEVTOOLS_GITHUB_TOKEN`. Решил пока сделать **MVP**.  проверили с @SevereCloud в сторонней репе

    <img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/206701416-5a5954af-0e79-4735-a33d-98e8044e4ba8.png">

---

- close #3259 