### PR TITLE
fix(FormLayoutGroup): rm `isolation` prop

### DIFF
--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.module.css
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.module.css
@@ -4,7 +4,6 @@
     var(--vkui--size_base_padding_horizontal--regular);
   flex-wrap: wrap;
   align-items: flex-start;
-  isolation: isolate;
 }
 
 .FormLayoutGroup__removable {


### PR DESCRIPTION
**Версия:** >= 5.1.0

Из-за `isolation: isolate` в ситуациях, когда всплывающее элемента рендерится без портала, перекрывается `z-index` этого элемента вне `FormLayoutGroup`.

<img width="320" src="https://github.com/VKCOM/VKUI/assets/5850354/b6b7cfc7-bd3c-4c72-abd6-f1de873e8098" /> 

_**Рис. 1** с `isolation: isolate`_

<img width="320" src="https://github.com/VKCOM/VKUI/assets/5850354/b04957ff-88ae-476d-af07-ae90e8c5692e" />

_**Рис. 2** без `isolation: isolate`_

Ссылка на воспроизведение https://codesandbox.io/s/pr5089-formlayoutgroup-isolation-problem-c0zher

<details><summary>backup кода из Codesandbox</summary>
<p>

```tsx
import {
  ConfigProvider,
  AdaptivityProvider,
  AppRoot,
  Group,
  Panel,
  PanelHeader,
  SimpleCell,
  View,
  FormLayoutGroup,
  FormItem,
  Textarea,
  unstable_ChipsSelect as ChipsSelect
} from "@vkontakte/vkui";
import { useState } from "react";

export default function App() {
  const colors = [
    { value: "red", label: "Красный" },
    { value: "blue", label: "Синий" },
    { value: "navarin", label: "Наваринского пламени с дымом" }
  ];
  const [selectedColors, setSelectedColors] = useState(colors.slice(0, 1));

  return (
    <ConfigProvider>
      <AdaptivityProvider>
        <AppRoot>
          <View activePanel="profile">
            <Panel id="profile">
              <PanelHeader>VKUI</PanelHeader>
              <Group>
                <SimpleCell>Hello</SimpleCell>
                <SimpleCell>world</SimpleCell>
                <FormLayoutGroup mode="horizontal">
                  <FormItem top="forceDropdownPortal={false}">
                    <ChipsSelect
                      value={selectedColors}
                      onChange={setSelectedColors}
                      options={colors}
                      placeholder="Не выбраны"
                      creatable
                      forceDropdownPortal={false} // рендерим без portal
                    />
                  </FormItem>
                </FormLayoutGroup>
                <FormItem top="About">
                  <Textarea />
                </FormItem>
              </Group>
            </Panel>
          </View>
        </AppRoot>
      </AdaptivityProvider>
    </ConfigProvider>
  );
}

```

</p>
</details> 

---

- caused by #3875