### PR TITLE
fix(ModalPage): bottom safe area

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPage.module.css
+++ b/packages/vkui/src/components/ModalPage/ModalPage.module.css
@@ -121,7 +121,12 @@
 
 .ModalPage__content-in {
   position: relative;
-  padding-bottom: var(--vkui_internal--safe_area_inset_bottom);
+}
+
+.ModalPage__content-in::after {
+  content: '';
+  height: var(--vkui_internal--safe_area_inset_bottom);
+  display: block;
 }
 
 /**


### PR DESCRIPTION
Перестал работать нижний отступ из-за height: 100%

- related #4625