### PR TITLE
refactor: remove null variant from class names maps

### DIFF
--- a/docs/ADAPTIVITY_GUIDE.md
+++ b/docs/ADAPTIVITY_GUIDE.md
@@ -48,13 +48,20 @@ import styles from './Component.module.css';
 const sizeXClassNames = {
   none: styles['Component--sizeX-none'],
   [SizeType.COMPACT]: styles['Component--sizeX-compact'],
-  [SizeType.REGULAR]: null, // в данном компоненте не используется
 };
 
 const Component = () => {
   const { sizeX = 'none' } = useAdaptivity();
 
-  return <div className={classNames(styles.Component, sizeXClassNames[sizeX])} />;
+  return (
+    <div
+      className={classNames(
+        styles.Component,
+        // компонент слушает только compact
+        sizeX !== SizeType.REGULAR && sizeXClassNames[sizeX],
+      )}
+    />
+  );
 };
 ```
 

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -16,7 +16,6 @@ import styles from './AppRoot.module.css';
 
 const vkuiSizeXClassNames = {
   none: 'vkui--sizeX-none',
-  [SizeType.COMPACT]: null,
   [SizeType.REGULAR]: 'vkui--sizeX-regular',
 };
 
@@ -140,7 +139,7 @@ export const AppRoot = ({
     if (mode === 'partial') {
       return noop;
     }
-    const className = vkuiSizeXClassNames[sizeX];
+    const className = sizeX !== SizeType.COMPACT ? vkuiSizeXClassNames[sizeX] : null;
     const container = mode === 'embedded' ? rootRef.current?.parentElement : document!.body;
 
     if (className === null || !container) {

--- a/packages/vkui/src/components/CardGrid/CardGrid.tsx
+++ b/packages/vkui/src/components/CardGrid/CardGrid.tsx
@@ -7,7 +7,6 @@ import styles from './CardGrid.module.css';
 const sizeXClassNames = {
   none: styles['CardGrid--sizeX-none'],
   [SizeType.COMPACT]: styles['CardGrid--sizeX-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface CardGridProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -37,7 +36,7 @@ export const CardGrid = ({
         styles['CardGrid'],
         spaced && styles['CardGrid--spaced'],
         styles[`CardGrid--size-${size}`],
-        sizeXClassNames[sizeX],
+        sizeX !== SizeType.REGULAR && sizeXClassNames[sizeX],
         className,
       )}
     >

--- a/packages/vkui/src/components/Chip/Chip.tsx
+++ b/packages/vkui/src/components/Chip/Chip.tsx
@@ -11,7 +11,6 @@ import styles from './Chip.module.css';
 const sizeYClassNames = {
   none: styles['Chip--sizeY-none'],
   [SizeType.COMPACT]: styles['Chip--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export type ChipValue = string | number;
@@ -66,7 +65,7 @@ export const Chip = ({
     <div
       className={classNames(
         styles['Chip'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         removable && styles['Chip--removable'],
         className,
       )}

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -11,7 +11,6 @@ import styles from './CustomSelectOption.module.css';
 
 const sizeYClassNames = {
   none: styles['CustomSelectOption--sizeY-none'],
-  [SizeType.COMPACT]: null,
   [SizeType.REGULAR]: styles['CustomSelectOption--sizeY-regular'],
 };
 
@@ -106,7 +105,7 @@ export const CustomSelectOption = ({
       aria-selected={selected}
       className={classNames(
         styles['CustomSelectOption'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.COMPACT && sizeYClassNames[sizeY],
         hovered && !disabled && styles['CustomSelectOption--hover'],
         // Note: пустой класс
         selected && styles['CustomSelectOption--selected'],

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -21,7 +21,6 @@ import styles from './DateInput.module.css';
 const sizeYClassNames = {
   none: styles['DateInput--sizeY-none'],
   [SizeType.COMPACT]: styles['DateInput--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface DateInputProps
@@ -220,7 +219,11 @@ export const DateInput = ({
   return (
     <FormField
       style={style}
-      className={classNames(styles['DateInput'], sizeYClassNames[sizeY], className)}
+      className={classNames(
+        styles['DateInput'],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
+        className,
+      )}
       getRootRef={handleRootRef}
       after={
         value ? (

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -21,7 +21,6 @@ import dateInputStyles from '../DateInput/DateInput.module.css';
 const sizeYClassNames = {
   none: styles['DateRangeInput--sizeY-none'],
   [SizeType.COMPACT]: styles['DateRangeInput--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface DateRangeInputProps
@@ -233,7 +232,11 @@ export const DateRangeInput = ({
   return (
     <FormField
       style={style}
-      className={classNames(styles['DateRangeInput'], sizeYClassNames[sizeY], className)}
+      className={classNames(
+        styles['DateRangeInput'],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
+        className,
+      )}
       getRootRef={handleRootRef}
       after={
         value ? (

--- a/packages/vkui/src/components/FormField/FormField.tsx
+++ b/packages/vkui/src/components/FormField/FormField.tsx
@@ -8,7 +8,6 @@ import styles from './FormField.module.css';
 const sizeYClassNames = {
   none: styles['FormField--sizeY-none'],
   [SizeType.COMPACT]: styles['FormField--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface FormFieldProps {
@@ -80,7 +79,7 @@ export const FormField = ({
         styles['FormField'],
         styles[`FormField--mode-${mode}`],
         styles[`FormField--status-${status}`],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         disabled && styles['FormField--disabled'],
         !disabled && hover && styles['FormField--hover'],
         className,

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -12,7 +12,6 @@ import styles from './FormItem.module.css';
 const sizeYClassNames = {
   none: styles['FormItem--sizeY-none'],
   [SizeType.COMPACT]: styles['FormItem--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface FormItemProps
@@ -63,7 +62,7 @@ export const FormItem = ({
       className={classNames(
         styles['FormItem'],
         status !== 'default' && styles[`FormItem--status-${status}`],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         hasReactNode(top) && styles['FormItem--withTop'],
         removable && styles['FormItem--removable'],
         className,

--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.tsx
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.tsx
@@ -10,7 +10,6 @@ import styles from './FormLayoutGroup.module.css';
 const sizeYClassNames = {
   none: styles['FormLayoutGroup--sizeY-none'],
   [SizeType.COMPACT]: styles['FormLayoutGroup--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface FormLayoutGroupProps
@@ -53,7 +52,7 @@ export const FormLayoutGroup = ({
       ref={rootEl}
       className={classNames(
         styles['FormLayoutGroup'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         styles[`FormLayoutGroup--mode-${mode}`],
         isRemovable && styles['FormLayoutGroup--removable'],
         isSegmented && styles['FormLayoutGroup--segmented'],

--- a/packages/vkui/src/components/IconButton/IconButton.tsx
+++ b/packages/vkui/src/components/IconButton/IconButton.tsx
@@ -11,7 +11,6 @@ import styles from './IconButton.module.css';
 const sizeYClassNames = {
   none: styles['IconButton--sizeY-none'],
   [SizeType.COMPACT]: styles['IconButton--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface IconButtonProps extends TappableProps {
@@ -48,7 +47,7 @@ export const IconButton = ({
       Component={restProps.href ? 'a' : Component}
       className={classNames(
         styles['IconButton'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         platform === Platform.IOS && styles['IconButton--ios'],
         className,
       )}

--- a/packages/vkui/src/components/Input/Input.tsx
+++ b/packages/vkui/src/components/Input/Input.tsx
@@ -9,7 +9,6 @@ import styles from './Input.module.css';
 const sizeYClassNames = {
   none: styles['Input--sizeY-none'],
   [SizeType.COMPACT]: styles['Input--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface InputProps
@@ -42,7 +41,7 @@ export const Input = ({
       className={classNames(
         styles['Input'],
         align && styles[`Input--align-${align}`],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         before && styles['Input--hasBefore'],
         after && styles['Input--hasAfter'],
         className,

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -17,7 +17,6 @@ import styles from '../Select/Select.module.css';
 const sizeYClassNames = {
   none: styles['Select--sizeY-none'],
   [SizeType.COMPACT]: styles['Select--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface NativeSelectProps
@@ -86,7 +85,7 @@ const NativeSelect = ({
         empty && styles['Select--empty'],
         multiline && styles['Select--multiline'],
         align && styles[`Select--align-${align}`],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         className,
       )}
       style={style}

--- a/packages/vkui/src/components/PanelHeaderBack/PanelHeaderBack.tsx
+++ b/packages/vkui/src/components/PanelHeaderBack/PanelHeaderBack.tsx
@@ -12,12 +12,6 @@ import { Platform } from '../../lib/platform';
 import { PanelHeaderButton, PanelHeaderButtonProps } from '../PanelHeaderButton/PanelHeaderButton';
 import styles from './PanelHeaderBack.module.css';
 
-const sizeXClassNames = {
-  none: null,
-  [SizeType.COMPACT]: styles['PanelHeaderBack--sizeX-compact'],
-  [SizeType.REGULAR]: null,
-};
-
 export type PanelHeaderBackProps = PanelHeaderButtonProps & {
   'aria-label'?: string;
 };
@@ -52,7 +46,7 @@ export const PanelHeaderBack = ({
       {...restProps}
       className={classNames(
         styles['PanelHeaderBack'],
-        sizeXClassNames[sizeX],
+        sizeX === SizeType.COMPACT && styles['PanelHeaderBack--sizeX-compact'],
         platform === Platform.IOS && styles['PanelHeaderBack--ios'],
         platform === Platform.VKCOM && styles['PanelHeaderBack--vkcom'],
         showLabel && !!label && styles['PanelHeaderBack--has-label'],

--- a/packages/vkui/src/components/Radio/Radio.tsx
+++ b/packages/vkui/src/components/Radio/Radio.tsx
@@ -13,7 +13,6 @@ import styles from './Radio.module.css';
 const sizeYClassNames = {
   none: styles['Radio--sizeY-none'],
   [SizeType.COMPACT]: styles['Radio--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 const RadioIcon = (props: React.SVGProps<SVGSVGElement>) => {
@@ -50,7 +49,11 @@ export const Radio = ({
     <Tappable
       Component="label"
       style={style}
-      className={classNames(styles['Radio'], sizeYClassNames[sizeY], className)}
+      className={classNames(
+        styles['Radio'],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
+        className,
+      )}
       activeEffectDelay={platform === Platform.IOS ? 100 : ACTIVE_EFFECT_DELAY}
       disabled={restProps.disabled}
       getRootRef={getRootRef}

--- a/packages/vkui/src/components/RangeSlider/UniversalSlider.tsx
+++ b/packages/vkui/src/components/RangeSlider/UniversalSlider.tsx
@@ -11,7 +11,6 @@ import styles from '../Slider/Slider.module.css';
 const sizeYClassNames = {
   none: styles['Slider--sizeY-none'],
   [SizeType.COMPACT]: styles['Slider--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export type UniversalValue = [number | null, number];
@@ -134,7 +133,7 @@ export const UniversalSlider = ({
       {...(disabled ? {} : { onStart, onMove, onEnd })}
       className={classNames(
         styles['Slider'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         disabled && styles['Slider--disabled'],
         className,
       )}

--- a/packages/vkui/src/components/RichCell/RichCell.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.tsx
@@ -9,7 +9,6 @@ import styles from './RichCell.module.css';
 const sizeYClassNames = {
   none: styles['RichCell--sizeY-none'],
   [SizeType.COMPACT]: styles['RichCell--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface RichCellProps extends TappableProps {
@@ -87,7 +86,7 @@ export const RichCell = ({
       className={classNames(
         styles['RichCell'],
         !multiline && styles['RichCell--text-ellipsis'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         className,
       )}
     >

--- a/packages/vkui/src/components/Search/Search.tsx
+++ b/packages/vkui/src/components/Search/Search.tsx
@@ -16,7 +16,6 @@ import styles from './Search.module.css';
 
 const sizeYClassNames = {
   none: styles['Search--sizeY-none'],
-  [SizeType.COMPACT]: null,
   [SizeType.REGULAR]: styles['Search--sizeY-regular'],
 };
 
@@ -124,7 +123,7 @@ export const Search = ({
       className={classNames(
         styles['Search'],
         platform === Platform.IOS && styles['Search--ios'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.COMPACT && sizeYClassNames[sizeY],
         isFocused && styles['Search--focused'],
         value && styles['Search--has-value'],
         after && styles['Search--has-after'],

--- a/packages/vkui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/vkui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -12,7 +12,6 @@ import styles from './SegmentedControl.module.css';
 
 const sizeYClassNames = {
   none: styles['SegmentedControl--sizeY-none'],
-  [SizeType.COMPACT]: null,
   [SizeType.REGULAR]: styles['SegmentedControl--sizeY-regular'],
 };
 
@@ -81,7 +80,7 @@ export const SegmentedControl = ({
       {...restProps}
       className={classNames(
         styles['SegmentedControl'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.COMPACT && sizeYClassNames[sizeY],
         styles[`SegmentedControl--size-${size}`],
         className,
       )}

--- a/packages/vkui/src/components/SegmentedControl/SegmentedControlOption/SegmentedControlOption.tsx
+++ b/packages/vkui/src/components/SegmentedControl/SegmentedControlOption/SegmentedControlOption.tsx
@@ -14,7 +14,6 @@ import styles from './SegmentedControlOption.module.css';
 const sizeYClassNames = {
   none: styles['SegmentedControlOption__content--sizeY-none'],
   [SizeType.COMPACT]: styles['SegmentedControlOption__content--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 /**
@@ -46,7 +45,10 @@ export const SegmentedControlOption = ({
         onFocus={callMultiple(onFocus, restProps.onFocus)}
       />
       <span
-        className={classNames(styles['SegmentedControlOption__content'], sizeYClassNames[sizeY])}
+        className={classNames(
+          styles['SegmentedControlOption__content'],
+          sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
+        )}
       >
         {children}
       </span>

--- a/packages/vkui/src/components/SelectMimicry/SelectMimicry.tsx
+++ b/packages/vkui/src/components/SelectMimicry/SelectMimicry.tsx
@@ -15,7 +15,6 @@ import styles from '../Select/Select.module.css';
 const sizeYClassNames = {
   none: styles['Select--sizeY-none'],
   [SizeType.COMPACT]: styles['Select--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface SelectMimicryProps
@@ -58,7 +57,7 @@ export const SelectMimicry = ({
       className={classNames(
         styles['Select'],
         getPlatformClassName(styles['Select'], platform),
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         multiline && styles['Select--multiline'],
         align && styles[`Select--align-${align}`],
         before && styles['Select--hasBefore'],

--- a/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
+++ b/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
@@ -13,7 +13,6 @@ import styles from './SubnavigationButton.module.css';
 const sizeYClassNames = {
   none: styles['SubnavigationButton--sizeY-none'],
   [SizeType.COMPACT]: styles['SubnavigationButton--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface SubnavigationButtonProps extends Omit<TappableProps, 'size'> {
@@ -80,7 +79,7 @@ export const SubnavigationButton = ({
         styles[`SubnavigationButton--size-${size}`],
         styles[`SubnavigationButton--mode-${mode}`],
         selected && styles['SubnavigationButton--selected'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         className,
       )}
       aria-label={getTitleFromChildren(children)}

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -17,7 +17,6 @@ import styles from './Switch.module.css';
 const sizeYClassNames = {
   none: styles['Switch--sizeY-none'],
   [SizeType.COMPACT]: styles['Switch--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface SwitchProps extends VisuallyHiddenInputProps, HasRootRef<HTMLLabelElement> {}
@@ -35,7 +34,7 @@ export const Switch = ({ style, className, getRootRef, ...restProps }: SwitchPro
       className={classNames(
         styles['Switch'],
         getPlatformClassName(styles['Switch'], platform),
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         restProps.disabled && styles['Switch--disabled'],
         focusVisible && styles['Switch--focus-visible'],
         className,

--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -12,7 +12,6 @@ import styles from './TabsItem.module.css';
 const sizeYClassNames = {
   none: styles['TabsItem--sizeY-none'],
   [SizeType.COMPACT]: styles['TabsItem--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface TabsItemProps extends React.HTMLAttributes<HTMLElement> {
@@ -101,7 +100,7 @@ export const TabsItem = ({
         styles['TabsItem'],
         mode && styles[`TabsItem--mode-${mode}`],
         selected && styles['TabsItem--selected'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         withGaps && styles['TabsItem--withGaps'],
         className,
       )}

--- a/packages/vkui/src/components/Textarea/Textarea.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.tsx
@@ -11,7 +11,6 @@ import styles from './Textarea.module.css';
 const sizeYClassNames = {
   none: styles['Textarea--sizeY-none'],
   [SizeType.COMPACT]: styles['Textarea--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface TextareaProps
@@ -69,7 +68,11 @@ export const Textarea = ({
 
   return (
     <FormField
-      className={classNames(styles['Textarea'], sizeYClassNames[sizeY], className)}
+      className={classNames(
+        styles['Textarea'],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
+        className,
+      )}
       style={style}
       getRootRef={getRootRef}
       disabled={restProps.disabled}

--- a/packages/vkui/src/components/Typography/Headline/Headline.tsx
+++ b/packages/vkui/src/components/Typography/Headline/Headline.tsx
@@ -9,7 +9,6 @@ import styles from './Headline.module.css';
 const sizeYClassNames = {
   none: styles['Headline--sizeY-none'],
   [SizeType.COMPACT]: styles['Headline--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface HeadlineProps
@@ -50,7 +49,7 @@ export const Headline = ({
       className={classNames(
         className,
         styles['Headline'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         styles[`Headline--level-${level}`],
         styles[`Headline--weight-${weight}`],
       )}

--- a/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
+++ b/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
@@ -8,7 +8,6 @@ import styles from './Subhead.module.css';
 const sizeYClassNames = {
   none: styles['Subhead--sizeY-none'],
   [SizeType.COMPACT]: styles['Subhead--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface SubheadProps extends React.AllHTMLAttributes<HTMLElement>, HasComponent {
@@ -36,7 +35,7 @@ export const Subhead = ({
       className={classNames(
         className,
         styles['Subhead'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         weight && styles[`Subhead--weight-${weight}`],
       )}
     >

--- a/packages/vkui/src/components/Typography/Text/Text.tsx
+++ b/packages/vkui/src/components/Typography/Text/Text.tsx
@@ -9,7 +9,6 @@ import styles from './Text.module.css';
 const sizeYClassNames = {
   none: styles['Text--sizeY-none'],
   [SizeType.COMPACT]: styles['Text--sizeY-compact'],
-  [SizeType.REGULAR]: null,
 };
 
 export interface TextProps
@@ -47,7 +46,7 @@ export const Text = ({
       className={classNames(
         className,
         styles['Text'],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         weight && styles[`Text--weight-${weight}`],
       )}
     >


### PR DESCRIPTION
Пример того, что было сделано:

```diff
- const sizeXClassNames = {
-  none: styles['Component--sizeX-none'],
-  [SizeType.COMPACT]: styles['Component--sizeX-compact'],
-  [SizeType.REGULAR]: null, 
- };
-
- sizeXClassNames[sizeX]

+ const sizeXClassNames = {
+  none: styles['Component--sizeX-none'],
+  [SizeType.COMPACT]: styles['Component--sizeX-compact'],
+ };
+
+ sizeX !== SizeType.REGULAR && sizeXClassNames[sizeX]
```

Проверка дешевле, чем обращение к объекту впустую.

---

- caused by #4241
- caused by #4259