### PR TITLE
chore: Fix push-screenshots action

### DIFF
--- a/.github/actions/push-screenshots/src/main.ts
+++ b/.github/actions/push-screenshots/src/main.ts
@@ -30,16 +30,12 @@ async function run(): Promise<void> {
     await retry(
       async () => {
         await exec.exec('git', ['add', './**/*.png']);
-        await exec.exec('git', [
-          'diff-index',
-          '--quiet',
-          'HEAD',
-          '||',
-          'git',
-          'commit',
-          '-m',
-          `"CHORE: Update screenshots"`,
-        ]);
+
+        try {
+          await exec.exec('git', ['diff-index', '--quiet', 'HEAD']);
+        } catch (e) {
+          await exec.exec('git', ['commit', '-m', `"CHORE: Update screenshots"`]);
+        }
       },
       async () => {
         await exec.exec('git', ['pull', '--rebase', '--autostash']);


### PR DESCRIPTION
`@actions/exec` не умеет в чейнинг команд 