### PR TITLE
ci(publish): use `--tag v4` for `yarn publish`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,8 @@ jobs:
           INPUT_GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
 
       - name: Publishing release
-        run: yarn publish --non-interactive
+        # Зашиваем тег v4, чтобы не перекрывать тегом latest мажорные версии выше
+        run: yarn publish --non-interactive --tag v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 


### PR DESCRIPTION
Тег `latest` сейчас используется для **v5**.

Тег `v4` будет означать `latest` для **v4**.