### PR TITLE
fix: remove listener if action type change

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -139,12 +139,23 @@ export const Popover = ({
     }
 
     targetClickEvent.add(childRef.current);
+  }, [childRef, targetClickEvent]);
+
+  React.useEffect(() => {
+    if (!childRef.current) {
+      return;
+    }
 
     if (hoverable) {
       targetEnterListener.add(childRef.current);
       targetLeaveListener.add(childRef.current);
     }
-  }, [childRef, hoverable, targetClickEvent, targetEnterListener, targetLeaveListener]);
+
+    return () => {
+      targetEnterListener.remove();
+      targetLeaveListener.remove();
+    };
+  }, [childRef, hoverable, targetEnterListener, targetLeaveListener]);
 
   return (
     <React.Fragment>

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -51,5 +51,5 @@ export function useEventListener<E extends Event, K extends keyof GlobalEventHan
   );
   React.useEffect(() => remove, [remove]);
 
-  return { add, remove };
+  return React.useMemo(() => ({ add, remove }), [add, remove]);
 }


### PR DESCRIPTION
Наткнулась на достаточно пограничный кейс - если динамически поменять `action`, то listener'ы от `hover`-состояния не удалялись, что приводило к багам