### PR TITLE
ci(@actions-internal/patch): fix 'invalid refspec' problem

### DIFF
--- a/.github/actions/patch/src/main.ts
+++ b/.github/actions/patch/src/main.ts
@@ -59,8 +59,7 @@ async function run(): Promise<void> {
     });
     const patchRefs = patchCommits.data
       .filter((commit) => commit.commit.message !== 'CHORE: Update screenshots')
-      .map((commit) => commit.sha)
-      .join(' ');
+      .map((commit) => commit.sha);
 
     if (forked) {
       const message = getPatchInstructions(
@@ -80,9 +79,9 @@ async function run(): Promise<void> {
     }
 
     try {
-      await exec.exec('git', ['fetch', 'origin', stableBranchRef, patchRefs]);
+      await exec.exec('git', ['fetch', 'origin', stableBranchRef, ...patchRefs]);
       await exec.exec('git', ['checkout', stableBranchRef]);
-      await exec.exec('git', ['cherry-pick', patchRefs]);
+      await exec.exec('git', ['cherry-pick', ...patchRefs]);
     } catch (e) {
       console.error(e);
 

--- a/.github/actions/patch/src/message.ts
+++ b/.github/actions/patch/src/message.ts
@@ -1,7 +1,7 @@
 export function getPatchInstructions(
   header: string,
   description: string,
-  patch: { stableBranchRef: string; patchRefs: string; pullNumber: number },
+  patch: { stableBranchRef: string; patchRefs: string[]; pullNumber: number },
 ) {
   const { stableBranchRef, patchRefs, pullNumber } = patch;
 
@@ -20,7 +20,7 @@ ${description}
 git stash # опционально
 git fetch origin ${stableBranchRef}
 git checkout -b patch/pr${pullNumber} origin/${stableBranchRef}
-git cherry-pick ${patchRefs}
+git cherry-pick ${patchRefs.join(' ')}
 \`\`\`
 
 2. Исправьте конфликты, следуя инструкциям из терминала


### PR DESCRIPTION
Исправляем проблему с `invalid refspec`, которая возникает когда у нас несколько коммитов.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/226410542-f805e8ee-44ac-4467-9835-b5e42fd15068.png">

_Пример из PR #4518 https://github.com/VKCOM/VKUI/actions/runs/4465844345/jobs/7850781149_

В #4518 получилась вот такая команда
```sh
git fetch origin 5.2-stable '274939a9c0ad1e23b8552c7ef027440368777b1e 6b33f880a3936b7e0a93cfcb97b2c7b75176f26b'
```

вместо
```sh
git fetch origin 5.2-stable 274939a9c0ad1e23b8552c7ef027440368777b1e 6b33f880a3936b7e0a93cfcb97b2c7b75176f26b
```