### PR TITLE
ci(file-filters.yml): fix bad glob pattern for package_vkui

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -13,7 +13,8 @@ dependencies: &dependencies
 # Отмечаем всё, что хоть как-то может повлиять на конечную сборку пакета vkui
 package_vkui: &package_vkui
   - *dependencies
-  - 'packages/vkui/**/!(storybook)/!(*.md|*.stories.*)'
+  - 'packages/vkui/*.!(md)'
+  - 'packages/vkui/!(.storybook)src/**/!(*.md|*.stories.*)'
   - 'tools/!(eslint-*|stylelint-*|storybook-*)/**'
   - 'e2e/**'
   - '.browserslistrc'


### PR DESCRIPTION
Была проблема в glob паттерне – не видел изменения на уровне `packages/vkui/*`. Разбил на два.

<img width="550" alt="image" src="https://user-images.githubusercontent.com/5850354/227260669-600f86d0-fab2-46bd-aeac-bbf2fa8aec68.png">

_Пример из PR #4575. Должен был тригернуться на `packages/vkui/package.json`_

---

- related to #4197