### PR TITLE
Revert "build(deps-dev): bump react-frame-component from 5.2.4 to 5.2.5"

### DIFF
--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "prop-types": "15.8.1",
     "react-docgen-typescript": "2.2.2",
-    "react-frame-component": "5.2.5",
+    "react-frame-component": "5.2.4",
     "react-styleguidist": "13.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9964,10 +9964,10 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-frame-component@5.2.5:
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.5.tgz#c16b12d9d0069f31a959a43ebef125440dfc201f"
-  integrity sha512-7PKQb/7r7o0fdKyHi47g09PfXcJf21BO+i6Z4h59KDaDu1nv6HIG+yLuPiLid0N6CAvmbHhHP8pdP+3WZuIIgg==
+react-frame-component@5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.4.tgz#8282849fe0eb315fb30b00c67e5e979f8f63c01a"
+  integrity sha512-4xpZFcLNS6LCEYSlWgsUy81v7LjdgbvB0VHIq7sNSD25PK+e5YYCrdy5557ebGwNLKNLEpYVfAkT3pVzFLPb1g==
 
 react-group@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This reverts commit 41bce82a9c9bba2a76df8897cc17651c1ad65cfd.

<img width="449" alt="image" src="https://user-images.githubusercontent.com/7431217/211737221-df2539d7-47ad-4753-be63-0634f9dfdd4f.png">

See [note](https://github.com/ryanseddon/react-frame-component/releases/tag/v5.2.5)