### PR TITLE
fix(FormItem): added <label> support

### DIFF
--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -47,6 +47,7 @@ export const FormItem = ({
   removePlaceholder = 'Удалить',
   getRootRef,
   className,
+  htmlFor,
   ...restProps
 }: FormItemProps) => {
   const rootEl = useExternRef(getRootRef);
@@ -54,7 +55,15 @@ export const FormItem = ({
 
   const wrappedChildren = (
     <React.Fragment>
-      {hasReactNode(top) && <Subhead className={styles['FormItem__top']}>{top}</Subhead>}
+      {hasReactNode(top) && (
+        <Subhead
+          className={styles['FormItem__top']}
+          Component={htmlFor ? 'label' : 'h5'}
+          htmlFor={htmlFor}
+        >
+          {top}
+        </Subhead>
+      )}
       {children}
       {hasReactNode(bottom) && <Footnote className={styles['FormItem__bottom']}>{bottom}</Footnote>}
     </React.Fragment>

--- a/packages/vkui/src/components/FormItem/Readme.md
+++ b/packages/vkui/src/components/FormItem/Readme.md
@@ -45,8 +45,8 @@ const Example = () => {
               <Input type="email" name="email" value={email} onChange={onChange} />
             </FormItem>
 
-            <FormItem top="Пароль">
-              <Input type="password" placeholder="Введите пароль" />
+            <FormItem top="Пароль" htmlFor="pass">
+              <Input id="pass" type="password" placeholder="Введите пароль" />
             </FormItem>
 
             <FormItem bottom="Пароль может содержать только латинские буквы и цифры.">

--- a/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
+++ b/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
@@ -19,12 +19,14 @@ export const Subhead = ({
   className,
   Component = 'h5',
   normalize = true,
+  htmlFor,
   ...restProps
 }: SubheadProps) => {
   const { sizeY = 'none' } = useAdaptivity();
 
   return (
     <Typography
+      htmlFor={htmlFor}
       Component={Component}
       normalize={normalize}
       className={classNames(


### PR DESCRIPTION
- fixes #5017


> Subhead принимает htmlFor. Это надо FormItem научить принимать htmlFor (или topHtmlFor) и передавать в Subhead. Также внутри FormItem указать для Subhead свойство Component="label" (c) @inomdzhon 

Старался научить FormItem работать с htmlFor, при клике на label нужный инпут полуачет фокус.

![image](https://github.com/VKCOM/VKUI/assets/67464545/efa90ce4-c6dc-46b1-9a8c-45c96765e53a)

Насколько я понял `htmlFor` не надо добавлять в `SubheadProps` и в `FormItemProps`.
