### PR TITLE
feat(warnOnce): add COMMON_WARNINGS object

### DIFF
--- a/packages/vkui/src/components/IconButton/IconButton.tsx
+++ b/packages/vkui/src/components/IconButton/IconButton.tsx
@@ -5,11 +5,14 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { Platform } from '../../lib/platform';
 import { getSizeYClassName } from '../../helpers/getSizeYClassName';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
+import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
 import styles from './IconButton.module.css';
 
 export interface IconButtonProps extends TappableProps {
   children?: React.ReactNode;
 }
+
+const warn = warnOnce('IconButton');
 
 /**
  * @see https://vkcom.github.io/VKUI/#/IconButton
@@ -22,6 +25,14 @@ export const IconButton = ({
 }: IconButtonProps) => {
   const platform = usePlatform();
   const { sizeY } = useAdaptivity();
+
+  if (process.env.NODE_ENV === 'development') {
+    const isAccessible = restProps['aria-label'] || restProps['aria-labelledby'];
+
+    if (!isAccessible) {
+      warn(COMMON_WARNINGS.a11y[restProps.href ? 'link-name' : 'button-name'], 'error');
+    }
+  }
 
   return (
     <Tappable

--- a/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
@@ -5,6 +5,7 @@ import { Tappable } from '../Tappable/Tappable';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { Platform } from '../../lib/platform';
 import { HasComponent, HasRootRef } from '../../types';
+import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
 import styles from './TabbarItem.module.css';
 
 export interface TabbarItemProps
@@ -22,6 +23,8 @@ export interface TabbarItemProps
   indicator?: React.ReactNode;
 }
 
+const warn = warnOnce('TabbarItem');
+
 /**
  * @see https://vkcom.github.io/VKUI/#/TabbarItem
  */
@@ -37,6 +40,14 @@ export const TabbarItem = ({
   ...restProps
 }: TabbarItemProps) => {
   const platform = usePlatform();
+
+  if (process.env.NODE_ENV === 'development') {
+    const isAccessible = !text && (!restProps['aria-label'] || !restProps['aria-labelledby']);
+
+    if (!isAccessible) {
+      warn(COMMON_WARNINGS.a11y[Component === 'a' ? 'link-name' : 'button-name'], 'error');
+    }
+  }
 
   return (
     <Component

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -46,29 +46,29 @@ export const WriteBarIcon = ({
   const platform = usePlatform();
 
   let icon: React.ReactNode;
-  let ariaLabel: string | undefined = undefined;
+  let modeLabel: string | undefined = undefined;
 
   switch (mode) {
     case 'attach':
       icon = platform === Platform.IOS ? <Icon28AddCircleOutline /> : <Icon28AttachOutline />;
-      ariaLabel = 'Прикрепить файл';
+      modeLabel = 'Прикрепить файл';
       break;
 
     case 'send':
       icon = platform === Platform.IOS ? <Icon48WritebarSend /> : <Icon24Send />;
-      ariaLabel = 'Отправить';
+      modeLabel = 'Отправить';
       break;
 
     case 'done':
       icon = platform === Platform.IOS ? <Icon48WritebarDone /> : <Icon28CheckCircleOutline />;
-      ariaLabel = 'Готово';
+      modeLabel = 'Готово';
       break;
 
     default:
       break;
   }
 
-  if (process.env.NODE_ENV === 'development' && !restProps['aria-label'] && !ariaLabel) {
+  if (process.env.NODE_ENV === 'development' && !restProps['aria-label'] && !modeLabel) {
     warn(
       'a11y: У WriteBarIcon нет aria-label. Кнопка будет недоступной для части пользователей.',
       'error',
@@ -77,7 +77,7 @@ export const WriteBarIcon = ({
 
   return (
     <Tappable
-      aria-label={ariaLabel}
+      aria-label={modeLabel}
       {...restProps}
       Component="button"
       hasHover={false}

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -12,7 +12,7 @@ import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { Platform } from '../../lib/platform';
 import { Counter } from '../Counter/Counter';
 import { Tappable } from '../Tappable/Tappable';
-import { warnOnce } from '../../lib/warnOnce';
+import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
 import styles from './WriteBarIcon.module.css';
 
 export interface WriteBarIconProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -68,11 +68,12 @@ export const WriteBarIcon = ({
       break;
   }
 
-  if (process.env.NODE_ENV === 'development' && !restProps['aria-label'] && !modeLabel) {
-    warn(
-      'a11y: У WriteBarIcon нет aria-label. Кнопка будет недоступной для части пользователей.',
-      'error',
-    );
+  if (process.env.NODE_ENV === 'development') {
+    const isAccessible = !modeLabel && (!restProps['aria-label'] || restProps['aria-labelledby']);
+
+    if (!isAccessible) {
+      warn(COMMON_WARNINGS.a11y['button-name'], 'error');
+    }
   }
 
   return (

--- a/packages/vkui/src/lib/warnOnce.ts
+++ b/packages/vkui/src/lib/warnOnce.ts
@@ -15,3 +15,21 @@ export function warnOnce(zone: string): WarnOnceHandler {
     }
   };
 }
+
+function getA11yRuleUrl(ruleName: string): string {
+  // see jest-axe's axe-core dependency
+  const AXE_CORE_MINOR_VERSION = '4.5';
+
+  return `https://dequeuniversity.com/rules/axe/${AXE_CORE_MINOR_VERSION}/${ruleName}`;
+}
+
+export const COMMON_WARNINGS = {
+  a11y: {
+    'button-name': `a11y: Кнопка должна содержать текст, доступный для скринридеров. Чтобы исправить эту ошибку, передайте компоненту текст или свойство aria-label.
+${getA11yRuleUrl('link-name')}`,
+    'link-name': `a11y: Ссыдка должна содержать текст, доступный для скринридеров. Чтобы исправить эту ошибку, передайте компоненту текст или свойство aria-label.
+${getA11yRuleUrl('link-name')}`,
+    'image-alt': `a11y: Изображение должно содержать альтернативный текст, который его описывает. Чтобы исправить эту ошибку, передайте компоненту свойство alt.
+${getA11yRuleUrl('image-alt')}`,
+  },
+};


### PR DESCRIPTION
И снова вытаскиваю всякое из https://github.com/VKCOM/VKUI/pull/3803.

Что сделала:
- добавила объект `COMMON_WARNINGS`, чтобы не переписывать одни и те же варнинги по несколько раз
- `WriteBarIcon`: исправила текст варнинга на текст из `COMMON_WARNINGS` внутри 
- `IconButton`: добавила a11y-варнинг
- `TabbarItem`: добавила a11y-варнинг

**Пример варнинга со ссылками на документацию axe:**
<img width="591" alt="image" src="https://user-images.githubusercontent.com/22026957/217272277-05bdf48b-6301-403a-bd19-aace568062fa.png">