### PR TITLE
fix(CustomSelect): Don't show clear button with empty props.value

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -554,4 +554,27 @@ describe('CustomSelect', () => {
     fireEvent.click(screen.getByRole('button', { hidden: true }));
     expect(getCustomSelectValue()).toEqual('');
   });
+
+  it('(controlled): clearButton is not shown when option selected without props.value change', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <CustomSelect
+        data-testid="target"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        allowClearButton
+        onChange={onChange}
+        value=""
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('target'));
+    fireEvent.mouseEnter(screen.getByTitle('Mike'));
+    fireEvent.click(screen.getByTitle('Mike'));
+
+    expect(screen.queryByRole('button', { hidden: true })).toBeFalsy();
+  });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -664,7 +664,10 @@ export function CustomSelect(props: SelectProps) {
     }
   }, [emptyText, options, renderDropdown, renderOption]);
 
-  const clearButtonShown = allowClearButton && !opened && nativeSelectValue !== '';
+  const controlledValueSet = isControlledOutside && props.value !== '';
+  const uncontrolledValueSet = !isControlledOutside && nativeSelectValue !== '';
+  const clearButtonShown =
+    allowClearButton && !opened && (controlledValueSet || uncontrolledValueSet);
 
   const clearButton = React.useMemo(() => {
     if (!clearButtonShown) {


### PR DESCRIPTION
## Changeset
- добавил логику чтобы для показа `clearButton` проверять значение `props.value` если компонент контролируемый или  `nativeSelectValue` если копмонент не контролируемый.

## Note
Если `CustomSelect` контролируемый, но при клике на опцию мы не меняем значение `props.value` и значение `props.value = ''` и включен флаг `allowClearButton`, то при клике на любую опцию из дропдауна мы показываем кнопку очистки, хотя значение самого селекта остается пустым.
Это происходит из-за того, что `Select` реализован так, что при клике на опцию мы всегда меням значение внутреннего состояния селекта (`nativeSelectValue`). При этом для того чтобы показать `clearButton` сейчас мы смотрим именно на значение `nativeSelectValue`. Хотя если селект контролируемый, то мы должны смотреть на значение props.value.

Шаги для воспроизведения:
- передать в проп `value` у `CustomSelect` значение `''` при этом при клике на опцию не менять значение `props.value` передаваемое в `CustomSelect`.
- добавить флаг `allowClearButton`
- выбрать любую опцию из дропдауна
- можно увидеть `clearButton` при том, что значение селекта пустое.

Пример кода для теста в styleguide
```jsx
const [value, setValue] = React.useState("");
const options = React.useMemo(() => ([{ label: 'Мужской', value: 'm' }, { label: 'Женский', value: 'f' }]), []);

<View activePanel="select">
  <Panel id="select">
    <PanelHeader>Select</PanelHeader>
    <Group>
      <FormItem top="Администратор">
        <Select
          placeholder="Не выбран"
          options={options}
          value={value}
          allowClearButton
        />
      </FormItem>
    </Group>
  </Panel>
</View>
```

<img width="327" alt="Снимок экрана 2023-05-31 в 15 32 48" src="https://github.com/VKCOM/VKUI/assets/5443359/79e3f56a-eb2d-4baf-ba90-77ab4e54e5f5">
