### PR TITLE
tech: generate customMedias.generated.css once

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,13 +24,6 @@
    ```
    Это поможет игнорировать коммиты, связанные с изменениями стиля кода. `git blame` будет чище.
 2. Запустить сборку пакета `@vkontakte/vkui`: `yarn build:vkui` или `yarn workspace @vkontakte/vkui build`.
-   > **PostCSS** сгенерирует файл `tmp/customMedias.generated.css`, основанный на
-   > [getCustomMedias()](https://github.com/VKCOM/VKUI/blob/master/shared.js)
-   >
-   > Это поможет IDE подсказать доступные `@custom-media`.
-   >
-   > **Tip.** Если у вас **WebStorm**, то вызовите контекстное меню на папке `tmp/` и выполните
-   > _"Mark directory as" | "Cancel Exclusion"_.
 
 ## Чеклист для компонента
 

--- a/packages/vkui/cssm/postcss.config.js
+++ b/packages/vkui/cssm/postcss.config.js
@@ -4,10 +4,7 @@ const restructureVariable = require('@project-tools/postcss-restructure-variable
 const autoprefixer = require('autoprefixer');
 const postcssCustomMedia = require('postcss-custom-media');
 const cssImport = require('postcss-import');
-const { generateCustomMedias, customMediasPath } = require('../../../postcss.config.js');
-const { VKUI_TOKENS_CSS } = require('../../../shared');
-
-generateCustomMedias();
+const { VKUI_TOKENS_CSS, VKUI_PACKAGE } = require('../../../shared');
 
 module.exports = () => {
   const plugins = [
@@ -16,7 +13,7 @@ module.exports = () => {
       VKUI_TOKENS_CSS.map((pathSegment) => path.join(__dirname, '../../../', pathSegment)),
     ),
     postcssGlobalData({
-      files: [customMediasPath].map((pathSegment) =>
+      files: [VKUI_PACKAGE.PATHS.CSS_CUSTOM_MEDIAS].map((pathSegment) =>
         path.join(__dirname, '../../../', pathSegment),
       ),
     }),

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -54,7 +54,8 @@
     "test:e2e:ci": "playwright test --config playwright-ct.config.ts",
     "test:e2e-update:ci": "yarn run test:e2e:ci --update-snapshots",
     "storybook": "cross-env SANDBOX=\\.storybook storybook dev -p 6006",
-    "storybook:build": "cross-env SANDBOX=\\.storybook FROM_STORYBOOK=1 storybook build"
+    "storybook:build": "cross-env SANDBOX=\\.storybook FROM_STORYBOOK=1 storybook build",
+    "generate:css-custom-medias": "node scripts/generateCSSCustomMedias.js"
   },
   "peerDependencies": {
     "@vkontakte/icons": "^2.41.0",

--- a/packages/vkui/scripts/generateCSSCustomMedias.js
+++ b/packages/vkui/scripts/generateCSSCustomMedias.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const { getCustomMedias, PATHS } = require('../shared.config');
+
+(function main() {
+  console.log('🔄 Processing...');
+
+  const { customMedia } = getCustomMedias();
+  const dataRaw = [];
+
+  dataRaw.push('/* ⚠️ Документ сгенерирован автоматически */');
+  dataRaw.push('/* 📝 Если требуется изменения, то запустите команду `yarn workspace @vkontakte/vkui run generate:css-custom-medias` */'); // prettier-ignore
+  dataRaw.push('');
+  dataRaw.push('/* stylelint-disable */');
+  dataRaw.push(
+    Object.entries(customMedia)
+      .map(([key, value]) => {
+        return ['/* prettier-ignore */', `@custom-media ${key} ${value};`].join('\n');
+      })
+      .join('\n'),
+  );
+  dataRaw.push('');
+
+  const data = dataRaw.join('\n');
+  const fileDir = path.resolve(__dirname, PATHS.CSS_CUSTOM_MEDIAS.replace(PATHS.ROOT_DIR, '../'));
+
+  fs.writeFileSync(fileDir, data, 'utf-8');
+
+  console.log(`✅ ${fileDir}`);
+})();

--- a/packages/vkui/shared.config.js
+++ b/packages/vkui/shared.config.js
@@ -17,7 +17,11 @@ module.exports.URLS = {
 
 /**
  * Возвращает медиа выражения необходимые по дизайн-системе. У ключей синтаксис должен быть как у CSS Custom Properties.
- * <br />
+ *
+ * > ❗️IMPORTANT❗️
+ * > При изменении функции следует вызвать команду `yarn workspace @vkontakte/vkui run generate:css-custom-medias`,
+ * > для обновления CSS файла, и закоммитить изменения.
+ *
  * {@link https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-media}
  */
 const getCustomMedias = () => {
@@ -65,6 +69,7 @@ const JS_MAIN_EXPORT = `${SRC_DIR}/vkui.js`;
 const COMPONENTS_DIR = `${SRC_DIR}/components`;
 const STYLES_DIR = `${SRC_DIR}/styles`;
 const CSS_CONSTANTS = `${STYLES_DIR}/constants.css`;
+const CSS_CUSTOM_MEDIAS = `${STYLES_DIR}/customMedias.generated.css`;
 const TYPES_DIR = `${SRC_DIR}/types`;
 const TEST_UTILS_DIR = `${SRC_DIR}/testing`;
 
@@ -76,6 +81,7 @@ module.exports.PATHS = {
   COMPONENTS_DIR,
   STYLES_DIR,
   CSS_CONSTANTS,
+  CSS_CUSTOM_MEDIAS,
   TYPES_DIR,
   TEST_UTILS_DIR,
 };

--- a/packages/vkui/src/styles/customMedias.generated.css
+++ b/packages/vkui/src/styles/customMedias.generated.css
@@ -1,0 +1,44 @@
+/* ⚠️ Документ сгенерирован автоматически */
+/* 📝 Если требуется изменения, то запустите команду `yarn workspace @vkontakte/vkui run generate:css-custom-medias` */
+
+/* stylelint-disable */
+/* prettier-ignore */
+@custom-media --sizeX-regular (min-width: 768px);
+/* prettier-ignore */
+@custom-media --sizeX-compact (max-width: 767.9px);
+/* prettier-ignore */
+@custom-media --sizeY-compact (pointer: fine) and (min-width: 768px), (max-height: 414.9px);
+/* prettier-ignore */
+@custom-media --sizeY-regular (pointer: coarse) and (min-height: 415px), (pointer: none) and (min-height: 415px), (max-width: 767.9px) and (min-height: 415px);
+/* prettier-ignore */
+@custom-media --hover-has (hover: hover);
+/* prettier-ignore */
+@custom-media --hover-has-not (hover: none);
+/* prettier-ignore */
+@custom-media --pointer-has (pointer: fine);
+/* prettier-ignore */
+@custom-media --pointer-has-not (pointer: coarse), (pointer: none);
+/* prettier-ignore */
+@custom-media --desktop (min-width: 768px) and (pointer: fine), (min-width: 768px) and (min-height: 720px);
+/* prettier-ignore */
+@custom-media --mobile (max-width: 767.9px), (pointer: none) and (max-height: 719.9px), (pointer: coarse) and (max-height: 719.9px);
+/* prettier-ignore */
+@custom-media --viewWidth-desktopPlus (min-width: 1280px);
+/* prettier-ignore */
+@custom-media --viewWidth-tabletPlus (min-width: 1024px);
+/* prettier-ignore */
+@custom-media --viewWidth-tablet (min-width: 1024px) and (max-width: 1279.9px);
+/* prettier-ignore */
+@custom-media --viewWidth-tabletMinus (max-width: 1023.9px);
+/* prettier-ignore */
+@custom-media --viewWidth-smallTabletPlus (min-width: 768px);
+/* prettier-ignore */
+@custom-media --viewWidth-smallTablet (min-width: 768px) and (max-width: 1023.9px);
+/* prettier-ignore */
+@custom-media --viewWidth-smallTabletMinus (max-width: 767.9px);
+/* prettier-ignore */
+@custom-media --viewWidth-mobilePlus (min-width: 320px);
+/* prettier-ignore */
+@custom-media --viewWidth-mobile (min-width: 320px) and (max-width: 767.9px);
+/* prettier-ignore */
+@custom-media --viewWidth-smallMobileMinus (max-width: 319.9px);

--- a/packages/vkui/tsconfig.json
+++ b/packages/vkui/tsconfig.json
@@ -25,7 +25,8 @@
     "*.setup.js",
     ".eslintrc.js",
     "playwright-ct.config.ts",
-    "playwright/index.tsx"
+    "playwright/index.tsx",
+    "scripts/*.js"
   ],
   "files": ["./global.d.ts", "types/env.d.ts"]
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const postcssGlobalData = require('@csstools/postcss-global-data');
 const restructureVariable = require('@project-tools/postcss-restructure-variable');
@@ -8,35 +7,7 @@ const postcssCustomMedia = require('postcss-custom-media');
 const cssCustomProperties = require('postcss-custom-properties');
 const cssImport = require('postcss-import');
 const cssModules = require('postcss-modules');
-const { VKUI_PACKAGE, VKUI_TOKENS_CSS, generateScopedName, getCustomMedias } = require('./shared');
-
-function getSafelyTmpDirPath(rootPath = __dirname) {
-  const tmpDir = path.join(rootPath, 'tmp');
-
-  if (!fs.existsSync(tmpDir)) {
-    fs.mkdirSync(tmpDir);
-  }
-
-  return tmpDir;
-}
-
-const customMediasPath = './tmp/customMedias.generated.css';
-
-function generateCustomMedias() {
-  const { customMedia } = getCustomMedias();
-
-  getSafelyTmpDirPath();
-
-  const data = Object.entries(customMedia)
-    .map(([key, value]) => {
-      return `@custom-media ${key} ${value};`;
-    })
-    .join('\n');
-
-  fs.writeFileSync(path.join(__dirname, customMediasPath), data, { flag: 'w' });
-}
-
-generateCustomMedias();
+const { VKUI_PACKAGE, VKUI_TOKENS_CSS, generateScopedName } = require('./shared');
 
 const IS_VKUI_PACKAGE_BUILD = Boolean(process.env.IS_VKUI_PACKAGE_BUILD);
 
@@ -48,7 +19,7 @@ module.exports = () => {
       files: [
         './node_modules/@vkontakte/vkui-tokens/themes/vkBase/cssVars/declarations/onlyVariables.css',
         VKUI_PACKAGE.PATHS.CSS_CONSTANTS,
-        customMediasPath,
+        VKUI_PACKAGE.PATHS.CSS_CUSTOM_MEDIAS,
       ].map((pathSegment) => path.join(__dirname, pathSegment)),
     }),
     cssCustomProperties({
@@ -91,6 +62,3 @@ module.exports = () => {
 
   return { plugins };
 };
-
-module.exports.generateCustomMedias = generateCustomMedias;
-module.exports.customMediasPath = customMediasPath;

--- a/shared.js
+++ b/shared.js
@@ -1,4 +1,4 @@
-const { VERSION, URLS, PATHS, getCustomMedias } = require('./packages/vkui/shared.config');
+const { VERSION, URLS, PATHS } = require('./packages/vkui/shared.config');
 
 module.exports = {
   VKUI_PACKAGE: {
@@ -16,8 +16,6 @@ module.exports = {
     './node_modules/@vkontakte/vkui-tokens/themes/vkCom/cssVars/declarations/onlyVariablesLocal.css',
     './node_modules/@vkontakte/vkui-tokens/themes/vkComDark/cssVars/declarations/onlyVariablesLocal.css',
   ],
-
-  getCustomMedias,
 
   generateScopedName: (name) => {
     return name.startsWith('vkui') || name === 'mount' ? name : `vkui${name}`;

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { VKUI_PACKAGE, getCustomMedias } = require('./shared');
+const { VKUI_PACKAGE } = require('./shared');
 
 module.exports = {
   extends: ['stylelint-config-standard', '@vkontakte/stylelint-config'],
@@ -66,7 +66,7 @@ module.exports = {
     'csstools/media-use-custom-media': [
       'known',
       {
-        importFrom: getCustomMedias,
+        importFrom: path.join(__dirname, VKUI_PACKAGE.PATHS.CSS_CUSTOM_MEDIAS),
       },
     ],
     // Skip reporting in pprecommit run, highlight in editor


### PR DESCRIPTION
## Проблема

После мажорного обновления плагина postcss-global-data (см. #5412) вернулась проблема с вечной компиляцией dev-сборки styleguide и storybook (см. #5127).

После очередного изучения проблемы выяснилось, что проблема в создании `/tmp/customMedias.generated.css` в `postcss.config.js` ([ссылка на код](https://github.com/VKCOM/VKUI/blob/bb226ff2edbf0b7954fca56e8e181ee575486306/postcss.config.js#L25-L39)).

Из-за того, что `postcss-loader` вызывает `postcss.config.js` для каждого CSS файла, функция создания `/tmp/customMedias.generated.css` вызывается каждый раз. Начиная с версии `postcss-global-data@1.0.2` эта проблема всплыла.

## Решение

Храним сгенерированный `customMedias.generated.css` в Git. И пересобираем при необходимости. Для этого была создана команда:

```sh
yarn workspace @vkontakte/vkui run generate:css-custom-medias
```

В `customMedias.generated.css` добавляется примечание, что файл запрещается модифицировать вручную.