### PR TITLE
docs: fix ReactDOM import

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm add @vkontakte/vkui @vkontakte/icons @vkontakte/vk-bridge
 
 ```jsx static
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import {
   AdaptivityProvider,
   ConfigProvider,

--- a/styleguide/pages/adaptivity.md
+++ b/styleguide/pages/adaptivity.md
@@ -11,7 +11,7 @@
 
 ```jsx static
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { ConfigProvider, AdaptivityProvider, AppRoot } from '@vkontakte/vkui';
 import '@vkontakte/vkui/dist/vkui.css';
 

--- a/styleguide/pages/quick_start.md
+++ b/styleguide/pages/quick_start.md
@@ -43,7 +43,7 @@ pnpm add @vkontakte/vkui @vkontakte/icons @vkontakte/vk-bridge
 
 ```jsx static
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import {
   AdaptivityProvider,
   ConfigProvider,

--- a/styleguide/pages/ssr.md
+++ b/styleguide/pages/ssr.md
@@ -3,7 +3,7 @@
 определения платформы пользователя (iOS или Android) на стороне сервера. Пример:
 
 ```jsx static
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { Button, SSRWrapper } from '@vkontakte/vkui';
 import express from 'express';
 import useragent from 'express-useragent';


### PR DESCRIPTION
Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".

Ref: https://github.com/facebook/create-react-app/issues/12219