### PR TITLE
fix(docs): edit header and desktop layout

### DIFF
--- a/styleguide/Components/Heading/Heading.css
+++ b/styleguide/Components/Heading/Heading.css
@@ -1,14 +1,14 @@
 .Heading--1 {
-  padding-top: 18px;
-  padding-bottom: 6px;
+  margin-top: 18px;
+  margin-bottom: 6px;
 }
 
 .Heading--2 {
-  padding-top: 12px;
-  padding-bottom: 8px;
+  margin-top: 12px;
+  margin-bottom: 8px;
 }
 
 .Heading--3 {
-  padding-top: 14px;
-  padding-bottom: 10px;
+  margin-top: 14px;
+  margin-bottom: 10px;
 }

--- a/styleguide/Components/Logo/Logo.js
+++ b/styleguide/Components/Logo/Logo.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export const Logo = () => {
+export const Logo = (props) => {
   return (
-    <svg width="46" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="46" height="24" xmlns="http://www.w3.org/2000/svg" {...props}>
       <path
         d="M0 11.52c0-5.43 0-8.146 1.687-9.833C3.374 0 6.09 0 11.52 0h.96c5.43 0 8.146 0 9.833 1.687C24 3.374 24 6.09 24 11.52v.96c0 5.43
        0 8.146-1.687 9.833C20.626 24 17.91 24 12.48 24h-.96c-5.43 0-8.146 0-9.833-1.687C0 20.626 0 17.91 0 12.48v-.96Z"

--- a/styleguide/Components/StyleGuide/StyleGuideDesktop.js
+++ b/styleguide/Components/StyleGuide/StyleGuideDesktop.js
@@ -19,22 +19,17 @@ export const StyleGuideDesktop = ({
         popout={popout}
         modal={<StyleGuideModal activeModal={activeModal} />}
       >
-        <SplitCol minWidth={340} width="30%" maxWidth={480} fixed>
+        <SplitCol minWidth={340} width="20%" maxWidth={480} fixed>
           <div className="StyleGuide__sidebar">
             <div className="StyleGuide__sidebarIn">{toc}</div>
           </div>
         </SplitCol>
         <SplitCol
-          width="70%"
-          style={{
-            /**
-             * `min-width` в контексте Flexbox по умолчанию имеет значение `auto`,
-             * из-за чего элементы при переполнении будут выходить за границы контейнера.
-             *
-             * Подробности по ссылке https://stackoverflow.com/a/66689926/2903061
-             */
-            minWidth: 0,
-          }}
+          width="80%"
+          // `min-width` в контексте Flexbox по умолчанию имеет значение `auto`, из-за чего элементы
+          // при переполнении будут выходить за границы контейнера.
+          // Подробности по ссылке https://stackoverflow.com/a/66689926/2903061
+          minWidth={0}
         >
           <div className="StyleGuide__content">
             <div className="StyleGuide__contentIn">{children}</div>

--- a/styleguide/Components/StyleGuide/StyleGuideHeader.css
+++ b/styleguide/Components/StyleGuide/StyleGuideHeader.css
@@ -12,49 +12,35 @@
 
 .StyleGuideHeader__left {
   display: flex;
-  justify-content: flex-end;
-}
-
-.StyleGuideHeader__leftIn {
-  width: 340px;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  max-width: 340px;
+  margin-left: auto;
   padding-left: 28px;
   box-sizing: border-box;
-  display: flex;
 }
 
 .StyleGuideHeader__logo {
-  display: flex;
-  align-items: center;
-  text-decoration: none;
   color: var(--vkui--color_text_primary);
-}
-
-.StyleGuideHeader__logo span {
-  position: relative;
-  top: 1px;
-  margin-left: 4px;
 }
 
 .StyleGuideHeader__links {
   display: flex;
-  height: 100%;
   align-items: center;
-  padding-left: 36px;
 }
 
-.StyleGuideHeader__link {
+.StyleGuideHeader__links > * {
   margin-right: 24px;
 }
 
-.StyleGuideHeader__main {
+.StyleGuideHeader__right {
   display: flex;
   justify-content: space-between;
+  height: 100%;
   max-width: 1440px;
+  padding-left: 36px;
   padding-right: 36px;
   box-sizing: border-box;
   align-items: center;
-}
-
-.StyleGuideHeader__scheme {
-  color: var(--vkui--color_icon_secondary);
 }

--- a/styleguide/Components/StyleGuide/StyleGuideHeader.js
+++ b/styleguide/Components/StyleGuide/StyleGuideHeader.js
@@ -46,35 +46,33 @@ export const StyleGuideHeader = ({ switchStyleGuideAppearance }) => {
   return (
     <div className="StyleGuideHeader">
       <SplitLayout>
-        <SplitCol minWidth={340} width="30%" maxWidth={480} className="StyleGuideHeader__left">
-          <div className="StyleGuideHeader__leftIn">
+        <SplitCol minWidth={340} width="20%" maxWidth={480}>
+          <div className="StyleGuideHeader__left">
             <Tappable
-              hasActive={false}
-              hasHover={false}
+              activeMode="opacity"
+              hoverMode="opacity"
               Component="a"
               href="#/About"
-              className="StyleGuideHeader__logo"
+              focusVisibleMode="outside"
             >
-              <Logo />
+              <Logo display="block" className="StyleGuideHeader__logo" />
             </Tappable>
           </div>
         </SplitCol>
-        <SplitCol width="100%" className="StyleGuideHeader__main">
-          <div className="StyleGuideHeader__links">
-            {links.map(({ title, ...props }, i) => (
-              <Link key={i} target="_blank" className="StyleGuideHeader__link" {...props}>
-                <Text>{title}</Text>
-              </Link>
-            ))}
-          </div>
-          <div className="StyleGuideHeader__aside">
-            <IconButton
-              aria-label="Сменить тему"
-              className="StyleGuideHeader__appearance"
-              onClick={switchStyleGuideAppearance}
-            >
-              {appearance === 'dark' ? <Icon28SunOutline /> : <Icon28MoonOutline />}
-            </IconButton>
+        <SplitCol width="80%">
+          <div className="StyleGuideHeader__right">
+            <div className="StyleGuideHeader__links">
+              {links.map(({ title, ...props }, i) => (
+                <Link key={i} target="_blank" {...props}>
+                  <Text>{title}</Text>
+                </Link>
+              ))}
+            </div>
+            <div className="StyleGuideHeader__aside">
+              <IconButton aria-label="Сменить тему" onClick={switchStyleGuideAppearance}>
+                {appearance === 'dark' ? <Icon28SunOutline /> : <Icon28MoonOutline />}
+              </IconButton>
+            </div>
           </div>
         </SplitCol>
       </SplitLayout>

--- a/styleguide/Components/StyleGuide/StyleGuideRenderer.css
+++ b/styleguide/Components/StyleGuide/StyleGuideRenderer.css
@@ -33,4 +33,13 @@
   padding: 0 36px 36px;
   max-width: 1440px;
   box-sizing: border-box;
+
+  /*
+   * Исправляем схлопывание margin-top.
+   *
+   * Пример см. ../Heading/Heading.css.
+  */
+  border-top-width: 0.5px;
+  border-top-style: solid;
+  border-top-color: transparent;
 }


### PR DESCRIPTION
В #5398 пропустили рефактор шапки доки.

Также получилось убрать перебивание VKUI стилей, которые нами
не приветствуются.

## `styleguide/Components/Heading`

Вернул `margin`'ы. А то возникла проблему (см. скрины ниже).

<img width="320" src="https://github.com/VKCOM/VKUI/assets/5850354/ccc37bb2-4566-4e62-a265-85a3e4888d3d" />

_До #5398. ✅ С отступами всё ок._

<img width="320" src="https://github.com/VKCOM/VKUI/assets/5850354/a4cec5e4-44e6-47bc-a8e8-99f04d63ecc0" />

_После #5398. ❌  Появились большие отступы._

Поправил схлопывание через `border-top: 0.5px` на
`StyleGuide__contentIn`.

---

- caused by #5398