### PR TITLE
fix(AvatarBadgeWithPreset): support className

### DIFF
--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
@@ -21,6 +21,7 @@ export interface AvatarBadgeWithPresetProps
 
 export const AvatarBadgeWithPreset = ({
   preset = 'online',
+  className,
   ...restProps
 }: AvatarBadgeWithPresetProps) => {
   const { size } = React.useContext(ImageBaseContext);
@@ -33,9 +34,9 @@ export const AvatarBadgeWithPreset = ({
 
   return (
     <ImageBase.Badge
-      {...restProps}
       background="stroke"
-      className={classNames(styles['AvatarBadge'], presetClassName)}
+      className={classNames(styles['AvatarBadge'], presetClassName, className)}
+      {...restProps}
     >
       <Icon width={badgeSize} height={badgeSize} />
     </ImageBase.Badge>


### PR DESCRIPTION
По типам пробрасывается className, но не применяется

---

- caused by #3718