### PR TITLE
fix(TabbarItem): use getRootRef prop in ref

### DIFF
--- a/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
@@ -37,6 +37,7 @@ export const TabbarItem = ({
   Component = href ? 'a' : 'button',
   disabled,
   className,
+  getRootRef,
   ...restProps
 }: TabbarItemProps) => {
   const platform = usePlatform();
@@ -52,6 +53,7 @@ export const TabbarItem = ({
   return (
     <Component
       {...restProps}
+      ref={getRootRef}
       disabled={disabled}
       href={href}
       className={classNames(


### PR DESCRIPTION
**Версия:** 5.5.1

## Проблема

Из-за того, что не пробрасывается `getRooRef` в атрибут `ref`, не работает, например, `TextTooltip`.

Пример кода, который не работает в https://vkcom.github.io/VKUI/5.5.1/#/TabbarItem

```jsx
const [simple, setSimple] = React.useState('one');

<Tabbar style={{ position: 'static', margin: '0 0 10px' }}>
  <TextTooltip text="Новости" placement="top" appearance="accent">
    <TabbarItem selected={simple === 'one'} onClick={() => setSimple('one')} aria-label="Новости">
      <Icon28NewsfeedOutline />
    </TabbarItem>
  </TextTooltip>
  <TextTooltip text="Профиль" placement="top" appearance="accent">
    <TabbarItem selected={simple === 'two'} onClick={() => setSimple('two')} aria-label="Профиль">
      <Icon28UserCircleOutline />
    </TabbarItem>
  </TextTooltip>
</Tabbar>
```