### PR TITLE
fix(Switch): remove role="presentation"

### DIFF
--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -36,7 +36,6 @@ export const Switch = ({ style, className, getRootRef, ...restProps }: SwitchPro
       )}
       style={style}
       ref={getRootRef}
-      role="presentation"
     >
       <VisuallyHiddenInput
         {...restProps}
@@ -45,7 +44,7 @@ export const Switch = ({ style, className, getRootRef, ...restProps }: SwitchPro
         onBlur={callMultiple(onBlur, restProps.onBlur)}
         onFocus={callMultiple(onFocus, restProps.onFocus)}
       />
-      <span role="presentation" className={styles['Switch__pseudo']} />
+      <span aria-hidden className={styles['Switch__pseudo']} />
       <FocusVisible mode="outside" />
     </label>
   );


### PR DESCRIPTION
Вытаскиваю лишнее из https://github.com/VKCOM/VKUI/pull/3803, часть четвертая.

Заменила `role="presentation"` на `aria-hidden` внутри `Switch`. [Почему?](https://dequeuniversity.com/rules/axe/4.6/aria-allowed-role?application=RuleDescription)