### PR TITLE
feat(Popper): add custom rootPortal prop for Popper

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useAppearance } from '../../hooks/useAppearance';
 import { useIsClient } from '../../hooks/useIsClient';
+import { isRefObject } from '../../lib/isRefObject';
 import { HasChildren } from '../../types';
 import { AppearanceProvider } from '../AppearanceProvider/AppearanceProvider';
 import { AppRootContext } from './AppRootContext';
@@ -9,12 +10,19 @@ import { AppRootContext } from './AppRootContext';
 export interface AppRootPortalProps extends HasChildren {
   className?: string;
   forcePortal?: boolean;
+  /**
+   * Кастомный root-элемент портала.
+   * При передаче вместе с `forcePorta=true` игнорируется `portalRoot` и `disablePortal`
+   * из контекста `AppRoot`.
+   */
+  portalRoot?: HTMLElement | React.RefObject<HTMLElement> | null;
 }
 
 export const AppRootPortal = ({
   children,
   className,
   forcePortal: forcePortalProp,
+  portalRoot: portalRootProp = null,
 }: AppRootPortalProps) => {
   const { portalRoot, mode, disablePortal } = React.useContext(AppRootContext);
   const appearance = useAppearance();
@@ -26,14 +34,45 @@ export const AppRootPortal = ({
 
   const forcePortal = forcePortalProp ?? mode !== 'full';
 
-  return !disablePortal && portalRoot && forcePortal ? (
+  const portalContainer = getPortalContainer(portalRootProp, portalRoot);
+
+  const ignoreDisablePortalFlagFromContext = portalRootProp && forcePortal;
+  const shouldUsePortal = ignoreDisablePortalFlagFromContext
+    ? true
+    : !disablePortal && portalContainer && forcePortal;
+
+  return shouldUsePortal && portalContainer ? (
     createPortal(
       <AppearanceProvider appearance={appearance}>
         <div className={className}>{children}</div>
       </AppearanceProvider>,
-      portalRoot,
+      portalContainer,
     )
   ) : (
     <React.Fragment>{children}</React.Fragment>
   );
 };
+
+/**
+ * Получает из кастомного пропа `partialRootProp` и `partialRoot` контекста
+ * контейнер-элемент для портала.
+ * `partialRootProp` может быть ref элементом.
+ *
+ */
+function getPortalContainer(
+  portalRootProp?: HTMLElement | React.RefObject<HTMLElement> | null,
+  portalRoot?: HTMLElement | null,
+) {
+  let portalContainer: HTMLElement | null = null;
+  if (!portalRootProp) {
+    return portalRoot;
+  }
+
+  if (isRefObject(portalRootProp)) {
+    portalContainer = portalRootProp.current;
+  } else {
+    portalContainer = portalRootProp;
+  }
+
+  return portalContainer;
+}

--- a/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
@@ -63,16 +63,9 @@ function getPortalContainer(
   portalRootProp?: HTMLElement | React.RefObject<HTMLElement> | null,
   portalRoot?: HTMLElement | null,
 ) {
-  let portalContainer: HTMLElement | null = null;
   if (!portalRootProp) {
     return portalRoot;
   }
 
-  if (isRefObject(portalRootProp)) {
-    portalContainer = portalRootProp.current;
-  } else {
-    portalContainer = portalRootProp;
-  }
-
-  return portalContainer;
+  return isRefObject(portalRootProp) ? portalRootProp.current : portalRootProp;
 }

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -82,6 +82,12 @@ export interface PopperCommonProps
   sameWidth?: boolean;
   forcePortal?: boolean;
   /**
+   * Кастомный root-элемент портала.
+   * При передаче вместе с `forcePorta=true` игнорируется `portalRoot` и `disablePortal`
+   * из контекста `AppRoot`.
+   */
+  portalRoot?: HTMLElement | React.RefObject<HTMLElement> | null;
+  /**
    * Подписывается на изменение геометрии `targetRef`, чтобы пересчитать свою позицию.
    */
   autoUpdateOnTargetResize?: boolean;
@@ -122,6 +128,7 @@ export const Popper = ({
   offsetDistance = 8,
   offsetSkidding = 0,
   forcePortal = true,
+  portalRoot,
   autoUpdateOnTargetResize = false,
   style: styleProp,
   customMiddlewares,
@@ -249,5 +256,9 @@ export const Popper = ({
     </div>
   );
 
-  return <AppRootPortal forcePortal={forcePortal}>{dropdown}</AppRootPortal>;
+  return (
+    <AppRootPortal forcePortal={forcePortal} portalRoot={portalRoot}>
+      {dropdown}
+    </AppRootPortal>
+  );
 };

--- a/packages/vkui/src/components/Popper/Readme.md
+++ b/packages/vkui/src/components/Popper/Readme.md
@@ -3,8 +3,8 @@
 > Это нестабильный компонент. Его API может меняться в рамках одной мажорной версии. [Подробнее про нестабильные компоненты](https://vkcom.github.io/VKUI/#/Unstable).
 
 Низкоуровневый компонент для отрисовки выпадающего блока. Единственная его задача — корректно позиционироваться
-рядом с целевым элементом. На основе этого компонента сделаны [ClickPopper](https://vkcom.github.io/VKUI/#/ClickPopper) и [HoverPopper](https://vkcom.github.io/VKUI/#/HoverPopper),
-реализующие логику скрытия и показа по клику и по ховеру соответственно.
+рядом с целевым элементом. На основе этого компонента сделан [HoverPopper](https://vkcom.github.io/VKUI/#/HoverPopper),
+реализующий логику скрытия и показа по ховеру.
 
 ```jsx { "props": { "layout": false, "iframe": false } }
 const [shown, setShown] = React.useState(false);


### PR DESCRIPTION
fix #4454 

## Changeset 
- Добавляем кастомный проп `rootPortal` в `Popper` для того, чтобы дать возможность переопределить элемент в котором будет отрисован портал.
- в `AppRootPortal` также добавлен такой же проп, так как `Popper` использует `AppRootPortal` у себя внутри.
- При передаче `rootPortal` и `forcePortal=true` в `Popper` или `AppRootPortal` игнорируется флаг `disablePortal` из контекста `AppRootContext`.

## Notes
Тестов нет, так как планируется избавиться от Popper в пользу `useFloating()` хука.