### PR TITLE
[v4] fix(CustomSelect): provide `before` prop of `FormField` to component

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -709,6 +709,7 @@ function CustomSelectComponent(props: CustomSelectProps) {
           onFocus={onFocus}
           onBlur={onBlur}
           vkuiClass={openedClassNames}
+          before={before}
           after={icon}
           selectType={selectType}
         >


### PR DESCRIPTION
- fix #4055
- related to #2447