### PR TITLE
fix(DateInput): remove dangerous tabIndex={1}

### DIFF
--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -239,7 +239,6 @@ export const DateInput = ({
       />
       <span className={styles['DateInput__input']} onKeyDown={handleKeyDown}>
         <InputLike
-          tabIndex={1}
           length={2}
           getRootRef={daysRef}
           index={0}


### PR DESCRIPTION
Вытаскиваю лишнее из https://github.com/VKCOM/VKUI/pull/3803, часть третья.

Убрала `tabIndex={1}` из `DateInput`. [У axe есть хорошее пояснение, почему не надо делать `tabindex`, отличающийся от `-1` и `0` (на английском)](https://dequeuniversity.com/rules/axe/4.4/tabindex).