### PR TITLE
fix(PanelHeader): replace sub-component with props

### DIFF
--- a/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -44,10 +44,12 @@ export const ModalPageHeader = ({
         fixed={false}
         separator={false}
         transparent
+        typographyProps={{
+          Component: 'h2',
+          id: labelId,
+        }}
       >
-        <PanelHeader.Content Component="h2" id={labelId}>
-          {children}
-        </PanelHeader.Content>
+        {children}
       </PanelHeader>
       {hasSeparator && <Separator wide />}
     </div>


### PR DESCRIPTION
> см. https://github.com/VKCOM/VKUI/issues/4963#issuecomment-1533140117

В данном случае можно было решить задачу через пропс вместо подкомпонента.

Кто-то мог уже завязаться на `PanelHeader.Content`, поэтому отметил его как `@deprecated` и добавил TODO на v6.

---

- fix #4963
- caused by #4808