### PR TITLE
ci(pr_dependabot): use head_ref for checkout

### DIFF
--- a/.github/workflows/pull_request_dependabot.yml
+++ b/.github/workflows/pull_request_dependabot.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ github.head_ref }}
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3


### PR DESCRIPTION
Чекаутимся на ветку с PR, чтобы появилась возможность пушить в ветку.

До этого чекаутились на `refs/pull/${{ github.event.pull_request.number }}/merge`, что приводило к ошибке при пуше.

<img width="320" src="https://github.com/VKCOM/VKUI/assets/5850354/ceebd3dc-4902-4600-a764-92cf37ac5ae6" />

_Воссозданная локально ошибка из CI https://github.com/VKCOM/VKUI/pull/5478_

- caused by #5391