### PR TITLE
tech(playwright): reset mouse pos for every tests

### DIFF
--- a/packages/vkui/src/components/SegmentedControl/SegmentedControl.e2e.tsx
+++ b/packages/vkui/src/components/SegmentedControl/SegmentedControl.e2e.tsx
@@ -4,12 +4,9 @@ import { SegmentedControlPlayground } from './SegmentedControl.e2e-playground';
 
 test('SegmentedControl', async ({
   mount,
-  page,
   expectScreenshotClippedToContent,
   componentPlaygroundProps,
 }) => {
   await mount(<SegmentedControlPlayground {...componentPlaygroundProps} />);
-  // см. https://github.com/VKCOM/VKUI/pull/4652 ("Подводные камни" -> "Firefox")
-  await page.hover('body', { position: { x: 0, y: 0 } });
   await expectScreenshotClippedToContent();
 });

--- a/packages/vkui/src/testing/e2e/index.playwright.ts
+++ b/packages/vkui/src/testing/e2e/index.playwright.ts
@@ -34,6 +34,18 @@ export const test = testBase.extend<VKUITestOptions & InternalVKUITestOptions & 
   adaptivityProviderProps: [null, { option: true }],
   onlyForPlatforms: [null, { option: true }],
 
+  /**
+   * см. https://playwright.dev/docs/test-fixtures#overriding-fixtures
+   *
+   * @override
+   */
+  page: async ({ page }, use) => {
+    // Сбрасываем курсор мыши перед началом каждого теста.
+    // см. https://github.com/VKCOM/VKUI/pull/4652#firefox-bottleneck
+    await page.mouse.move(0, 0);
+    await use(page);
+  },
+
   expectScreenshotClippedToContent: async (
     { page, platform, browserName, appearance },
     use,


### PR DESCRIPTION
Вынес сброс позиции мыши в единое место. В рамках https://github.com/microsoft/playwright/issues/22432#issuecomment-1512307007 подсказали, что в целом перед каждым тестом стоит сбрасывать позицию мыши. Добавил **UPD** в PR по Playwright https://github.com/VKCOM/VKUI/pull/4652#firefox-bottleneck.

---

- related to #4652