### PR TITLE
chore(webpack-styles): fix warning

### DIFF
--- a/packages/vkui/webpack.styles.config.js
+++ b/packages/vkui/webpack.styles.config.js
@@ -18,6 +18,13 @@ module.exports = {
         test: /\.[jt]sx?$/,
         exclude: /node_modules/,
         loader: 'swc-loader',
+        options: {
+          jsc: {
+            experimental: {
+              plugins: [['@project-tools/swc-transform-css-modules', {}]],
+            },
+          },
+        },
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
Убираем предупреждения при сборке css


<img width="1053" alt="image" src="https://user-images.githubusercontent.com/14944123/225007296-b42256b9-098f-4ef4-9d1d-1451accb5d8e.png">
