### PR TITLE
fix(adaptivity): create viewWidthToClassName()

### DIFF
--- a/packages/vkui/src/components/SplitCol/SplitCol.module.css
+++ b/packages/vkui/src/components/SplitCol/SplitCol.module.css
@@ -10,7 +10,7 @@
   margin: 0 var(--vkui--size_split_col_padding_horizontal--regular);
 }
 
-.SplitCol--viewWidth-tabletPlus.SplitCol--spaced-none.SplitCol--spaced-auto {
+.SplitCol--viewWidth-smallTabletPlus.SplitCol--spaced-none.SplitCol--spaced-auto {
   margin: 0 var(--vkui--size_split_col_padding_horizontal--regular);
 }
 
@@ -20,9 +20,7 @@
   }
 }
 
-.SplitCol--viewWidth-smallTablet.SplitCol--stretched-on-mobile,
-.SplitCol--viewWidth-mobile.SplitCol--stretched-on-mobile,
-.SplitCol--viewWidth-smallMobile.SplitCol--stretched-on-mobile {
+.SplitCol--viewWidth-tabletMinus.SplitCol--stretched-on-mobile {
   width: 100% !important;
   max-width: 100% !important;
 }

--- a/packages/vkui/src/components/SplitCol/SplitCol.tsx
+++ b/packages/vkui/src/components/SplitCol/SplitCol.tsx
@@ -3,17 +3,15 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useMediaQueries } from '../../hooks/useMediaQueries';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
-import { ViewWidth } from '../../lib/adaptivity';
+import { ViewWidth, viewWidthToClassName } from '../../lib/adaptivity';
 import { matchMediaListAddListener, matchMediaListRemoveListener } from '../../lib/matchMedia';
 import { SplitColContext } from './SplitColContext';
 import styles from './SplitCol.module.css';
 
-const viewWidthClassNames = {
+const breakpointClassNames = {
   none: styles['SplitCol--viewWidth-none'],
-  [ViewWidth.SMALL_MOBILE]: styles['SplitCol--viewWidth-smallMobile'],
-  [ViewWidth.MOBILE]: styles['SplitCol--viewWidth-mobile'],
-  [ViewWidth.SMALL_TABLET]: styles['SplitCol--viewWidth-smallTablet'],
-  [ViewWidth.TABLET]: styles['SplitCol--viewWidth-tabletPlus'],
+  tabletMinus: styles['SplitCol--viewWidth-tabletMinus'],
+  smallTabletPlus: styles['SplitCol--viewWidth-smallTabletPlus'],
 };
 
 function useTransitionAnimate(animateProp?: boolean) {
@@ -87,7 +85,7 @@ export const SplitCol = (props: SplitColProps) => {
     ...restProps
   } = props;
   const baseRef = React.useRef<HTMLDivElement>(null);
-  const { viewWidth = 'none' } = useAdaptivity();
+  const { viewWidth } = useAdaptivity();
   const animate = useTransitionAnimate(animateProp);
 
   const contextValue = useObjectMemo({
@@ -107,7 +105,7 @@ export const SplitCol = (props: SplitColProps) => {
       ref={baseRef}
       className={classNames(
         styles['SplitCol'],
-        viewWidthClassNames.hasOwnProperty(viewWidth) && viewWidthClassNames[viewWidth],
+        viewWidthToClassName(breakpointClassNames, viewWidth),
         spaced && styles['SplitCol--spaced'],
         spaced === undefined && styles['SplitCol--spaced-none'],
         autoSpaced && styles['SplitCol--spaced-auto'],

--- a/packages/vkui/src/lib/adaptivity/constants.ts
+++ b/packages/vkui/src/lib/adaptivity/constants.ts
@@ -38,3 +38,11 @@ export enum SizeType {
   COMPACT = 'compact',
   REGULAR = 'regular',
 }
+
+export const VIEW_WIDTH_TO_CSS_BREAKPOINT_MAP = {
+  [ViewWidth.SMALL_MOBILE]: 'smallMobileMinus',
+  [ViewWidth.MOBILE]: 'mobile',
+  [ViewWidth.SMALL_TABLET]: 'smallTablet',
+  [ViewWidth.TABLET]: 'tablet',
+  [ViewWidth.DESKTOP]: 'desktopPlus',
+} as const;

--- a/packages/vkui/src/lib/adaptivity/functions.test.ts
+++ b/packages/vkui/src/lib/adaptivity/functions.test.ts
@@ -1,6 +1,6 @@
 import { Platform } from '../platform';
 import { ViewHeight, ViewWidth } from './constants';
-import { tryToCheckIsDesktop } from './functions';
+import { tryToCheckIsDesktop, viewWidthToClassName } from './functions';
 
 describe('adaptivity/functions', () => {
   describe(tryToCheckIsDesktop, () => {
@@ -65,6 +65,111 @@ describe('adaptivity/functions', () => {
         expect(tryToCheckIsDesktop(ViewWidth.MOBILE, ViewHeight.EXTRA_SMALL, undefined, Platform.VKCOM)).toBeTruthy(); // prettier-ignore
         expect(tryToCheckIsDesktop(ViewWidth.MOBILE, ViewHeight.EXTRA_SMALL, true, Platform.VKCOM)).toBeTruthy(); // prettier-ignore
         expect(tryToCheckIsDesktop(ViewWidth.SMALL_TABLET, undefined, false, Platform.VKCOM)).toBeTruthy(); // prettier-ignore
+      });
+    });
+  });
+
+  describe(viewWidthToClassName, () => {
+    describe('with full classNames', () => {
+      const classNames = {
+        none: 'some-hash-none',
+        smallMobileMinus: 'some-hash-smallMobileMinus',
+        mobile: 'some-hash-mobile',
+        mobilePlus: 'some-hash-mobilePlus',
+        smallTabletMinus: 'some-hash-smallTabletMinus',
+        smallTablet: 'some-hash-smallTablet',
+        smallTabletPlus: 'some-hash-smallTabletPlus',
+        tabletMinus: 'some-hash-tabletMinus',
+        tablet: 'some-hash-tablet',
+        tabletPlus: 'some-hash-tabletPlus',
+        desktopPlus: 'some-hash-desktopPlus',
+      };
+
+      it('should return "none" class name if viewWidth is "none"', () => {
+        expect(viewWidthToClassName(classNames)).toBe(classNames['none']);
+      });
+
+      it('should return "smallMobile" class names', () => {
+        expect(viewWidthToClassName(classNames, ViewWidth.SMALL_MOBILE)).toBe(
+          [classNames.smallMobileMinus, classNames.smallTabletMinus, classNames.tabletMinus].join(
+            ' ',
+          ),
+        );
+      });
+
+      it('should return "mobile" class names', () => {
+        expect(viewWidthToClassName(classNames, ViewWidth.MOBILE)).toBe(
+          [
+            classNames.mobile,
+            classNames.mobilePlus,
+            classNames.smallTabletMinus,
+            classNames.tabletMinus,
+          ].join(' '),
+        );
+      });
+
+      it('should return "smallTablet" class names', () => {
+        expect(viewWidthToClassName(classNames, ViewWidth.SMALL_TABLET)).toBe(
+          [
+            classNames.smallTablet,
+            classNames.mobilePlus,
+            classNames.smallTabletPlus,
+            classNames.tabletMinus,
+          ].join(' '),
+        );
+      });
+
+      it('should return "tablet" class names', () => {
+        expect(viewWidthToClassName(classNames, ViewWidth.TABLET)).toBe(
+          [
+            classNames.tablet,
+            classNames.mobilePlus,
+            classNames.smallTabletPlus,
+            classNames.tabletPlus,
+          ].join(' '),
+        );
+      });
+
+      it('should return "desktop" class names', () => {
+        expect(viewWidthToClassName(classNames, ViewWidth.DESKTOP)).toBe(
+          [
+            classNames.desktopPlus,
+            classNames.mobilePlus,
+            classNames.smallTabletPlus,
+            classNames.tabletPlus,
+          ].join(' '),
+        );
+      });
+    });
+
+    describe('with partially classNames', () => {
+      it('should return null', () => {
+        const classNames = {};
+        expect(viewWidthToClassName(classNames)).toBe(null);
+        expect(viewWidthToClassName(classNames, ViewWidth.SMALL_MOBILE)).toBe(null);
+        expect(viewWidthToClassName(classNames, ViewWidth.MOBILE)).toBe(null);
+        expect(viewWidthToClassName(classNames, ViewWidth.SMALL_TABLET)).toBe(null);
+        expect(viewWidthToClassName(classNames, ViewWidth.TABLET)).toBe(null);
+        expect(viewWidthToClassName(classNames, ViewWidth.DESKTOP)).toBe(null);
+      });
+
+      it('should return null when viewWidth is "smallTabletPlus"', () => {
+        const classNames = {
+          mobile: 'some-hash-mobile',
+          desktopPlus: 'some-hash-desktopPlus',
+        };
+        expect(viewWidthToClassName(classNames, ViewWidth.MOBILE)).toBe(classNames['mobile']);
+      });
+
+      it('should return null when viewWidth is "smallTabletMinus"', () => {
+        const classNames = {
+          mobile: 'some-hash-mobile',
+          mobilePlus: 'some-hash-mobilePlus',
+          desktopPlus: 'some-hash-desktopPlus',
+        };
+        expect(viewWidthToClassName(classNames, ViewWidth.MOBILE)).toBe(
+          [classNames['mobile'], classNames['mobilePlus']].join(' '),
+        );
       });
     });
   });

--- a/packages/vkui/src/lib/adaptivity/functions.ts
+++ b/packages/vkui/src/lib/adaptivity/functions.ts
@@ -1,6 +1,7 @@
+import type { Exact } from '../../types';
 import { Platform, type PlatformType } from '../platform';
-import { SizeType, ViewHeight, ViewWidth } from './constants';
-import type { MediaQueries } from './types';
+import { SizeType, VIEW_WIDTH_TO_CSS_BREAKPOINT_MAP, ViewHeight, ViewWidth } from './constants';
+import type { CSSBreakpointsClassNames, MediaQueries } from './types';
 
 export function getViewWidthByMediaQueries(mediaQueries: MediaQueries): ViewWidth {
   /* eslint-disable no-restricted-properties */
@@ -84,4 +85,54 @@ export function tryToCheckIsDesktop(
     hasPointer || (viewHeight !== undefined ? viewHeight >= ViewHeight.MEDIUM : false);
 
   return (widthIsLikeDesktop && otherParametersIsLikeDesktop) || IS_VKCOM_CRUTCH;
+}
+
+/**
+ * Конвертирует `viewWidth` в CSS брейкпоинты (см. тесты для наглядности).
+ *
+ * > Note: используется восклицательный знак (!), чтобы принудить TS поверить, что св-во точно не может быть
+ * > `undefined`. Это всё из-за применения `Partial<...>` для объекта.
+ */
+export function viewWidthToClassName<T extends Partial<CSSBreakpointsClassNames>>(
+  breakpointClassNames: Exact<CSSBreakpointsClassNames, T>,
+  viewWidth: ViewWidth | 'none' = 'none',
+): string | null {
+  if (viewWidth === 'none') {
+    return breakpointClassNames.hasOwnProperty('none') ? breakpointClassNames['none']! : null;
+  }
+
+  const breakpoints: string[] = [];
+  const breakpointName = VIEW_WIDTH_TO_CSS_BREAKPOINT_MAP[viewWidth];
+
+  if (breakpointClassNames.hasOwnProperty(breakpointName)) {
+    breakpoints.push(breakpointClassNames[breakpointName]!);
+  }
+
+  if (viewWidth >= ViewWidth.MOBILE) {
+    if (breakpointClassNames.hasOwnProperty('mobilePlus')) {
+      breakpoints.push(breakpointClassNames['mobilePlus']!);
+    }
+  }
+
+  if (viewWidth >= ViewWidth.SMALL_TABLET) {
+    if (breakpointClassNames.hasOwnProperty('smallTabletPlus')) {
+      breakpoints.push(breakpointClassNames['smallTabletPlus']!);
+    }
+  } else {
+    if (breakpointClassNames.hasOwnProperty('smallTabletMinus')) {
+      breakpoints.push(breakpointClassNames['smallTabletMinus']!);
+    }
+  }
+
+  if (viewWidth >= ViewWidth.TABLET) {
+    if (breakpointClassNames.hasOwnProperty('tabletPlus')) {
+      breakpoints.push(breakpointClassNames['tabletPlus']!);
+    }
+  } else {
+    if (breakpointClassNames.hasOwnProperty('tabletMinus')) {
+      breakpoints.push(breakpointClassNames['tabletMinus']!);
+    }
+  }
+
+  return breakpoints.length > 0 ? breakpoints.join(' ') : null;
 }

--- a/packages/vkui/src/lib/adaptivity/types.ts
+++ b/packages/vkui/src/lib/adaptivity/types.ts
@@ -1,7 +1,7 @@
 /**
  * Соответствуют тому, что генерирует функция `getCustomMedias()`.
  *
- * {@link import('../../shared.js') ../../shared.js}
+ * {@link import('../../../shared.config.js') ../../../shared.config.js}
  */
 export type CSSBreakpoints =
   | 'desktopPlus'
@@ -14,6 +14,8 @@ export type CSSBreakpoints =
   | 'mobilePlus'
   | 'mobile'
   | 'smallMobileMinus';
+
+export type CSSBreakpointsClassNames = Record<CSSBreakpoints | 'none', string>;
 
 /**
  * JS брейкпоинты выделены в отдельный тип, т.к. на данный момент нужны не все брейкпоинты, что используются в

--- a/packages/vkui/src/types.ts
+++ b/packages/vkui/src/types.ts
@@ -55,3 +55,12 @@ export type AnchorHTMLAttributesOnly = Omit<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   keyof React.HTMLAttributes<HTMLAnchorElement>
 >;
+
+/**
+ * Проверяет, является ли тип подтипом другого.
+ *
+ * В TS не реализовано.
+ *
+ * @see {@link https://github.com/microsoft/TypeScript/issues/12936}
+ */
+export type Exact<A, B> = A extends B ? B : never;


### PR DESCRIPTION
## Проблема

В рамках #4275 неверно удалил `getViewWidthClassName()` – надо было её переделать под **CSS Modules**.

## Решение

Переделал и переименовал во `viewWidthToClassName()`

Применил в компоненте `SplitCol` (получилось упростить CSS).

## Дополнительно

Обновил `docs/ADAPTIVITY_GUIDE.md`.

---

- caused by #4275