### PR TITLE
Add curly & eqeqeq eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,8 @@
         "allowSeparatedGroups": true,
         "memberSyntaxSortOrder": ["none", "single", "all", "multiple"]
       }
-    ]
+    ],
+    "curly": "error", // Enforce consistent brace style
+    "eqeqeq": "error" // Only type-safe equality operators
   }
 }

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -17,3 +17,7 @@
 # eslint: fix imports order #4238
 # https://github.com/VKCOM/VKUI/pull/4242/commits/4d9b40ac9970932637f643d4b8fe1c32a5680821
 4d9b40ac9970932637f643d4b8fe1c32a5680821
+
+# eslint: add curly & eqeqeq rules
+# https://github.com/VKCOM/VKUI/pull/4450/commits/d097bd0981e57982c5aac2ed823b4f0f3397cfaf
+d097bd0981e57982c5aac2ed823b4f0f3397cfaf

--- a/packages/token-translator/.eslintrc.json
+++ b/packages/token-translator/.eslintrc.json
@@ -25,6 +25,8 @@
         "allowSeparatedGroups": true,
         "memberSyntaxSortOrder": ["none", "single", "all", "multiple"]
       }
-    ]
+    ],
+    "curly": "error", // Enforce consistent brace style
+    "eqeqeq": "error" // Only type-safe equality operators
   }
 }

--- a/styleguide/.eslintrc.json
+++ b/styleguide/.eslintrc.json
@@ -53,6 +53,8 @@
         "allowSeparatedGroups": true,
         "memberSyntaxSortOrder": ["none", "single", "all", "multiple"]
       }
-    ]
+    ],
+    "curly": "error", // Enforce consistent brace style
+    "eqeqeq": "error" // Only type-safe equality operators
   }
 }

--- a/styleguide/Components/Modals/useFetch.js
+++ b/styleguide/Components/Modals/useFetch.js
@@ -32,7 +32,9 @@ export function useFetch(url, options) {
   const [state, dispatch] = useReducer(fetchReducer, initialState);
 
   useEffect(() => {
-    if (!url) return;
+    if (!url) {
+      return;
+    }
 
     cancelRequest.current = false;
 
@@ -52,11 +54,15 @@ export function useFetch(url, options) {
 
         const data = await response.json();
         cache.current[url] = data;
-        if (cancelRequest.current) return;
+        if (cancelRequest.current) {
+          return;
+        }
 
         dispatch({ type: 'fetched', payload: data });
       } catch (error) {
-        if (cancelRequest.current) return;
+        if (cancelRequest.current) {
+          return;
+        }
 
         dispatch({ type: 'error', payload: error });
       }


### PR DESCRIPTION
Adding new eslint rules:

 - `curly`: Enforce consistent brace style
 - `eqeqeq`: Only type-safe equality operators