### PR TITLE
fix(CustomSelect): provide `before` prop of `FormField` to component

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -643,7 +643,6 @@ export function CustomSelect(props: SelectProps) {
           onClick={props.onClick}
           before={before}
           after={icon}
-          placeholder={restProps.placeholder}
           mode={getFormFieldModeFromSelectType(selectType)}
         />
       ) : (
@@ -656,6 +655,7 @@ export function CustomSelect(props: SelectProps) {
           onFocus={onFocus}
           onBlur={onBlur}
           className={openedClassNames}
+          before={before}
           after={icon}
           selectType={selectType}
         >


### PR DESCRIPTION
**Additional:** remove reachable code like `placeholder={restProps.placeholder}`

---

- fix #4055
- related to #2447