### PR TITLE
feat(ButtonGroup): align button group buttons in horizontal mode

### DIFF
--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.e2e-playground.tsx
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.e2e-playground.tsx
@@ -61,12 +61,13 @@ export const ButtonGroupWithAlignPlayground = (props: ComponentPlaygroundProps) 
       {...props}
       propSets={[
         {
+          mode: ['vertical', 'horizontal'],
           align: ['left', 'center', 'right'],
         },
       ]}
     >
-      {({ align }: ButtonGroupProps) => (
-        <ButtonGroup mode="vertical" align={align} style={{ width: '100%' }}>
+      {({ mode, align }: ButtonGroupProps) => (
+        <ButtonGroup mode={mode} align={align} style={{ width: '100%' }}>
           <Button size="l" appearance="accent">
             Разрешить
           </Button>

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.e2e.tsx
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.e2e.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { test } from '@vkui-e2e/test';
+import { ViewWidth } from '../../lib/adaptivity';
 import {
   ButtonGroupPlayground,
   ButtonGroupWithAlignPlayground,
@@ -15,6 +16,11 @@ test('ButtonGroup', async ({
 });
 
 test.describe('ButtonGroup', () => {
+  test.use({
+    adaptivityProviderProps: {
+      viewWidth: ViewWidth.SMALL_TABLET,
+    },
+  });
   test('align', async ({ mount, expectScreenshotClippedToContent, componentPlaygroundProps }) => {
     await mount(<ButtonGroupWithAlignPlayground {...componentPlaygroundProps} />);
     await expectScreenshotClippedToContent();

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.module.css
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.module.css
@@ -62,14 +62,26 @@
 
 /* stylelint-enable @project-tools/stylelint-atomic */
 
-.ButtonGroup--align-left {
+.ButtonGroup--mode-vertical.ButtonGroup--align-left {
   align-items: flex-start;
 }
 
-.ButtonGroup--align-center {
+.ButtonGroup--mode-vertical.ButtonGroup--align-center {
   align-items: center;
 }
 
-.ButtonGroup--align-right {
+.ButtonGroup--mode-vertical.ButtonGroup--align-right {
   align-items: flex-end;
+}
+
+.ButtonGroup--mode-horizontal.ButtonGroup--align-left {
+  justify-content: flex-start;
+}
+
+.ButtonGroup--mode-horizontal.ButtonGroup--align-center {
+  justify-content: center;
+}
+
+.ButtonGroup--mode-horizontal.ButtonGroup--align-right {
+  justify-content: flex-end;
 }

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.module.css
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.module.css
@@ -14,7 +14,8 @@
 
 .ButtonGroup--mode-horizontal {
   flex-direction: row;
-  align-items: center;
+  /* чтобы блоки не растягивались на всю высоту контейнера */
+  align-items: flex-start;
 }
 
 /* stylelint-disable @project-tools/stylelint-atomic */

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.module.css
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.module.css
@@ -14,6 +14,7 @@
 
 .ButtonGroup--mode-horizontal {
   flex-direction: row;
+  align-items: center;
 }
 
 /* stylelint-disable @project-tools/stylelint-atomic */

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.tsx
@@ -21,7 +21,7 @@ export interface ButtonGroupProps
    */
   stretched?: boolean;
   /**
-   * Горизонтальное выравнивание элементов внутри группы. Работает только с mode="vertical".
+   * Горизонтальное выравнивание элементов внутри группы.
    */
   align?: AlignType;
 }

--- a/packages/vkui/src/components/ButtonGroup/Readme.md
+++ b/packages/vkui/src/components/ButtonGroup/Readme.md
@@ -6,7 +6,7 @@
 2. Исходя из п. 1, параметр `stretched` растягивает тот [ButtonGroup](#!/ButtonGroup), который имеет это свойство. Для компонента [Button](#!/Button) и вложенных [ButtonGroup](#!/ButtonGroup) его следует определять самостоятельно, где это необходимо.
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-const ButtonGroupPropsForm = ({ caption, defaultProps, onChange, isNested = false }) => {
+const ButtonGroupPropsForm = ({ caption, defaultProps, onChange }) => {
   const [{ mode, gap, align }, setProps] = React.useState(() => defaultProps);
 
   const handleChange = React.useCallback(
@@ -22,7 +22,6 @@ const ButtonGroupPropsForm = ({ caption, defaultProps, onChange, isNested = fals
 
   return (
     <React.Fragment>
-      <div>The change to see on the page</div>
       <FormItem top="mode">
         <Select
           value={mode}
@@ -45,20 +44,17 @@ const ButtonGroupPropsForm = ({ caption, defaultProps, onChange, isNested = fals
           ]}
         />
       </FormItem>
-      {((mode === 'vertical' && isNested) || !isNested) && (
-        <FormItem top="align">
-          <Select
-            value={align}
-            onChange={(e) => handleChange('align', e.target.value)}
-            options={[
-              { label: '', value: undefined },
-              { label: 'left', value: 'left' },
-              { label: 'center', value: 'center' },
-              { label: 'right', value: 'right' },
-            ]}
-          />
-        </FormItem>
-      )}
+      <FormItem top="align">
+        <Select
+          value={align}
+          onChange={(e) => handleChange('align', e.target.value)}
+          options={[
+            { label: 'left', value: 'left' },
+            { label: 'center', value: 'center' },
+            { label: 'right', value: 'right' },
+          ]}
+        />
+      </FormItem>
       <Checkbox onChange={(e) => handleChange('stretched', e.target.checked)}>stretched</Checkbox>
       {caption && (
         <FormItem>
@@ -183,7 +179,7 @@ const ExampleNested = () => {
   const [props, setProps] = useState({
     mode: 'vertical',
     gap: 's',
-    align: 'undefined',
+    align: 'left',
     stretched: false,
   });
 
@@ -196,7 +192,6 @@ const ExampleNested = () => {
         caption="параметры передаются корневому элементу"
         defaultProps={props}
         onChange={setProps}
-        isNested
       />
       <Div>
         <ButtonGroup {...props}>

--- a/packages/vkui/src/components/ButtonGroup/Readme.md
+++ b/packages/vkui/src/components/ButtonGroup/Readme.md
@@ -6,7 +6,7 @@
 2. Исходя из п. 1, параметр `stretched` растягивает тот [ButtonGroup](#!/ButtonGroup), который имеет это свойство. Для компонента [Button](#!/Button) и вложенных [ButtonGroup](#!/ButtonGroup) его следует определять самостоятельно, где это необходимо.
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-const ButtonGroupPropsForm = ({ caption, defaultProps, onChange }) => {
+const ButtonGroupPropsForm = ({ caption, defaultProps, onChange, isNested = false }) => {
   const [{ mode, gap, align }, setProps] = React.useState(() => defaultProps);
 
   const handleChange = React.useCallback(
@@ -22,6 +22,7 @@ const ButtonGroupPropsForm = ({ caption, defaultProps, onChange }) => {
 
   return (
     <React.Fragment>
+      <div>The change to see on the page</div>
       <FormItem top="mode">
         <Select
           value={mode}
@@ -44,12 +45,13 @@ const ButtonGroupPropsForm = ({ caption, defaultProps, onChange }) => {
           ]}
         />
       </FormItem>
-      {mode === 'vertical' && (
+      {((mode === 'vertical' && isNested) || !isNested) && (
         <FormItem top="align">
           <Select
             value={align}
             onChange={(e) => handleChange('align', e.target.value)}
             options={[
+              { label: '', value: undefined },
               { label: 'left', value: 'left' },
               { label: 'center', value: 'center' },
               { label: 'right', value: 'right' },
@@ -158,6 +160,16 @@ const ExampleBase = () => {
           <Button size="l" appearance="accent" before={<Icon24Add />} stretched />
         </ButtonGroup>
       </Div>
+      <Div>
+        <ButtonGroup {...props}>
+          <Button size="l" appearance="accent">
+            {buttonText}
+          </Button>
+          <Button size="l" appearance="accent">
+            {buttonText}
+          </Button>
+        </ButtonGroup>
+      </Div>
     </React.Fragment>
   );
 };
@@ -171,7 +183,7 @@ const ExampleNested = () => {
   const [props, setProps] = useState({
     mode: 'vertical',
     gap: 's',
-    align: 'left',
+    align: 'undefined',
     stretched: false,
   });
 
@@ -184,6 +196,7 @@ const ExampleNested = () => {
         caption="параметры передаются корневому элементу"
         defaultProps={props}
         onChange={setProps}
+        isNested
       />
       <Div>
         <ButtonGroup {...props}>

--- a/packages/vkui/src/components/ButtonGroup/Readme.md
+++ b/packages/vkui/src/components/ButtonGroup/Readme.md
@@ -130,6 +130,11 @@ const ExampleUseCases = () => {
 const buttonText = 'Button';
 const stretchedButtonText = 'Button (stretched)';
 
+const buttonGroupHighlightStyles = {
+  border: '2px dotted tomato',
+  boxSizing: 'border-box',
+};
+
 const ExampleBase = () => {
   const [props, setProps] = useState({
     mode: 'horizontal',
@@ -145,7 +150,7 @@ const ExampleBase = () => {
       </Div>
       <ButtonGroupPropsForm defaultProps={props} onChange={setProps} />
       <Div>
-        <ButtonGroup {...props}>
+        <ButtonGroup {...props} style={buttonGroupHighlightStyles}>
           <Button size="l" appearance="accent">
             {buttonText}
           </Button>
@@ -157,7 +162,7 @@ const ExampleBase = () => {
         </ButtonGroup>
       </Div>
       <Div>
-        <ButtonGroup {...props}>
+        <ButtonGroup {...props} style={buttonGroupHighlightStyles} stretched>
           <Button size="l" appearance="accent">
             {buttonText}
           </Button>
@@ -168,11 +173,6 @@ const ExampleBase = () => {
       </Div>
     </React.Fragment>
   );
-};
-
-const buttonGroupHighlightStyles = {
-  border: '2px dotted tomato',
-  boxSizing: 'border-box',
 };
 
 const ExampleNested = () => {

--- a/packages/vkui/src/components/ButtonGroup/Readme.md
+++ b/packages/vkui/src/components/ButtonGroup/Readme.md
@@ -196,6 +196,13 @@ const ExampleNested = () => {
     stretched: false,
   });
 
+  const [horizontalProps, setHorizontalProps] = useState({
+    mode: 'horizontal',
+    gap: 's',
+    align: 'left',
+    stretched: false,
+  });
+
   return (
     <React.Fragment>
       <Div>
@@ -272,13 +279,18 @@ const ExampleNested = () => {
       </Div>
       <ButtonGroupPropsForm
         caption="параметры передаются корневому элементу"
-        defaultProps={props}
-        onChange={setProps}
+        defaultProps={horizontalProps}
+        onChange={setHorizontalProps}
         showMode={false}
         showStretched={false}
       />
       <Div>
-        <ButtonGroup {...props} mode="horizontal" stretched style={buttonGroupHighlightStyles}>
+        <ButtonGroup
+          {...horizontalProps}
+          mode="horizontal"
+          stretched
+          style={buttonGroupHighlightStyles}
+        >
           <ButtonGroup
             mode="horizontal"
             gap="m"

--- a/packages/vkui/src/components/ButtonGroup/Readme.md
+++ b/packages/vkui/src/components/ButtonGroup/Readme.md
@@ -6,7 +6,13 @@
 2. Исходя из п. 1, параметр `stretched` растягивает тот [ButtonGroup](#!/ButtonGroup), который имеет это свойство. Для компонента [Button](#!/Button) и вложенных [ButtonGroup](#!/ButtonGroup) его следует определять самостоятельно, где это необходимо.
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-const ButtonGroupPropsForm = ({ caption, defaultProps, onChange }) => {
+const ButtonGroupPropsForm = ({
+  caption,
+  defaultProps,
+  onChange,
+  showMode = true,
+  showStretched = true,
+}) => {
   const [{ mode, gap, align }, setProps] = React.useState(() => defaultProps);
 
   const handleChange = React.useCallback(
@@ -22,16 +28,18 @@ const ButtonGroupPropsForm = ({ caption, defaultProps, onChange }) => {
 
   return (
     <React.Fragment>
-      <FormItem top="mode">
-        <Select
-          value={mode}
-          onChange={(e) => handleChange('mode', e.target.value)}
-          options={[
-            { label: 'vertical', value: 'vertical' },
-            { label: 'horizontal', value: 'horizontal' },
-          ]}
-        />
-      </FormItem>
+      {showMode && (
+        <FormItem top="mode">
+          <Select
+            value={mode}
+            onChange={(e) => handleChange('mode', e.target.value)}
+            options={[
+              { label: 'vertical', value: 'vertical' },
+              { label: 'horizontal', value: 'horizontal' },
+            ]}
+          />
+        </FormItem>
+      )}
       <FormItem top="gap">
         <Select
           value={gap}
@@ -55,7 +63,9 @@ const ButtonGroupPropsForm = ({ caption, defaultProps, onChange }) => {
           ]}
         />
       </FormItem>
-      <Checkbox onChange={(e) => handleChange('stretched', e.target.checked)}>stretched</Checkbox>
+      {showStretched && (
+        <Checkbox onChange={(e) => handleChange('stretched', e.target.checked)}>stretched</Checkbox>
+      )}
       {caption && (
         <FormItem>
           <Footnote>({caption})</Footnote>
@@ -161,6 +171,9 @@ const ExampleBase = () => {
           <Button size="l" appearance="accent" before={<Icon24Add />} stretched />
         </ButtonGroup>
       </Div>
+      <FormItem>
+        <Footnote>(stretched ButtonGroup)</Footnote>
+      </FormItem>
       <Div>
         <ButtonGroup {...props} style={buttonGroupHighlightStyles} stretched>
           <Button size="l" appearance="accent">
@@ -188,13 +201,19 @@ const ExampleNested = () => {
       <Div>
         <Title level="3">Пример с вложенным ButtonGroup</Title>
       </Div>
+      <Div>
+        <Headline level="1" weight="1">
+          Mode: Vertical
+        </Headline>
+      </Div>
       <ButtonGroupPropsForm
         caption="параметры передаются корневому элементу"
         defaultProps={props}
         onChange={setProps}
+        showMode={false}
       />
       <Div>
-        <ButtonGroup {...props}>
+        <ButtonGroup {...props} mode="vertical">
           <ButtonGroup mode="horizontal" gap="m" stretched style={buttonGroupHighlightStyles}>
             <Button size="l" appearance="accent" stretched>
               {stretchedButtonText}
@@ -231,6 +250,45 @@ const ExampleNested = () => {
             <Button size="l" appearance="accent">
               {buttonText}
             </Button>
+          </ButtonGroup>
+          <ButtonGroup mode="vertical" gap="m" stretched={false} style={buttonGroupHighlightStyles}>
+            <Button size="l" appearance="accent" stretched>
+              {stretchedButtonText}
+            </Button>
+            <Button size="l" appearance="accent" before={<Icon24Add />} stretched />
+            <ButtonGroup mode="horizontal" stretched style={buttonGroupHighlightStyles}>
+              <Button size="l" appearance="accent" before={<Icon24Add />} />
+              <Button size="l" appearance="accent" stretched>
+                {stretchedButtonText}
+              </Button>
+            </ButtonGroup>
+          </ButtonGroup>
+        </ButtonGroup>
+      </Div>
+      <Div>
+        <Headline level="1" weight="1">
+          Mode: Horizontal
+        </Headline>
+      </Div>
+      <ButtonGroupPropsForm
+        caption="параметры передаются корневому элементу"
+        defaultProps={props}
+        onChange={setProps}
+        showMode={false}
+        showStretched={false}
+      />
+      <Div>
+        <ButtonGroup {...props} mode="horizontal" stretched style={buttonGroupHighlightStyles}>
+          <ButtonGroup
+            mode="horizontal"
+            gap="m"
+            stretched={false}
+            style={buttonGroupHighlightStyles}
+          >
+            <Button size="l" appearance="accent">
+              {buttonText}
+            </Button>
+            <Button size="l" appearance="accent" before={<Icon24Add />} />
           </ButtonGroup>
           <ButtonGroup mode="vertical" gap="m" stretched={false} style={buttonGroupHighlightStyles}>
             <Button size="l" appearance="accent" stretched>

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76007cb6bac480f802d0c507f6ef4a9ca52c037c660130bfc9efdc38415d9eb0
-size 26834
+oid sha256:6e7d2e28a2db212dea69245cb410dbc20cc09241dce6ec639048de36e43136eb
+size 58874

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:066edc8be0d0defbb4f64b596fa742cd81053480cf9016936d79c3057eb4b4fe
-size 26517
+oid sha256:2d50e016e95a81e240d23ca7da27cb0705a79930d77c33cc127eb105bef140bd
+size 58860

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1af7941f3f50fa7f1b9d2fa4a47fea37d33fa207f58a6d742aafdb25934c5af4
-size 26610
+oid sha256:d3824f90dcf4479c01c138b4c6f6744739e9b0bca40ef9b8d94f7977381cdd36
+size 57257

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e67dc25f20b4785b3085f86d64105e03023bad2902fef86bbd51bbd28b1a07db
-size 25822
+oid sha256:ce742093b0f9b49c0c7adeffbeeda9af22b387d6987313906ca74677a601f577
+size 56737

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96361f01e7729d598e6bce6c38fff7a042a198f273cfc14dffb84b020fed33a0
-size 24200
+oid sha256:128764d05a7e31e5b6c522b165b78caf00bad38bdcf6013356802d53c50a0d6e
+size 54272

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5ad84e88de4cbef4640158e918b056ca6ad600c8d0a5885981142d12b29595e
-size 24246
+oid sha256:e308067ebbc7f2c3b98bee41344a615b77a48e2f8454862b3b8f377e8263e7cc
+size 53921

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52513aa39773b2c8577ceddbd5af8a598b5d4dd0b896fc55963839b3a02e9985
-size 28133
+oid sha256:788979bef173cf87f6e8cc0c5d64d9225633d3c67b2ecc2083b40b733aa893ca
+size 75370

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d8547b1931cdbc78a957db9e585b668ce68110105c1fe1fff0901cc9cb18f67
-size 27789
+oid sha256:8f5c3167eb4c15699c338834fdbdc0afbc4f8b744b13710fea8506fc9b368e57
+size 73243

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21727f66d7f1521f7545c92e80b15e55adba50139170231b25e13932719c8d2f
-size 23072
+oid sha256:c7acab4686d5dc09c5d76ba86274adb51de00b1fa93c8b579109b4d58a24f878
+size 51333

--- a/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ButtonGroup/__image_snapshots__/buttongroup-align-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9cdb73147a518b594b4a20799323229b01db3d2aa39a80d6663c17f856a731a9
-size 22829
+oid sha256:ebd64f9262eb4efc1575b5286b362de69028d6f8e2f813b5e98646c32a4b53cb
+size 50304


### PR DESCRIPTION
fix #4651 

- [x] пример в документации обновлен.

## Changeset
- добавлена возможность выравнивания по правому/левому краю в режиме mode="horizontal".
- по умолчанию в `mode="horizontal"` `align-items` теперь `"center"`. Неявно оно было `"flex-start"` если `align` проп не передан, так как умолчанию он устанавливался в значение "left", или `"flex-end"` если `align="right"`.
- обновлен пример в документации.