### PR TITLE
fix(SubnavigationButton): fix aria-label

### DIFF
--- a/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.a11y.test.tsx
+++ b/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.a11y.test.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { a11yBasicTest } from '../../testing/a11y';
+import { SubnavigationButton } from './SubnavigationButton';
+
+describe('SubnavigationButton', () => {
+  a11yBasicTest((props) => (
+    <SubnavigationButton {...props}>Subnavigation Button</SubnavigationButton>
+  ));
+});

--- a/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
+++ b/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
@@ -3,7 +3,6 @@ import { Icon16Dropdown } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { SizeType } from '../../lib/adaptivity';
-import { getTitleFromChildren } from '../../lib/utils';
 import { HasChildren, HasComponent } from '../../types';
 import { Tappable, TappableProps } from '../Tappable/Tappable';
 import { Caption } from '../Typography/Caption/Caption';
@@ -90,7 +89,6 @@ export const SubnavigationButton = ({
         sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         className,
       )}
-      aria-label={getTitleFromChildren(children)}
     >
       <span className={styles['SubnavigationButton__in']}>
         {before && <span className={styles['SubnavigationButton__before']}>{before}</span>}


### PR DESCRIPTION
**Зачем:** в `aria-label` собиралось значение только из `children`, из-за чего значение каунтера, переданного в `after`, не учитывалось скринридерами и портило невизуальную доступность.

Выпилила `aria-label`, добавила тест на доступность.