### PR TITLE
chore: fix dependabot ignore version type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,10 @@ updates:
     ignore:
       # Для разработки v5 фиксируем 17 версию.
       - dependency-name: 'react*'
-        update-types: ['18.x']
+        update-types: ['version-update:semver-major']
       # Для разработки v5 фиксируем 17 версию.
       - dependency-name: '@types/react*'
-        update-types: ['18.x']
+        update-types: ['version-update:semver-major']
     groups:
       react:
         patterns:


### PR DESCRIPTION
- caused by https://github.com/VKCOM/VKUI/pull/5563