### PR TITLE
fix(polyfills): MediaQueryListEvent API

### DIFF
--- a/packages/vkui/global.d.ts
+++ b/packages/vkui/global.d.ts
@@ -1,4 +1,4 @@
-// addEventListener и removeEventListener имеют плохую поддержку в Safari.
+// addEventListener и removeEventListener имеют плохую поддержку в Safari < 14.
 //
 // https://caniuse.com/mdn-api_mediaquerylistevent
 interface MediaQueryList {

--- a/packages/vkui/global.d.ts
+++ b/packages/vkui/global.d.ts
@@ -1,0 +1,25 @@
+// addEventListener и removeEventListener имеют плохую поддержку в Safari.
+//
+// https://caniuse.com/mdn-api_mediaquerylistevent
+interface MediaQueryList {
+  addEventListener?<K extends keyof MediaQueryListEventMap>(
+    type: K,
+    listener: (this: MediaQueryList, ev: MediaQueryListEventMap[K]) => any,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  addEventListener?(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener?<K extends keyof MediaQueryListEventMap>(
+    type: K,
+    listener: (this: MediaQueryList, ev: MediaQueryListEventMap[K]) => any,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  removeEventListener?(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}

--- a/packages/vkui/src/components/SplitCol/SplitCol.tsx
+++ b/packages/vkui/src/components/SplitCol/SplitCol.tsx
@@ -6,6 +6,7 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { ViewWidth } from '../../lib/adaptivity';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { useMediaQueries } from '../../hooks/useMediaQueries';
+import { matchMediaListAddListener, matchMediaListRemoveListener } from '../../lib/matchMedia';
 import styles from './SplitCol.module.css';
 
 function useTransitionAnimate(animateProp?: boolean) {
@@ -28,9 +29,9 @@ function useTransitionAnimate(animateProp?: boolean) {
     const listener = () => setAnimate(!mediaQueries.smallTabletPlus.matches);
     listener();
 
-    mediaQueries.smallTabletPlus.addEventListener('change', listener);
+    matchMediaListAddListener(mediaQueries.smallTabletPlus, listener);
     return () => {
-      mediaQueries.smallTabletPlus.removeEventListener('change', listener);
+      matchMediaListRemoveListener(mediaQueries.smallTabletPlus, listener);
     };
   }, [animateProp, viewWidth, mediaQueries]);
 

--- a/packages/vkui/src/hooks/useAdaptivityWithJSMediaQueries.ts
+++ b/packages/vkui/src/hooks/useAdaptivityWithJSMediaQueries.ts
@@ -14,6 +14,7 @@ import {
 } from '../lib/adaptivity';
 import { useMediaQueries } from './useMediaQueries';
 import { usePlatform } from './usePlatform';
+import { matchMediaListAddListener, matchMediaListRemoveListener } from '../lib/matchMedia';
 
 export interface UseAdaptivityWithJSMediaQueries extends Required<BaseAdaptivityProps> {
   isDesktop: boolean;
@@ -114,24 +115,33 @@ export const useAdaptivityWithJSMediaQueries = (): UseAdaptivityWithJSMediaQueri
     };
 
     if (!viewWidthContext) {
-      mediaQueries.desktopPlus.addEventListener('change', handleMediaQuery);
-      mediaQueries.tablet.addEventListener('change', handleMediaQuery);
-      mediaQueries.smallTablet.addEventListener('change', handleMediaQuery);
-      mediaQueries.mobile.addEventListener('change', handleMediaQuery);
+      [
+        mediaQueries.desktopPlus,
+        mediaQueries.tablet,
+        mediaQueries.smallTablet,
+        mediaQueries.mobile,
+      ].forEach((matchMediaListener) =>
+        matchMediaListAddListener(matchMediaListener, handleMediaQuery),
+      );
     }
 
     if (!viewHeightContext) {
-      mediaQueries.mediumHeight.addEventListener('change', handleMediaQuery);
-      mediaQueries.mobileLandscapeHeight.addEventListener('change', handleMediaQuery);
+      [mediaQueries.mediumHeight, mediaQueries.mobileLandscapeHeight].forEach(
+        (matchMediaListener) => matchMediaListAddListener(matchMediaListener, handleMediaQuery),
+      );
     }
 
     return () => {
-      mediaQueries.desktopPlus.removeEventListener('change', handleMediaQuery);
-      mediaQueries.tablet.removeEventListener('change', handleMediaQuery);
-      mediaQueries.smallTablet.removeEventListener('change', handleMediaQuery);
-      mediaQueries.mobile.removeEventListener('change', handleMediaQuery);
-      mediaQueries.mediumHeight.removeEventListener('change', handleMediaQuery);
-      mediaQueries.mobileLandscapeHeight.removeEventListener('change', handleMediaQuery);
+      [
+        mediaQueries.desktopPlus,
+        mediaQueries.tablet,
+        mediaQueries.smallTablet,
+        mediaQueries.mobile,
+        mediaQueries.mediumHeight,
+        mediaQueries.mobileLandscapeHeight,
+      ].forEach((matchMediaListener) =>
+        matchMediaListRemoveListener(matchMediaListener, handleMediaQuery),
+      );
     };
   }, [mediaQueries, viewWidthContext, viewHeightContext]);
 

--- a/packages/vkui/src/hooks/useAutoDetectAppearance.tsx
+++ b/packages/vkui/src/hooks/useAutoDetectAppearance.tsx
@@ -7,6 +7,7 @@ import vkBridge, {
 import { useDOM } from '../lib/dom';
 import { noop } from '@vkontakte/vkjs';
 import { resolveAppearance, VKBridgeConfigData } from '../helpers/appearance';
+import { matchMediaListAddListener, matchMediaListRemoveListener } from '../lib/matchMedia';
 
 let initialAppearance: AppearanceType | null = null;
 
@@ -58,9 +59,9 @@ function autoDetectAppearance(
   };
 
   check(mediaQuery);
-  mediaQuery.addEventListener('change', check);
+  matchMediaListAddListener(mediaQuery, check);
 
-  return () => mediaQuery.removeEventListener('change', check);
+  return () => matchMediaListRemoveListener(mediaQuery, check);
 }
 
 export const useAutoDetectAppearance = (

--- a/packages/vkui/src/lib/matchMedia.ts
+++ b/packages/vkui/src/lib/matchMedia.ts
@@ -1,0 +1,17 @@
+export function matchMediaListAddListener(
+  mediaQueryList: MediaQueryList,
+  listener: (this: MediaQueryList, ev: MediaQueryListEvent) => any,
+) {
+  mediaQueryList.addEventListener
+    ? mediaQueryList.addEventListener('change', listener)
+    : mediaQueryList.addListener(listener);
+}
+
+export function matchMediaListRemoveListener(
+  mediaQueryList: MediaQueryList,
+  listener: (this: MediaQueryList, ev: MediaQueryListEvent) => any,
+) {
+  mediaQueryList.removeEventListener
+    ? mediaQueryList.removeEventListener('change', listener)
+    : mediaQueryList.removeListener(listener);
+}

--- a/packages/vkui/tsconfig.json
+++ b/packages/vkui/tsconfig.json
@@ -12,5 +12,5 @@
     ]
   },
   "include": ["src/**/*.ts*", "src/**/*.js", "*.config.js", "*.setup.js", ".eslintrc.js"],
-  "files": ["types/env.d.ts"]
+  "files": ["./global.d.ts", "types/env.d.ts"]
 }


### PR DESCRIPTION
Старые версии safari не поддерживают `MediaQueryList.prototype.addEventListener` и `MediaQueryList.prototype.removeEventListener`

https://caniuse.com/mdn-api_mediaquerylistevent