### PR TITLE
chore(types): use `HasChildren` 

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -5,7 +5,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { useWaitTransitionFinish } from '../../hooks/useWaitTransitionFinish';
 import { Platform } from '../../lib/platform';
 import { stopPropagation } from '../../lib/utils';
-import { AnchorHTMLAttributesOnly } from '../../types';
+import { AnchorHTMLAttributesOnly, HasChildren } from '../../types';
 import { useScrollLock } from '../AppRoot/ScrollContext';
 import { Button, ButtonProps } from '../Button/Button';
 import { FocusTrap } from '../FocusTrap/FocusTrap';
@@ -42,9 +42,8 @@ export interface AlertProps extends React.HTMLAttributes<HTMLElement> {
 
 type ItemClickHandler = (item: AlertActionInterface) => void;
 
-interface AlertTypography {
+interface AlertTypography extends HasChildren {
   id: string;
-  children?: React.ReactNode;
 }
 
 const AlertHeader = (props: AlertTypography) => {

--- a/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useAppearance } from '../../hooks/useAppearance';
 import { useIsClient } from '../../hooks/useIsClient';
+import { HasChildren } from '../../types';
 import { AppearanceProvider } from '../AppearanceProvider/AppearanceProvider';
 import { AppRootContext } from './AppRootContext';
 
-export interface AppRootPortalProps {
+export interface AppRootPortalProps extends HasChildren {
   className?: string;
   forcePortal?: boolean;
-  children?: React.ReactNode;
 }
 
 export const AppRootPortal = ({

--- a/packages/vkui/src/components/AppRoot/ScrollContext.tsx
+++ b/packages/vkui/src/components/AppRoot/ScrollContext.tsx
@@ -3,6 +3,7 @@ import { noop } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';
 import { useDOM } from '../../lib/dom';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { HasChildren } from '../../types';
 
 const clearDisableScrollStyle = (node: HTMLElement) => {
   Object.assign(node.style, {
@@ -43,9 +44,8 @@ export const ScrollContext = React.createContext<ScrollContextInterface>({
 
 export const useScroll = () => React.useContext(ScrollContext);
 
-export interface ScrollControllerProps {
+export interface ScrollControllerProps extends HasChildren {
   elRef: React.RefObject<HTMLElement>;
-  children?: React.ReactNode;
 }
 
 export const GlobalScrollController = ({ children }: ScrollControllerProps) => {

--- a/packages/vkui/src/components/Epic/ScrollSaver.tsx
+++ b/packages/vkui/src/components/Epic/ScrollSaver.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { HasChildren } from '../../types';
 import { ScrollContext } from '../AppRoot/ScrollContext';
 
-export interface ScrollSaverProps {
+export interface ScrollSaverProps extends HasChildren {
   initialScroll?: number;
   saveScroll: (this: void, scroll: number) => any;
-  children?: React.ReactNode;
 }
 
 /**

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -5,7 +5,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { SizeType } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';
 import { warnOnce } from '../../lib/warnOnce';
-import { HasRootRef } from '../../types';
+import { HasChildren, HasRootRef } from '../../types';
 import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { Separator } from '../Separator/Separator';
 import { Spacing } from '../Spacing/Spacing';
@@ -18,7 +18,10 @@ const sizeXClassNames = {
   [SizeType.REGULAR]: styles['Group--sizeX-regular'],
 };
 
-export interface GroupProps extends HasRootRef<HTMLElement>, React.HTMLAttributes<HTMLElement> {
+export interface GroupProps
+  extends HasRootRef<HTMLElement>,
+    React.HTMLAttributes<HTMLElement>,
+    HasChildren {
   header?: React.ReactNode;
   description?: React.ReactNode;
   /**
@@ -38,7 +41,6 @@ export interface GroupProps extends HasRootRef<HTMLElement>, React.HTMLAttribute
    * Отвечает за отступы вокруг контента в режиме 'card'.
    */
   padding?: 's' | 'm';
-  children?: React.ReactNode;
 }
 
 const warn = warnOnce('Group');

--- a/packages/vkui/src/components/IconButton/IconButton.tsx
+++ b/packages/vkui/src/components/IconButton/IconButton.tsx
@@ -5,6 +5,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { SizeType } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';
 import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
+import { HasChildren } from '../../types';
 import { Tappable, TappableProps } from '../Tappable/Tappable';
 import styles from './IconButton.module.css';
 
@@ -13,9 +14,7 @@ const sizeYClassNames = {
   [SizeType.COMPACT]: styles['IconButton--sizeY-compact'],
 };
 
-export interface IconButtonProps extends TappableProps {
-  children?: React.ReactNode;
-}
+export interface IconButtonProps extends TappableProps, HasChildren {}
 
 const warn = warnOnce('IconButton');
 

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.stories.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.stories.tsx
@@ -10,7 +10,8 @@ import { Placeholder } from '../Placeholder/Placeholder';
 import { Spinner } from '../Spinner/Spinner';
 import { SplitCol } from '../SplitCol/SplitCol';
 import { SplitLayout } from '../SplitLayout/SplitLayout';
-import { ModalRoot, ModalRootProps } from './ModalRootAdaptive';
+import { ModalRoot } from './ModalRootAdaptive';
+import { ModalRootProps } from './types';
 import { useModalRootContext } from './useModalRootContext';
 
 const story: Meta<ModalRootProps> = {

--- a/packages/vkui/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -3,31 +3,7 @@ import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJS
 import { useScrollLock } from '../AppRoot/ScrollContext';
 import { ModalRootTouch } from './ModalRoot';
 import { ModalRootDesktop } from './ModalRootDesktop';
-
-export interface ModalRootProps {
-  activeModal?: string | null;
-
-  /**
-   * Будет вызвано при начале открытия активной модалки с её id
-   */
-  onOpen?(modalId: string): void;
-
-  /**
-   * Будет вызвано при окончательном открытии активной модалки с её id
-   */
-  onOpened?(modalId: string): void;
-
-  /**
-   * Будет вызвано при начале закрытия активной модалки с её id
-   */
-  onClose?(modalId: string): void;
-
-  /**
-   * Будет вызвано при окончательном закрытии активной модалки с её id
-   */
-  onClosed?(modalId: string): void;
-  children?: React.ReactNode;
-}
+import { ModalRootProps } from './types';
 
 /**
  * @see https://vkcom.github.io/VKUI/#/ModalRoot

--- a/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -8,48 +8,14 @@ import { useDOM } from '../../lib/dom';
 import { getNavId } from '../../lib/getNavId';
 import { Platform } from '../../lib/platform';
 import { warnOnce } from '../../lib/warnOnce';
-import { HasPlatform } from '../../types';
-import {
-  ConfigProviderContextInterface,
-  useConfigProvider,
-  WebviewType,
-} from '../ConfigProvider/ConfigProviderContext';
+import { useConfigProvider, WebviewType } from '../ConfigProvider/ConfigProviderContext';
 import { FocusTrap } from '../FocusTrap/FocusTrap';
 import { ModalRootContext, ModalRootContextInterface } from './ModalRootContext';
-import { ModalsStateEntry } from './types';
+import { ModalRootWithDOMProps, ModalsStateEntry } from './types';
 import { useModalManager } from './useModalManager';
 import styles from './ModalRoot.module.css';
 
 const warn = warnOnce('ModalRoot');
-
-export interface ModalRootProps extends HasPlatform {
-  activeModal?: string | null;
-  /**
-   * @ignore
-   */
-  configProvider?: ConfigProviderContextInterface;
-  children?: React.ReactNode;
-
-  /**
-   * Будет вызвано при начале открытия активной модалки с её id
-   */
-  onOpen?(modalId: string): void;
-
-  /**
-   * Будет вызвано при окончательном открытии активной модалки с её id
-   */
-  onOpened?(modalId: string): void;
-
-  /**
-   * Будет вызвано при начале закрытия активной модалки с её id
-   */
-  onClose?(modalId: string): void;
-
-  /**
-   * Будет вызвано при окончательном закрытии активной модалки с её id
-   */
-  onClosed?(modalId: string): void;
-}
 
 export const ModalRootDesktop = ({
   activeModal: activeModalProp,
@@ -58,7 +24,7 @@ export const ModalRootDesktop = ({
   onOpened,
   onClose,
   onClosed,
-}: ModalRootProps) => {
+}: ModalRootWithDOMProps) => {
   const maskElementRef = React.useRef<HTMLDivElement>(null);
   const maskAnimationFrame = React.useRef<number | undefined>(undefined);
   const restoreFocusTo = React.useRef<HTMLElement | undefined>(undefined);

--- a/packages/vkui/src/components/ModalRoot/types.ts
+++ b/packages/vkui/src/components/ModalRoot/types.ts
@@ -1,3 +1,7 @@
+import { DOMContextInterface } from '../../lib/dom';
+import { HasChildren, HasPlatform } from '../../types';
+import { ConfigProviderContextInterface } from '../ConfigProvider/ConfigProviderContext';
+
 export enum ModalType {
   PAGE = 'page',
   CARD = 'card',
@@ -65,4 +69,35 @@ export interface ModalsStateEntry extends ModalElements {
   expandedRange?: TranslateRange;
   collapsedRange?: TranslateRange;
   hiddenRange?: TranslateRange;
+}
+
+export interface ModalRootProps extends HasChildren {
+  activeModal?: string | null;
+
+  /**
+   * Будет вызвано при начале открытия активной модалки с её id
+   */
+  onOpen?(modalId: string): void;
+
+  /**
+   * Будет вызвано при окончательном открытии активной модалки с её id
+   */
+  onOpened?(modalId: string): void;
+
+  /**
+   * Будет вызвано при начале закрытия активной модалки с её id
+   */
+  onClose?(modalId: string): void;
+
+  /**
+   * Будет вызвано при окончательном закрытии активной модалки с её id
+   */
+  onClosed?(modalId: string): void;
+}
+
+export interface ModalRootWithDOMProps extends HasPlatform, ModalRootProps, DOMContextInterface {
+  /**
+   * @ignore
+   */
+  configProvider?: ConfigProviderContextInterface;
 }

--- a/packages/vkui/src/components/ModalRoot/useModalManager.tsx
+++ b/packages/vkui/src/components/ModalRoot/useModalManager.tsx
@@ -3,13 +3,13 @@ import { isFunction, noop } from '@vkontakte/vkjs';
 import { getNavId } from '../../lib/getNavId';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { warnOnce } from '../../lib/warnOnce';
+import { HasChildren } from '../../types';
 import { ModalsState, ModalsStateEntry, ModalType } from './types';
 
 interface ModalTransitionState {
   activeModal?: string | null;
   enteringModal?: string | null;
   exitingModal?: string | null;
-
   history?: string[];
   isBack?: boolean | null;
 }
@@ -190,7 +190,7 @@ export function useModalManager(
     if (modalState) {
       if (isFunction(modalState.onOpen)) {
         modalState.onOpen();
-      } else if (isFunction(onOpen)) {
+      } else if (isFunction(onOpen) && modalState.id) {
         onOpen(modalState.id);
       }
     }
@@ -201,7 +201,7 @@ export function useModalManager(
     if (modalState) {
       if (isFunction(modalState.onClose)) {
         modalState.onClose();
-      } else if (isFunction(onClose)) {
+      } else if (isFunction(onClose) && modalState.id) {
         onClose(modalState.id);
       }
     }
@@ -218,15 +218,15 @@ export function useModalManager(
   };
 }
 
+type WithModalManager<Props extends ModalTransitionProps> = HasChildren &
+  Omit<Props, keyof ModalTransitionProps> & {
+    activeModal?: string | null;
+  };
+
 export function withModalManager(initModal: (a: ModalsStateEntry) => void = noop) {
   return function <Props extends ModalTransitionProps>(
     Wrapped: React.ComponentType<Props>,
-  ): React.ComponentType<
-    Omit<Props, keyof ModalTransitionProps> & {
-      activeModal?: string | null;
-      children?: React.ReactNode;
-    }
-  > {
+  ): React.ComponentType<WithModalManager<Props>> {
     return function WithModalManager(props) {
       const transitionManager = useModalManager(
         props.activeModal,

--- a/packages/vkui/src/components/PanelHeaderContent/PanelHeaderContent.tsx
+++ b/packages/vkui/src/components/PanelHeaderContent/PanelHeaderContent.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';
 import { Platform } from '../../lib/platform';
+import { HasChildren } from '../../types';
 import { Tappable } from '../Tappable/Tappable';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { Headline } from '../Typography/Headline/Headline';
@@ -20,10 +21,9 @@ export interface PanelHeaderContentProps extends React.HTMLAttributes<HTMLDivEle
   status?: React.ReactNode;
 }
 
-interface PanelHeaderChildrenProps {
+interface PanelHeaderChildrenProps extends HasChildren {
   hasStatus: boolean;
   hasBefore: boolean;
-  children?: React.ReactNode;
 }
 
 const PanelHeaderChildren = ({ hasStatus, hasBefore, children }: PanelHeaderChildrenProps) => {

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
@@ -9,7 +9,7 @@ import { DOMProps, useDOM } from '../../lib/dom';
 import { Platform } from '../../lib/platform';
 import { runTapticImpactOccurred } from '../../lib/taptic';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
-import { AnyFunction } from '../../types';
+import { AnyFunction, HasChildren } from '../../types';
 import { ScrollContextInterface, useScroll } from '../AppRoot/ScrollContext';
 import { FixedLayout } from '../FixedLayout/FixedLayout';
 import { Touch, TouchEvent, TouchProps } from '../Touch/Touch';
@@ -33,7 +33,7 @@ function cancelEvent(event: any) {
   return false;
 }
 
-export interface PullToRefreshProps extends DOMProps, TouchProps {
+export interface PullToRefreshProps extends DOMProps, TouchProps, HasChildren {
   /**
    * Будет вызвана для обновления контента (прим.: функция должна быть мемоизированным коллбэком)
    */
@@ -44,7 +44,6 @@ export interface PullToRefreshProps extends DOMProps, TouchProps {
   isFetching?: boolean;
   /** @ignore */
   scroll?: ScrollContextInterface;
-  children?: React.ReactNode;
 }
 
 const TOUCH_MOVE_EVENT_PARAMS = {

--- a/packages/vkui/src/components/Removable/Removable.tsx
+++ b/packages/vkui/src/components/Removable/Removable.tsx
@@ -7,7 +7,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { useDOM } from '../../lib/dom';
 import { Platform } from '../../lib/platform';
 import { getTitleFromChildren } from '../../lib/utils';
-import { HasRootRef } from '../../types';
+import { HasChildren, HasRootRef } from '../../types';
 import { IconButton } from '../IconButton/IconButton';
 import { Tappable } from '../Tappable/Tappable';
 import styles from './Removable.module.css';
@@ -23,9 +23,8 @@ export interface RemovableProps {
   onRemove?: (e: React.MouseEvent, rootEl?: HTMLElement | null) => void;
 }
 
-interface RemovableIosOwnProps extends RemovableProps {
+interface RemovableIosOwnProps extends RemovableProps, HasChildren {
   removePlaceholderString?: string;
-  children?: React.ReactNode;
 }
 
 /**
@@ -108,7 +107,7 @@ const RemovableIos = ({
 };
 
 interface RemovableOwnProps
-  extends React.AllHTMLAttributes<HTMLElement>,
+  extends React.HTMLAttributes<HTMLDivElement>,
     RemovableProps,
     HasRootRef<HTMLDivElement> {
   /**

--- a/packages/vkui/src/components/SelectTypography/SelectTypography.tsx
+++ b/packages/vkui/src/components/SelectTypography/SelectTypography.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { usePlatform } from '../../hooks/usePlatform';
 import { SizeType } from '../../lib/adaptivity';
+import { HasChildren } from '../../types';
 import type { SelectType } from '../Select/Select';
 import styles from './SelectTypography.module.css';
 
@@ -16,10 +17,8 @@ const platformClassNames = {
   android: styles['SelectTypography--android'],
 };
 
-export interface SelectTypographyProps {
+export interface SelectTypographyProps extends React.HTMLAttributes<HTMLSpanElement>, HasChildren {
   selectType?: SelectType;
-  className?: string;
-  children?: React.ReactNode;
 }
 
 /**

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
+import { HasChildren } from '../../types';
 import styles from './Spacing.module.css';
 
-export interface SpacingProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface SpacingProps extends React.HTMLAttributes<HTMLDivElement>, HasChildren {
   /**
    * Высота спэйсинга
    */
   size?: number;
-  children?: React.ReactNode;
 }
 
 /**

--- a/packages/vkui/src/components/Tabs/Tabs.e2e-playground.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.e2e-playground.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Icon16Dropdown, Icon20PictureOutline, Icon24PictureOutline } from '@vkontakte/icons';
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
+import { HasChildren } from '../../types';
 import { Badge } from '../Badge/Badge';
 import { Counter } from '../Counter/Counter';
 import { HorizontalScroll } from '../HorizontalScroll/HorizontalScroll';
@@ -15,9 +16,8 @@ function useIconByMode() {
 const Unscrollable = ({
   status,
   children,
-}: {
+}: HasChildren & {
   status?: TabsItemProps['status'];
-  children?: React.ReactNode;
 }) => {
   const beforeIconByMode = useIconByMode();
 

--- a/packages/vkui/src/components/Tappable/Tappable.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.tsx
@@ -16,7 +16,7 @@ import { getOffsetRect } from '../../lib/offset';
 import { Platform } from '../../lib/platform';
 import { coordX, coordY } from '../../lib/touch';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
-import { AnchorHTMLAttributesOnly, HasComponent, HasRootRef } from '../../types';
+import { AnchorHTMLAttributesOnly, HasChildren, HasComponent, HasRootRef } from '../../types';
 import { FocusVisible, FocusVisibleMode } from '../FocusVisible/FocusVisible';
 import { Touch, TouchEvent, TouchProps } from '../Touch/Touch';
 import TouchRootContext from '../Touch/TouchContext';
@@ -48,6 +48,7 @@ export interface TappableProps
   extends TappableElementProps,
     HasRootRef<HTMLElement>,
     HasComponent,
+    HasChildren,
     Pick<TouchProps, 'onStart' | 'onEnd' | 'onMove'> {
   /**
    * Длительность показа active-состояния
@@ -74,7 +75,6 @@ export interface TappableProps
    * Стиль аутлайна focus visible. Если передать произвольную строку, она добавится как css-класс во время focus-visible
    */
   focusVisibleMode?: FocusVisibleMode | string;
-  children?: React.ReactNode;
   onEnter?(outputEvent: MouseEvent): void;
   onLeave?(outputEvent: MouseEvent): void;
 }

--- a/packages/vkui/src/components/Typography/Typography.stories.tsx
+++ b/packages/vkui/src/components/Typography/Typography.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../storybook/constants';
+import { HasChildren } from '../../types';
 import {
   Playground as CaptionStory,
   WithCaps as CaptionWithCapsStory,
@@ -36,7 +37,7 @@ export default story;
 
 type Story = StoryObj<TypographyOverview>;
 
-const TypographyWrapper = ({ children }: { children?: React.ReactNode }) => {
+const TypographyWrapper = ({ children }: HasChildren) => {
   return <div style={{ margin: 5 }}>{children}</div>;
 };
 

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -102,7 +102,7 @@ export type { SnackbarProps } from './components/Snackbar/Snackbar';
  * Modals
  */
 export { ModalRoot } from './components/ModalRoot/ModalRootAdaptive';
-export type { ModalRootProps } from './components/ModalRoot/ModalRootAdaptive';
+export type { ModalRootProps } from './components/ModalRoot/types';
 export { withModalRootContext } from './components/ModalRoot/withModalRootContext';
 export { ModalRootContext } from './components/ModalRoot/ModalRootContext';
 export { ModalPage } from './components/ModalPage/ModalPage';


### PR DESCRIPTION
- переправила везде `children?: React.ReactNode` на импорт типа `HasChildren`
- `ModalRoot`: глобально поправила типы, чтобы не было дублирования
- `RemovableOwnProps`: заменила экстенд на более точный `React.HTMLAttributes<HTMLDivElement>`
- `SelectTypographyProps` (помимо `HasChildren`): добавила `extends React.HTMLAttributes<HTMLSpanElement>` и выпилила ставший ненужным благодаря этоему `className`