### PR TITLE
feature(ActionSheet): add information about close initiator

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -46,8 +46,14 @@ describe('ActionSheet', () => {
       ])('when %s', async (props) => {
         const onCloseHandler = jest.fn();
         const handlers = { onClick: jest.fn(), onChange: jest.fn() };
+
         const { unmount } = render(
-          <ActionSheet onClose={(...args) => onCloseHandler(...args) && unmount()}>
+          <ActionSheet
+            onClose={(...args) => {
+              onCloseHandler(...args);
+              unmount();
+            }}
+          >
             <ActionSheetItem {...props} {...handlers} {...props} data-testid="item" />
           </ActionSheet>,
         );

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -67,9 +67,9 @@ describe('ActionSheet', () => {
         if (!props.autoClose) {
           expect(onCloseHandler).not.toBeCalled();
         } else if (props.autoClose && props.isCancelItem) {
-          expect(onCloseHandler).toBeCalledWith({ closedBy: 'cancelItem' });
+          expect(onCloseHandler).toBeCalledWith({ closedBy: 'cancel-item' });
         } else {
-          props.autoClose && expect(onCloseHandler).toBeCalledWith({ closedBy: 'actionItem' });
+          props.autoClose && expect(onCloseHandler).toBeCalledWith({ closedBy: 'action-item' });
         }
       });
     });

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -42,10 +42,12 @@ describe('ActionSheet', () => {
         { selectable: true },
         { autoClose: true },
         { autoClose: true, selectable: true },
+        { autoClose: true, isCancelItem: true },
       ])('when %s', async (props) => {
+        const onCloseHandler = jest.fn();
         const handlers = { onClick: jest.fn(), onChange: jest.fn() };
         const { unmount } = render(
-          <ActionSheet onClose={() => unmount()}>
+          <ActionSheet onClose={(...args) => onCloseHandler(...args) && unmount()}>
             <ActionSheetItem {...props} {...handlers} {...props} data-testid="item" />
           </ActionSheet>,
         );
@@ -55,6 +57,14 @@ describe('ActionSheet', () => {
         runAllTimers();
         expect(handlers.onClick).toBeCalled();
         props.selectable && expect(handlers.onChange).toBeCalled();
+
+        if (!props.autoClose) {
+          expect(onCloseHandler).not.toBeCalled();
+        } else if (props.autoClose && props.isCancelItem) {
+          expect(onCloseHandler).toBeCalledWith({ closedBy: 'cancelItem' });
+        } else {
+          props.autoClose && expect(onCloseHandler).toBeCalledWith({ closedBy: 'actionItem' });
+        }
       });
     });
 
@@ -84,6 +94,17 @@ describe('ActionSheet', () => {
       userEvent.click(document.body);
       runAllTimers();
       expect(onClose).toBeCalledTimes(1);
+      expect(onClose).toBeCalledWith({ closedBy: 'other' });
+    });
+    it('closes on item click with autoClose', async () => {
+      const onClose = jest.fn();
+      render(<ActionSheetDesktop onClose={onClose} />);
+      await waitForFloatingPosition();
+      runAllTimers();
+      userEvent.click(document.body);
+      runAllTimers();
+      expect(onClose).toBeCalledTimes(1);
+      expect(onClose).toBeCalledWith({ closedBy: 'other' });
     });
     it('calls popupDirection with element', async () => {
       const popupDirection = jest.fn();
@@ -104,6 +125,7 @@ describe('ActionSheet', () => {
       userEvent.click(document.querySelector('.vkuiPopoutWrapper__overlay') as Element);
       runAllTimers();
       expect(onClose).toBeCalledTimes(1);
+      expect(onClose).toBeCalledWith({ closedBy: 'other' });
     });
   });
 });

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -17,7 +17,8 @@ import { SharedDropdownProps } from './types';
 import styles from './ActionSheet.module.css';
 
 const warn = warnOnce('ActionSheet');
-type CloseInitiators = 'actionItem' | 'cancelItem' | 'other';
+type CloseInitiators = 'action-item' | 'cancel-item' | 'other';
+export type ActionSheetOnCloseHandler = (options: { closedBy: CloseInitiators }) => void;
 
 export interface ActionSheetProps
   extends Pick<
@@ -30,7 +31,7 @@ export interface ActionSheetProps
   /**
    * Закрыть попап по клику снаружи.
    */
-  onClose(options: { closedBy: CloseInitiators }): void;
+  onClose: ActionSheetOnCloseHandler;
   /**
    * Только мобильный iOS.
    */
@@ -89,7 +90,7 @@ export const ActionSheet = ({
         immediateAction && immediateAction(event);
         if (autoClose) {
           _action.current = () => action && action(event);
-          setClosingBy(isCancelItem ? 'cancelItem' : 'actionItem');
+          setClosingBy(isCancelItem ? 'cancel-item' : 'action-item');
         } else {
           action && action(event);
         }

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -33,7 +33,7 @@ export interface ActionSheetProps
   /**
    * Закрыть попап по клику снаружи.
    */
-  onClose(options: ActionSheetOnCloseOptions): VoidFunction;
+  onClose(options: ActionSheetOnCloseOptions): void;
   /**
    * Только мобильный iOS.
    */

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -18,7 +18,9 @@ import styles from './ActionSheet.module.css';
 
 const warn = warnOnce('ActionSheet');
 type CloseInitiators = 'action-item' | 'cancel-item' | 'other';
-export type ActionSheetOnCloseHandler = (options: { closedBy: CloseInitiators }) => void;
+export interface ActionSheetOnCloseOptions {
+  closedBy: CloseInitiators;
+}
 
 export interface ActionSheetProps
   extends Pick<
@@ -31,7 +33,7 @@ export interface ActionSheetProps
   /**
    * Закрыть попап по клику снаружи.
    */
-  onClose: ActionSheetOnCloseHandler;
+  onClose(options: ActionSheetOnCloseOptions): VoidFunction;
   /**
    * Только мобильный iOS.
    */

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -17,6 +17,7 @@ import { SharedDropdownProps } from './types';
 import styles from './ActionSheet.module.css';
 
 const warn = warnOnce('ActionSheet');
+type CloseInitiators = 'actionItem' | 'cancelItem' | 'other';
 
 export interface ActionSheetProps
   extends Pick<
@@ -29,7 +30,7 @@ export interface ActionSheetProps
   /**
    * Закрыть попап по клику снаружи.
    */
-  onClose: VoidFunction;
+  onClose(options: { closedBy: CloseInitiators }): void;
   /**
    * Только мобильный iOS.
    */
@@ -52,12 +53,12 @@ export const ActionSheet = ({
   ...restProps
 }: ActionSheetProps) => {
   const platform = usePlatform();
-  const [closing, setClosing] = React.useState(false);
-  const onClose = () => setClosing(true);
+  const [closingBy, setClosingBy] = React.useState<undefined | CloseInitiators>(undefined);
+  const onClose = () => setClosingBy('other');
   const _action = React.useRef(noop);
 
   const afterClose = () => {
-    restProps.onClose();
+    restProps.onClose({ closedBy: closingBy || 'other' });
     _action.current();
     _action.current = noop;
   };
@@ -74,24 +75,25 @@ export const ActionSheet = ({
 
   const fallbackTransitionFinish = useTimeout(afterClose, timeout);
   React.useEffect(() => {
-    if (closing) {
+    if (closingBy) {
       fallbackTransitionFinish.set();
     } else {
       fallbackTransitionFinish.clear();
     }
-  }, [closing, fallbackTransitionFinish]);
+  }, [closingBy, fallbackTransitionFinish]);
 
   const onItemClick = React.useCallback<ItemClickHandler>(
-    (action, immediateAction, autoClose) => (event) => {
-      event.persist();
-      immediateAction && immediateAction(event);
-      if (autoClose) {
-        _action.current = () => action && action(event);
-        setClosing(true);
-      } else {
-        action && action(event);
-      }
-    },
+    ({ action, immediateAction, autoClose, isCancelItem }) =>
+      (event) => {
+        event.persist();
+        immediateAction && immediateAction(event);
+        if (autoClose) {
+          _action.current = () => action && action(event);
+          setClosingBy(isCancelItem ? 'cancelItem' : 'actionItem');
+        } else {
+          action && action(event);
+        }
+      },
     [],
   );
   const contextValue = useObjectMemo({ onItemClick, isDesktop });
@@ -112,7 +114,7 @@ export const ActionSheet = ({
   const actionSheet = (
     <ActionSheetContext.Provider value={contextValue}>
       <DropdownComponent
-        closing={closing}
+        closing={Boolean(closingBy)}
         timeout={timeout}
         {...dropdownProps}
         onClose={onClose}
@@ -143,7 +145,7 @@ export const ActionSheet = ({
 
   return (
     <PopoutWrapper
-      closing={closing}
+      closing={Boolean(closingBy)}
       alignY="bottom"
       className={className}
       style={style}

--- a/packages/vkui/src/components/ActionSheet/ActionSheetContext.ts
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetContext.ts
@@ -2,11 +2,12 @@ import * as React from 'react';
 
 export type ActionType<T> = (event: React.MouseEvent<T>) => void;
 
-export type ItemClickHandler<T extends Element = Element> = (
-  action: ActionType<T> | undefined,
-  immediateAction: ActionType<T> | undefined,
-  autoClose: boolean,
-) => (event: React.MouseEvent) => void;
+export type ItemClickHandler<T extends Element = Element> = (options: {
+  action: ActionType<T> | undefined;
+  immediateAction: ActionType<T> | undefined;
+  autoClose: boolean;
+  isCancelItem: boolean;
+}) => (event: React.MouseEvent) => void;
 
 export type ActionSheetContextType<T extends Element = Element> = {
   onItemClick?: ItemClickHandler<T>;

--- a/packages/vkui/src/components/ActionSheet/ActionSheetDefaultIosCloseItem.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetDefaultIosCloseItem.tsx
@@ -3,7 +3,7 @@ import { ActionSheetItem, ActionSheetItemProps } from '../ActionSheetItem/Action
 
 export const ActionSheetDefaultIosCloseItem = (props: ActionSheetItemProps) => {
   return (
-    <ActionSheetItem autoClose mode="cancel" {...props}>
+    <ActionSheetItem autoClose mode="cancel" isCancelItem {...props}>
       Отмена
     </ActionSheetItem>
   );

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -39,7 +39,8 @@ export interface ActionSheetItemProps
    */
   iconChecked?: React.ReactNode;
   /**
-   * Позволяет отделить ActionItem от CancelItem
+   * Позволяет отделить ActionItem от CancelItem для определении того,
+   * кто вызвал закрытие ActionSheet. Используется в ActionSheet.onClose()
    */
   isCancelItem?: boolean;
 }

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -38,6 +38,10 @@ export interface ActionSheetItemProps
    * Иконка для `checked` режима.
    */
   iconChecked?: React.ReactNode;
+  /**
+   * Позволяет отделить ActionItem от CancelItem
+   */
+  isCancelItem?: boolean;
 }
 
 /**
@@ -61,6 +65,7 @@ const ActionSheetItem = ({
   multiline = false,
   iconChecked: iconCheckedProp,
   className,
+  isCancelItem,
   ...restProps
 }: ActionSheetItemProps) => {
   const platform = usePlatform();
@@ -85,7 +90,16 @@ const ActionSheetItem = ({
     <Tappable
       Component={Component}
       {...restProps}
-      onClick={selectable ? onClick : onItemClick(onClick, onImmediateClick, Boolean(autoClose))}
+      onClick={
+        selectable
+          ? onClick
+          : onItemClick({
+              action: onClick,
+              immediateAction: onImmediateClick,
+              autoClose: Boolean(autoClose),
+              isCancelItem: Boolean(isCancelItem),
+            })
+      }
       activeMode={platform === Platform.IOS ? styles['ActionSheetItem--active'] : undefined}
       className={classNames(
         styles['ActionSheetItem'],
@@ -135,7 +149,12 @@ const ActionSheetItem = ({
             name={name}
             value={value}
             onChange={onChange}
-            onClick={onItemClick(noop, noop, Boolean(autoClose))}
+            onClick={onItemClick({
+              action: noop,
+              immediateAction: noop,
+              autoClose: Boolean(autoClose),
+              isCancelItem: Boolean(isCancelItem),
+            })}
             defaultChecked={defaultChecked}
             checked={checked}
             disabled={restProps.disabled}

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -95,7 +95,7 @@ export type { AlertProps, AlertActionInterface } from './components/Alert/Alert'
 export { ActionSheet } from './components/ActionSheet/ActionSheet';
 export type {
   ActionSheetProps,
-  ActionSheetOnCloseHandler,
+  ActionSheetOnCloseOptions,
 } from './components/ActionSheet/ActionSheet';
 export { ActionSheetItem } from './components/ActionSheetItem/ActionSheetItem';
 export type { ActionSheetItemProps } from './components/ActionSheetItem/ActionSheetItem';

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -93,7 +93,10 @@ export type { PopoutWrapperProps } from './components/PopoutWrapper/PopoutWrappe
 export { Alert } from './components/Alert/Alert';
 export type { AlertProps, AlertActionInterface } from './components/Alert/Alert';
 export { ActionSheet } from './components/ActionSheet/ActionSheet';
-export type { ActionSheetProps } from './components/ActionSheet/ActionSheet';
+export type {
+  ActionSheetProps,
+  ActionSheetOnCloseHandler,
+} from './components/ActionSheet/ActionSheet';
 export { ActionSheetItem } from './components/ActionSheetItem/ActionSheetItem';
 export type { ActionSheetItemProps } from './components/ActionSheetItem/ActionSheetItem';
 export { ActionSheetDefaultIosCloseItem } from './components/ActionSheet/ActionSheetDefaultIosCloseItem';


### PR DESCRIPTION
resolves: #5458

##  Изменения
В `ActionSheet.onClose` добавляем информацию об инициаторе закрытия. Это может быть пункт меню с пропом `autoClose`, может быть кнопка отмены на iOS, может быть клик вне зоны меню или нажатие `Esc`.

Добавляем в `onClose` колбэк объект со свойством `closedBy`, которое имеет одно из значений: `actionItem`, `cancelItem`, `others`. 

В `ActionSheet` нету сильной разницы между пунктом меню `cancel` и  обычным пунктом меню. Оба пункта сделаны с помощью `ActionSheetItem` и разным значением `mode`. Для того чтобы разделить их добавил проп `isCancelItem` проп `ActionSheetItem`.

Хотелось использовать mode=`cancel`, но он скорее для внешнего вида, так как `ActionItem mode='cancel'` может быть частью меню с каким-то значение и просто иметь mode=`cancel` для вида.