### PR TITLE
fix(CustomSelect): исправляет выбор элемента с `currentIndex - 1` при `searchable`

### DIFF
--- a/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/src/components/CustomSelect/CustomSelect.test.tsx
@@ -1,10 +1,23 @@
 import * as React from 'react';
+import '@testing-library/jest-dom/extend-expect';
 import { baselineComponent, waitForPopper } from '../../testing/utils';
-import { CustomSelect } from './CustomSelect';
+import { type SelectProps, CustomSelect } from './CustomSelect';
 import { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 const getCustomSelectValue = () => screen.getByTestId('target').textContent;
+
+const CustomSelectControlled = ({
+  options,
+  initialValue,
+  ...restProps
+}: Omit<SelectProps, 'value' | 'onChange'> & { initialValue?: string }) => {
+  const [value, setValue] = React.useState(initialValue);
+  const handleChange: React.ChangeEventHandler<HTMLSelectElement> = (event) => {
+    setValue(event.target.value);
+  };
+  return <CustomSelect {...restProps} options={options} value={value} onChange={handleChange} />;
+};
 
 describe('CustomSelect', () => {
   baselineComponent(CustomSelect);
@@ -310,6 +323,36 @@ describe('CustomSelect', () => {
     );
 
     expect(screen.getByTitle('Joe').getAttribute('aria-selected')).toEqual('true');
+  });
+
+  // см. https://github.com/VKCOM/VKUI/issues/3600
+  it('is searchable – should correct re-calculate index of the options when them will be filtered', async () => {
+    render(
+      <CustomSelectControlled
+        searchable
+        data-testid="target"
+        initialValue="3"
+        options={[
+          { value: '0', label: 'Не выбрано' },
+          { value: '1', label: 'Категория 1' },
+          { value: '2', label: 'Категория 2' },
+          { value: '3', label: 'Категория 3' },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('target'));
+
+    expect(screen.getByTitle('Категория 3')).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.change(screen.getByTestId('target'), { target: { value: 'Кат' } });
+
+    expect(screen.getByTitle('Категория 3')).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.mouseEnter(screen.getByTitle('Категория 2'));
+    fireEvent.click(screen.getByTitle('Категория 2'));
+
+    expect(getCustomSelectValue()).toEqual('Категория 2');
   });
 
   it('fires onOpen and onClose correctly', async () => {

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -105,6 +105,10 @@ export interface SelectProps extends NativeSelectProps, FormFieldProps, TrackerO
    * Текст, который будет отображен, если приходит пустой `options`.
    */
   emptyText?: string;
+  /**
+   * > ⚠️ В v6 из возвращаемых типов будет удалён `CustomSelectOptionInterface[]`. Для кастомной фильтрации используйте
+   * > `filterFn`.
+   */
   onInputChange?: (
     e: React.ChangeEvent,
     options: CustomSelectOptionInterface[],
@@ -471,13 +475,14 @@ export function CustomSelect(props: SelectProps) {
 
   const onInputChange: React.ChangeEventHandler<HTMLInputElement> = React.useCallback(
     (e) => {
+      // TODO v6 удалить `onInputChangeProp`.
       if (onInputChangeProp) {
         const options = onInputChangeProp(e, optionsProp);
         if (options) {
           if (process.env.NODE_ENV === 'development') {
             warn(
               'Этот метод фильтрации устарел. Возвращаемое значение onInputChange будет ' +
-                'проигнорировано в v5.0.0. Для фильтрации обновляйте props.options самостоятельно или используйте свойство filterFn.',
+                'проигнорировано в v6.0.0. Для фильтрации обновляйте props.options самостоятельно или используйте свойство filterFn.',
             );
           }
           setOptions(options);

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -335,15 +335,18 @@ export function CustomSelect(props: SelectProps) {
     [focusOptionByIndex, keyboardInput, options],
   );
 
+  /**
+   * Note: сбрасывать `options` через `setOptions(optionsProp)` не нужно.
+   *  Сброс происходит в одном из эффекте `updateOptionsAndSelectedOptionIndex()`.
+   */
   const close = React.useCallback(() => {
     resetKeyboardInput();
 
     setInputValue('');
     setOpened(false);
     setFocusedOptionIndex(-1);
-    setOptions(optionsProp);
     onClose?.();
-  }, [onClose, optionsProp, resetKeyboardInput]);
+  }, [onClose, resetKeyboardInput]);
 
   const selectFocused = React.useCallback(() => {
     if (focusedOptionIndex !== undefined && isValidIndex(focusedOptionIndex)) {
@@ -405,25 +408,28 @@ export function CustomSelect(props: SelectProps) {
     [focusOptionByIndex, focusedOptionIndex, options],
   );
 
-  React.useEffect(() => {
-    const value = props.value ?? nativeSelectValue ?? props.defaultValue;
+  React.useEffect(
+    function updateOptionsAndSelectedOptionIndex() {
+      const value = props.value ?? nativeSelectValue ?? props.defaultValue;
 
-    const options =
-      searchable && inputValue !== undefined
-        ? filter(optionsProp, inputValue, filterFn)
-        : optionsProp;
+      const options =
+        searchable && inputValue !== undefined
+          ? filter(optionsProp, inputValue, filterFn)
+          : optionsProp;
 
-    setOptions(options);
-    setSelectedOptionIndex(findSelectedIndex(options, value));
-  }, [
-    filterFn,
-    inputValue,
-    nativeSelectValue,
-    optionsProp,
-    props.defaultValue,
-    props.value,
-    searchable,
-  ]);
+      setOptions(options);
+      setSelectedOptionIndex(findSelectedIndex(options, value));
+    },
+    [
+      filterFn,
+      inputValue,
+      nativeSelectValue,
+      optionsProp,
+      props.defaultValue,
+      props.value,
+      searchable,
+    ],
+  );
 
   /**
    * Нужен для правильного поведения обработчика onClick на select. Фильтрует клики, которые были сделаны по
@@ -435,19 +441,16 @@ export function CustomSelect(props: SelectProps) {
     }
   }, []);
 
-  const onNativeSelectChange: React.ChangeEventHandler<HTMLSelectElement> = React.useCallback(
-    (e) => {
-      const newSelectedOptionIndex = findSelectedIndex(options, e.currentTarget.value);
+  const onNativeSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
+    const newSelectedOptionIndex = findSelectedIndex(options, e.currentTarget.value);
 
-      if (selectedOptionIndex !== newSelectedOptionIndex) {
-        if (!isControlledOutside) {
-          setSelectedOptionIndex(newSelectedOptionIndex);
-        }
-        onChange?.(e);
+    if (selectedOptionIndex !== newSelectedOptionIndex) {
+      if (!isControlledOutside) {
+        setSelectedOptionIndex(newSelectedOptionIndex);
       }
-    },
-    [isControlledOutside, onChange, options, selectedOptionIndex],
-  );
+      onChange?.(e);
+    }
+  };
 
   const onInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> = React.useCallback(
     (event) => {


### PR DESCRIPTION
- Удалил лишний `setOptions`, который был в `close()` – из-за него в `onNativeSelectChange`, при `searchable={true}`, мы получали не отфильтрованный `options`, тем самым `findSelectedIndex` возвращал не соотвествующий действительности `index`. Написал **unit test** на этой кейс, по нему нагляднее понять о чём речь.
- Поправил TODO про `onInputChage`

---

- fix #3600