### PR TITLE
ci(@actions-internal/patch): mv fetch to try catch block

### DIFF
--- a/.github/actions/patch/src/main.ts
+++ b/.github/actions/patch/src/main.ts
@@ -79,9 +79,9 @@ async function run(): Promise<void> {
       return;
     }
 
-    await exec.exec('git', ['fetch', 'origin', stableBranchRef, patchRefs]);
-    await exec.exec('git', ['checkout', stableBranchRef]);
     try {
+      await exec.exec('git', ['fetch', 'origin', stableBranchRef, patchRefs]);
+      await exec.exec('git', ['checkout', stableBranchRef]);
       await exec.exec('git', ['cherry-pick', patchRefs]);
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Оборачиваем в `try catch`, потому что порой `git fetch` падает из-за якобы не валидных SHA

Пример

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/219611244-220413d7-334c-42df-a077-24584916eada.png">

_https://github.com/VKCOM/VKUI/actions/runs/4196621551/jobs/7277839717_