### PR TITLE
fix(@vkontakte/vkui): copy docs/assets dir before publish

### DIFF
--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -7,7 +7,8 @@
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
-    "./dist"
+    "./dist",
+    "./docs/assets"
   ],
   "sideEffects": [
     "./dist/lib/polyfills.js",
@@ -27,8 +28,9 @@
   "bugs": "https://github.com/VKCOM/VKUI/issues",
   "homepage": "https://vkcom.github.io/VKUI/",
   "scripts": {
-    "prepublishOnly": "yarn copy-essensial-files && yarn build",
+    "prepublishOnly": "yarn copy-essensial-files && yarn copy-docs-assets && yarn build",
     "copy-essensial-files": "cp ../../LICENSE . && cp ../../README.md .",
+    "copy-docs-assets": "mkdir -p docs/assets && cp -r ../../docs/assets/ docs/assets/",
     "package:version": "echo $npm_package_version",
     "size": "yarn clear && yarn build:no-types && size-limit",
     "size:ci": "yarn install --frozen-lockfile --ignore-scripts && yarn build:no-types",


### PR DESCRIPTION
## Проблема

Из-за того, что `docs/assets` лежит в корне проекта, а `README.md` копируется в `packages/vkui` при создании артефакта, получается так, что пути до лого резолвятся не верно.

<img width="320" src="https://user-images.githubusercontent.com/5850354/227244900-5bf2e994-4df5-41d5-8925-db4b8d942023.png" /> <img width="320" src="https://user-images.githubusercontent.com/5850354/227244948-9e89a38c-b175-44e4-95f6-9ebfc1f653ae.png" />

_Вот примеры из NPM. Нет папки `docs/assets`, поэтому и картинка не грузится в доке_

## Решение

Во время создания артефакта, также копируем `docs/assets` в `packages/vkui`