### PR TITLE
docs(VisuallyHidden): show docs

### DIFF
--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -9,12 +9,11 @@ interface VisuallyHiddenProps
     HasComponent {}
 
 /**
- * @since v5.4.0
- * @see https://vkcom.github.io/VKUI/#/VisuallyHidden
- * @description
- *
  * Компонент-обертка. Позволяет скрыть контент визуально, но оставить его
  * доступным для ассистивных технологий. По умолчанию — `span`.
+ *
+ * @since v5.4.0
+ * @see https://vkcom.github.io/VKUI/#/VisuallyHidden
  */
 export const VisuallyHidden = ({
   Component = 'span',


### PR DESCRIPTION
Перетасовала jsdoc-описание, чтобы пофиксить отображение [документации](https://vkcom.github.io/VKUI/#/VisuallyHidden).