### PR TITLE
ci(file-filters.yml): exclude *.md from package_vkui

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -13,7 +13,7 @@ dependencies: &dependencies
 # Отмечаем всё, что хоть как-то может повлиять на конечную сборку пакета vkui
 package_vkui: &package_vkui
   - *dependencies
-  - 'packages/vkui/**'
+  - 'packages/vkui/**/!(*.md)'
   - 'tools/!(eslint-*|stylelint-*)/**'
   - 'e2e/**'
   - '.browserslistrc'
@@ -23,4 +23,5 @@ package_vkui: &package_vkui
 
 docs_styleguide:
   - *package_vkui
+  - 'packages/vkui/src/**/*.md'
   - 'styleguide/**'


### PR DESCRIPTION
Не запускаем e2e тесты, если поменялись `packages/vkui/**/*.md` файлы, но при этом продолжаем собирать `styleguide` если затронуло `packages/vkui/src/**/*.md` файлы.

---

- related to #4197