### PR TITLE
tech(deps): add schedule for complex cargo update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,16 @@ updates:
     directory: '/tools/swc-transform-css-modules'
     schedule:
       interval: 'weekly'
+      # Чтобы отдать приоритет .github/workflows/schedule_cargo_update.yml, переносим расписание
+      # Dependabot на +10 часов. Так частично избежим захламления PR'ами.
+      #
+      # Дублируем конфигурацию в Dependabot ради security updates, который может прилететь как
+      # только так сразу.
+      time: '15:00'
+      day: 'monday'
     allow:
       - dependency-type: 'indirect'
+    open-pull-requests-limit: 20
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'

--- a/.github/workflows/schedule_cargo_update.yml
+++ b/.github/workflows/schedule_cargo_update.yml
@@ -1,0 +1,31 @@
+name: 'Schedule / Cargo update'
+on:
+  schedule:
+    # Запускается по ПН в 05:00.
+    # Также за обновлениями следит Dependabot (см. .github/dependabot.yml).
+    - cron: '0 5 * * 1'
+
+jobs:
+  cargo-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Run cargo update
+        run: cargo update --verbose
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: Cargo update
+          branch: github-actions/build/deps/cargo-update
+          commit-message: 'build(deps): cargo update'
+          body: Automated cargo update
+          labels: dependencies, rust
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}


### PR DESCRIPTION
Чтобы комплексно обновлять зависимости Rust, добавляем отдельный
воркфлоу, который по крону будет проверять обновления, и если они есть,
то обновлять и создавать один PR. Проверять будет по ПН в 05:00.

В Dependabot увеличили лимиты на PR до 20, а также отложили обновления
на 10 часов относительно расписания по крону, чтобы не было лишних PR.

Конечно, Dependabot автоматически закрывает PR, если зависимость была
обновлена. Этот сценарий возможен в двух случаях: если PR с
обновлениями всех возможных зависимсотей смержили позже расписания
Dependabot; если к моменту запуску Dependabot появились ещё обновления.