### PR TITLE
fix(swc-transform-css-modules): use rust 1.66.0

### DIFF
--- a/tools/swc-transform-css-modules/rust-toolchain.toml
+++ b/tools/swc-transform-css-modules/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+# https://github.com/swc-project/swc/issues/6807
+channel = "1.66.0" 
+components = [ "clippy" ]
+targets = [ "wasm32-wasi" ]
+profile = "minimal"


### PR DESCRIPTION
На новых версиях  rust-а плагины собираются поврежденными

 - see [swc 6807](https://togithub.com/swc-project/swc/issues/6807)