### PR TITLE
chore: Add exempt pr label

### DIFF
--- a/.github/workflows/inactive_contributions.yml
+++ b/.github/workflows/inactive_contributions.yml
@@ -20,4 +20,5 @@ jobs:
           days-before-pr-close: 7
           stale-pr-label: 'pr-needs-work'
           close-pr-message: 'PR закрыт из-за отсутствия активности в течение последних 14 дней. Если это произошло по ошибке или изменения все ещё актуальны, откройте PR повторно.'
+          exempt-pr-labels: 'no-stale'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Добавляем лейбл `no-stale` для того, чтобы определенные PRы не помечались как `stale`