### PR TITLE
types: fixes

### DIFF
--- a/packages/vkui/src/components/ActionSheet/types.ts
+++ b/packages/vkui/src/components/ActionSheet/types.ts
@@ -7,7 +7,7 @@ export type PopupDirection =
   | ((elRef: React.RefObject<HTMLDivElement>) => 'top' | 'bottom');
 export type ToggleRef = Element | null | undefined | React.RefObject<Element>;
 
-export interface SharedDropdownProps extends React.AllHTMLAttributes<HTMLElement>, FocusTrapProps {
+export interface SharedDropdownProps extends FocusTrapProps {
   closing: boolean;
   /**
    * Элемент, рядом с которым вылезает попап на десктопе.

--- a/packages/vkui/src/components/Typography/Caption/Caption.tsx
+++ b/packages/vkui/src/components/Typography/Caption/Caption.tsx
@@ -1,15 +1,10 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { HasComponent } from '../../../types';
+import { HasCaps, TypographyProps } from '../types';
 import styles from './Caption.module.css';
 
-export interface CaptionProps extends React.AllHTMLAttributes<HTMLElement>, HasComponent {
-  /**
-   * Задаёт начертание шрифта отличное от стандартного.
-   */
-  weight?: '1' | '2' | '3';
+export interface CaptionProps extends TypographyProps, HasCaps {
   level?: '1' | '2' | '3';
-  caps?: boolean;
 }
 
 /**

--- a/packages/vkui/src/components/Typography/Footnote/Footnote.tsx
+++ b/packages/vkui/src/components/Typography/Footnote/Footnote.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { HasComponent } from '../../../types';
+import { HasCaps, TypographyProps } from '../types';
 import styles from './Footnote.module.css';
 
-export interface FootnoteProps extends React.AllHTMLAttributes<HTMLElement>, HasComponent {
-  /**
-   * Задаёт начертание шрифта отличное от стандартного.
-   */
-  weight?: '1' | '2' | '3';
-  caps?: boolean;
-}
+export interface FootnoteProps extends TypographyProps, HasCaps {}
 
 /**
  * @see https://vkcom.github.io/VKUI/#/Footnote

--- a/packages/vkui/src/components/Typography/Headline/Headline.tsx
+++ b/packages/vkui/src/components/Typography/Headline/Headline.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { SizeType } from '../../../lib/adaptivity';
-import { warnOnce } from '../../../lib/warnOnce';
 import { HasRootRef } from '../../../types';
 import { TypographyProps } from '../types';
 import styles from './Headline.module.css';
@@ -15,8 +14,6 @@ const sizeYClassNames = {
 export interface HeadlineProps extends TypographyProps, HasRootRef<HTMLElement> {
   level?: '1' | '2';
 }
-
-const warn = warnOnce('Headline');
 
 /**
  * @see https://vkcom.github.io/VKUI/#/Headline
@@ -31,10 +28,6 @@ export const Headline = ({
   ...restProps
 }: HeadlineProps) => {
   const { sizeY = 'none' } = useAdaptivity();
-
-  if (process.env.NODE_ENV === 'development' && typeof Component !== 'string' && getRootRef) {
-    warn('getRootRef может использоваться только с элементами DOM', 'error');
-  }
 
   return (
     <Component

--- a/packages/vkui/src/components/Typography/Headline/Headline.tsx
+++ b/packages/vkui/src/components/Typography/Headline/Headline.tsx
@@ -3,7 +3,8 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { SizeType } from '../../../lib/adaptivity';
 import { warnOnce } from '../../../lib/warnOnce';
-import { HasComponent, HasRootRef } from '../../../types';
+import { HasRootRef } from '../../../types';
+import { TypographyProps } from '../types';
 import styles from './Headline.module.css';
 
 const sizeYClassNames = {
@@ -11,14 +12,7 @@ const sizeYClassNames = {
   [SizeType.COMPACT]: styles['Headline--sizeY-compact'],
 };
 
-export interface HeadlineProps
-  extends React.AllHTMLAttributes<HTMLElement>,
-    HasRootRef<HTMLElement>,
-    HasComponent {
-  /**
-   * Задаёт начертание шрифта отличное от стандартного.
-   */
-  weight?: '1' | '2' | '3';
+export interface HeadlineProps extends TypographyProps, HasRootRef<HTMLElement> {
   level?: '1' | '2';
 }
 

--- a/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { warnOnce } from '../../../lib/warnOnce';
 import { HasRootRef } from '../../../types';
 import { TypographyProps } from '../types';
 import styles from './Paragraph.module.css';
 
 export interface ParagraphProps extends TypographyProps, HasRootRef<HTMLElement> {}
 
-const warn = warnOnce('Paragraph');
 /**
  * @see https://vkcom.github.io/VKUI/#/Paragraph
  */
@@ -19,10 +17,6 @@ export const Paragraph = ({
   children,
   ...restProps
 }: ParagraphProps) => {
-  if (process.env.NODE_ENV === 'development' && typeof Component !== 'string' && getRootRef) {
-    warn('getRootRef может использоваться только с элементами DOM', 'error');
-  }
-
   return (
     <Component
       {...restProps}

--- a/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,21 +1,13 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { warnOnce } from '../../../lib/warnOnce';
-import { HasComponent, HasRootRef } from '../../../types';
+import { HasRootRef } from '../../../types';
+import { TypographyProps } from '../types';
 import styles from './Paragraph.module.css';
 
-export interface ParagraphProps
-  extends React.AllHTMLAttributes<HTMLElement>,
-    HasRootRef<HTMLElement>,
-    HasComponent {
-  /**
-   * Задаёт начертание шрифта, отличное от стандартного.
-   */
-  weight?: '1' | '2' | '3';
-}
+export interface ParagraphProps extends TypographyProps, HasRootRef<HTMLElement> {}
 
 const warn = warnOnce('Paragraph');
-
 /**
  * @see https://vkcom.github.io/VKUI/#/Paragraph
  */

--- a/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
+++ b/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { SizeType } from '../../../lib/adaptivity';
-import { HasComponent } from '../../../types';
+import { TypographyProps } from '../types';
 import styles from './Subhead.module.css';
 
 const sizeYClassNames = {
@@ -10,12 +10,7 @@ const sizeYClassNames = {
   [SizeType.COMPACT]: styles['Subhead--sizeY-compact'],
 };
 
-export interface SubheadProps extends React.AllHTMLAttributes<HTMLElement>, HasComponent {
-  /**
-   * Задаёт начертание шрифта отличное от стандартного.
-   */
-  weight?: '1' | '2' | '3';
-}
+export type SubheadProps = TypographyProps;
 
 /**
  * @see https://vkcom.github.io/VKUI/#/Subhead

--- a/packages/vkui/src/components/Typography/Text/Text.tsx
+++ b/packages/vkui/src/components/Typography/Text/Text.tsx
@@ -3,7 +3,8 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { SizeType } from '../../../lib/adaptivity';
 import { warnOnce } from '../../../lib/warnOnce';
-import { HasComponent, HasRootRef } from '../../../types';
+import { HasRootRef } from '../../../types';
+import { TypographyProps } from '../types';
 import styles from './Text.module.css';
 
 const sizeYClassNames = {
@@ -11,15 +12,7 @@ const sizeYClassNames = {
   [SizeType.COMPACT]: styles['Text--sizeY-compact'],
 };
 
-export interface TextProps
-  extends React.AllHTMLAttributes<HTMLElement>,
-    HasRootRef<HTMLElement>,
-    HasComponent {
-  /**
-   * Задаёт начертание шрифта, отличное от стандартного.
-   */
-  weight?: '1' | '2' | '3';
-}
+export interface TextProps extends TypographyProps, HasRootRef<HTMLElement> {}
 
 const warn = warnOnce('Text');
 /**

--- a/packages/vkui/src/components/Typography/Text/Text.tsx
+++ b/packages/vkui/src/components/Typography/Text/Text.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { SizeType } from '../../../lib/adaptivity';
-import { warnOnce } from '../../../lib/warnOnce';
 import { HasRootRef } from '../../../types';
 import { TypographyProps } from '../types';
 import styles from './Text.module.css';
@@ -14,7 +13,6 @@ const sizeYClassNames = {
 
 export interface TextProps extends TypographyProps, HasRootRef<HTMLElement> {}
 
-const warn = warnOnce('Text');
 /**
  * @see https://vkcom.github.io/VKUI/#/Text
  */
@@ -26,10 +24,6 @@ export const Text = ({
   getRootRef,
   ...restProps
 }: TextProps) => {
-  if (process.env.NODE_ENV === 'development' && typeof Component !== 'string' && getRootRef) {
-    warn(`Свойство "getRootRef" может использоваться только с компонентами DOM`, 'error');
-  }
-
   const { sizeY = 'none' } = useAdaptivity();
 
   return (

--- a/packages/vkui/src/components/Typography/Title/Title.tsx
+++ b/packages/vkui/src/components/Typography/Title/Title.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { HasComponent } from '../../../types';
+import { TypographyProps } from '../types';
 import styles from './Title.module.css';
 
-export interface TitleProps extends React.AllHTMLAttributes<HTMLElement>, HasComponent {
-  /**
-   * Задаёт начертание шрифта отличное от стандартного.
-   */
-  weight?: '1' | '2' | '3';
+export interface TitleProps extends TypographyProps {
   level?: '1' | '2' | '3';
 }
 

--- a/packages/vkui/src/components/Typography/types.ts
+++ b/packages/vkui/src/components/Typography/types.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { HasComponent } from '../../types';
+
+export interface TypographyProps extends React.AllHTMLAttributes<HTMLElement>, HasComponent {
+  /**
+   * Задаёт начертание шрифта, отличное от стандартного.
+   */
+  weight?: '1' | '2' | '3';
+}
+
+export interface HasCaps {
+  caps?: boolean;
+}


### PR DESCRIPTION
Подчистила типы.

**`SharedDropdownProps`**
- убрала лишний `React.AllHTMLAttributes<HTMLElement>` (он уже есть в `FocusTrapProps`)

**Компоненты типографики**
- создала `TypographyProps` и `HasCaps`,
- порефакторила все типографические компоненты на это дело,
- удалила лишние варнинги об использовании нестрокового `Component` с `getRootRef`