### PR TITLE
fix: Small docs typos

### DIFF
--- a/src/components/Badge/Readme.md
+++ b/src/components/Badge/Readme.md
@@ -6,7 +6,11 @@
     <PanelHeader>Бейдж</PanelHeader>
 
     <Group header={<Header mode="secondary">В пунктах меню</Header>}>
-      <Cell expandable before={<Icon28Notifications />} badge={<Badge aria-label="Есть новые" />}>
+      <Cell
+        expandable
+        before={<Icon28Notifications />}
+        badgeAfterTitle={<Badge aria-label="Есть новые" />}
+      >
         Уведомления
       </Cell>
     </Group>

--- a/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -15,6 +15,7 @@ export interface CustomSelectOptionProps
     HasRootRef<HTMLDivElement> {
   /**
    * Вставляет основной контент.
+   * @deprecated since v6.0.0
    */
   option?: any;
   /**
@@ -86,7 +87,8 @@ export const CustomSelectOption = ({
   );
 
   if (!!option && process.env.NODE_ENV === 'development') {
-    warn('Свойство option было добавлено по ошибке и будет удалено в 5.0.0.');
+    // TODO v6.0.0. Удалить св-во `option`
+    warn('Свойство option было добавлено по ошибке и будет удалено в v6.0.0.');
   }
 
   return (


### PR DESCRIPTION
- в доке `Cell` был не переименован проп 
- в `CustomSelectOption` удаление пропа перенесено в `v6`