### PR TITLE
feat(ActionSheet): add default iOS close item

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.e2e-playground.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.e2e-playground.tsx
@@ -12,7 +12,6 @@ import { HasChildren } from '../../types';
 import { ActionSheetItem } from '../ActionSheetItem/ActionSheetItem';
 import { AppRoot } from '../AppRoot/AppRoot';
 import { ActionSheet, type ActionSheetProps } from './ActionSheet';
-import { ActionSheetDefaultIosCloseItem } from './ActionSheetDefaultIosCloseItem';
 
 const AppWrapper = ({ children, ...restProps }: HasChildren) => (
   <AppRoot mode="embedded" scroll="contain" {...restProps}>
@@ -31,7 +30,6 @@ const ActionSheetWrapper = (props: ActionSheetProps) => {
       </button>
       <ActionSheet
         {...props}
-        iosCloseItem={<ActionSheetDefaultIosCloseItem />}
         style={{
           // Перебиваем "absolute", чтобы не задавать фиксированную высоту для тестов под iOS и Android
           position: 'relative',

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.stories.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.stories.tsx
@@ -17,7 +17,6 @@ import { Placeholder } from '../Placeholder/Placeholder';
 import { SplitCol } from '../SplitCol/SplitCol';
 import { SplitLayout } from '../SplitLayout/SplitLayout';
 import { ActionSheet, ActionSheetProps } from './ActionSheet';
-import { ActionSheetDefaultIosCloseItem } from './ActionSheetDefaultIosCloseItem';
 
 const story: Meta<ActionSheetProps> = {
   title: 'Popouts/ActionSheet',
@@ -38,12 +37,7 @@ export const Base: Story = {
     const baseToggleRef = React.useRef(null);
     const [visible, setVisible] = React.useState(true);
     const popout = visible ? (
-      <ActionSheet
-        {...args}
-        onClose={() => setVisible(false)}
-        iosCloseItem={<ActionSheetDefaultIosCloseItem />}
-        toggleRef={baseToggleRef}
-      >
+      <ActionSheet {...args} onClose={() => setVisible(false)} toggleRef={baseToggleRef}>
         {items.map(({ children, ...rest }, index) => (
           <ActionSheetItem autoClose key={index} {...rest}>
             {children}

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -16,13 +16,13 @@ describe('ActionSheet', () => {
   const ActionSheetDesktop = (props: Partial<ActionSheetProps>) => (
     <ConfigProvider platform={Platform.VKCOM}>
       <AdaptivityProvider viewWidth={ViewWidth.DESKTOP} hasPointer>
-        <ActionSheet toggleRef={toggle} onClose={jest.fn()} {...props} iosCloseItem={null} />
+        <ActionSheet toggleRef={toggle} onClose={jest.fn()} {...props} />
       </AdaptivityProvider>
     </ConfigProvider>
   );
   const ActionSheetMobile = (props: Partial<ActionSheetProps>) => (
     <AdaptivityProvider viewWidth={ViewWidth.MOBILE} hasPointer={false}>
-      <ActionSheet toggleRef={toggle} onClose={jest.fn()} {...props} iosCloseItem={null} />
+      <ActionSheet toggleRef={toggle} onClose={jest.fn()} {...props} />
     </AdaptivityProvider>
   );
 

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -9,6 +9,7 @@ import { useScrollLock } from '../AppRoot/ScrollContext';
 import { PopoutWrapper } from '../PopoutWrapper/PopoutWrapper';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { ActionSheetContext, ItemClickHandler } from './ActionSheetContext';
+import { ActionSheetDefaultIosCloseItem } from './ActionSheetDefaultIosCloseItem';
 import { ActionSheetDropdown } from './ActionSheetDropdown';
 import { ActionSheetDropdownDesktop } from './ActionSheetDropdownDesktop';
 import { SharedDropdownProps } from './types';
@@ -24,9 +25,9 @@ export interface ActionSheetProps
    */
   onClose: VoidFunction;
   /**
-   * Только iOS.
+   * Только мобильный iOS.
    */
-  iosCloseItem: React.ReactNode;
+  iosCloseItem?: React.ReactNode;
 }
 
 /**
@@ -115,7 +116,9 @@ export const ActionSheet = ({
           </header>
         )}
         {children}
-        {platform === Platform.IOS && !isDesktop && iosCloseItem}
+        {platform === Platform.IOS &&
+          !isDesktop &&
+          (iosCloseItem ?? <ActionSheetDefaultIosCloseItem />)}
       </DropdownComponent>
     </ActionSheetContext.Provider>
   );

--- a/packages/vkui/src/components/ActionSheet/Readme.md
+++ b/packages/vkui/src/components/ActionSheet/Readme.md
@@ -8,8 +8,7 @@ ActionSheet – имитация [нативного компонента](https
 > **Важно**
 >
 > - Нужно обязательно передать `onClose` для обработки закрытия `ActionSheet` изнутри.
-> - Согласно гайдлайнам Apple, в `ActionSheet` должен быть элемент для закрытия, для этого предусмотрен атрибут `iosCloseItem`.
->   В коде примера ниже можно посмотреть, как добавить такой элемент.
+> - Согласно гайдлайнам Apple, в `ActionSheet` должен быть элемент для закрытия, для этого предусмотрен атрибут `iosCloseItem`. По умолчанию будет использоваться `ActionSheetDefaultIosCloseItem`.
 >   Для Android версии он не нужен.
 
 ```jsx { "props": { "layout": false, "adaptivity": true } }
@@ -26,11 +25,7 @@ const baseTopTargetRef = React.useRef();
 
 const openBase = () =>
   setPopout(
-    <ActionSheet
-      onClose={onClose}
-      iosCloseItem={<ActionSheetDefaultIosCloseItem />}
-      toggleRef={baseTargetRef}
-    >
+    <ActionSheet onClose={onClose} toggleRef={baseTargetRef}>
       <ActionSheetItem autoClose>Сохранить в закладках</ActionSheetItem>
       <ActionSheetItem autoClose>Закрепить запись</ActionSheetItem>
       <ActionSheetItem autoClose>Выключить комментирование</ActionSheetItem>
@@ -43,11 +38,7 @@ const openBase = () =>
 
 const openIcons = () =>
   setPopout(
-    <ActionSheet
-      onClose={onClose}
-      iosCloseItem={<ActionSheetDefaultIosCloseItem />}
-      toggleRef={iconsTargetRef}
-    >
+    <ActionSheet onClose={onClose} toggleRef={iconsTargetRef}>
       <ActionSheetItem
         autoClose
         before={
@@ -104,11 +95,7 @@ const openIcons = () =>
 
 const openSubtitle = () =>
   setPopout(
-    <ActionSheet
-      onClose={onClose}
-      iosCloseItem={<ActionSheetDefaultIosCloseItem />}
-      toggleRef={subtitleTargetRef}
-    >
+    <ActionSheet onClose={onClose} toggleRef={subtitleTargetRef}>
       <ActionSheetItem
         before={
           <AdaptiveIconRenderer
@@ -148,11 +135,7 @@ const openSubtitle = () =>
 
 const openSelectable = () =>
   setPopout(
-    <ActionSheet
-      onClose={onClose}
-      iosCloseItem={<ActionSheetDefaultIosCloseItem />}
-      toggleRef={selectableTargetRef}
-    >
+    <ActionSheet onClose={onClose} toggleRef={selectableTargetRef}>
       <ActionSheetItem
         onChange={onChange}
         checked={filter === 'best'}
@@ -210,7 +193,6 @@ const openTitle = () =>
   setPopout(
     <ActionSheet
       onClose={onClose}
-      iosCloseItem={<ActionSheetDefaultIosCloseItem />}
       header="Вы действительно хотите удалить это видео из Ваших видео?"
       toggleRef={titleTargetRef}
     >
@@ -222,11 +204,7 @@ const openTitle = () =>
 
 const openBaseTop = () =>
   setPopout(
-    <ActionSheet
-      onClose={onClose}
-      iosCloseItem={<ActionSheetDefaultIosCloseItem />}
-      toggleRef={baseTopTargetRef}
-    >
+    <ActionSheet onClose={onClose} toggleRef={baseTopTargetRef}>
       <ActionSheetItem autoClose>Сохранить в закладках</ActionSheetItem>
       <ActionSheetItem autoClose>Закрепить запись</ActionSheetItem>
       <ActionSheetItem autoClose>Выключить комментирование</ActionSheetItem>

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
@@ -34,13 +34,7 @@ const ActionSheetTest = ({
   };
 
   const _actionSheet = (
-    <ActionSheet
-      data-testid="sheet"
-      toggleRef={toggleRef}
-      onClose={_onClose}
-      iosCloseItem={null}
-      {...props}
-    >
+    <ActionSheet data-testid="sheet" toggleRef={toggleRef} onClose={_onClose} {...props}>
       {children}
     </ActionSheet>
   );


### PR DESCRIPTION
Делаем проп `iosCloseItem` необязательным и по дефолту проставляем `ActionSheetDefaultIosCloseItem`, чтобы не нужно было прокидывать вручную. 