### PR TITLE
Fix Group padding for modal

### DIFF
--- a/packages/vkui/src/components/Group/Group.module.css
+++ b/packages/vkui/src/components/Group/Group.module.css
@@ -53,10 +53,12 @@
 }
 
 @media (--sizeX-regular) {
+  .Group--sizeX-none.Group--inside-modal.Group--padding-s,
   .Group--sizeX-none.Group--mode-none.Group--padding-s {
     padding: 4px;
   }
 
+  .Group--sizeX-none.Group--inside-modal.Group--padding-m,
   .Group--sizeX-none.Group--mode-none.Group--padding-m {
     padding: 8px;
   }

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -101,6 +101,7 @@ export const Group = ({
         className={classNames(
           'vkuiInternalGroup',
           styles['Group'],
+          isInsideModal && styles['Group--inside-modal'],
           platform === Platform.IOS && styles['Group--ios'],
           sizeX !== SizeType.REGULAR && sizeXClassNames[sizeX],
           mode &&


### PR DESCRIPTION
Сломались отступы `Group` в модалках, возвращаем, как было

---

- caused by #5364