### PR TITLE
test(unit): fix testRegex

### DIFF
--- a/packages/vkui/jest.config.js
+++ b/packages/vkui/jest.config.js
@@ -14,7 +14,7 @@ const config = {
   displayName: 'unit',
   roots: [path.join(__dirname, 'src')],
   setupFilesAfterEnv: [path.join(__dirname, 'jest.setup.js')],
-  testRegex: '[^(\\.a11y)]\\.test\\.tsx?$',
+  testRegex: '(?<!\\.a11y)\\.test\\.tsx?$',
   collectCoverage: true,
   collectCoverageFrom: ['src/*/**/**.{ts,tsx}'],
   coveragePathIgnorePatterns: [


### PR DESCRIPTION
Тесты, название которых оканчивались на `a` или `y`, не работали
(например `Textarea.test.tsx`)

- related #4768