### PR TITLE
fix(a11y): Расставляем пробелы для скринридеров

### DIFF
--- a/packages/vkui/src/components/Banner/Banner.module.css
+++ b/packages/vkui/src/components/Banner/Banner.module.css
@@ -47,15 +47,7 @@
   z-index: var(--vkui_internal--z_index_banner_content);
 }
 
-.Banner__header {
-  display: block;
-}
-
-.Banner__subheader {
-  display: block;
-  color: var(--vkui--color_text_subhead);
-}
-
+.Banner__subheader,
 .Banner__text {
   color: var(--vkui--color_text_subhead);
 }

--- a/packages/vkui/src/components/Banner/Banner.tsx
+++ b/packages/vkui/src/components/Banner/Banner.tsx
@@ -116,7 +116,7 @@ export const Banner = ({
   const IconDismissIOS = mode === 'image' ? Icon24DismissDark : Icon24DismissSubstract;
 
   const content = (
-    <React.Fragment>
+    <>
       {mode === 'image' && background && (
         <div aria-hidden className={styles['Banner__bg']}>
           {background}
@@ -127,26 +127,25 @@ export const Banner = ({
 
       <div className={styles['Banner__content']}>
         {hasReactNode(header) && (
-          <HeaderTypography
-            Component="span"
-            className={styles['Banner__header']}
-            weight="2"
-            level={size === 'm' ? '2' : '1'}
-          >
+          <HeaderTypography Component="p" weight="2" level={size === 'm' ? '2' : '1'}>
             {header}
           </HeaderTypography>
         )}
         {hasReactNode(subheader) && (
-          <SubheaderTypography Component="span" className={styles['Banner__subheader']}>
+          <SubheaderTypography Component="p" className={styles['Banner__subheader']}>
             {subheader}
           </SubheaderTypography>
         )}
-        {hasReactNode(text) && <Text className={styles['Banner__text']}>{text}</Text>}
+        {hasReactNode(text) && (
+          <Text Component="p" className={styles['Banner__text']}>
+            {text}
+          </Text>
+        )}
         {hasReactNode(actions) && React.Children.count(actions) > 0 && (
           <div className={styles['Banner__actions']}>{actions}</div>
         )}
       </div>
-    </React.Fragment>
+    </>
   );
 
   return (

--- a/packages/vkui/src/components/InfoRow/InfoRow.tsx
+++ b/packages/vkui/src/components/InfoRow/InfoRow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { Headline } from '../Typography/Headline/Headline';
 import { Subhead } from '../Typography/Subhead/Subhead';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './InfoRow.module.css';
 
 export interface InfoRowProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -19,8 +20,9 @@ export const InfoRow = ({ header, children, className, ...restProps }: InfoRowPr
     weight="3"
   >
     {hasReactNode(header) && (
-      <Subhead Component="span" className={styles['InfoRow__header']}>
+      <Subhead Component="strong" className={styles['InfoRow__header']}>
         {header}
+        <VisuallyHidden>&nbsp;</VisuallyHidden>
       </Subhead>
     )}
     {children}

--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -7,6 +7,7 @@ import { TabsContextProps, TabsModeContext } from '../Tabs/Tabs';
 import { Tappable } from '../Tappable/Tappable';
 import { Headline } from '../Typography/Headline/Headline';
 import { Subhead } from '../Typography/Subhead/Subhead';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './TabsItem.module.css';
 
 const sizeYClassNames = {
@@ -70,10 +71,14 @@ export const TabsItem = ({
           className={classNames(styles['TabsItem__status'], styles['TabsItem__status--count'])}
           weight="2"
         >
+          <VisuallyHidden>&nbsp;</VisuallyHidden>
           {status}
         </Subhead>
       ) : (
-        <span className={styles['TabsItem__status']}>{status}</span>
+        <span className={styles['TabsItem__status']}>
+          <VisuallyHidden>&nbsp;</VisuallyHidden>
+          {status}
+        </span>
       );
   }
 

--- a/packages/vkui/src/components/Typography/Typography.module.css
+++ b/packages/vkui/src/components/Typography/Typography.module.css
@@ -1,6 +1,7 @@
 .Typography--normalize {
-  margin: 0;
   display: block;
+  margin: 0;
+  padding: 0;
 }
 
 /* Мы утяжеляем селектор, чтобы перебить другие селекторы */

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.module.css
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.module.css
@@ -1,9 +1,13 @@
 .VisuallyHidden {
-  position: absolute;
-  height: 1px;
-  white-space: nowrap;
-  clip: rect(0 0 0 0);
+  position: absolute !important;
+  height: 1px !important;
+  width: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important; /* Fix for https://github.com/twbs/bootstrap/issues/25686 */
+  white-space: nowrap !important;
+  clip: rect(0, 0, 0, 0) !important;
   clip-path: inset(50%);
-  overflow: hidden;
+  overflow: hidden !important;
+  border: 0 !important;
   opacity: 0;
 }


### PR DESCRIPTION
В некоторых браузерах NVDA не добавляет автоматически пробелы между двумя span.

Что сделала, чтобы это исправить:
- [x] `Banner`: перевела на `p` вместо `span`,
- [x] `InfoRow`: добавила скрытый визуально неразрывный пробел перед полем `header`
- [x] `TabsItem`: добавила скрытый визуально неразрывный пробел перед полем `status`

----- 
- Изменения в `Header` вынесла в отдельный пулл https://github.com/VKCOM/VKUI/pull/5019