### PR TITLE
deps(@csstools/postcss-global-data): fix to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@project-tools/swc-transform-css-modules": "0.1.0"
   },
   "devDependencies": {
-    "@csstools/postcss-global-data": "^1.0.1",
+    "@csstools/postcss-global-data": "1.0.1",
     "@playwright/experimental-ct-react17": "1.33.0",
     "@playwright/test": "1.33.0",
     "@size-limit/file": "^8.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,10 +1111,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.0.4.tgz#466bd254041530dfd1e88bcb1921e8ca4af75b6a"
   integrity sha512-GyYot6jHgcSDZZ+tLSnrzkR7aJhF2ZW6d+CXH66mjy5WpAQhZD4HDke2OQ36SivGRWlZJpAz7TzbW6OKlEpxAA==
 
-"@csstools/postcss-global-data@^1.0.1":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@csstools/postcss-global-data/-/postcss-global-data-1.0.3.tgz#baa266a7ed2372d4f7d0996f9148809134d901af"
-  integrity sha512-x2fZOl7RJJtKC9ZfG+1bdrQKeRfP1a3Ff4uF2/fykNUKly8E8Q7lw7oegsEnqenSEDC1xjk6qXJ/fcJkTAdcNg==
+"@csstools/postcss-global-data@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@csstools/postcss-global-data/-/postcss-global-data-1.0.1.tgz#a5564588ed695e329f889aae852650c3645554b7"
+  integrity sha512-0StaHO7xWGnUJhhiQH0ZlJRW3izRqESuI/lhNZL0weOcWcu3quuyGKp/xB6Y78U0NfVw3FDl91W6Vrsi255jBg==
 
 "@csstools/selector-specificity@^2.2.0":
   version "2.2.0"


### PR DESCRIPTION
Из-за апгрейда зависимости с **1.0.1** до **1.0.3** были проблемы со сборкой. Что **styleguide**, что **storybook** по долгу запускались и не могли закончить компиляцию.

В репозитории issue не нашёл ([ссылка на issues по **postcss-global-data**](https://github.com/csstools/postcss-plugins/issues?q=is%3Aopen+is%3Aissue+label%3Aplugins%2Fpostcss-global-data)) – _создаю issue_.

---

- caused by #5066