### PR TITLE
fix(CustomSelect): click on already selected option triggers onChange

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -530,7 +530,7 @@ describe('CustomSelect', () => {
       />,
     );
 
-    expect(onChange).toBeCalledTimes(0);
+    expect(onChange).toBeCalledTimes(2);
     expect(getCustomSelectValue()).toEqual('');
   });
 
@@ -550,6 +550,7 @@ describe('CustomSelect', () => {
       />,
     );
 
+    expect(onChange).toBeCalledTimes(1);
     expect(getCustomSelectValue()).toEqual('Mike');
     fireEvent.click(screen.getByRole('button', { hidden: true }));
     expect(getCustomSelectValue()).toEqual('');

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -530,7 +530,7 @@ describe('CustomSelect', () => {
       />,
     );
 
-    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toBeCalledTimes(0);
     expect(getCustomSelectValue()).toEqual('');
   });
 
@@ -580,7 +580,7 @@ describe('CustomSelect', () => {
     expect(screen.queryByRole('button', { hidden: true })).toBeFalsy();
   });
 
-  it('calls onChange when click on already selected option (value is not changed)', async () => {
+  it('(controlled): calls onChange when click on unselected option without value change', async () => {
     const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
 
     render(
@@ -592,24 +592,42 @@ describe('CustomSelect', () => {
         ]}
         allowClearButton
         onChange={onChange}
-        defaultValue={1}
+        value={0}
       />,
     );
 
     expect(onChange).toBeCalledTimes(0);
-    expect(getCustomSelectValue()).toEqual('Josh');
+    expect(getCustomSelectValue()).toEqual('Mike');
 
+    // первый клик по опции не выбранной опции без изменения value
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Josh')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
+    fireEvent.mouseEnter(screen.getByTitle('Josh'));
     fireEvent.click(screen.getByTitle('Josh'));
 
     expect(onChange).toBeCalledTimes(1);
-    // onChange возвращает событие с value Josh
     expect(onChange).toHaveReturnedWith('1');
-    // onChange возвращает событие с value Josh при повторном клике по уже выбранной опции
 
-    // Josh is still selected
+    // второй клик по опции не выбранной опции без изменения value
+    // нужно проверить потому что при первом клике внутреннее value селекта (nativeSelectValue) изменилось
+    // на value опиции по которой кликнули.
+    // При втором оно уже не меняется если кликнули по той же опции, но onChange должен отработать как в первый раз.
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Josh')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
+    fireEvent.mouseEnter(screen.getByTitle('Josh'));
+    fireEvent.click(screen.getByTitle('Josh'));
+
+    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toHaveReturnedWith('1');
+
+    // третий клик уже по выбранной опции (соответствующей value переданному в контролируемый селект),
+    // onChange не должен вызываться.
+    fireEvent.click(screen.getByTestId('target'));
+    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
+    fireEvent.mouseEnter(screen.getByTitle('Mike'));
+    fireEvent.click(screen.getByTitle('Mike'));
+
+    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toHaveReturnedWith('1');
   });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -580,6 +580,38 @@ describe('CustomSelect', () => {
     expect(screen.queryByRole('button', { hidden: true })).toBeFalsy();
   });
 
+  it('(controlled): calls onChange expected amount of times after clearing uncontrolled component and clicking on option', async () => {
+    const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
+
+    render(
+      <CustomSelect
+        data-testid="target"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        allowClearButton
+        onChange={onChange}
+        value={0}
+      />,
+    );
+
+    expect(onChange).toBeCalledTimes(0);
+    expect(getCustomSelectValue()).toEqual('Mike');
+
+    // clear input
+    fireEvent.click(screen.getByRole('button', { hidden: true }));
+
+    expect(onChange).toBeCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.mouseEnter(screen.getByTitle('Josh'));
+    fireEvent.click(screen.getByTitle('Josh'));
+
+    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toHaveReturnedWith('1');
+  });
+
   it('(controlled): calls onChange when click on unselected option without value change', async () => {
     const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
 

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -45,8 +45,9 @@ describe('CustomSelect', () => {
     expect(getCustomSelectValue()).toEqual('');
 
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const unselectedOption = screen.getByRole('option', { selected: false, name: 'Josh' });
+    fireEvent.mouseEnter(unselectedOption);
+    fireEvent.click(unselectedOption);
 
     expect(getCustomSelectValue()).toEqual('Josh');
   });
@@ -70,8 +71,9 @@ describe('CustomSelect', () => {
     render(<SelectController />);
     expect(getCustomSelectValue()).toEqual('Mike');
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const unselectedOption = screen.getByRole('option', { selected: false, name: 'Josh' });
+    fireEvent.mouseEnter(unselectedOption);
+    fireEvent.click(unselectedOption);
     expect(getCustomSelectValue()).toEqual('Josh');
   });
 
@@ -85,8 +87,9 @@ describe('CustomSelect', () => {
 
     expect(getCustomSelectValue()).toEqual('Mike');
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const unselectedOption = screen.getByRole('option', { selected: false, name: 'Josh' });
+    fireEvent.mouseEnter(unselectedOption);
+    fireEvent.click(unselectedOption);
     expect(getCustomSelectValue()).toEqual('Mike');
   });
 
@@ -158,8 +161,9 @@ describe('CustomSelect', () => {
     expect(getCustomSelectValue()).toEqual('Josh');
 
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Mike'));
-    fireEvent.click(screen.getByTitle('Mike'));
+    const unselectedOption = screen.getByRole('option', { selected: false, name: 'Mike' });
+    fireEvent.mouseEnter(unselectedOption);
+    fireEvent.click(unselectedOption);
 
     expect(getCustomSelectValue()).toEqual('Mike');
   });
@@ -291,11 +295,11 @@ describe('CustomSelect', () => {
 
     await waitForFloatingPosition();
 
-    expect(screen.getByTitle('Josh').getAttribute('aria-selected')).toEqual('true');
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Josh');
 
     fireEvent.change(screen.getByTestId('target'), { target: { value: 'Jo' } });
 
-    expect(screen.getByTitle('Josh').getAttribute('aria-selected')).toEqual('true');
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Josh');
 
     rerender(
       <CustomSelect
@@ -310,7 +314,7 @@ describe('CustomSelect', () => {
       />,
     );
 
-    expect(screen.getByTitle('Josh').getAttribute('aria-selected')).toEqual('true');
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Josh');
 
     rerender(
       <CustomSelect
@@ -326,7 +330,7 @@ describe('CustomSelect', () => {
       />,
     );
 
-    expect(screen.getByTitle('Joe').getAttribute('aria-selected')).toEqual('true');
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Joe');
   });
 
   // см. https://github.com/VKCOM/VKUI/issues/3600
@@ -347,14 +351,15 @@ describe('CustomSelect', () => {
 
     fireEvent.click(screen.getByTestId('target'));
 
-    expect(screen.getByTitle('Категория 3')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Категория 3');
 
     fireEvent.change(screen.getByTestId('target'), { target: { value: 'Кат' } });
 
-    expect(screen.getByTitle('Категория 3')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Категория 3');
 
-    fireEvent.mouseEnter(screen.getByTitle('Категория 2'));
-    fireEvent.click(screen.getByTitle('Категория 2'));
+    const unselectedOption = screen.getByRole('option', { selected: false, name: 'Категория 2' });
+    fireEvent.mouseEnter(unselectedOption);
+    fireEvent.click(unselectedOption);
 
     expect(getCustomSelectValue()).toEqual('Категория 2');
   });
@@ -586,6 +591,44 @@ describe('CustomSelect', () => {
     expect(screen.queryByRole('button', { hidden: true })).toBeFalsy();
   });
 
+  it('(uncontrolled): calls onChange when click on unselected option and does not call when click on selected ', async () => {
+    const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
+
+    render(
+      <CustomSelect
+        data-testid="target"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        allowClearButton
+        onChange={onChange}
+        defaultValue={0}
+      />,
+    );
+
+    expect(onChange).toBeCalledTimes(0);
+    expect(getCustomSelectValue()).toEqual('Mike');
+
+    fireEvent.click(screen.getByTestId('target'));
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Mike');
+    const unselectedOption = screen.getByRole('option', { selected: false, name: 'Josh' });
+    fireEvent.mouseEnter(unselectedOption);
+    fireEvent.click(unselectedOption);
+
+    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toHaveReturnedWith('1');
+
+    fireEvent.click(screen.getByTestId('target'));
+
+    const selectedOption = screen.getByRole('option', { selected: true, name: 'Josh' });
+    fireEvent.mouseEnter(selectedOption);
+    fireEvent.click(selectedOption);
+
+    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toHaveReturnedWith('1');
+  });
+
   it('(controlled): calls onChange expected amount of times after clearing component and clicking on option without updating controlled prop value', async () => {
     // мы намеренно проверяем кейсы где при нажатии на опцию или на кнопку очистки value проп не меняется
     const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
@@ -612,8 +655,12 @@ describe('CustomSelect', () => {
     expect(onChange).toBeCalledTimes(1);
 
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const unselectedOptionFirstClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Josh',
+    });
+    fireEvent.mouseEnter(unselectedOptionFirstClick);
+    fireEvent.click(unselectedOptionFirstClick);
 
     expect(onChange).toBeCalledTimes(2);
     expect(onChange).toHaveReturnedWith('1');
@@ -633,14 +680,22 @@ describe('CustomSelect', () => {
     );
 
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Mike'));
-    fireEvent.click(screen.getByTitle('Mike'));
+    const unselectedOptionSecondClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Mike',
+    });
+    fireEvent.mouseEnter(unselectedOptionSecondClick);
+    fireEvent.click(unselectedOptionSecondClick);
 
     expect(onChange).toBeCalledTimes(3);
 
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const unselectedOptionThirdClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Josh',
+    });
+    fireEvent.mouseEnter(unselectedOptionThirdClick);
+    fireEvent.click(unselectedOptionThirdClick);
 
     expect(onChange).toBeCalledTimes(4);
   });
@@ -666,9 +721,13 @@ describe('CustomSelect', () => {
 
     // первый клик по не выбранной опции без изменения value
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Mike');
+    const unselectedOptionFirstClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Josh',
+    });
+    fireEvent.mouseEnter(unselectedOptionFirstClick);
+    fireEvent.click(unselectedOptionFirstClick);
 
     expect(onChange).toBeCalledTimes(1);
     expect(onChange).toHaveReturnedWith('1');
@@ -678,9 +737,13 @@ describe('CustomSelect', () => {
     // на value опиции по которой кликнули.
     // При втором оно уже не меняется если кликнули по той же опции, но onChange должен отработать как в первый раз.
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Mike');
+    const unselectedOptionSecondClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Josh',
+    });
+    fireEvent.mouseEnter(unselectedOptionSecondClick);
+    fireEvent.click(unselectedOptionSecondClick);
 
     expect(onChange).toBeCalledTimes(2);
     expect(onChange).toHaveReturnedWith('1');
@@ -688,9 +751,12 @@ describe('CustomSelect', () => {
     // третий клик уже по выбранной опции (соответствующей value переданному в контролируемый селект),
     // onChange не должен вызываться.
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
-    fireEvent.mouseEnter(screen.getByTitle('Mike'));
-    fireEvent.click(screen.getByTitle('Mike'));
+    const selectedOptionThirdClick = screen.getByRole('option', {
+      selected: true,
+      name: 'Mike',
+    });
+    fireEvent.mouseEnter(selectedOptionThirdClick);
+    fireEvent.click(selectedOptionThirdClick);
 
     expect(onChange).toBeCalledTimes(2);
     expect(onChange).toHaveReturnedWith('1');
@@ -718,9 +784,13 @@ describe('CustomSelect', () => {
 
     // первый клик по не выбранной опции с изменением value
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Mike');
+    const unselectedOptionFirstClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Josh',
+    });
+    fireEvent.mouseEnter(unselectedOptionFirstClick);
+    fireEvent.click(unselectedOptionFirstClick);
 
     // onChange должен вызываться
     expect(onChangeStub).toBeCalledTimes(1);
@@ -728,9 +798,9 @@ describe('CustomSelect', () => {
 
     // второй клик по выбранной опции
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Josh')).toHaveAttribute('aria-selected', 'true');
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const selectedOptionSecondClick = screen.getByRole('option', { selected: true, name: 'Josh' });
+    fireEvent.mouseEnter(selectedOptionSecondClick);
+    fireEvent.click(selectedOptionSecondClick);
 
     // onChange не должен вызываться
     expect(onChangeStub).toBeCalledTimes(1);
@@ -738,9 +808,13 @@ describe('CustomSelect', () => {
 
     // третий клик по не выбранной опции
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Josh')).toHaveAttribute('aria-selected', 'true');
-    fireEvent.mouseEnter(screen.getByTitle('Mike'));
-    fireEvent.click(screen.getByTitle('Mike'));
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Josh');
+    const unselectedOptionThirdClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Mike',
+    });
+    fireEvent.mouseEnter(unselectedOptionThirdClick);
+    fireEvent.click(unselectedOptionThirdClick);
 
     // onChange должен быть вызван
     expect(onChangeStub).toBeCalledTimes(2);
@@ -748,9 +822,9 @@ describe('CustomSelect', () => {
 
     // четвертый клик по выбранной опции
     fireEvent.click(screen.getByTestId('target'));
-    expect(screen.getByTitle('Mike')).toHaveAttribute('aria-selected', 'true');
-    fireEvent.mouseEnter(screen.getByTitle('Mike'));
-    fireEvent.click(screen.getByTitle('Mike'));
+    const selectedOptionFourthClick = screen.getByRole('option', { selected: true, name: 'Mike' });
+    fireEvent.mouseEnter(selectedOptionFourthClick);
+    fireEvent.click(selectedOptionFourthClick);
 
     // onChange не должен вызываться
     expect(onChangeStub).toBeCalledTimes(2);
@@ -778,8 +852,12 @@ describe('CustomSelect', () => {
 
     // первый клик по не выбранной опции без изменения value
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Mike'));
-    fireEvent.click(screen.getByTitle('Mike'));
+    const unselectedOptionFirstClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Mike',
+    });
+    fireEvent.mouseEnter(unselectedOptionFirstClick);
+    fireEvent.click(unselectedOptionFirstClick);
 
     // onChange должен быть вызван
     expect(onChange).toBeCalledTimes(1);
@@ -787,8 +865,12 @@ describe('CustomSelect', () => {
 
     // второй клик по другой опции без изменения value
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const unselectedOptionSecondClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Josh',
+    });
+    fireEvent.mouseEnter(unselectedOptionSecondClick);
+    fireEvent.click(unselectedOptionSecondClick);
 
     // onChange должен быть вызван
     expect(onChange).toBeCalledTimes(2);
@@ -796,8 +878,12 @@ describe('CustomSelect', () => {
 
     // третий клик по той же опции что и в предыдущий раз
     fireEvent.click(screen.getByTestId('target'));
-    fireEvent.mouseEnter(screen.getByTitle('Josh'));
-    fireEvent.click(screen.getByTitle('Josh'));
+    const unselectedOptionThirdClick = screen.getByRole('option', {
+      selected: false,
+      name: 'Josh',
+    });
+    fireEvent.mouseEnter(unselectedOptionThirdClick);
+    fireEvent.click(unselectedOptionThirdClick);
 
     // onChange должен быть вызван
     expect(onChange).toBeCalledTimes(3);

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -578,4 +578,38 @@ describe('CustomSelect', () => {
 
     expect(screen.queryByRole('button', { hidden: true })).toBeFalsy();
   });
+
+  it('calls onChange when click on already selected option (value is not changed)', async () => {
+    const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
+
+    render(
+      <CustomSelect
+        data-testid="target"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        allowClearButton
+        onChange={onChange}
+        defaultValue={1}
+      />,
+    );
+
+    expect(onChange).toBeCalledTimes(1);
+    expect(getCustomSelectValue()).toEqual('Josh');
+
+    fireEvent.click(screen.getByTestId('target'));
+    expect(screen.getByTitle('Josh')).toHaveAttribute('aria-selected', 'true');
+    fireEvent.click(screen.getByTitle('Josh'));
+
+    expect(onChange).toBeCalledTimes(2);
+    // onChange возвращает событие с value Josh
+    expect(onChange).toHaveNthReturnedWith(1, '1');
+    // onChange возвращает событие с value Josh при повторном клике по уже выбранной опции
+    expect(onChange).toHaveNthReturnedWith(2, '1');
+
+    // Josh is still selected
+    fireEvent.click(screen.getByTestId('target'));
+    expect(screen.getByTitle('Josh')).toHaveAttribute('aria-selected', 'true');
+  });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -756,4 +756,51 @@ describe('CustomSelect', () => {
     expect(onChangeStub).toBeCalledTimes(2);
     expect(onChangeStub).toHaveReturnedWith('0');
   });
+
+  it('(controlled): does call onChange on option click when prop value is empty and value is not changning', async () => {
+    const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
+
+    render(
+      <CustomSelect
+        data-testid="target"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        allowClearButton
+        onChange={onChange}
+        value=""
+      />,
+    );
+
+    expect(onChange).toBeCalledTimes(0);
+    expect(getCustomSelectValue()).toEqual('');
+
+    // первый клик по не выбранной опции без изменения value
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.mouseEnter(screen.getByTitle('Mike'));
+    fireEvent.click(screen.getByTitle('Mike'));
+
+    // onChange должен быть вызван
+    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toHaveReturnedWith('0');
+
+    // второй клик по другой опции без изменения value
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.mouseEnter(screen.getByTitle('Josh'));
+    fireEvent.click(screen.getByTitle('Josh'));
+
+    // onChange должен быть вызван
+    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toHaveReturnedWith('1');
+
+    // третий клик по той же опции что и в предыдущий раз
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.mouseEnter(screen.getByTitle('Josh'));
+    fireEvent.click(screen.getByTitle('Josh'));
+
+    // onChange должен быть вызван
+    expect(onChange).toBeCalledTimes(3);
+    expect(onChange).toHaveReturnedWith('0');
+  });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -587,7 +587,7 @@ describe('CustomSelect', () => {
   });
 
   it('(controlled): calls onChange expected amount of times after clearing component and clicking on option without updating controlled prop value', async () => {
-    // мы намеренно проверяем кейсы где при нажатии на опцию или на кнопку очискти value проп не меняется.
+    // мы намеренно проверяем кейсы где при нажатии на опцию или на кнопку очистки value проп не меняется
     const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
 
     const { rerender } = render(

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -554,6 +554,7 @@ describe('CustomSelect', () => {
     expect(getCustomSelectValue()).toEqual('Mike');
     fireEvent.click(screen.getByRole('button', { hidden: true }));
     expect(getCustomSelectValue()).toEqual('');
+    expect(onChange).toBeCalledTimes(2);
   });
 
   it('(controlled): clearButton is not shown when option selected without props.value change', async () => {

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -530,7 +530,7 @@ describe('CustomSelect', () => {
       />,
     );
 
-    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toBeCalledTimes(1);
     expect(getCustomSelectValue()).toEqual('');
   });
 
@@ -550,11 +550,11 @@ describe('CustomSelect', () => {
       />,
     );
 
-    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toBeCalledTimes(0);
     expect(getCustomSelectValue()).toEqual('Mike');
     fireEvent.click(screen.getByRole('button', { hidden: true }));
     expect(getCustomSelectValue()).toEqual('');
-    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toBeCalledTimes(1);
   });
 
   it('(controlled): clearButton is not shown when option selected without props.value change', async () => {
@@ -596,18 +596,17 @@ describe('CustomSelect', () => {
       />,
     );
 
-    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toBeCalledTimes(0);
     expect(getCustomSelectValue()).toEqual('Josh');
 
     fireEvent.click(screen.getByTestId('target'));
     expect(screen.getByTitle('Josh')).toHaveAttribute('aria-selected', 'true');
     fireEvent.click(screen.getByTitle('Josh'));
 
-    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toBeCalledTimes(1);
     // onChange возвращает событие с value Josh
-    expect(onChange).toHaveNthReturnedWith(1, '1');
+    expect(onChange).toHaveReturnedWith('1');
     // onChange возвращает событие с value Josh при повторном клике по уже выбранной опции
-    expect(onChange).toHaveNthReturnedWith(2, '1');
 
     // Josh is still selected
     fireEvent.click(screen.getByTestId('target'));

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -554,6 +554,7 @@ describe('CustomSelect', () => {
     expect(getCustomSelectValue()).toEqual('Mike');
     fireEvent.click(screen.getByRole('button', { hidden: true }));
     expect(getCustomSelectValue()).toEqual('');
+
     expect(onChange).toBeCalledTimes(1);
   });
 
@@ -580,10 +581,11 @@ describe('CustomSelect', () => {
     expect(screen.queryByRole('button', { hidden: true })).toBeFalsy();
   });
 
-  it('(controlled): calls onChange expected amount of times after clearing uncontrolled component and clicking on option', async () => {
+  it('(controlled): calls onChange expected amount of times after clearing component and clicking on option without updating controlled prop value', async () => {
+    // мы намеренно проверяем кейсы где при нажатии на опцию или на кнопку очискти value проп не меняется.
     const onChange = jest.fn((event: React.ChangeEvent<HTMLSelectElement>) => event.target.value);
 
-    render(
+    const { rerender } = render(
       <CustomSelect
         data-testid="target"
         options={[
@@ -610,6 +612,32 @@ describe('CustomSelect', () => {
 
     expect(onChange).toBeCalledTimes(2);
     expect(onChange).toHaveReturnedWith('1');
+
+    // clear input through prop
+    rerender(
+      <CustomSelect
+        data-testid="target"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        allowClearButton
+        onChange={onChange}
+        value=""
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.mouseEnter(screen.getByTitle('Mike'));
+    fireEvent.click(screen.getByTitle('Mike'));
+
+    expect(onChange).toBeCalledTimes(3);
+
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.mouseEnter(screen.getByTitle('Josh'));
+    fireEvent.click(screen.getByTitle('Josh'));
+
+    expect(onChange).toBeCalledTimes(4);
   });
 
   it('(controlled): calls onChange when click on unselected option without value change', async () => {

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -386,8 +386,6 @@ export function CustomSelect(props: SelectProps) {
     onClose?.();
   }, [onClose, resetKeyboardInput]);
 
-  console.log('Props value:', props.value);
-  console.log('nativeSelectValue:', nativeSelectValue);
   const selectFocused = React.useCallback(() => {
     if (focusedOptionIndex !== undefined && isValidIndex(focusedOptionIndex)) {
       const item = options[focusedOptionIndex];
@@ -402,17 +400,6 @@ export function CustomSelect(props: SelectProps) {
         nativeSelectValue !== '' &&
         focusedOptionIndex !== selectedOptionIndex;
 
-      console.log(
-        'Should trigger on change from selectFocused: ',
-        shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync,
-      );
-      console.log('Data: ', {
-        isControlledOutside,
-        propsValue: props.value,
-        nativeSelectValue,
-        focusedOptionIndex,
-        selectedOptionIndex,
-      });
       if (shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync) {
         const event = new Event('change', { bubbles: true });
         selectElRef.current?.dispatchEvent(event);

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -487,6 +487,11 @@ export function CustomSelect(props: SelectProps) {
     }
   }, []);
 
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const onNativeSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
     if (!isControlledOutside) {
       const newSelectedOptionIndex = findSelectedIndex(
@@ -495,12 +500,14 @@ export function CustomSelect(props: SelectProps) {
         allowClearButton,
       );
 
-      if (selectedOptionIndex !== newSelectedOptionIndex && !isControlledOutside) {
+      if (selectedOptionIndex !== newSelectedOptionIndex) {
         setSelectedOptionIndex(newSelectedOptionIndex);
       }
     }
 
-    onChange?.(e);
+    if (mounted) {
+      onChange?.(e);
+    }
   };
 
   const onInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> = React.useCallback(

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -481,18 +481,19 @@ export function CustomSelect(props: SelectProps) {
   }, []);
 
   const onNativeSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
-    const newSelectedOptionIndex = findSelectedIndex(
-      options,
-      e.currentTarget.value,
-      allowClearButton,
-    );
+    if (!isControlledOutside) {
+      const newSelectedOptionIndex = findSelectedIndex(
+        options,
+        e.currentTarget.value,
+        allowClearButton,
+      );
 
-    if (selectedOptionIndex !== newSelectedOptionIndex) {
-      if (!isControlledOutside) {
+      if (selectedOptionIndex !== newSelectedOptionIndex && !isControlledOutside) {
         setSelectedOptionIndex(newSelectedOptionIndex);
       }
-      onChange?.(e);
     }
+
+    onChange?.(e);
   };
 
   const onInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> = React.useCallback(

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -396,9 +396,7 @@ export function CustomSelect(props: SelectProps) {
       const shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync =
         isControlledOutside &&
         props.value !== nativeSelectValue &&
-        props.value !== '' &&
-        nativeSelectValue !== '' &&
-        focusedOptionIndex !== selectedOptionIndex;
+        nativeSelectValue === item?.value;
 
       if (shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync) {
         const event = new Event('change', { bubbles: true });
@@ -411,7 +409,6 @@ export function CustomSelect(props: SelectProps) {
     isValidIndex,
     options,
     selectElRef,
-    selectedOptionIndex,
     isControlledOutside,
     props.value,
     nativeSelectValue,

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -393,14 +393,27 @@ export function CustomSelect(props: SelectProps) {
       setNativeSelectValue(item?.value);
       close();
 
-      const shouldTriggerOnChangeWhenSameOptionSelected =
-        focusedOptionIndex === selectedOptionIndex;
-      if (shouldTriggerOnChangeWhenSameOptionSelected) {
+      const shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync =
+        isControlledOutside &&
+        props.value !== nativeSelectValue &&
+        focusedOptionIndex !== selectedOptionIndex;
+
+      if (shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync) {
         const event = new Event('change', { bubbles: true });
         selectElRef.current?.dispatchEvent(event);
       }
     }
-  }, [close, focusedOptionIndex, isValidIndex, options, selectElRef, selectedOptionIndex]);
+  }, [
+    close,
+    focusedOptionIndex,
+    isValidIndex,
+    options,
+    selectElRef,
+    selectedOptionIndex,
+    isControlledOutside,
+    props.value,
+    nativeSelectValue,
+  ]);
 
   const open = React.useCallback(() => {
     setOpened(true);
@@ -487,25 +500,17 @@ export function CustomSelect(props: SelectProps) {
     }
   }, []);
 
-  const [mounted, setMounted] = React.useState(false);
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
-
   const onNativeSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
-    if (!isControlledOutside) {
-      const newSelectedOptionIndex = findSelectedIndex(
-        options,
-        e.currentTarget.value,
-        allowClearButton,
-      );
+    const newSelectedOptionIndex = findSelectedIndex(
+      options,
+      e.currentTarget.value,
+      allowClearButton,
+    );
 
-      if (selectedOptionIndex !== newSelectedOptionIndex) {
+    if (selectedOptionIndex !== newSelectedOptionIndex) {
+      if (!isControlledOutside) {
         setSelectedOptionIndex(newSelectedOptionIndex);
       }
-    }
-
-    if (mounted) {
       onChange?.(e);
     }
   };

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -392,8 +392,15 @@ export function CustomSelect(props: SelectProps) {
 
       setNativeSelectValue(item?.value);
       close();
+
+      const shouldTriggerOnChangeWhenSameOptionSelected =
+        focusedOptionIndex === selectedOptionIndex;
+      if (shouldTriggerOnChangeWhenSameOptionSelected) {
+        const event = new Event('change', { bubbles: true });
+        selectElRef.current?.dispatchEvent(event);
+      }
     }
-  }, [close, focusedOptionIndex, isValidIndex, options]);
+  }, [close, focusedOptionIndex, isValidIndex, options, selectElRef, selectedOptionIndex]);
 
   const open = React.useCallback(() => {
     setOpened(true);

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -398,6 +398,7 @@ export function CustomSelect(props: SelectProps) {
       const shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync =
         isControlledOutside &&
         props.value !== nativeSelectValue &&
+        props.value !== '' &&
         nativeSelectValue !== '' &&
         focusedOptionIndex !== selectedOptionIndex;
 

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -386,6 +386,8 @@ export function CustomSelect(props: SelectProps) {
     onClose?.();
   }, [onClose, resetKeyboardInput]);
 
+  console.log('Props value:', props.value);
+  console.log('nativeSelectValue:', nativeSelectValue);
   const selectFocused = React.useCallback(() => {
     if (focusedOptionIndex !== undefined && isValidIndex(focusedOptionIndex)) {
       const item = options[focusedOptionIndex];
@@ -396,8 +398,20 @@ export function CustomSelect(props: SelectProps) {
       const shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync =
         isControlledOutside &&
         props.value !== nativeSelectValue &&
+        nativeSelectValue !== '' &&
         focusedOptionIndex !== selectedOptionIndex;
 
+      console.log(
+        'Should trigger on change from selectFocused: ',
+        shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync,
+      );
+      console.log('Data: ', {
+        isControlledOutside,
+        propsValue: props.value,
+        nativeSelectValue,
+        focusedOptionIndex,
+        selectedOptionIndex,
+      });
       if (shouldTriggerOnChangeWhenControlledAndInnerValueIsOutOfSync) {
         const event = new Event('change', { bubbles: true });
         selectElRef.current?.dispatchEvent(event);


### PR DESCRIPTION
- fix #5010 

## Changeset
- программно вызываем событие `change` у Select когда пользователь кликает на уже выбранную опцию, то есть когда value у селекта не меняется.

## Notes
Мы вынуждены программно вызывать `change` у селекта в обработчике клика на опцию, потому что функция `onNativeSelectChange`, которая  висит на `onChange` нативного селекта, вызывается только когда `value` меняется у селекта. А наша задача также поддержать вариант когда value не меняется при клике.
https://github.com/VKCOM/VKUI/blob/017fa68c9f687e3a337c15d482be9c8b9622965b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx#L747-L750
https://github.com/VKCOM/VKUI/blob/017fa68c9f687e3a337c15d482be9c8b9622965b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx#L483-L497

Для того, чтобы `onChange` prop  `CustomSelect` вызывался при повторном клике на опцию (без изменения `props.value`) мы должны вызывать `change` при выборе опции.
`selectFocused` функция, которая и вызывается при выборе опции с клавиатуры, или при клике  выглядит как лучшее место для вызова `change` события.
https://github.com/VKCOM/VKUI/blob/017fa68c9f687e3a337c15d482be9c8b9622965b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx#L389-L397