### PR TITLE
docs(styleguide): fix list styles

### DIFF
--- a/styleguide/Components/List/List.css
+++ b/styleguide/Components/List/List.css
@@ -17,3 +17,8 @@ ol.List li::before {
 .List li > p {
   display: inline;
 }
+
+.List li > ul {
+  padding-top: 8px;
+  padding-left: 24px;
+}


### PR DESCRIPTION
<details>
<summary>Стало посимпатичнее 😉 </summary>

-----
<img width="100%" alt="Скриншот с новым отображением списков в styleguide" src="https://user-images.githubusercontent.com/22026957/217878424-afcdb994-eb33-47b3-bc35-215c2b18abf3.png">
</details>

-----

- fixes https://github.com/VKCOM/VKUI/issues/2199