### PR TITLE
feat(Header): address design review notes

### DIFF
--- a/packages/vkui/src/components/Header/Header.module.css
+++ b/packages/vkui/src/components/Header/Header.module.css
@@ -11,8 +11,6 @@
 
 .Header__main {
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
   color: var(--vkui--color_text_primary);
 }
 
@@ -21,7 +19,8 @@
   align-items: baseline;
 }
 
-.Header__content-in {
+.Header__content-in,
+.Header__subtitle {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
@@ -37,6 +36,7 @@
 }
 
 .Header__subtitle {
+  display: block;
   color: var(--vkui--color_text_secondary);
 }
 
@@ -44,7 +44,7 @@
   margin-top: -1px;
 }
 
-.Header--mode-secondary:not(.Header--pi) .Header__main,
+.Header--mode-secondary:not(.Header--pi):not(.Header--with-subtitle) .Header__main,
 .Header--mode-tertiary .Header__main {
   color: var(--vkui--color_text_secondary);
 }
@@ -92,8 +92,25 @@
   margin: 15px 0 9px;
 }
 
+.Header--android.Header--mode-primary .Header__main {
+  margin-bottom: 7px;
+}
+
+.Header--android.Header--mode-primary .Header__content:not(:last-child) {
+  margin-top: 0;
+}
+
+.Header--android.Header--mode-primary .Header__content:last-child {
+  margin-bottom: 2px;
+}
+
 .Header--android.Header--mode-tertiary .Header__main {
   margin-top: 11px;
+}
+
+.Header--android.Header--mode-secondary .Header__indicator {
+  align-self: stretch;
+  max-height: 0;
 }
 
 /**
@@ -104,12 +121,17 @@
   margin: 13px 0 9px;
 }
 
+.Header--ios.Header--mode-primary .Header__main {
+  margin: 16px 0 7px;
+}
+
 .Header--ios.Header--mode-secondary .Header__main {
   margin: 14px 0 10px;
 }
 
 .Header--ios.Header--mode-tertiary .Header__main {
-  margin-top: 9px;
+  margin-top: 12px;
+  margin-bottom: 8px;
 }
 
 /**

--- a/packages/vkui/src/components/Header/Header.tsx
+++ b/packages/vkui/src/components/Header/Header.tsx
@@ -5,8 +5,8 @@ import { Platform } from '../../lib/platform';
 import { HasComponent, HasRootRef } from '../../types';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { Headline } from '../Typography/Headline/Headline';
+import { Paragraph } from '../Typography/Paragraph/Paragraph';
 import { Subhead } from '../Typography/Subhead/Subhead';
-import { Text } from '../Typography/Text/Text';
 import { Title } from '../Typography/Title/Title';
 import styles from './Header.module.css';
 
@@ -40,10 +40,10 @@ const HeaderContent = ({ mode, size, ...restProps }: HeaderContentProps) => {
         ) : (
           <Title weight="1" level="3" {...restProps} />
         );
+      case 'secondary':
+        return <Footnote weight="1" caps {...restProps} />;
       case 'tertiary':
         return <Title weight="1" level="3" {...restProps} />;
-      case 'secondary':
-        return <Footnote weight="2" caps {...restProps} />;
     }
   }
 
@@ -53,9 +53,10 @@ const HeaderContent = ({ mode, size, ...restProps }: HeaderContentProps) => {
         return isLarge ? (
           <Title level="2" weight="1" {...restProps} />
         ) : (
-          <Headline weight="3" {...restProps} />
+          <Headline level="1" weight="2" {...restProps} />
         );
       case 'secondary':
+        return <Footnote caps weight="1" {...restProps} />;
       case 'tertiary':
         return <Footnote {...restProps} />;
     }
@@ -68,10 +69,10 @@ const HeaderContent = ({ mode, size, ...restProps }: HeaderContentProps) => {
       ) : (
         <Headline weight="2" {...restProps} />
       );
-    case 'tertiary':
-      return <Headline weight="2" {...restProps} />;
     case 'secondary':
       return <Footnote weight="1" caps {...restProps} />;
+    case 'tertiary':
+      return <Headline weight="2" {...restProps} />;
   }
 
   return null;
@@ -94,8 +95,7 @@ export const Header = ({
 }: HeaderProps) => {
   const platform = usePlatform();
 
-  const AsideTypography = platform === Platform.VKCOM ? Subhead : Text;
-  const SubtitleTypography = mode === 'secondary' ? Subhead : Footnote;
+  const AsideTypography = platform === Platform.VKCOM ? Subhead : Paragraph;
 
   return (
     <header
@@ -112,6 +112,7 @@ export const Header = ({
           tertiary: styles['Header--mode-tertiary'],
         }[mode],
         isPrimitiveReactNode(indicator) && styles['Header--pi'],
+        hasReactNode(subtitle) && styles['Header--with-subtitle'],
         className,
       )}
     >
@@ -131,19 +132,16 @@ export const Header = ({
             {children}
           </span>
           {hasReactNode(indicator) && (
-            <Footnote
-              className={styles['Header__indicator']}
-              weight={mode === 'primary' || mode === 'secondary' ? '1' : undefined}
-            >
+            <Footnote className={styles['Header__indicator']} weight="2">
               {indicator}
             </Footnote>
           )}
         </HeaderContent>
 
         {hasReactNode(subtitle) && (
-          <SubtitleTypography className={styles['Header__subtitle']} Component="span">
+          <Subhead className={styles['Header__subtitle']} Component="span">
             {subtitle}
-          </SubtitleTypography>
+          </Subhead>
         )}
       </div>
 

--- a/packages/vkui/src/components/Link/Link.module.css
+++ b/packages/vkui/src/components/Link/Link.module.css
@@ -12,6 +12,10 @@
   border-radius: 0;
 }
 
+.Header__aside > .Link {
+  color: var(--vkui--color_text_accent);
+}
+
 /* See https://www.ctrl.blog/entry/css-media-hover-samsung.html */
 @media (hover: hover) and (pointer: fine) {
   .Link:hover {


### PR DESCRIPTION
В данном ПРе внесены некоторые изменения в компонент `Header`:
- для Android:
  - в качестве `subtitle` используется `subhead` вместо `footnote`
  - для `aside` используется `Paragraph` и цвет ссылки меняется на `text_accent`
  - вес шрифта number_indicator изменен с 600 на 500
  - вариант `primary` настроен так, чтобы высота вместе с `subtitle` была 60
  - вариант `secondary` настроен так, чтобы `counter` не растягивал высоту блока *
- для iOS: 
  - в качестве `subtitle` используется `subhead` вместо `footnote`
  - для `aside` используется `Paragraph` и цвет ссылки меняется на `text_accent`
  - вес шрифта number_indicator изменен с 600 на 500
  - вариант `primary` настроен так, чтобы высота вместе с `subtitle` была 62
  - в варианте `secondary` вес шрифта изменен с 500 на 600

* По умолчанию высота блока контента (`vkuiHeader__content`) равна высоте блока текста заголовка (`vkuiHeader__content-in`). Блок с индикатором (`vkuiHeader__indicator`) тоже лежит внутри блока контента и растягивает его, если высота каунтера больше высоты блока текста заголовка. Чтобы этому помешать, мы устанавливаем максимальную высоту блока с индикатором (`vkuiHeader__indicator`) равной `0`. Но тут возникает другая проблема - основной блок (`Header__main`) не показывает содержимое, выходящее за его пределы (`overflow: hidden`). Это нужно для того, чтобы текст заголовка схлопывался когда заголовок не влезает по ширине в контейнер. Из-ха этого каунтер начинает обрезаться. Чтобы это исправить - мы переносим настройки схлопывания текста с основного блока на сами блоки текстового контента (`Header__content-in` и `Header__subtitle`). 

- fix #4202 