### PR TITLE
tech(dependabot): ignore react 18.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       interval: 'weekly'
     allow:
       - dependency-type: 'direct'
+    ignore:
+      # Для разработки v5 фиксируем 17 версию.
+      - dependency-name: 'react*'
+        update-types: ['18.x']
+      # Для разработки v5 фиксируем 17 версию.
+      - dependency-name: '@types/react*'
+        update-types: ['18.x']
     groups:
       react:
         patterns:


### PR DESCRIPTION
Каждую неделю **Dependabot** пытается обновить **React** до 18 версии (например, https://github.com/VKCOM/VKUI/pull/5553). В рамках разработки v5 мы используем 17 версию, поэтому игнорируем 18 версию.