### PR TITLE
fix(@vkontakte/vkui): копирует рутовые `LICENSE` и `README.md` перед паблишом

### DIFF
--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -27,7 +27,8 @@
   "bugs": "https://github.com/VKCOM/VKUI/issues",
   "homepage": "https://vkcom.github.io/VKUI/",
   "scripts": {
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": "yarn copy-essensial-files && yarn build",
+    "copy-essensial-files": "cp ../../LICENSE . && cp ../../README.md .",
     "package:version": "echo $npm_package_version",
     "size": "yarn clear && concurrently 'yarn:babel' 'yarn:postcss' && size-limit",
     "size:ci": "yarn install --frozen-lockfile --ignore-scripts && concurrently 'yarn:babel' 'yarn:postcss'",


### PR DESCRIPTION
Потерялись `LICENSE` и `README.md` в артефакте

<img width="320" src="https://user-images.githubusercontent.com/5850354/213140856-aab48b2b-d75d-4be3-864b-7751c225fcd7.png" />

<img width="320" src="https://user-images.githubusercontent.com/5850354/213140877-332d8b87-5b2e-4b52-8587-f2f807410126.png" />


---

- caused by #3902 