### PR TITLE
fix(a11y/NativeSelect): hide duplication of selected option from screen reader

### DIFF
--- a/packages/vkui/src/components/NativeSelect/NativeSelect.test.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.test.tsx
@@ -1,11 +1,21 @@
 import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { a11yBasicTest } from '../../testing/a11y';
 import { baselineComponent } from '../../testing/utils';
 import { NativeSelect } from './NativeSelect';
 
 describe('NativeSelect', () => {
   baselineComponent(NativeSelect);
+  a11yBasicTest(() => (
+    <>
+      <label htmlFor="name">Name:</label>
+      <NativeSelect id="name" data-testid="target" value="0">
+        <option value="0">Mike</option>
+        <option value="1">Josh</option>
+      </NativeSelect>
+    </>
+  ));
 
   it('works correctly with value and onChange', () => {
     const SelectController = () => {

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -111,7 +111,7 @@ const NativeSelect = ({
         {placeholder && <option value="">{placeholder}</option>}
         {children}
       </select>
-      <div className={styles['Select__container']}>
+      <div className={styles['Select__container']} aria-hidden>
         <SelectTypography className={styles['Select__title']} selectType={selectType}>
           {title}
         </SelectTypography>


### PR DESCRIPTION
- fix #4988 