### PR TITLE
fix(HorizontalScroll): Show arrows on hover even though element is memorized

### DIFF
--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { HorizontalScroll } from './HorizontalScroll';
 
@@ -24,5 +24,37 @@ describe('HorizontalScroll', () => {
     });
 
     expect(scrollBy).toBeCalledTimes(1);
+  });
+
+  it('calculates and shows arrow on hover', async () => {
+    function mockRef(element: HTMLDivElement) {
+      if (!element) {
+        return;
+      }
+
+      // to make sure we really call the logic that calculates show flag using element properties
+      // we return 0 for first initial render, so, arrow won't be visible,
+      // and on second call, we return value, which will allows us to see arrow on hover.
+      jest
+        .spyOn(element, 'scrollWidth', 'get')
+        .mockImplementationOnce(() => {
+          return 0;
+        })
+        .mockImplementation(() => {
+          return 300;
+        });
+    }
+
+    render(
+      <HorizontalScroll getRef={mockRef} data-testid="horizontal-scroll">
+        <div style={{ width: '800px', height: '50px' }} />
+      </HorizontalScroll>,
+    );
+    // no arrow button on the screen on first render
+    expect(screen.queryByRole('button')).toBeFalsy();
+
+    fireEvent.mouseEnter(screen.getByTestId('horizontal-scroll'));
+
+    await screen.findByRole('button');
   });
 });

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -190,7 +190,7 @@ export const HorizontalScroll = ({
     scrollTo(getScrollPosition);
   }, [getScrollToRight, scrollTo, scrollerRef]);
 
-  const onscroll = React.useCallback(() => {
+  const calculateArrowsVisibility = React.useCallback(() => {
     if (showArrows && hasPointer && scrollerRef.current && !isCustomScrollingRef.current) {
       const scrollElement = scrollerRef.current;
 
@@ -202,13 +202,20 @@ export const HorizontalScroll = ({
     }
   }, [hasPointer, scrollerRef, showArrows]);
 
-  const scrollEvent = useEventListener('scroll', onscroll);
-  React.useEffect(() => {
-    if (scrollerRef.current) {
+  const scrollEvent = useEventListener('scroll', calculateArrowsVisibility);
+  React.useEffect(
+    function addScrollerRefToScrollEvent() {
+      if (!scrollerRef.current) {
+        return noop;
+      }
+
       scrollEvent.add(scrollerRef.current);
-    }
-  }, [scrollEvent, scrollerRef]);
-  React.useEffect(onscroll, [scrollerRef, children, onscroll]);
+      return scrollEvent.remove;
+    },
+    [scrollEvent, scrollerRef],
+  );
+
+  React.useEffect(calculateArrowsVisibility, [calculateArrowsVisibility]);
 
   /**
    * Прокрутка с помощью любого колеса мыши
@@ -222,15 +229,18 @@ export const HorizontalScroll = ({
   );
 
   const wheelEvent = useEventListener('wheel', onwheel);
-  React.useEffect(() => {
-    if (!scrollerRef.current || !scrollOnAnyWheel) {
-      return noop;
-    }
+  React.useEffect(
+    function addScrollerRefToWheelEvent() {
+      if (!scrollerRef.current || !scrollOnAnyWheel) {
+        return noop;
+      }
 
-    wheelEvent.add(scrollerRef.current);
+      wheelEvent.add(scrollerRef.current);
 
-    return wheelEvent.remove;
-  }, [wheelEvent, scrollerRef, scrollOnAnyWheel]);
+      return wheelEvent.remove;
+    },
+    [wheelEvent, scrollerRef, scrollOnAnyWheel],
+  );
 
   return (
     <div
@@ -241,6 +251,7 @@ export const HorizontalScroll = ({
         showArrows === 'always' && styles['HorizontalScroll--withConstArrows'],
         className,
       )}
+      onMouseEnter={calculateArrowsVisibility}
     >
       {showArrows && (hasPointer || hasPointer === undefined) && canScrollLeft && (
         <ScrollArrow

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -215,7 +215,7 @@ export const HorizontalScroll = ({
     [scrollEvent, scrollerRef],
   );
 
-  React.useEffect(calculateArrowsVisibility, [calculateArrowsVisibility]);
+  React.useEffect(calculateArrowsVisibility, [calculateArrowsVisibility, children]);
 
   /**
    * Прокрутка с помощью любого колеса мыши


### PR DESCRIPTION
fixes: #5568 

## Описание
Для рендеринга стрелок наведения мы используем стейт.
Надо или не надо их рендерить мы определяем каждый раз при скролле, чтобы спрятать стрелку вправо, если пользователь доскролил вправо до конца.
Также мы определяем это при первом рендеринге.

Но может быть так, что `HorizontalScroll` был обернут в `useMemo` и отрендерен изначально в компоненте с `display: none`. В таком случае в `useMemo` будет храниться `HorizontalScroll` с состоянием без стрелок, так как он был отрендерен внутри компонента c `display: none` и при вычислении свойства размеров были нулевые . Если родительский компонент поменяет `display` на `block`, то `HorizontalScroll` покажется, но стрелок у него не будет при наведении.

## Решение
Добавить вычисление показа стрелок при наведении (`onMouseEnter`).