### PR TITLE
fix(PopoutWrapper): remove preventDefault() on touchmove event

### DIFF
--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
@@ -1,29 +1,11 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { PopoutWrapper } from './PopoutWrapper';
 
 describe('PopoutWrapper', () => {
   baselineComponent(PopoutWrapper);
-
-  describe('prevents touchmove', () => {
-    it('while mounted', () => {
-      render(<PopoutWrapper />);
-      const e = new TouchEvent('touchmove');
-      const preventDefault = jest.spyOn(e, 'preventDefault');
-      fireEvent(window, e);
-      expect(preventDefault).toBeCalled();
-    });
-    it('clears after unmount', () => {
-      const h = render(<PopoutWrapper />);
-      h.unmount();
-      const e = new TouchEvent('touchmove');
-      const preventDefault = jest.spyOn(e, 'preventDefault');
-      fireEvent(window, e);
-      expect(preventDefault).not.toBeCalled();
-    });
-  });
 
   describe('gets opened', () => {
     const isOpened = () => !!document.querySelector('.vkuiPopoutWrapper--opened');

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useTimeout } from '../../hooks/useTimeout';
-import { useDOM } from '../../lib/dom';
 import { Platform } from '../../lib/platform';
 import styles from './PopoutWrapper.module.css';
 
@@ -42,11 +40,6 @@ export const PopoutWrapper = ({
   React.useEffect(() => {
     !opened && animationFinishFallback.set();
   }, [animationFinishFallback, opened]);
-
-  const { window } = useDOM();
-  useGlobalEventListener(window, 'touchmove', (e) => e.preventDefault(), {
-    passive: false,
-  });
 
   return (
     <div


### PR DESCRIPTION
Теперь, при использовании `PopoutWrapper` напрямую, необходимо самостоятельно импортировать и вызывать `useScrollLock()` (см. #4314).

---

- fix #4314 