### PR TITLE
Mark e2e workflow as failed on error

### DIFF
--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -56,8 +56,9 @@ jobs:
 
       - name: Run e2e tests for @vkontakte/vkui workspace
         # Почему HOME=/root см. https://github.com/microsoft/playwright/issues/6500
-        run: HOME=/root yarn run test:e2e:ci
-        continue-on-error: true
+        run: |
+          HOME=/root yarn run test:e2e:ci
+          # echo "E2E_TESTS_EXIST_CODE=$?" >> "$GITHUB_ENV"
 
       # TODO Playwright реализовать покрытие
       # - name: Upload coverage to Codecov

--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -58,7 +58,6 @@ jobs:
         # Почему HOME=/root см. https://github.com/microsoft/playwright/issues/6500
         run: |
           HOME=/root yarn run test:e2e:ci
-          # echo "E2E_TESTS_EXIST_CODE=$?" >> "$GITHUB_ENV"
 
       # TODO Playwright реализовать покрытие
       # - name: Upload coverage to Codecov

--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -56,8 +56,7 @@ jobs:
 
       - name: Run e2e tests for @vkontakte/vkui workspace
         # Почему HOME=/root см. https://github.com/microsoft/playwright/issues/6500
-        run: |
-          HOME=/root yarn run test:e2e:ci
+        run: HOME=/root yarn run test:e2e:ci
 
       # TODO Playwright реализовать покрытие
       # - name: Upload coverage to Codecov


### PR DESCRIPTION
Убрал `continue-on-error: true` из e2e workflow. 
С этим параметром не видно, что скриншотные тесты упали, и очень легко упустить этот файкт из виду.

Этот параметр был нужен в прошлом workflow, когда скриншоты сравнивались с master и тесты падали при обновлении скриншотов в рамках PR.

Больше не актуально.
Вот тестовый [PR](https://github.com/VKCOM/VKUI/pull/5457) где e2e тесты упали и workflow помечен как failed.

![Снимок экрана 2023-07-11 в 17 24 10](https://github.com/VKCOM/VKUI/assets/5443359/4bae5f93-fba8-4aa6-a113-c3337758c0b5)

P.S.
В этом PR есть [комментарий](https://github.com/VKCOM/VKUI/pull/5456#issuecomment-1630874866) от github-actions по поводу e2e тестов, но он устаревший, с прошлого состояния PR где тут были изменения в PullToRefresh компонете, с тех пор я форспушнул.