### PR TITLE
tech(playwright): rm mouse pos reset

### DIFF
--- a/packages/vkui/src/testing/e2e/index.playwright.ts
+++ b/packages/vkui/src/testing/e2e/index.playwright.ts
@@ -35,18 +35,6 @@ export const test = testBase.extend<VKUITestOptions & InternalVKUITestOptions & 
   onlyForPlatforms: [null, { option: true }],
   onlyForAppearances: [null, { option: true }],
 
-  /**
-   * см. https://playwright.dev/docs/test-fixtures#overriding-fixtures
-   *
-   * @override
-   */
-  page: async ({ page }, use) => {
-    // Сбрасываем курсор мыши перед началом каждого теста.
-    // см. https://github.com/VKCOM/VKUI/pull/4652#firefox-bottleneck
-    await page.mouse.move(0, 0);
-    await use(page);
-  },
-
   expectScreenshotClippedToContent: async (
     { page, platform, browserName, appearance },
     use,


### PR DESCRIPTION
Удаляем фикс #4891, т.к. проблема была исправлена на уровне библиотеки Playwright (см. https://github.com/microsoft/playwright/issues/22432)