### PR TITLE
chore: replace `IS_DEV` w/ `process.env.NODE_ENV === 'development'`

### DIFF
--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -26,7 +26,6 @@ import { clamp } from '../../helpers/math';
 import styles from './ModalRoot.module.css';
 
 const warn = warnOnce('ModalRoot');
-const IS_DEV = process.env.NODE_ENV === 'development';
 
 function numberInRange(number: number, range: TranslateRange | undefined) {
   if (!range) {
@@ -669,7 +668,7 @@ function initModal(modalState: ModalsStateEntry) {
     case ModalType.CARD:
       return initCardModal(modalState);
     default:
-      IS_DEV &&
+      process.env.NODE_ENV === 'development' &&
         warn(`initActiveModal: modalState.type="${modalState.type}" не поддерживается`, 'error');
   }
 }

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -48,7 +48,6 @@ const isDOMTypeElement = <
 };
 
 const warn = warnOnce('Tooltip');
-const IS_DEV = process.env.NODE_ENV === 'development';
 
 const SimpleTooltip = React.forwardRef<HTMLDivElement, SimpleTooltipProps>(function SimpleTooltip(
   { appearance = 'accent', header, text, arrow, style: popperStyles = {}, attributes, className },
@@ -199,7 +198,7 @@ export const Tooltip = ({
   const [tooltipRef, setTooltipRef] = React.useState<HTMLElement | null>(null);
   const [target, setTarget] = React.useState<HTMLElement>();
 
-  if (IS_DEV) {
+  if (process.env.NODE_ENV === 'development') {
     const multiChildren = React.Children.count(children) > 1;
     // Empty children is a noop
     const primitiveChild = hasReactNode(children) && typeof children !== 'object';
@@ -229,7 +228,7 @@ export const Tooltip = ({
   /* eslint-enable @typescript-eslint/no-unnecessary-type-assertion*/
   /* eslint-enable no-restricted-properties */
 
-  if (IS_DEV && target && !tooltipContainer) {
+  if (process.env.NODE_ENV === 'development' && target && !tooltipContainer) {
     throw new Error('Use TooltipContainer for Tooltip outside Panel (see docs)');
   }
 

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -32,7 +32,6 @@ export interface WriteBarIconProps extends React.ButtonHTMLAttributes<HTMLButton
 }
 
 const warn = warnOnce('WriteBarIcon');
-const IS_DEV = process.env.NODE_ENV === 'development';
 
 /**
  * @see https://vkcom.github.io/VKUI/#/WriteBarIcon
@@ -69,7 +68,7 @@ export const WriteBarIcon = ({
       break;
   }
 
-  if (IS_DEV && !restProps['aria-label'] && !ariaLabel) {
+  if (process.env.NODE_ENV === 'development' && !restProps['aria-label'] && !ariaLabel) {
     warn(
       'a11y: У WriteBarIcon нет aria-label. Кнопка будет недоступной для части пользователей.',
       'error',


### PR DESCRIPTION
Вытаскиваю лишнее из https://github.com/VKCOM/VKUI/pull/3803, часть шестая.

Заменила `IS_DEV` везде, где он еще был, на `process.env.NODE_ENV === 'development'`, для консистентности. Как сказал @inomdzhon:

> многие сборщики, конечно, выкупят `IS_DEV` для удаления условия, но как-будто лучше если мы будем примерно одинаково такие условия писать
>
> зачастую у нас везде используется прямая (`process.env.NODE_ENV === 'development'`) проверка окружения в условиях