### PR TITLE
fix(a11y/getTitleFromChildren): add space

### DIFF
--- a/packages/vkui/src/lib/utils.ts
+++ b/packages/vkui/src/lib/utils.ts
@@ -44,11 +44,11 @@ export function getTitleFromChildren(children: React.ReactNode): string {
 
   React.Children.map(children, (child) => {
     if (typeof child === 'string') {
-      label += child;
+      label += ' ' + child;
     }
   });
 
-  return label;
+  return label.trim();
 }
 
 export const stopPropagation = <T extends React.SyntheticEvent>(event: T) =>


### PR DESCRIPTION
Некоторые скринридеры при отсутствии пробелов даже раздробленный на разные `span` текст зачитывают как одно слово.

Добавляем уверенности, что наш `getTitleFromChildren` себя так не поведет. (%