### PR TITLE
docs: jsdoc fixes

### DIFF
--- a/packages/vkui/src/components/Accordion/Accordion.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.tsx
@@ -13,8 +13,8 @@ export type AccordionProps = React.DetailsHTMLAttributes<HTMLDetailsElement> &
  *
  * Обертка над details.
  *
- * @version 5.3.0
- * @see  https://vkcom.github.io/VKUI/#/Accordion
+ * @since 5.3.0
+ * @see https://vkcom.github.io/VKUI/#/Accordion
  */
 export const Accordion = ({ getRootRef, className, ...restProps }: AccordionProps) => (
   <details className={classNames(styles['Accordion'], className)} ref={getRootRef} {...restProps} />

--- a/packages/vkui/src/components/Accordion/AccordionSummary.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionSummary.tsx
@@ -22,7 +22,7 @@ export interface AccordionSummaryProps extends Omit<SimpleCellProps, 'expandable
 /**
  * Обертка над summary.
  *
- * @version 5.3.0
+ * @since 5.3.0
  * @see  https://vkcom.github.io/VKUI/#/Accordion
  */
 export const AccordionSummary = ({

--- a/packages/vkui/src/components/AdaptiveIconRenderer/AdaptiveIconRenderer.tsx
+++ b/packages/vkui/src/components/AdaptiveIconRenderer/AdaptiveIconRenderer.tsx
@@ -6,6 +6,10 @@ export interface AdaptiveIconRendererProps {
   IconRegular: React.ComponentType<{ className?: string }>;
 }
 
+/**
+ * @since 5.4.0
+ * @see https://vkcom.github.io/VKUI/#/AdaptiveIconRenderer
+ */
 export const AdaptiveIconRenderer = ({ IconCompact, IconRegular }: AdaptiveIconRendererProps) => {
   const { sizeY } = useAdaptivityConditionalRender();
 

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -41,8 +41,7 @@ export interface GroupProps extends HasRootRef<HTMLElement>, React.HTMLAttribute
   children?: React.ReactNode;
 }
 
-const warn = warnOnce('TabsItem');
-
+const warn = warnOnce('Group');
 export const Group = ({
   header,
   description,

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -42,6 +42,9 @@ export interface GroupProps extends HasRootRef<HTMLElement>, React.HTMLAttribute
 }
 
 const warn = warnOnce('Group');
+/**
+ * @see https://vkcom.github.io/VKUI/#/Group
+ */
 export const Group = ({
   header,
   description,

--- a/packages/vkui/src/components/LocaleProvider/LocaleProvider.tsx
+++ b/packages/vkui/src/components/LocaleProvider/LocaleProvider.tsx
@@ -12,9 +12,9 @@ export interface LocaleProviderProps {
 
 /**
  * Компонент, прокидывающий локаль. Список можно найти в
- * [реестре языковых подмёток IANA](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
+ * [реестре языковых подметок IANA](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
  *
- * @version 5.0.0
+ * @since 5.0.0
  * @see https://vkcom.github.io/VKUI/#/LocaleProvider
  */
 export function LocaleProvider({ value, children }: LocaleProviderProps) {

--- a/packages/vkui/src/components/PlatformProvider/PlatformProvider.tsx
+++ b/packages/vkui/src/components/PlatformProvider/PlatformProvider.tsx
@@ -15,7 +15,7 @@ export interface PlatformProviderProps {
 /**
  * Компонент, позволяющий переопределить платформу для части приложения
  *
- * @version 5.1.0
+ * @since 5.1.0
  * @see https://vkcom.github.io/VKUI/#/PlatformProvider
  */
 export function PlatformProvider({ value, children }: PlatformProviderProps) {

--- a/packages/vkui/src/components/UsersStack/UsersStack.tsx
+++ b/packages/vkui/src/components/UsersStack/UsersStack.tsx
@@ -35,7 +35,7 @@ export interface UsersStackProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Определяет положение элементов
    * Режим `column` рекомендуется использовать с размером `m`
-   * @version 5.3.0
+   * @since 5.3.0
    */
   direction?: 'row' | 'row-reverse' | 'column';
 }


### PR DESCRIPTION
- заменила `@version` на `@since`, потому что мы указываем не _версию_ компонента/пропса, а _с какой версии_ VKUI компонент/пропс стал доступен
- добавила пару потерявшихся `@see`
- поправила пару мелких опечаток.