### PR TITLE
ci(deps): bump JamesIves/github-pages-deploy-action from 3.7.1 to 4.4.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,9 +83,10 @@ jobs:
           mv ${{ steps.updated_version.outputs.version }} dist/${{ steps.updated_version.outputs.version }}
 
       - name: Publishing doc
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: styleguide/dist
-          CLEAN: false
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: styleguide/dist
+          clean: false
+          force: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,6 +42,8 @@ jobs:
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn run docs:styleguide:build
       - name: Uploading styleguide artifact
+        # Skip upload if it is dependabot's PR
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: actions/upload-artifact@v3
         with:
           name: styleguide-dist

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,23 +74,27 @@ jobs:
     concurrency: ci-gh-pages
     runs-on: ubuntu-latest
     needs: styleguide
-    # Skip deploy from dependabot
+    # Skip deploy if it is dependabot's PR
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Download styleguide artifact
         uses: actions/download-artifact@v3
         with:
           name: styleguide-dist
           path: tmp
       - name: Publishing styleguide to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
-          COMMIT_MESSAGE: 'Publish PR ${{ github.event.pull_request.number }}'
-          BRANCH: gh-pages
-          FOLDER: tmp
-          TARGET_FOLDER: pull/${{ github.event.pull_request.number }}
-          CLEAN: true
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          commit-message: 'Publish PR ${{ github.event.pull_request.number }}'
+          branch: gh-pages
+          folder: tmp
+          target-folder: pull/${{ github.event.pull_request.number }}
+          clean: true
+          force: false
       - name: Find styleguide URL comment
         uses: peter-evans/find-comment@v2
         id: find_url_comment


### PR DESCRIPTION
Следовал **Version 4 Migration Guide** (https://github.com/JamesIves/github-pages-deploy-action/discussions/592)

### Дополнительно

Отключил выгрузку `styleguide` в артифакты если это PR от `dependabot`, т.к. мы не запускаем `deploy_styleguide` для него