### PR TITLE
fix(pull_request_packages.yml): fix glob pattern in paths-ignore

### DIFF
--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -22,8 +22,8 @@ on:
       - '!.github/actions/**'
       - '.github/actions/**/*.yml'
       - '**/*.md'
-      - '!packages/vkui/src/*.md'
-      - '!styleguide/pages/*.md'
+      - '!packages/vkui/src/**/*.md'
+      - '!styleguide/pages/**/*.md'
       - '**/__image_snapshots__/*.png'
 
 concurrency:


### PR DESCRIPTION
Ошибся в регулярке в двух исключениях для `*.md` файлов.

---

- caused by #4197
- related to #4482