### PR TITLE
tech: cleanup project configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,60 +1,28 @@
 version: 2
 updates:
+  # NPM
+
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     allow:
       - dependency-type: 'direct'
+    ignore:
+      # Игнорируем адоны во избежание отдельного PR от бота по каждому из них.
+      # Вместо этого, ориентируемся на обновление Storybook – если он обновился, то и адоны надо
+      # будет обновить (вручную).
+      #
+      # TODO заменить на групповое обновление, когда его завезут в Dependabot https://github.com/dependabot/dependabot-core/issues/1190
+      - dependency-name: '@storybook/*'
+    versioning-strategy: increase
+    open-pull-requests-limit: 20
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'
 
-  # PACKAGES
+  # Cargo
 
-  - package-ecosystem: 'npm'
-    directory: '/packages/token-translator'
-    schedule:
-      interval: 'daily'
-    allow:
-      - dependency-type: 'direct'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/vkui'
-    schedule:
-      interval: 'daily'
-    allow:
-      - dependency-type: 'direct'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
-
-  # TOOLS PACKAGES
-
-  - package-ecosystem: 'npm'
-    directory: '/tools/eslint-plugin-vkui'
-    schedule:
-      interval: 'daily'
-    allow:
-      - dependency-type: 'direct'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
-
-  - package-ecosystem: 'npm'
-    directory: '/tools/swc-transform-css-modules'
-    schedule:
-      interval: 'daily'
-    allow:
-      - dependency-type: 'direct'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
-
-  # Maintain dependencies for Cargo
   - package-ecosystem: 'cargo'
     directory: '/tools/swc-transform-css-modules'
     schedule:
@@ -65,21 +33,7 @@ updates:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'
 
-  - package-ecosystem: 'npm'
-    directory: '/tools/storybook-addon-cartesian'
-    schedule:
-      interval: 'weekly'
-    allow:
-      - dependency-type: 'direct'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
-    # TODO удалить настройки ниже после того, как завезут групповое обновление зависимостей https://github.com/dependabot/dependabot-core/issues/1190
-    open-pull-requests-limit: 1
-    labels:
-      - 'maybe-need-manual-group-update'
-    commit-message:
-      prefix: '[@storybook deps] '
+  # GitHub Actions
 
   - package-ecosystem: 'github-actions'
     # Workflow files stored in the

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -16,7 +16,6 @@ package_vkui: &package_vkui
   - 'packages/vkui/*.!(md)'
   - 'packages/vkui/!(.storybook)src/**/!(*.md|*.stories.*)'
   - 'tools/!(eslint-*|stylelint-*|storybook-*)/**'
-  - 'e2e/**'
   - 'postcss.*'
   - '.browserslistrc'
   - 'webpack.*'

--- a/package.json
+++ b/package.json
@@ -147,8 +147,6 @@
   "packageManager": "yarn@1.22.19",
   "workspaces": {
     "packages": [
-      ".github/actions/*",
-      "e2e",
       "styleguide",
       "packages/*",
       "tools/*"


### PR DESCRIPTION
1. Удалил из `file-filters.yml` и `package.json` несуществующие ныне папки.
2. Изменения #4883 в `dependabot.yml` не увенчались успехом – PR по Storybook продолжают сыпаться в течение недели. Из следующего issue https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437 узнал, что для монорепы достаточно указать `directory: /` и далее он сам выкупит что обновить, поэтому:
    1. удалил точечные объявления пакетов
    2. в `ignore` добавил зависимости `@storybook/*`, чтобы мы ориентировались только на `storybook`
    3. также советуют установить `versioning-strategy: increase`, чтобы локфайлы всегда обновлялись – скорей всего в настройках репы он и указан, но на всякий захардкодил;
    4. ⚠️ заменил частоту проверки обновления на `weekly`