### PR TITLE
fix(CellButton): add default Component

### DIFF
--- a/packages/vkui/src/components/CellButton/CellButton.a11y.test.tsx
+++ b/packages/vkui/src/components/CellButton/CellButton.a11y.test.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { a11yBasicTest } from '../../testing/a11y';
+import { CellButton } from './CellButton';
+
+describe('CellButton', () => {
+  a11yBasicTest((props) => <CellButton {...props}>Добавить новую школу</CellButton>);
+});

--- a/packages/vkui/src/components/CellButton/CellButton.tsx
+++ b/packages/vkui/src/components/CellButton/CellButton.tsx
@@ -15,12 +15,14 @@ export const CellButton = ({
   centered = false,
   mode = 'primary',
   className,
+  Component = 'button',
   ...restProps
 }: CellButtonProps) => {
   return (
     <SimpleCell
       stopPropagation={true}
       {...restProps}
+      Component={Component}
       className={classNames(
         styles['CellButton'],
         {

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
@@ -13,11 +13,8 @@
   white-space: normal;
 }
 
-.SimpleCell--mult .SimpleCell__children {
-  text-overflow: initial;
-}
-
 .SimpleCell__main {
+  display: block;
   max-width: 100%;
   flex-grow: 1;
   min-width: 0;
@@ -50,16 +47,16 @@
   color: var(--vkui--color_text_secondary);
 }
 
-.SimpleCell .SimpleCell__content {
+.SimpleCell__content {
   display: flex;
   align-content: flex-start;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   max-width: 100%;
 }
 
-.SimpleCell:not(.SimpleCell--mult) .SimpleCell__content {
-  justify-content: flex-start;
+.SimpleCell--mult .SimpleCell__content {
+  justify-content: space-between;
 }
 
 .SimpleCell__children {
@@ -69,7 +66,11 @@
   display: block;
 }
 
-.SimpleCell--mult .SimpleCell__children,
+.SimpleCell--mult .SimpleCell__children {
+  flex: 1 1 auto;
+  text-overflow: initial;
+}
+
 .SimpleCell--mult .SimpleCell__subtitle {
   flex: 1 1 auto;
 }

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
@@ -119,7 +119,7 @@ export const SimpleCell = ({
       )}
     >
       {before}
-      <div className={styles['SimpleCell__main']}>
+      <span className={styles['SimpleCell__main']}>
         {subhead && (
           <Subhead
             Component="span"
@@ -128,7 +128,7 @@ export const SimpleCell = ({
             {subhead}
           </Subhead>
         )}
-        <div className={styles['SimpleCell__content']}>
+        <span className={styles['SimpleCell__content']}>
           {badgeBeforeTitle && (
             <span className={styles['SimpleCell__badge']}>{badgeBeforeTitle}</span>
           )}
@@ -138,9 +138,9 @@ export const SimpleCell = ({
           {hasReactNode(badgeAfterTitle) && (
             <span className={styles['SimpleCell__badge']}>{badgeAfterTitle}</span>
           )}
-        </div>
+        </span>
         {subtitle && (
-          <div className={styles['SimpleCell__content']}>
+          <span className={styles['SimpleCell__content']}>
             {badgeBeforeSubtitle && (
               <span className={styles['SimpleCell__badge']}>{badgeBeforeSubtitle}</span>
             )}
@@ -156,7 +156,7 @@ export const SimpleCell = ({
             {badgeAfterSubtitle && (
               <span className={styles['SimpleCell__badge']}>{badgeAfterSubtitle}</span>
             )}
-          </div>
+          </span>
         )}
         {extraSubtitle && (
           <span
@@ -169,17 +169,17 @@ export const SimpleCell = ({
             {extraSubtitle}
           </span>
         )}
-      </div>
+      </span>
       {hasReactNode(indicator) && (
         <Headline Component="span" weight="3" className={styles['SimpleCell__indicator']}>
           {indicator}
         </Headline>
       )}
       {hasAfter && (
-        <div className={styles['SimpleCell__after']}>
+        <span className={styles['SimpleCell__after']}>
           {after}
           {expandable && platform === Platform.IOS && <Icon24Chevron />}
-        </div>
+        </span>
       )}
     </Tappable>
   );


### PR DESCRIPTION
В процессе тестирования невизуальной доступности обнаружили, что `CellButton` не выглядит как кнопка и не подписан для скринридеров.