### PR TITLE
ci(publish_prerelease deps): bump JamesIves/github-pages-deploy-action from 3.7.1 to 4.4.1 (v4)

### DIFF
--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -79,9 +79,10 @@ jobs:
         run: yarn run docs:styleguide:build --dist dist/${{ steps.updated_version.outputs.version }}
 
       - name: Publishing doc
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: styleguide/dist
-          CLEAN: false
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: styleguide/dist
+          clean: false
+          force: false


### PR DESCRIPTION
- caused by #4046