### PR TITLE
ci(e2e): lfs cache

### DIFF
--- a/.github/workflows/update_screens.yml
+++ b/.github/workflows/update_screens.yml
@@ -24,10 +24,19 @@ jobs:
             browser: chromium
     steps:
       - uses: actions/checkout@v3
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v3
         with:
-          lfs: true
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
       - name: Checkout LFS objects
-        run: git lfs checkout
+        run: git lfs pull
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/workflow_test_e2e.yml
+++ b/.github/workflows/workflow_test_e2e.yml
@@ -28,13 +28,24 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          lfs: true
           ref: ${{ inputs.ref }}
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v3
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
       - name: Checkout LFS objects
-        run: git lfs checkout
+        run: git lfs pull
+
       - name: Checkout base snapshots
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         run: git fetch --no-tags --depth=1 origin $GITHUB_BASE_REF && git checkout origin/$GITHUB_BASE_REF packages/vkui/src/**/__image_snapshots__/*.png
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ __diff_output__
 
 # CI
 .env
+.lfs-assets-id
 
 # IDE
 .idea/


### PR DESCRIPTION
Кешируем lfs.

Используем подход, описанный в https://github.com/actions/checkout/issues/165

---

Что дает:

- уменьшение передаваемого трафика до lfs
- ускорение чекаута с кешем (~12 cек -> ~3 cек)

#### Без кеша

<img width="895" alt="image" src="https://user-images.githubusercontent.com/14944123/215741776-b794cd6b-deff-4424-a5fa-248f4fcff7ab.png">

#### С кешем

<img width="882" alt="image" src="https://user-images.githubusercontent.com/14944123/215741922-43576b73-9f31-4a8f-a102-c63da0d9f3a8.png">
