### PR TITLE
ci: skip clear for dependabot

### DIFF
--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   clear_styleguide:
     concurrency: ci-gh-pages
+    # skip clear for dependabot
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Пропускаем очистку для dependabot, поскольку тот не деплоит стайлгайд