### PR TITLE
ci: complete Playwright and Storybook update

### DIFF
--- a/.github/actions/complete_playwright_update.yml
+++ b/.github/actions/complete_playwright_update.yml
@@ -1,0 +1,52 @@
+name: Publish Workflow / Complete Playwright update
+description: It updates Playwright scope dependencies and version of container image
+
+inputs:
+  branch:
+    description: target branch for git push
+    required: true
+  token:
+    description: token for write access to repository
+    required: true
+  prev_version:
+    description: previous version of Playwright
+    required: true
+  next_version:
+    description: next version of Playwright
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Update '@playwright/experimental-ct-react17' dependency
+      run: |
+        yarn add -W @playwright/experimental-ct-react17@${{ inputs.next_version }} --dev
+      shell: bash
+
+    - name: Commit changes
+      run: |
+        git add package.json yarn.lock
+        git diff-index --quiet HEAD || git commit -m 'bump(playwright-deps): @playwright/experimental-ct-react17 from ${{ inputs.prev_version }} to ${{ inputs.next_version }}'
+      shell: bash
+
+    - name: Update container image version in config files
+      # Пример,
+      # ```sh
+      # perl -pi -e "s/v1.35.1/v1.35.2/" packages/vkui/docker-compose.yml
+      # ```
+      run: |
+        perl -pi -e "s/v${{ inputs.prev_version }}/v${{ inputs.next_version }}/" packages/vkui/docker-compose.yml
+        perl -pi -e "s/v${{ inputs.prev_version }}/v${{ inputs.next_version }}/" .github/workflows/reusable_workflow_test_e2e.yml
+      shell: bash
+
+    - name: Commit changes
+      run: |
+        git add packages/vkui/docker-compose.yml .github/workflows/reusable_workflow_test_e2e.yml
+        git diff-index --quiet HEAD || git commit -m 'bump(playwright-deps): Docker container image from ${{ inputs.prev_version }} to ${{ inputs.next_version }}'
+      shell: bash
+
+    - name: Pushing changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.token }}
+        branch: ${{ inputs.branch }}

--- a/.github/actions/complete_storybook_update.yml
+++ b/.github/actions/complete_storybook_update.yml
@@ -1,0 +1,49 @@
+name: Publish Workflow / Complete Storybook update
+description: It updates Storybook scope dependencies
+
+inputs:
+  branch:
+    description: target branch for git push
+    required: true
+  token:
+    description: token for write access to repository
+    required: true
+  prev_version:
+    description: previous version of Storybook
+    required: true
+  next_version:
+    description: next version of Storybook
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Update '@storybook/' scope dependencies
+      run: |
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/addon-a11y@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/addon-actions@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/addon-essentials@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/addon-interactions@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/addon-links@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/api@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/blocks@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/components@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/manager-api@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/preview-api@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/react@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/react-webpack5@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/theming@${{ inputs.next_version }}
+        yarn workspace @project-tools/storybook-addon-cartesian add @storybook/types@${{ inputs.next_version }}
+      shell: bash
+
+    - name: Commit changes
+      run: |
+        git add tools/storybook-addon-cartesian/package.json yarn.lock
+        git diff-index --quiet HEAD || git commit -m 'bump(storybook-deps): @storybook/* from ${{ inputs.prev_version }} to ${{ inputs.next_version }}'
+      shell: bash
+
+    - name: Pushing changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.token }}
+        branch: ${{ inputs.branch }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,25 @@ updates:
     allow:
       - dependency-type: 'direct'
     ignore:
-      # Игнорируем адоны во избежание отдельного PR от бота по каждому из них.
-      # Вместо этого, ориентируемся на обновление Storybook – если он обновился, то и адоны надо
-      # будет обновить (вручную).
       #
-      # TODO заменить на групповое обновление, когда его завезут в Dependabot https://github.com/dependabot/dependabot-core/issues/1190
+      # Игнорируем адоны во избежание отдельного PR от бота по каждому из них.
+      # Вместо этого, ориентируемся на обновление Storybook и запускаем
+      # `./.github/actions/complete_storybook_update`.
+      #
+      # TODO
+      #   1. заменить на групповое обновление, когда его завезут в Dependabot
+      #      https://github.com/dependabot/dependabot-core/issues/1190
+      #   2. удалить экшен ./.github/actions/complete_storybook_update и его запуск
       - dependency-name: '@storybook/*'
+      #
+      # Обновляем в экшене `./.github/actions/complete_playwright_update` (на момент создания
+      # комментария это строки с 21 по 30).
+      #
+      # TODO
+      #   1. заменить на групповое обновление, когда его завезут в Dependabot
+      #      https://github.com/dependabot/dependabot-core/issues/1190
+      #   2. удалить соответствующие строки из `./.github/actions/complete_playwright_update`
+      - dependency-name: '@playwright/experimental-ct-react17'
     versioning-strategy: increase
     open-pull-requests-limit: 20
     reviewers:

--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -39,3 +39,61 @@ jobs:
 
       - name: Run Prettier
         run: yarn run lint:prettier
+
+  dependabot_check_need_complete_update:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    name: '[Dependabot] Check if "@playwright/test" or "storybook" update needs to be completed'
+    outputs:
+      value: ${{ steps.result.outputs.value }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+
+      - name: Check is '@playwrgiht/test' or 'storybook'
+        id: result
+        run: echo "value=${{ contains(steps.metadata.outputs.dependency-names, '@playwright/test') || contains(steps.metadata.outputs.dependency-names, 'storybook') }}" >> "$GITHUB_OUTPUT"
+
+  dependabot_complete_update:
+    needs: dependabot_check_need_complete_update
+    if: ${{ fromJSON(needs.dependabot_check_need_complete_update.outputs.value) }}
+    runs-on: ubuntu-latest
+    name: '[Dependabot] Complete "@playwright/test" or "storybook" update'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+
+      - name: Complete Playwright update
+        if: ${{ contains(steps.metadata.outputs.dependency-names, '@playwright/test') }}
+        uses: ./.github/actions/complete_playwright_update
+        with:
+          branch: refs/pull/${{ github.event.pull_request.number }}/merge
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          prev_version: ${{ steps.metadata.outputs.previous-version }}
+          next_version: ${{ steps.metadata.outputs.new-version }}
+
+      - name: Complete Storybook update
+        if: ${{ contains(steps.metadata.outputs.dependency-names, 'storybook') }}
+        uses: ./.github/actions/complete_storybook_update
+        with:
+          branch: refs/pull/${{ github.event.pull_request.number }}/merge
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          prev_version: ${{ steps.metadata.outputs.previous-version }}
+          next_version: ${{ steps.metadata.outputs.new-version }}


### PR DESCRIPTION
## Проблема

1. Dependabot не умеет делать групповое обновление зависимостей Playwright и Storybook. Приходится обновлять их вручную и создавать отдельный PR.
2. Если бы Dependabot и умел делать групповое обновление, то всё-равно для Playwright нужно будет вручную обновлять версии Docker контейнеров.

## Решение

До-обновляем зависимости с помощью GitHub Workflows.

1. В `pull_request_common.yml` создаём джобу, которая проверяет не обновился ли Playwright или Storybook.
2. Если да, то запускаем процесс обновления зависимостей этих библиотек и создаём новый коммит в PR от Dependabot.

Когда Dependabot  ребейзит себе мастер, то `pull_request_common.yml` запускается заново. А это значит, что и джоба по обновлению будет запускаться заново. Риска дублирования коммита быть не должно, т.к. из мастер вряд ли прилетят изменения, которые аффектят операции по обновлению в джобе. `git add` и `git commit` (*) должны будут выполнится впустую.

\* `git diff-index --quiet HEAD || git commit -m ''`