### PR TITLE
feat(types): Улучшенная типизация полиморфных компонентов

### DIFF
--- a/packages/vkui/src/components/FormItem/FormItem.test.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.test.tsx
@@ -1,6 +1,7 @@
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, polymorphicComponent } from '../../testing/utils';
 import { FormItem } from './FormItem';
 
 describe('FormItem', () => {
   baselineComponent(FormItem);
+  polymorphicComponent(FormItem<'div'>);
 });

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -3,7 +3,7 @@ import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
 import { SizeType } from '../../lib/adaptivity';
-import { HasComponent, HasRootRef } from '../../types';
+import { HasComponent, HasComponentProps, HasRootRef } from '../../types';
 import { Removable, RemovableProps } from '../Removable/Removable';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { Subhead } from '../Typography/Subhead/Subhead';
@@ -17,8 +17,8 @@ const sizeYClassNames = {
   ),
 };
 
-export interface FormItemProps
-  extends React.AllHTMLAttributes<HTMLElement>,
+export interface FormItemProps<T = 'div'>
+  extends React.HTMLAttributes<T>,
     HasRootRef<HTMLElement>,
     HasComponent,
     RemovableProps {
@@ -34,7 +34,7 @@ export interface FormItemProps
 /**
  * @see https://vkcom.github.io/VKUI/#/FormItem
  */
-export const FormItem = ({
+export const FormItem = <C extends React.ElementType = 'div'>({
   children,
   top,
   bottom,
@@ -46,7 +46,7 @@ export const FormItem = ({
   getRootRef,
   className,
   ...restProps
-}: FormItemProps) => {
+}: HasComponentProps<C, FormItemProps<C>>) => {
   const rootEl = useExternRef(getRootRef);
   const { sizeY = 'none' } = useAdaptivity();
 
@@ -65,17 +65,10 @@ export const FormItem = ({
       className={classNames(
         styles['FormItem'],
         'vkuiInternalFormItem',
-        status !== 'default' &&
-          {
-            error: classNames(
-              styles['FormItem--status-error'],
-              'vkuiInternalFormItem--status-error',
-            ),
-            valid: classNames(
-              styles['FormItem--status-valid'],
-              'vkuiInternalFormItem--status-valid',
-            ),
-          }[status],
+        status === 'error' &&
+          classNames(styles['FormItem--status-error'], 'vkuiInternalFormItem--status-error'),
+        status === 'valid' &&
+          classNames(styles['FormItem--status-valid'], 'vkuiInternalFormItem--status-valid'),
         sizeY !== SizeType.REGULAR && sizeYClassNames[sizeY],
         hasReactNode(top) &&
           classNames(styles['FormItem--withTop'], 'vkuiInternalFormItem--withTop'),

--- a/packages/vkui/src/components/Touch/Touch.test.tsx
+++ b/packages/vkui/src/components/Touch/Touch.test.tsx
@@ -3,7 +3,7 @@ import { createElement } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { noop } from '@vkontakte/vkjs';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, polymorphicComponent } from '../../testing/utils';
 import { Button } from '../Button/Button';
 import { Card } from '../Card/Card';
 import { CardScroll } from '../CardScroll/CardScroll';
@@ -63,6 +63,7 @@ afterEach(() => delete window['ontouchstart']);
 
 describe('Touch', () => {
   baselineComponent(Touch);
+  polymorphicComponent(Touch<'div'>);
 
   it('does not leak listeners when unmounting during gesture', () => {
     let moved = false;

--- a/packages/vkui/src/components/Touch/Touch.tsx
+++ b/packages/vkui/src/components/Touch/Touch.tsx
@@ -4,10 +4,10 @@ import { useExternRef } from '../../hooks/useExternRef';
 import { useDOM } from '../../lib/dom';
 import { coordX, coordY, getSupportedEvents, touchEnabled, VKUITouchEvent } from '../../lib/touch';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
-import { HasComponent, HasRootRef } from '../../types';
+import { HasComponent, HasComponentProps, HasRootRef } from '../../types';
 
-export interface TouchProps
-  extends React.AllHTMLAttributes<HTMLElement>,
+export interface TouchProps<T = 'div'>
+  extends React.HTMLAttributes<T>,
     HasRootRef<HTMLElement>,
     HasComponent {
   /**
@@ -60,7 +60,7 @@ export type DragHandler = (e: React.DragEvent<HTMLElement>) => void;
 /**
  * @see https://vkcom.github.io/VKUI/#/Touch
  */
-export const Touch = ({
+export const Touch = <C extends React.ElementType = 'div'>({
   onStart,
   onStartX,
   onStartY,
@@ -81,7 +81,7 @@ export const Touch = ({
   noSlideClick = false,
   stopPropagation = false,
   ...restProps
-}: TouchProps) => {
+}: HasComponentProps<C, TouchProps<C>>) => {
   const { document } = useDOM();
   const events = React.useMemo(getSupportedEvents, []);
   const didSlide = React.useRef(false);

--- a/packages/vkui/src/types.ts
+++ b/packages/vkui/src/types.ts
@@ -104,5 +104,7 @@ type DefaultComponentProps<M extends ComponentTypeMap> = ComponentProps<M> &
   HasComponent;
 
 export type HasComponentProps<C extends React.ElementType, P extends {} = {}> =
-  | (PolymorphicComponentProps<HasComponentTypeMap<C, P>, C> & P)
-  | (DefaultComponentProps<HasComponentTypeMap<C, P>> & P);
+  | (PolymorphicComponentProps<HasComponentTypeMap<C, DistributiveOmit<P, keyof HasComponent>>, C> &
+      DistributiveOmit<P, keyof HasComponent>)
+  | (DefaultComponentProps<HasComponentTypeMap<C, DistributiveOmit<P, keyof HasComponent>>> &
+      DistributiveOmit<P, keyof HasComponent>);


### PR DESCRIPTION
- [x] Добавила новый тип `HasComponentProps`
- [x] Добавила хелпер `polymorphicComponent` в юнит-тесты
- [x] Перевела на `HasComponentProps`:
  - [ ] `FocusTrap`
  - [ ] `Footer`
  - [ ] `FormField`
  - [x] `FormItem`
  - [ ] `Header`
  - [ ] `HorizontalCell`
  - [ ] `PanelHeader`
  - [ ] `SimpleCell`
  - [ ] `SubnavigationButton`
  - [ ] `TabbarItem`
  - [ ] `Tappable`
  - [x] `Touch`
  - [ ] типографические компоненты
- [ ] Проверила работу с `forwardRef`
    > Можешь ещё потестить с forwardRef плиз? Помню были проблемы с женерик типами при обёртке в неё


-----

- Closes https://github.com/VKCOM/VKUI/issues/4846
