### PR TITLE
doc(CustomSelectOption): Don't allow to use disabled directly on CustomSelectOption inside Select

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -144,6 +144,10 @@ export interface SelectProps extends NativeSelectProps, FormFieldProps, TrackerO
   /**
    * Рендер-проп для кастомного рендера опции.
    * В объекте аргумента приходят [свойства опции](https://vkcom.github.io/VKUI/#/CustomSelectOption?id=props)
+   *
+   * > ⚠️  Важно: cвойство опции `disabled` должно выставляться только через проп `options`.
+   * > Запрещается выставлять `disabled` проп опциям в обход `options`, иначе селект не будет знать об актуальном состоянии
+   * опции.
    */
   renderOption?: (props: CustomSelectOptionProps) => React.ReactNode;
   /**

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -98,7 +98,6 @@ export const CustomSelectOption = ({
 
   return (
     <Paragraph
-      tabIndex={disabled ? -1 : undefined}
       {...restProps}
       onClick={disabled ? undefined : onClick}
       Component="div"

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -98,6 +98,7 @@ export const CustomSelectOption = ({
 
   return (
     <Paragraph
+      tabIndex={disabled ? -1 : undefined}
       {...restProps}
       onClick={disabled ? undefined : onClick}
       Component="div"

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -54,6 +54,10 @@ export interface CustomSelectOptionProps
   focused?: boolean;
   /**
    * Блокирует весь блок.
+   *
+   * > ⚠️  Важно: если CustomSelectOption используется внутри [Select](https://vkcom.github.io/VKUI/#/Select) или [CustomSelect](https://vkcom.github.io/VKUI/#/CustomSelect), то свойство явно должно выставляться только через структуру `options`.
+   * > Запрещается выставлять `disabled` проп опциям в обход `options`, иначе селект не будет знать об актуальном состоянии
+   * опции.
    */
   disabled?: boolean;
 }

--- a/packages/vkui/src/components/Select/Readme.md
+++ b/packages/vkui/src/components/Select/Readme.md
@@ -1,43 +1,28 @@
 Отрисовывает [CustomSelect](#!/CustomSelect), если есть мышка, либо [NativeSelect](#!/NativeSelect)
 
 ```jsx
-const [value, setValue] = React.useState('');
-const options = React.useMemo(
-  () => [
-    { label: 'Мужской', value: 'm' },
-    { label: 'Женский', value: 'f' },
-    { label: 'Other', value: 'o' },
-  ],
-  [],
-);
-
 <View activePanel="select">
   <Panel id="select">
     <PanelHeader>Select</PanelHeader>
     <Group>
-      <Button onClick={() => setValue('')}>reset</Button>
       <FormItem top="Администратор">
-        <CustomSelect
-          value={value}
-          placeholder="Не задан"
-          options={options}
-          onChange={(event) => {
-            console.log('TEST', event.target.value);
-            setValue(event.target.value);
-          }}
-          renderOption={({ option, ...restProps }) => {
-            const shouldBeDisabled = option.value === 'f';
-            return (
-              <CustomSelectOption
-                {...restProps}
-                description={`"${option.value}"`}
-                disabled={shouldBeDisabled}
-              />
-            );
-          }}
+        <Select
+          placeholder="Не выбран"
+          options={getRandomUsers(10).map((user) => ({
+            label: user.name,
+            value: user.id,
+            avatar: user.photo_100,
+          }))}
+          renderOption={({ option, ...restProps }) => (
+            <CustomSelectOption
+              {...restProps}
+              key={option.value}
+              before={<Avatar size={24} src={option.avatar} />}
+            />
+          )}
         />
       </FormItem>
     </Group>
   </Panel>
-</View>;
+</View>
 ```

--- a/packages/vkui/src/components/Select/Readme.md
+++ b/packages/vkui/src/components/Select/Readme.md
@@ -1,28 +1,43 @@
 Отрисовывает [CustomSelect](#!/CustomSelect), если есть мышка, либо [NativeSelect](#!/NativeSelect)
 
 ```jsx
+const [value, setValue] = React.useState('');
+const options = React.useMemo(
+  () => [
+    { label: 'Мужской', value: 'm' },
+    { label: 'Женский', value: 'f' },
+    { label: 'Other', value: 'o' },
+  ],
+  [],
+);
+
 <View activePanel="select">
   <Panel id="select">
     <PanelHeader>Select</PanelHeader>
     <Group>
+      <Button onClick={() => setValue('')}>reset</Button>
       <FormItem top="Администратор">
-        <Select
-          placeholder="Не выбран"
-          options={getRandomUsers(10).map((user) => ({
-            label: user.name,
-            value: user.id,
-            avatar: user.photo_100,
-          }))}
-          renderOption={({ option, ...restProps }) => (
-            <CustomSelectOption
-              {...restProps}
-              key={option.value}
-              before={<Avatar size={24} src={option.avatar} />}
-            />
-          )}
+        <CustomSelect
+          value={value}
+          placeholder="Не задан"
+          options={options}
+          onChange={(event) => {
+            console.log('TEST', event.target.value);
+            setValue(event.target.value);
+          }}
+          renderOption={({ option, ...restProps }) => {
+            const shouldBeDisabled = option.value === 'f';
+            return (
+              <CustomSelectOption
+                {...restProps}
+                description={`"${option.value}"`}
+                disabled={shouldBeDisabled}
+              />
+            );
+          }}
         />
       </FormItem>
     </Group>
   </Panel>
-</View>
+</View>;
 ```


### PR DESCRIPTION
Добавлен запрет на использование `disabled` пропа прямо на `CustomSelectOption` если он рендерится внутри `Select` или `CustomSelect` через  `renderOption`.

Иначе Select не знает о состоянии опции и может позволить выбрать disabled элемент с клавиатуры.

<details>
<summary>Пример неправильного использования.</summary>

 ```jsx
const [value, setValue] = React.useState('');
const options = React.useMemo(
  () => [
    { label: 'Мужской', value: 'm' },
    { label: 'Женский', value: 'f' },
  ],
  [],
);

<View activePanel="select">
  <Panel id="select">
    <PanelHeader>Select</PanelHeader>
    <Group>
      <Button onClick={() => setValue('')}>reset</Button>
      <FormItem top="Администратор">
        <CustomSelect
          value={value}
          placeholder="Не задан"
          options={options}
          onChange={(event) => {
            console.log('TEST', event.target.value);
            setValue(event.target.value);
          }}
          renderOption={({ option, ...restProps }) => {
            const shouldBeDisabled = option.value === 'f';
            return (
              <CustomSelectOption
                {...restProps}
                disabled={shouldBeDisabled}
              />
            );
          }}
        />
      </FormItem>
    </Group>
  </Panel>
</View>;
```

</details>
