### PR TITLE
ci(pull_request.yml): использует `github.event.pull_request.number` для `currency.group`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,9 +1,21 @@
 name: 'Pull Request'
 
+# > Про 'pull_request_target' и про риски его использования можно ознакомиться в статье по ссылке ниже
+# > https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# При 'pull_request_target' свойство `github.ref` будет соответствовать `refs/head/master`, поэтому необходимо
+# вручную перебивать его на `github.event.pull_request.number` там, где это необходимо.
+#
+# Пример:
+# ```
+# - uses: actions/checkout@v3
+#   with:
+#     ref: refs/pull/${{ github.event.pull_request.number }}/merge
+# ```
 on: ['pull_request_target']
 
 concurrency:
-  group: pr-${{ github.ref }}
+  group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Джобы в PR из форкнутых реп не работали параллельно, т.к. у них был общий `currency.group`.

---

- relate #3765