### PR TITLE
fix(CusomSelectOption): don't pass onClick when option is disabled

### DIFF
--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.test.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.test.tsx
@@ -1,6 +1,28 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { CustomSelectOption } from './CustomSelectOption';
 
 describe('CustomSelectOption', () => {
   baselineComponent(CustomSelectOption);
+
+  it('does not handle onClick when disabled', () => {
+    const onClick = jest.fn();
+
+    const { rerender } = render(
+      <CustomSelectOption onClick={onClick}>Дмитрий Безуглый</CustomSelectOption>,
+    );
+
+    fireEvent.click(screen.getByText('Дмитрий Безуглый'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <CustomSelectOption disabled onClick={onClick}>
+        Дмитрий Безуглый
+      </CustomSelectOption>,
+    );
+
+    fireEvent.click(screen.getByText('Дмитрий Безуглый'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -75,6 +75,7 @@ export const CustomSelectOption = ({
   disabled,
   style: styleProp,
   className,
+  onClick,
   ...restProps
 }: CustomSelectOptionProps) => {
   const title = typeof children === 'string' ? children : undefined;
@@ -98,6 +99,7 @@ export const CustomSelectOption = ({
   return (
     <Paragraph
       {...restProps}
+      onClick={disabled ? undefined : onClick}
       Component="div"
       role="option"
       title={title}


### PR DESCRIPTION
- fix #4516 

## Changeset
- останавливаем прокидывание `onClick` если элемент `disabled`.