### PR TITLE
feat(ModalPage, PanelHeader): upgrade a11y

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -98,6 +98,8 @@ export const ModalPage = ({
   return (
     <div
       {...restProps}
+      role="dialog"
+      aria-modal="true"
       id={id}
       className={classNames(
         styles['ModalPage'],

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -84,7 +84,7 @@ export const ModalPage = ({
   ...restProps
 }: ModalPageProps) => {
   const generatingId = useId();
-  const id = _id || randomId;
+  const id = idProp || generatingId;
 
   const { updateModalHeight } = React.useContext(ModalRootContext);
 

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -78,7 +78,7 @@ export const ModalPage = ({
   dynamicContentHeight,
   getModalContentRef,
   nav,
-  id: _id,
+  id: idProp,
   hideCloseButton = false,
   className,
   ...restProps

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
+import { useId } from '../../hooks/useId';
 import { useOrientationChange } from '../../hooks/useOrientationChange';
 import { usePlatform } from '../../hooks/usePlatform';
 import { SizeType } from '../../lib/adaptivity';
@@ -11,6 +12,7 @@ import { warnOnce } from '../../lib/warnOnce';
 import { ModalDismissButton } from '../ModalDismissButton/ModalDismissButton';
 import { ModalRootContext, useModalRegistry } from '../ModalRoot/ModalRootContext';
 import { ModalType } from '../ModalRoot/types';
+import { ModalPageContext } from './ModalPageContext';
 import styles from './ModalPage.module.css';
 
 const sizeClassName = {
@@ -76,11 +78,14 @@ export const ModalPage = ({
   dynamicContentHeight,
   getModalContentRef,
   nav,
-  id,
+  id: _id,
   hideCloseButton = false,
   className,
   ...restProps
 }: ModalPageProps) => {
+  const randomId = useId();
+  const id = _id || randomId;
+
   const { updateModalHeight } = React.useContext(ModalRootContext);
 
   const platform = usePlatform();
@@ -95,44 +100,49 @@ export const ModalPage = ({
   const modalContext = React.useContext(ModalRootContext);
   const { refs } = useModalRegistry(getNavId({ nav, id }, warn), ModalType.PAGE);
 
-  return (
-    <div
-      {...restProps}
-      role="dialog"
-      aria-modal="true"
-      id={id}
-      className={classNames(
-        styles['ModalPage'],
-        platform === Platform.IOS && styles['ModalPage--ios'],
-        isDesktop && styles['ModalPage--desktop'],
-        sizeX === SizeType.REGULAR && 'vkuiInternalModalPage--sizeX-regular',
-        typeof size === 'string' && sizeClassName[size],
-        className,
-      )}
-    >
-      <div
-        className={styles['ModalPage__in-wrap']}
-        style={{
-          maxWidth: typeof size === 'number' ? size : undefined,
-        }}
-        ref={refs.innerElement}
-      >
-        <div className={styles['ModalPage__in']}>
-          <div className={styles['ModalPage__header']} ref={refs.headerElement}>
-            {header}
-          </div>
+  const contextValue = React.useMemo(() => ({ labelId: `${id}-label` }), [id]);
 
-          <div className={styles['ModalPage__content-wrap']}>
-            <div
-              className={styles['ModalPage__content']}
-              ref={multiRef<HTMLDivElement>(refs.contentElement, getModalContentRef)}
-            >
-              <div className={styles['ModalPage__content-in']}>{children}</div>
+  return (
+    <ModalPageContext.Provider value={contextValue}>
+      <div
+        {...restProps}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={contextValue.labelId}
+        id={id}
+        className={classNames(
+          styles['ModalPage'],
+          platform === Platform.IOS && styles['ModalPage--ios'],
+          isDesktop && styles['ModalPage--desktop'],
+          sizeX === SizeType.REGULAR && 'vkuiInternalModalPage--sizeX-regular',
+          typeof size === 'string' && sizeClassName[size],
+          className,
+        )}
+      >
+        <div
+          className={styles['ModalPage__in-wrap']}
+          style={{
+            maxWidth: typeof size === 'number' ? size : undefined,
+          }}
+          ref={refs.innerElement}
+        >
+          <div className={styles['ModalPage__in']}>
+            <div className={styles['ModalPage__header']} ref={refs.headerElement}>
+              {header}
             </div>
+
+            <div className={styles['ModalPage__content-wrap']}>
+              <div
+                className={styles['ModalPage__content']}
+                ref={multiRef<HTMLDivElement>(refs.contentElement, getModalContentRef)}
+              >
+                <div className={styles['ModalPage__content-in']}>{children}</div>
+              </div>
+            </div>
+            {isCloseButtonShown && <ModalDismissButton onClick={onClose || modalContext.onClose} />}
           </div>
-          {isCloseButtonShown && <ModalDismissButton onClick={onClose || modalContext.onClose} />}
         </div>
       </div>
-    </div>
+    </ModalPageContext.Provider>
   );
 };

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -83,7 +83,7 @@ export const ModalPage = ({
   className,
   ...restProps
 }: ModalPageProps) => {
-  const randomId = useId();
+  const generatingId = useId();
   const id = _id || randomId;
 
   const { updateModalHeight } = React.useContext(ModalRootContext);

--- a/packages/vkui/src/components/ModalPage/ModalPageContext.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPageContext.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export interface ModalPageContextInterface {
+  labelId?: string;
+}
+
+export const ModalPageContext = React.createContext<ModalPageContextInterface>({});

--- a/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -4,6 +4,7 @@ import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJS
 import { usePlatform } from '../../hooks/usePlatform';
 import { Platform } from '../../lib/platform';
 import { HasRef } from '../../types';
+import { ModalPageContext } from '../ModalPage/ModalPageContext';
 import { PanelHeader, PanelHeaderProps } from '../PanelHeader/PanelHeader';
 import { Separator } from '../Separator/Separator';
 import styles from './ModalPageHeader.module.css';
@@ -26,6 +27,7 @@ export const ModalPageHeader = ({
   const platform = usePlatform();
   const hasSeparator = separator && platform === Platform.VKCOM;
   const { isDesktop } = useAdaptivityWithJSMediaQueries();
+  const { labelId } = React.useContext(ModalPageContext);
 
   return (
     <div
@@ -43,7 +45,9 @@ export const ModalPageHeader = ({
         separator={false}
         transparent
       >
-        {children}
+        <PanelHeader.Content Component="h2" id={labelId}>
+          {children}
+        </PanelHeader.Content>
       </PanelHeader>
       {hasSeparator && <Separator wide />}
     </div>

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -8,6 +8,7 @@ import { Platform } from '../../lib/platform';
 import { HasRef, HasRootRef } from '../../types';
 import { useConfigProvider, WebviewType } from '../ConfigProvider/ConfigProviderContext';
 import { FixedLayout } from '../FixedLayout/FixedLayout';
+import { ModalPageContext } from '../ModalPage/ModalPageContext';
 import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { Separator } from '../Separator/Separator';
 import { Spacing } from '../Spacing/Spacing';
@@ -48,6 +49,7 @@ export interface PanelHeaderProps
 const PanelHeaderIn = ({ before, after, separator, children }: PanelHeaderProps) => {
   const { webviewType } = useConfigProvider();
   const { isInsideModal } = React.useContext(ModalRootContext);
+  const { labelId } = React.useContext(ModalPageContext);
   const platform = usePlatform();
 
   return (
@@ -60,11 +62,13 @@ const PanelHeaderIn = ({ before, after, separator, children }: PanelHeaderProps)
         </div>
         <div className={styles['PanelHeader__content']}>
           {platform === Platform.VKCOM ? (
-            <Text weight="2" Component="h2">
+            <Text weight="2" Component="h2" id={labelId}>
               {children}
             </Text>
           ) : (
-            <h2 className={styles['PanelHeader__content-in']}>{children}</h2>
+            <h2 className={styles['PanelHeader__content-in']} id={labelId}>
+              {children}
+            </h2>
           )}
         </div>
         <div className={classNames(styles['PanelHeader__after'], 'vkuiInternalPanelHeader__after')}>

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -5,10 +5,9 @@ import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditi
 import { usePlatform } from '../../hooks/usePlatform';
 import { SizeType } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';
-import { HasRef, HasRootRef } from '../../types';
+import { HasComponent, HasRef, HasRootRef } from '../../types';
 import { useConfigProvider, WebviewType } from '../ConfigProvider/ConfigProviderContext';
 import { FixedLayout } from '../FixedLayout/FixedLayout';
-import { ModalPageContext } from '../ModalPage/ModalPageContext';
 import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { Separator } from '../Separator/Separator';
 import { Spacing } from '../Spacing/Spacing';
@@ -46,10 +45,27 @@ export interface PanelHeaderProps
   fixed?: boolean;
 }
 
+interface PanelHeaderContentProps extends React.HTMLAttributes<HTMLElement>, HasComponent {}
+
+const PanelHeaderContent = ({ children, Component = 'span', id }: PanelHeaderContentProps) => {
+  const platform = usePlatform();
+
+  return platform === Platform.VKCOM ? (
+    <Text weight="2" Component={Component} id={id}>
+      {children}
+    </Text>
+  ) : (
+    <Component className={styles['PanelHeader__content-in']} id={id}>
+      {children}
+    </Component>
+  );
+};
+
+PanelHeaderContent.displayName = 'PanelHeaderContent';
+
 const PanelHeaderIn = ({ before, after, separator, children }: PanelHeaderProps) => {
   const { webviewType } = useConfigProvider();
   const { isInsideModal } = React.useContext(ModalRootContext);
-  const { labelId } = React.useContext(ModalPageContext);
   const platform = usePlatform();
 
   return (
@@ -61,14 +77,12 @@ const PanelHeaderIn = ({ before, after, separator, children }: PanelHeaderProps)
           {before}
         </div>
         <div className={styles['PanelHeader__content']}>
-          {platform === Platform.VKCOM ? (
-            <Text weight="2" Component="h2" id={labelId}>
-              {children}
-            </Text>
+          {/* Поддерживаем обратную совместимость для подкомпонентного подхода */}
+          {React.isValidElement(children) &&
+          (children as JSX.Element).type.displayName === PanelHeaderContent.displayName ? (
+            children
           ) : (
-            <h2 className={styles['PanelHeader__content-in']} id={labelId}>
-              {children}
-            </h2>
+            <PanelHeaderContent>{children}</PanelHeaderContent>
           )}
         </div>
         <div className={classNames(styles['PanelHeader__after'], 'vkuiInternalPanelHeader__after')}>
@@ -156,3 +170,5 @@ export const PanelHeader = ({
     </div>
   );
 };
+
+PanelHeader.Content = PanelHeaderContent;

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -60,9 +60,11 @@ const PanelHeaderIn = ({ before, after, separator, children }: PanelHeaderProps)
         </div>
         <div className={styles['PanelHeader__content']}>
           {platform === Platform.VKCOM ? (
-            <Text weight="2">{children}</Text>
+            <Text weight="2" Component="h2">
+              {children}
+            </Text>
           ) : (
-            <span className={styles['PanelHeader__content-in']}>{children}</span>
+            <h2 className={styles['PanelHeader__content-in']}>{children}</h2>
           )}
         </div>
         <div className={classNames(styles['PanelHeader__after'], 'vkuiInternalPanelHeader__after')}>


### PR DESCRIPTION
Относится к https://github.com/VKCOM/VKUI/issues/3041, ориентировался на [WCAG пример](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/).

Возможно, изменение `PanelHeader` в таком явном виде не нужно (как я понял, компонент используется не только внутри модалок?), а следует трогать `ModalPageHeader`, передавая `PanelHeader` новые пропсы   - нужно ваше мнение.

Помимо `ModalPage` могу помочь и с `ModalCard` в рамках новой задачи.