### PR TITLE
docs(styleguide): fix configuration

### DIFF
--- a/styleguide/Components/Section/SectionRenderer.js
+++ b/styleguide/Components/Section/SectionRenderer.js
@@ -4,8 +4,18 @@ import SectionHeading from '@rsg-components/SectionHeading';
 import PropTypes from 'prop-types';
 
 export const SectionRenderer = (allProps) => {
-  const { title, name, slug, content, components, sections, depth, description, pagePerSection } =
-    allProps;
+  const {
+    title,
+    name,
+    slug,
+    content,
+    contentTitle,
+    components,
+    sections,
+    depth,
+    description,
+    pagePerSection,
+  } = allProps;
 
   return (
     <section data-testid={`section-${slug}`}>
@@ -17,7 +27,7 @@ export const SectionRenderer = (allProps) => {
           pagePerSection={pagePerSection}
           slotProps={allProps}
         >
-          {title || name}
+          {contentTitle || title || name}
         </SectionHeading>
       )}
       {description && <Markdown text={description} />}
@@ -33,6 +43,7 @@ SectionRenderer.propTypes = {
   description: PropTypes.string,
   slug: PropTypes.string.isRequired,
   content: PropTypes.node,
+  contentTitle: PropTypes.string,
   components: PropTypes.node,
   sections: PropTypes.node,
   isolated: PropTypes.bool,

--- a/styleguide/Components/Section/index.js
+++ b/styleguide/Components/Section/index.js
@@ -2,9 +2,9 @@ import React from 'react';
 import Components from '@rsg-components/Components';
 import { useStyleGuideContext } from '@rsg-components/Context';
 import Examples from '@rsg-components/Examples';
-import SectionRenderer from '@rsg-components/Section/SectionRenderer';
 import Sections from '@rsg-components/Sections';
 import PropTypes from 'prop-types';
+import SectionRenderer from './SectionRenderer';
 
 const Section = ({ section, depth }) => {
   const {

--- a/styleguide/Components/Section/index.js
+++ b/styleguide/Components/Section/index.js
@@ -15,6 +15,7 @@ const Section = ({ section, depth }) => {
     slug,
     filepath,
     content,
+    contentTitle,
     components,
     sections,
     description,
@@ -46,6 +47,7 @@ const Section = ({ section, depth }) => {
       slug={slug}
       filepath={filepath}
       content={contentJsx}
+      contentTitle={contentTitle}
       components={componentsJsx}
       sections={sectionsJsx}
       depth={depth}


### PR DESCRIPTION
## `SectionRenderer`

Не использовался созданный `styleguide/Components/Section/SectionRenderer.js`, а бралась из либы `@rsg-components/*`. Из-за чего для заголовка страницы применялся `name` (текст, который используется как имя страницы), а не `title` (текст, который отображается в слева в меню)

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/6f8d9ce8-95c9-4bab-9d3a-74711c8d1bf6">

_Было_

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/5dcb11ff-93dc-41ba-a354-9a6a2ffc3936">

_Стало_

## `contentTitle`

Заодно добавил новый параметр, который позволит задавать свой заголовок страницы.

Полезно когда хотим отметить принадлежность страницы к какой-либо группе.

<img width="400" src="https://github.com/VKCOM/VKUI/assets/5850354/5ebb224f-e5a5-4ef8-97b1-7a2b9e0b281e">

_Пример из https://github.com/VKCOM/VKUI/pull/5496. Отмечаем, что эта страницы является подразделом._
