### PR TITLE
docs: fix avoiding recreating

### DIFF
--- a/src/components/Calendar/Readme.md
+++ b/src/components/Calendar/Readme.md
@@ -7,7 +7,7 @@
 import { format } from '../../lib/date';
 
 const Example = () => {
-  const [value, setValue] = useState(new Date());
+  const [value, setValue] = useState(() => new Date());
   const [enableTime, setEnableTime] = useState(false);
   const [disablePast, setDisablePast] = useState(false);
   const [disableFuture, setDisableFuture] = useState(false);

--- a/src/components/DateInput/Readme.md
+++ b/src/components/DateInput/Readme.md
@@ -9,7 +9,7 @@
 import { format } from '../../lib/date';
 
 const Example = () => {
-  const [value, setValue] = useState(new Date());
+  const [value, setValue] = useState(() => new Date());
   const [enableTime, setEnableTime] = useState(false);
   const [disablePast, setDisablePast] = useState(false);
   const [disableFuture, setDisableFuture] = useState(false);


### PR DESCRIPTION
React сохраняет начальное значение один раз и игнорирует его при
следующем рендеринге

```tsx
const [value, setValue] = useState(new Date());
```

Хотя результат `new Date()` используется только  для начального
рендеринга, функция по прежнему вызывается при каждом рендеринге.
Это может быть расточительно, если создаются дорогие объекты