### PR TITLE
refactor: remove empty variant from class names maps

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { useOrientationChange } from '../../hooks/useOrientationChange';
 import { usePlatform } from '../../hooks/usePlatform';
+import { SizeType } from '../../lib/adaptivity';
 import { getNavId, NavIdProps } from '../../lib/getNavId';
 import { Platform } from '../../lib/platform';
 import { multiRef } from '../../lib/utils';
@@ -11,11 +12,6 @@ import { ModalDismissButton } from '../ModalDismissButton/ModalDismissButton';
 import { ModalRootContext, useModalRegistry } from '../ModalRoot/ModalRootContext';
 import { ModalType } from '../ModalRoot/types';
 import styles from './ModalPage.module.css';
-
-const sizeXClassNames = {
-  regular: styles['ModalPage--sizeX-regular'],
-  compact: '',
-};
 
 const sizeClassName = {
   s: styles[`ModalPage--size-s`],
@@ -107,7 +103,7 @@ export const ModalPage = ({
         styles['ModalPage'],
         platform === Platform.IOS && styles['ModalPage--ios'],
         isDesktop && styles['ModalPage--desktop'],
-        sizeXClassNames[sizeX],
+        sizeX === SizeType.REGULAR && styles['ModalPage--sizeX-regular'],
         typeof size === 'string' && sizeClassName[size],
         className,
       )}

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditionalRender';
 import { usePlatform } from '../../hooks/usePlatform';
+import { SizeType } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';
 import { HasRef, HasRootRef } from '../../types';
 import { useConfigProvider, WebviewType } from '../ConfigProvider/ConfigProviderContext';
@@ -26,9 +27,8 @@ function getPlatformClassName(platform: string): string {
 }
 
 const sizeXClassNames = {
-  compact: '',
-  regular: styles['PanelHeader--sizeX-regular'],
   none: styles['PanelHeader--sizeX-none'],
+  regular: styles['PanelHeader--sizeX-regular'],
 };
 
 export interface PanelHeaderProps
@@ -113,7 +113,7 @@ export const PanelHeader = ({
         !before && styles['PanelHeader--no-before'],
         !after && styles['PanelHeader--no-after'],
         isFixed && styles['PanelHeader--fixed'],
-        sizeXClassNames[sizeX],
+        sizeX !== SizeType.COMPACT && sizeXClassNames[sizeX],
         className,
       )}
       ref={isFixed ? getRootRef : getRef}

--- a/packages/vkui/src/components/SelectTypography/SelectTypography.tsx
+++ b/packages/vkui/src/components/SelectTypography/SelectTypography.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { usePlatform } from '../../hooks/usePlatform';
+import { SizeType } from '../../lib/adaptivity';
 import type { SelectType } from '../Select/Select';
 import styles from './SelectTypography.module.css';
 
 const sizeYClassNames = {
   none: styles['SelectTypography--sizeY-none'],
   compact: styles['SelectTypography--sizeY-compact'],
-  regular: '',
 };
 
 const platformClassNames: Record<string, string> = {
@@ -45,7 +45,7 @@ export const SelectTypography = ({
       className={classNames(
         styles['SelectTypography'],
         platformClassNames[platform],
-        sizeYClassNames[sizeY],
+        sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         selectTypeClassNames[selectType],
         className,
       )}


### PR DESCRIPTION
Пропустил в #4261 варианты с пустой строкой вместо `null`.

---

- caused by #4261