### PR TITLE
fix(NativeSelect): omit `multiple`

### DIFF
--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -18,7 +18,7 @@ const sizeYClassNames = {
 };
 
 export interface NativeSelectProps
-  extends React.SelectHTMLAttributes<HTMLSelectElement>,
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'multiply'>,
     HasRef<HTMLSelectElement>,
     HasRootRef<HTMLLabelElement>,
     HasAlign,

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -18,7 +18,7 @@ const sizeYClassNames = {
 };
 
 export interface NativeSelectProps
-  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'multiply'>,
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'multiple'>,
     HasRef<HTMLSelectElement>,
     HasRootRef<HTMLLabelElement>,
     HasAlign,


### PR DESCRIPTION
Убираем свойство `multiple` из типов