### PR TITLE
fix(FocusVisible): use border for inside

### DIFF
--- a/src/components/Alert/Alert.module.css
+++ b/src/components/Alert/Alert.module.css
@@ -183,11 +183,11 @@
 }
 
 .Alert--ios.Alert--h .Alert__action:first-child {
-  border-bottom-left-radius: 12px;
+  border-bottom-left-radius: var(--vkui--size_border_radius_paper--regular);
 }
 
 .Alert--ios.Alert--h .Alert__action:last-child {
-  border-bottom-right-radius: 12px;
+  border-bottom-right-radius: var(--vkui--size_border_radius_paper--regular);
 }
 
 .Alert--ios.Alert--v .Alert__action::after {

--- a/src/components/FocusVisible/FocusVisible.module.css
+++ b/src/components/FocusVisible/FocusVisible.module.css
@@ -1,15 +1,21 @@
 [class$='--focus-visible'] > .FocusVisible {
   position: absolute;
-  top: 2px;
-  left: 2px;
-  right: 2px;
-  bottom: 2px;
   border-radius: inherit;
-  box-shadow: 0 0 0 2px var(--vkui--color_stroke_accent);
   user-select: none;
   pointer-events: none;
   overflow: hidden;
   z-index: 0;
+}
+
+[class$='--focus-visible'] > .FocusVisible--mode-inside {
+  top: 2px;
+  left: 2px;
+  right: 2px;
+  bottom: 2px;
+  border-color: var(--vkui--color_stroke_accent);
+  border-width: 2px;
+  border-style: solid;
+  box-sizing: border-box;
 }
 
 [class$='--focus-visible'] > .FocusVisible--mode-outside {
@@ -17,6 +23,7 @@
   left: -2px;
   right: -2px;
   bottom: -2px;
+  box-shadow: 0 0 0 2px var(--vkui--color_stroke_accent);
 }
 
 /**
@@ -49,10 +56,10 @@
     }
 
     100% {
-      top: 2px;
-      left: 2px;
-      bottom: 2px;
-      right: 2px;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
       will-change: auto;
     }
   }
@@ -69,8 +76,4 @@
       will-change: auto;
     }
   }
-}
-
-.FocusVisible--mode-inside {
-  /* Пустой класс для CSS Modules (см. CONTRIBUTING.md)  */
 }


### PR DESCRIPTION
Используем border вместо box-shadow для inside мода


До|После
-|-
<img width="809" alt="image" src="https://user-images.githubusercontent.com/14944123/208933232-085c86b0-87ee-42f2-bc2d-8bcd40e4060f.png">|<img width="836" alt="image" src="https://user-images.githubusercontent.com/14944123/208933713-c6834b21-a639-4d4d-8ca3-856537a125b8.png">
<img width="777" alt="image" src="https://user-images.githubusercontent.com/14944123/208933932-60cdfcc4-3aba-4a56-9a94-96ea08e39d24.png">|<img width="786" alt="image" src="https://user-images.githubusercontent.com/14944123/208933963-7690abad-5e5b-4ade-9bf7-4c578336c501.png">
<img width="870" alt="image" src="https://user-images.githubusercontent.com/14944123/208934126-f9b4f1c0-3dfa-45e9-8fdc-be083144f847.png">|<img width="887" alt="image" src="https://user-images.githubusercontent.com/14944123/208934170-883730c3-126c-468e-a823-472ee6582f57.png">



