### PR TITLE
Fix contenteditable with user-select: none

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRoot.module.css
+++ b/packages/vkui/src/components/AppRoot/AppRoot.module.css
@@ -6,9 +6,21 @@
   user-select: none;
 }
 
+/** 
+ * Хак для webkit-based браузеров, потому что на версиях iOS <= 14.* исчезает возможность 
+ * редактировать contenteditable элементы, если выше по дереву задан user-select: none; 
+ */
+.AppRoot--pointer-has-not [contenteditable] {
+  user-select: text;
+}
+
 @media (--pointer-has-not) {
   .AppRoot--pointer-none {
     user-select: none;
+  }
+
+  .AppRoot--pointer-none [contenteditable] {
+    user-select: text;
   }
 }
 


### PR DESCRIPTION
На мобилке добавляется класс .vkuiAppRoot--pointer-none со стилями user-select: none, который дизейблит использование contenteditable-элемента. Причем в ios 16 все работает корректно, в версиях ниже (проверена на 14.7.1) в элемент невозможно вписать текст