### PR TITLE
styleguide: use npm registry for get versions

### DIFF
--- a/styleguide/Components/Modals/Versions.js
+++ b/styleguide/Components/Modals/Versions.js
@@ -2,8 +2,20 @@ import React from 'react';
 import { Div, ModalPage, ModalPageHeader, PanelSpinner, SimpleCell } from '@vkui';
 import { useFetch } from './useFetch';
 
+const MINIMUM_VERSION = '3.12.4';
+
+const filterPrereleaseVersion = (version) => !version.includes('-');
+
 export function Versions({ id }) {
-  const { data, error } = useFetch('https://vkcom.github.io/VKUI/versions.json');
+  const { data: dataRaw, error } = useFetch('https://registry.npmjs.org/@vkontakte/vkui');
+  const data = React.useMemo(() => {
+    if (!dataRaw) {
+      return null;
+    }
+    const allVersions = Object.keys(dataRaw.versions);
+    const fromIndex = allVersions.indexOf(MINIMUM_VERSION);
+    return allVersions.slice(fromIndex).filter(filterPrereleaseVersion).reverse();
+  }, [dataRaw]);
 
   return (
     <ModalPage
@@ -13,8 +25,7 @@ export function Versions({ id }) {
       header={<ModalPageHeader>Версии</ModalPageHeader>}
     >
       {error && <Div>Произошла ошибка</Div>}
-      {!data && <PanelSpinner />}
-      {data &&
+      {data ? (
         data.map((version) => (
           <SimpleCell
             key={version}
@@ -23,7 +34,10 @@ export function Versions({ id }) {
           >
             {version}
           </SimpleCell>
-        ))}
+        ))
+      ) : (
+        <PanelSpinner />
+      )}
     </ModalPage>
   );
 }


### PR DESCRIPTION
Используем https://registry.npmjs.org/@vkontakte/vkui для получения версий, чтобы не обновлять каждый раз https://github.com/VKCOM/VKUI/blob/gh-pages/versions.json.