### PR TITLE
fix(UsersStack): add aria-hidden to othersElement

### DIFF
--- a/packages/vkui/src/components/UsersStack/UsersStack.tsx
+++ b/packages/vkui/src/components/UsersStack/UsersStack.tsx
@@ -195,7 +195,7 @@ export const UsersStack = ({
       )}
     >
       {(photosElements.length > 0 || othersElement) && (
-        <div className={styles['UsersStack__photos']} role="presentation">
+        <div className={styles['UsersStack__photos']} aria-hidden>
           {photosElements}
           {othersElement}
         </div>


### PR DESCRIPTION
<img width="379" alt="image" src="https://user-images.githubusercontent.com/22026957/229196479-d64d1d2b-d002-49bb-b60a-9edcda0ba9ff.png">

NVDA зачитывает этот компонент так: "+1Алексей, Илья, Михаил и ещё 1 человек".

"+1" зачитывать вообще не нужно, аватарки здесь тоже идут скорее как визуальный мусор, поэтому я поправила `role="presentation"` на `aria-hidden` на `.UsersStack__photos`.