### PR TITLE
refactor(Separator, Spacing): fix a11y

### DIFF
--- a/packages/vkui/src/components/Separator/Separator.a11y.test.tsx
+++ b/packages/vkui/src/components/Separator/Separator.a11y.test.tsx
@@ -1,0 +1,6 @@
+import { a11yBasicTest } from '../../testing/a11y';
+import { Separator } from './Separator';
+
+describe('Separator', () => {
+  a11yBasicTest(Separator);
+});

--- a/packages/vkui/src/components/Separator/Separator.module.css
+++ b/packages/vkui/src/components/Separator/Separator.module.css
@@ -16,7 +16,10 @@
 
 .Separator__in {
   height: var(--vkui_internal--thin_border);
+  margin: 0;
   background: currentColor;
+  color: inherit;
+  border: none;
   transform-origin: center top;
 }
 

--- a/packages/vkui/src/components/Separator/Separator.tsx
+++ b/packages/vkui/src/components/Separator/Separator.tsx
@@ -15,10 +15,8 @@ export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
 export const Separator = ({ wide, className, ...restProps }: SeparatorProps) => (
   <div
     {...restProps}
-    aria-hidden
     className={classNames(styles['Separator'], !wide && styles['Separator--padded'], className)}
-    role="separator"
   >
-    <div className={styles['Separator__in']} />
+    <hr className={styles['Separator__in']} />
   </div>
 );

--- a/packages/vkui/src/components/Spacing/Spacing.a11y.test.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.a11y.test.tsx
@@ -1,0 +1,6 @@
+import { a11yBasicTest } from '../../testing/a11y';
+import { Spacing } from './Spacing';
+
+describe('Spacing', () => {
+  a11yBasicTest(Spacing);
+});

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -20,12 +20,5 @@ export const Spacing = ({ size = 8, style: styleProp, className, ...restProps }:
     ...styleProp,
   };
 
-  return (
-    <div
-      {...restProps}
-      aria-hidden
-      className={classNames(className, styles['Spacing'])}
-      style={style}
-    />
-  );
+  return <div {...restProps} className={classNames(className, styles['Spacing'])} style={style} />;
 };


### PR DESCRIPTION
`Separator` был отмечен как `role='separator'`, но роль не считывалась из-за `aria-hidden`. 😆

Соответственно:
- `Separator`: перевела на `hr`, выкинула `aria-hidden` и лишнюю роль, подбила стили
- `Spacing`: выкинула `aria-hidden`, т.к. внутрь может передаваться  `Separator`
- Добавила a11y-тесты для этих двух компонентов