### PR TITLE
fix(fix-TextTooltip): add `useEventListener` on `wheel` event

### DIFF
--- a/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
+++ b/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
@@ -97,6 +97,7 @@ export const HoverPopper = ({
           {...restProps}
           onMouseOver={hideTimeout.clear}
           onMouseOut={onTargetLeave}
+          onWheel={onTargetWheel}
           getRef={getRef}
           targetRef={childRef}
         >

--- a/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
+++ b/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
@@ -75,11 +75,13 @@ export const HoverPopper = ({
 
   const targetEnterListener = useEventListener('pointerenter', onTargetEnter);
   const targetLeaveListener = useEventListener('pointerleave', onTargetLeave);
+  const targetWheelListener = useEventListener('wheel', onTargetLeave);
 
   useIsomorphicLayoutEffect(() => {
     if (childRef.current) {
       targetEnterListener.add(childRef.current);
       targetLeaveListener.add(childRef.current);
+      targetWheelListener.add(childRef.current);
     }
   }, []);
 

--- a/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
+++ b/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
@@ -73,9 +73,13 @@ export const HoverPopper = ({
     hideTimeout.set();
   };
 
+  const onTargetWheel = () => {
+    setShown(false);
+  };
+
   const targetEnterListener = useEventListener('pointerenter', onTargetEnter);
   const targetLeaveListener = useEventListener('pointerleave', onTargetLeave);
-  const targetWheelListener = useEventListener('wheel', onTargetLeave);
+  const targetWheelListener = useEventListener('wheel', onTargetWheel);
 
   useIsomorphicLayoutEffect(() => {
     if (childRef.current) {

--- a/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
+++ b/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
@@ -74,12 +74,14 @@ export const HoverPopper = ({
   };
 
   const targetEnterListener = useEventListener('pointerenter', onTargetEnter);
-  const targetLeaveListener = useEventListener('mouseleave', onTargetLeave);
+  const targetLeaveListener = useEventListener('pointerleave', onTargetLeave);
+  const targetWheelListener = useEventListener('wheel', onTargetLeave);
 
   useIsomorphicLayoutEffect(() => {
     if (childRef.current) {
       targetEnterListener.add(childRef.current);
       targetLeaveListener.add(childRef.current);
+      targetWheelListener.add(childRef.current);
     }
   }, []);
 

--- a/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
+++ b/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
@@ -74,14 +74,12 @@ export const HoverPopper = ({
   };
 
   const targetEnterListener = useEventListener('pointerenter', onTargetEnter);
-  const targetLeaveListener = useEventListener('pointerleave', onTargetLeave);
-  const targetWheelListener = useEventListener('wheel', onTargetLeave);
+  const targetLeaveListener = useEventListener('mouseleave', onTargetLeave);
 
   useIsomorphicLayoutEffect(() => {
     if (childRef.current) {
       targetEnterListener.add(childRef.current);
       targetLeaveListener.add(childRef.current);
-      targetWheelListener.add(childRef.current);
     }
   }, []);
 


### PR DESCRIPTION
- fixes #5393 

Возможно `pointerleave` вызывается при изменении положения курсора, а при скролле курсор может быть статичен. Обработка ивента `wheel` спасает.

UPD:
Если заменить `pointerleave` на `mouseleave`, то работает как надо и без обработки ивента `wheel`.

UPD: 
Воспроизводится очень нестабильно