### PR TITLE
feat(PopoutRoot): popout:empty display: none

### DIFF
--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.module.css
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.module.css
@@ -26,6 +26,7 @@
   height: 100%;
 }
 
+.PopoutRoot__popout:empty,
 .PopoutRoot__modal:empty {
   display: none;
 }


### PR DESCRIPTION
Не закрываем экран, если внутри PopoutRoot__popout ничего нет