### PR TITLE
ci(pull_request_dependabot): use pull_request_target

### DIFF
--- a/.github/workflows/pull_request_dependabot.yml
+++ b/.github/workflows/pull_request_dependabot.yml
@@ -1,7 +1,7 @@
 name: 'Pull Request / Dependabot'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches: [master]
 


### PR DESCRIPTION
При использования события `pull_request`, нет доступа к `secrets.DEVTOOLS_GITHUB_TOKEN` в контексте **Dependabot**.

- caused by #5391