### PR TITLE
ci(pr_dependabot): use correct branch ref

### DIFF
--- a/.github/workflows/pull_request_dependabot.yml
+++ b/.github/workflows/pull_request_dependabot.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -52,7 +54,7 @@ jobs:
         if: ${{ contains(steps.metadata.outputs.dependency-names, '@playwright/test') }}
         uses: ./.github/actions/complete_playwright_update
         with:
-          branch: ${{ github.ref }}
+          branch: ${{ github.head_ref }}
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           prev_version: ${{ steps.metadata.outputs.previous-version }}
           next_version: ${{ steps.metadata.outputs.new-version }}


### PR DESCRIPTION
При использования события `pull_request_target` ссылка `github.ref` соответствует целевой ветке.

Поэтому используем:
- `refs/pull/${{ github.event.pull_request.number }}/merge` для чекаута
- `github.head.ref` для пуша в ветку.
  <img width="320" src="https://github.com/VKCOM/VKUI/assets/5850354/af9b70bf-f286-4d1e-9996-398b90933145" />

- caused by #5413