### PR TITLE
fix(Epic): add hasTabbar

### DIFF
--- a/packages/vkui/src/components/Epic/Epic.module.css
+++ b/packages/vkui/src/components/Epic/Epic.module.css
@@ -2,3 +2,7 @@
   width: 100%;
   height: 100%;
 }
+
+.Epic--hasTabbar {
+  /* Пустой класс для CSS Modules (см. CONTRIBUTING.md)  */
+}

--- a/packages/vkui/src/components/Epic/Epic.tsx
+++ b/packages/vkui/src/components/Epic/Epic.tsx
@@ -25,7 +25,10 @@ export const Epic = (props: EpicProps) => {
     ) as React.ReactElement | undefined) ?? null;
 
   return (
-    <div {...restProps} className={classNames(styles['Epic'], className)}>
+    <div
+      {...restProps}
+      className={classNames(styles['Epic'], tabbar && styles['Epic--hasTabbar'], className)}
+    >
       <ScrollSaver
         key={activeStory}
         initialScroll={scroll[activeStory] || 0}

--- a/packages/vkui/src/components/FixedLayout/FixedLayout.module.css
+++ b/packages/vkui/src/components/FixedLayout/FixedLayout.module.css
@@ -36,7 +36,7 @@
  * CMP:
  * Epic
  */
-.Epic .FixedLayout--vertical-bottom {
+.Epic--hasTabbar .FixedLayout--vertical-bottom {
   padding-bottom: calc(
     var(--vkui_internal--tabbar_height) + var(--vkui_internal--safe_area_inset_bottom)
   );

--- a/packages/vkui/src/components/Panel/Panel.module.css
+++ b/packages/vkui/src/components/Panel/Panel.module.css
@@ -106,7 +106,7 @@
   }
 }
 
-.Epic .Panel__in {
+.Epic--hasTabbar .Panel__in {
   padding-bottom: var(--vkui_internal--tabbar_height);
   padding-bottom: calc(
     var(--vkui_internal--safe_area_inset_bottom) + var(--vkui_internal--tabbar_height)

--- a/packages/vkui/src/components/Snackbar/Snackbar.module.css
+++ b/packages/vkui/src/components/Snackbar/Snackbar.module.css
@@ -10,7 +10,7 @@
   padding-bottom: var(--vkui_internal--safe_area_inset_bottom);
 }
 
-.Epic .Snackbar {
+.Epic--hasTabbar .Snackbar {
   padding-bottom: calc(
     var(--vkui_internal--tabbar_height) + var(--vkui_internal--safe_area_inset_bottom)
   );


### PR DESCRIPTION
Добавляем класс hasTabbar для проверки использования tabbar

### Почему?

Был вот такой запрос:

> [Epic](https://vkcom.github.io/VKUI/5.1.0/#/Epic) требует нижней панели навигации и занимают свободное место под `tabbar`.
>
> В приложении не планируются табы снизу.