### PR TITLE
fix(@actions-internal/patch): rm `--depth=1` flag

### DIFF
--- a/.github/actions/patch/src/main.ts
+++ b/.github/actions/patch/src/main.ts
@@ -78,14 +78,7 @@ async function run(): Promise<void> {
     }
 
     try {
-      await exec.exec('git', [
-        'fetch',
-        '--no-tags',
-        '--depth=1',
-        'origin',
-        stableBranchRef,
-        ...patchRefs,
-      ]);
+      await exec.exec('git', ['fetch', '--no-tags', 'origin', stableBranchRef, ...patchRefs]);
       await exec.exec('git', ['checkout', stableBranchRef]);
 
       for (const patchRef of patchRefs) {


### PR DESCRIPTION
Из-за `--depth=1` черри-пик проходит с конфликтами

<img width="320" src="https://user-images.githubusercontent.com/5850354/233951981-f5c81ab5-8577-4454-9b2c-3ce0e320c0c0.png" />

_https://github.com/VKCOM/VKUI/actions/runs/4784365452/jobs/8505771574_

---

- caused by #4853