### PR TITLE
fix(ModalPage): ModalPage__content-in height: 100%

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPage.module.css
+++ b/packages/vkui/src/components/ModalPage/ModalPage.module.css
@@ -110,6 +110,7 @@
 
 .ModalPage__content-in {
   position: relative;
+  height: 100%;
   padding-bottom: var(--vkui_internal--safe_area_inset_bottom);
 }
 


### PR DESCRIPTION
Требуется многим для возможности растянуть контент внутри