### PR TITLE
fix: postcss-modules use `vkui[local]`

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -17,7 +17,5 @@ module.exports = {
     './node_modules/@vkontakte/vkui-tokens/themes/vkComDark/cssVars/declarations/onlyVariablesLocal.css',
   ],
 
-  generateScopedName: (name) => {
-    return name.startsWith('vkui') || name === 'mount' ? name : `vkui${name}`;
-  },
+  generateScopedName: 'vkui[local]',
 };


### PR DESCRIPTION
Название анимаций в js генерируется с префиксом, а в css могло без. Из-за этого в 5.7.0 не работают переходы между панелями