### PR TITLE
fix(docs): refactor styleguide layout

### DIFF
--- a/styleguide/Components/Heading/Heading.css
+++ b/styleguide/Components/Heading/Heading.css
@@ -1,14 +1,14 @@
 .Heading--1 {
-  margin-top: 18px;
-  margin-bottom: 6px;
+  padding-top: 18px;
+  padding-bottom: 6px;
 }
 
 .Heading--2 {
-  margin-top: 12px;
-  margin-bottom: 8px;
+  padding-top: 12px;
+  padding-bottom: 8px;
 }
 
 .Heading--3 {
-  margin-top: 14px;
-  margin-bottom: 10px;
+  padding-top: 14px;
+  padding-bottom: 10px;
 }

--- a/styleguide/Components/StyleGuide/StyleGuideDesktop.css
+++ b/styleguide/Components/StyleGuide/StyleGuideDesktop.css
@@ -1,3 +1,7 @@
+.StyleGuideDesktop {
+  height: 100%;
+}
+
 @media (--sizeX-compact) {
   .StyleGuideDesktop {
     display: none;

--- a/styleguide/Components/StyleGuide/StyleGuideDesktop.js
+++ b/styleguide/Components/StyleGuide/StyleGuideDesktop.js
@@ -19,11 +19,26 @@ export const StyleGuideDesktop = ({
         popout={popout}
         modal={<StyleGuideModal activeModal={activeModal} />}
       >
-        <SplitCol minWidth={340} width="30%" maxWidth={480} className="StyleGuide__sidebar">
-          <div className="StyleGuide__sidebarIn">{toc}</div>
+        <SplitCol minWidth={340} width="30%" maxWidth={480} fixed>
+          <div className="StyleGuide__sidebar">
+            <div className="StyleGuide__sidebarIn">{toc}</div>
+          </div>
         </SplitCol>
-        <SplitCol width="100%" className="StyleGuide__content">
-          <div className="StyleGuide__contentIn">{children}</div>
+        <SplitCol
+          width="70%"
+          style={{
+            /**
+             * `min-width` в контексте Flexbox по умолчанию имеет значение `auto`,
+             * из-за чего элементы при переполнении будут выходить за границы контейнера.
+             *
+             * Подробности по ссылке https://stackoverflow.com/a/66689926/2903061
+             */
+            minWidth: 0,
+          }}
+        >
+          <div className="StyleGuide__content">
+            <div className="StyleGuide__contentIn">{children}</div>
+          </div>
         </SplitCol>
       </SplitLayout>
     </div>

--- a/styleguide/Components/StyleGuide/StyleGuideHeader.css
+++ b/styleguide/Components/StyleGuide/StyleGuideHeader.css
@@ -4,6 +4,7 @@
   border-bottom: 1px solid var(--vkui--color_image_border_alpha);
   box-sizing: border-box;
   position: fixed;
+  top: 0;
   left: 0;
   width: 100%;
   z-index: 3;

--- a/styleguide/Components/StyleGuide/StyleGuideRenderer.css
+++ b/styleguide/Components/StyleGuide/StyleGuideRenderer.css
@@ -1,21 +1,18 @@
 .StyleGuide {
-  height: auto;
-  align-items: stretch;
   padding-top: var(--vkui--size_panel_header_height--regular);
-}
-
-.StyleGuide__sidebar,
-.StyleGuide__content {
-  height: auto;
+  max-height: calc(100% - var(--vkui--size_panel_header_height--regular));
 }
 
 .StyleGuide__sidebar {
   display: flex;
   justify-content: flex-end;
   border-right: 1px solid var(--vkui--color_image_border_alpha);
-  background: var(--vkui--color_background_tertiary);
-  position: relative;
-  z-index: 2;
+  background-color: var(--vkui--color_background_tertiary);
+  position: absolute;
+  top: var(--vkui--size_panel_header_height--regular);
+  left: 0;
+  width: 100%;
+  height: calc(100% - var(--vkui--size_panel_header_height--regular));
   box-sizing: border-box;
 }
 
@@ -24,17 +21,12 @@
   padding-right: 16px;
   padding-left: 16px;
   box-sizing: border-box;
-  height: calc(100vh - var(--vkui--size_panel_header_height--regular));
-  position: fixed;
   overflow: auto;
 }
 
 .StyleGuide__content {
-  background: var(--vkui--color_background_content);
-  min-height: calc(100vh - var(--vkui--size_panel_header_height--regular));
-  position: relative;
-  z-index: 1;
-  overflow: hidden;
+  min-height: 100%;
+  background-color: var(--vkui--color_background_content);
 }
 
 .StyleGuide__contentIn {


### PR DESCRIPTION
**Версия:** >= 5

## Проблема

Шапка и сайдбар прыгают при открытии модалки с версиями.

## Воспроизведение

1. Перейти, например, на https://vkcom.github.io/VKUI/5.5.5/#/Button
2. Немного проскролить страницу.
3. Вызвать из шапки модалку со всеми версиями.

<details><summary>Видео</summary>
<p>

https://github.com/VKCOM/VKUI/assets/5850354/5d0c4f5e-43be-4840-9e1a-282500c22d29

</p>
</details> 

## Как решил?

1. Основная причина была в том, что в компонент `SplitCol` для сайдбар
  не передавалось св-во `fixed` – теперь передаётся.
1. После указания `fixed`,  переписал стили под лэйаут документации
  styleguide, чтобы починить скролл. Получилось убрать перебивание VKUI
  стилей, которые нами не приветствуются.
1. У `styleguide/Components/Heading` заменил `margin` на `padding`,
  чтобы исправить проблему со "схлопыванием `margin`".