### PR TITLE
ci(codecov): add fail_ci_if_error

### DIFF
--- a/.github/workflows/reusable_workflow_test.yml
+++ b/.github/workflows/reusable_workflow_test.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           flags: unittests
           files: .nyc_output/coverage-final.json
+          fail_ci_if_error: true
 
       - name: Upload test artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable_workflow_test_a11y.yml
+++ b/.github/workflows/reusable_workflow_test_a11y.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           flags: a11ytests
           files: .nyc_a11y_output/coverage-final.json
+          fail_ci_if_error: true
 
       - name: Upload test artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           flags: e2e-${{ matrix.browser }}-${{ matrix.platform }}-${{ matrix.appearance }}
           files: .nyc_output/coverage.json
+          fail_ci_if_error: true
 
       - name: Upload test artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Добавляем fail_ci_if_error чтобы ронять ci, если отчет не загрузился