### PR TITLE
test(pr4197): check different cases

### DIFF
--- a/.github/actions/patch/action.yml
+++ b/.github/actions/patch/action.yml
@@ -1,3 +1,4 @@
+# test pr4197
 name: 'Patch'
 description: 'GitLab Flow create patch'
 inputs:

--- a/.github/actions/push-screenshots/src/main.ts
+++ b/.github/actions/push-screenshots/src/main.ts
@@ -1,3 +1,4 @@
+// test pr
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# test pr4197
 version: 2
 updates:
   - package-ecosystem: 'npm'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Test pr4197
+
 <h1 align="center">
   <a href="https://vkcom.github.io/VKUI/"><img src="styleguide/assets/static/vkui_logo.png?raw=true" width="300" alt="VKUI logo"></a>
 </h1>

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -1,3 +1,4 @@
+// test pr4197
 import './lib/polyfills';
 
 import './styles/constants.css';


### PR DESCRIPTION
> Note: Если что в коммитах на скриншотах неправильно указан номер PR, должно быть `test(pr4197)`, а не `test(pr4114)`

https://github.com/VKCOM/VKUI/blob/c6469d674715eb5362b538a22193dcf10c8552a0/.github/workflows/pull_request_packages.yml#L15-L27

## Кейс 1 – запуск только `pull_request_common.yml`

При коммитах файлов, которые удовлетворяют условию в `paths-ignore` в `pull_request_packages.yml` запускается только `pull_request_common.yml` (пример на скриншотах ниже)

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218110257-c676ac47-b47d-40a6-8029-5ca304ed9056.png"> <img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218110188-717556e1-3f66-46c4-ae54-98d0b27fa6a5.png">

## Кейс 2 – запуск `pull_request_packages.yml` при необходимости

> Note: На скриншотах старый префикс `Tests /`, позже переименовал в `Call reusable <type> tests workflow /`

При коммитах файлов, которые НЕ удовлетворяют условию в `paths-ignore` в `pull_request_packages.yml` помимо `pull_request_common.yml` запускается и `pull_request_packages.yml`

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218110920-7257ba7d-45a1-46ca-b2c5-d7d470621bcb.png"> <img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218114409-c2f248e1-01bd-45e3-bb85-5a0ba917f0fd.png">

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218111700-26f16bd4-1afa-4d60-a9b7-32a731c5f316.png">

## Кейс 3 (`pull_request_packages.yml`) – запуск джоб `test:e2e`, `size`, `styleguide` только если изменились файлы, которые аффектят `packages/vkui`

Фильтруем измененные файлы с помощью экшена [dorny/paths-filter](https://github.com/dorny/paths-filter/tree/v2).

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218456202-d4c45e7b-0fbf-4736-be5b-10b163bfd915.png">  <img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218460249-1bb3c9d0-02a5-47ea-94f3-c0e2ec577362.png">

**Рис. 1** Изменили `.github/actions/push-screenshots/src/main.ts`, которая не влияет на `packages/vkui`.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218479480-8fac5cb5-4ea1-4112-adf3-523e8677670d.png"> <img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/218479938-9e4672f0-06a7-42f7-9499-671002fbb015.png">


**Рис. 2** Изменили `packages/vkui/src/index.ts`, которая напрямую влияет на  `packages/vkui`.

---

- test #4197