### PR TITLE
ci(s3): undeploy always

### DIFF
--- a/.github/actions/s3/src/main.ts
+++ b/.github/actions/s3/src/main.ts
@@ -88,12 +88,17 @@ class Action {
       Prefix: prefix,
     });
 
-    const objects = data.Contents?.map((content) => {
+    if (!data.Contents) {
+      core.info('Nothing to delete');
+      return;
+    }
+
+    const objects = data.Contents.map((content) => {
       return { Key: content.Key };
     });
 
     core.debug('deleteObjects');
-    core.debug(`length ${objects?.length}`);
+    core.debug(`length ${objects.length}`);
     await this.s3.deleteObjects({
       Bucket: this.bucket,
       Delete: {

--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -6,8 +6,6 @@ on:
 
 jobs:
   undeploy_s3:
-    # [Примечание 1] Пропускаем очищение, т.к. для PR от dependabot песочница не создаётся
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     name: Undeploy S3
     steps:
@@ -25,7 +23,6 @@ jobs:
         working-directory: ./.github/actions/s3
 
       - name: Delete from S3
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/s3
         with:
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Удаляем папку с PR-ом всегда.
Если в PR dependabot кто-то запушит коммит, то документация все равно задеплоится