### PR TITLE
fix(Avatar/BaseImage): Dispatch load img event if resource is already loaded but onload was not fired

### DIFF
--- a/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
@@ -19,7 +19,8 @@ const ImageBaseTest = (props: ImageBaseProps) => (
 
 const getImageBaseRootEl = () => screen.getByTestId(TEST_LOCATORS.ROOT);
 
-const getImageBaseImgEl = (elParent = getImageBaseRootEl()) => elParent.querySelector('img');
+const getImageBaseImgEl = (elParent = getImageBaseRootEl()) =>
+  elParent.querySelector<HTMLImageElement>('img');
 
 describe(ImageBase, () => {
   baselineComponent(ImageBase);
@@ -55,7 +56,10 @@ describe(ImageBase, () => {
     );
 
     const elImageBase = getImageBaseRootEl();
-    const elImg = getImageBaseImgEl(elImageBase) as HTMLImageElement; // Note: потому что точно знаем, что не null
+    const elImg = getImageBaseImgEl(elImageBase);
+    if (!elImg) {
+      throw new Error('Cannot find img element');
+    }
 
     elImg.onerror = jest.fn(() => {
       // ждём re-render со стороны react
@@ -105,17 +109,18 @@ describe(ImageBase, () => {
     });
   });
 
-  it('calls onLoad prop when image emits laod event', () => {
+  it('calls onLoad prop when image emits load event', () => {
     const onLoadMock = jest.fn();
     render(<ImageBaseTest onLoad={onLoadMock} src="https://image.to.load" />);
 
     expect(onLoadMock).not.toBeCalled();
 
-    const imageBaseElement = getImageBaseRootEl();
-    const imageElement = getImageBaseImgEl(imageBaseElement) as HTMLImageElement;
-    if (imageElement) {
-      fireEvent.load(imageElement);
+    const imageElement = getImageBaseImgEl();
+    if (!imageElement) {
+      throw new Error('Cannot find img element');
     }
+
+    fireEvent.load(imageElement);
 
     expect(onLoadMock).toBeCalledTimes(1);
   });
@@ -140,11 +145,12 @@ describe(ImageBase, () => {
     // make sure onLoad prop is called as is if img elment has 'complete=true'
     expect(onLoadMock).toBeCalledTimes(1);
 
-    const imageBaseElement = getImageBaseRootEl();
-    const imageElement = getImageBaseImgEl(imageBaseElement) as HTMLImageElement;
-    if (imageElement) {
-      fireEvent.load(imageElement);
+    const imageElement = getImageBaseImgEl();
+    if (!imageElement) {
+      throw new Error('Cannot find img element');
     }
+
+    fireEvent.load(imageElement);
 
     // make sure we ignore img.onLoad that is fired for some reason after we manually handled the complete state.
     expect(onLoadMock).toBeCalledTimes(1);

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -102,6 +102,10 @@ export const ImageBase = ({
   }
 
   const handleImageLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+    if (loaded) {
+      return;
+    }
+
     setLoaded(true);
     setFailed(false);
     onLoad?.(event);
@@ -114,13 +118,13 @@ export const ImageBase = ({
   };
 
   const imgRef = useExternRef(getRef);
-  const isMountedRef = React.useRef(false);
+  const isOnLoadStatusCheckedRef = React.useRef(false);
   React.useEffect(
-    function dispatchLoadEventForAlreadyLoadedResource() {
-      if (isMountedRef.current) {
+    function dispatchLoadEventForAlreadyLoadedResourceIfReactInitializedLater() {
+      if (isOnLoadStatusCheckedRef.current) {
         return;
       }
-      isMountedRef.current = true;
+      isOnLoadStatusCheckedRef.current = true;
 
       if (imgRef.current && imgRef.current.complete && !loaded) {
         const event = new Event('load');

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
+import { useExternRef } from '../../hooks/useExternRef';
 import type { HasRef, HasRootRef, LiteralUnion } from '../../types';
 import { ImageBaseBadge, type ImageBaseBadgeProps } from './ImageBaseBadge/ImageBaseBadge';
 import { ImageBaseOverlay, type ImageBaseOverlayProps } from './ImageBaseOverlay/ImageBaseOverlay';
@@ -112,6 +113,23 @@ export const ImageBase = ({
     onError?.(event);
   };
 
+  const imgRef = useExternRef(getRef);
+  const isMountedRef = React.useRef(false);
+  React.useEffect(
+    function dispatchLoadEventForAlreadyLoadedResource() {
+      if (isMountedRef.current) {
+        return;
+      }
+      isMountedRef.current = true;
+
+      if (imgRef.current && imgRef.current.complete && !loaded) {
+        const event = new Event('load');
+        imgRef.current.dispatchEvent(event);
+      }
+    },
+    [imgRef, loaded],
+  );
+
   const sizeClassName = (() => {
     switch (size) {
       case 28:
@@ -147,7 +165,7 @@ export const ImageBase = ({
       >
         {hasSrc && (
           <img
-            ref={getRef}
+            ref={imgRef}
             alt={alt}
             className={styles['ImageBase__img']}
             crossOrigin={crossOrigin}


### PR DESCRIPTION
resolves: #5599 


## Описание
При SSR изображение может загрузится раньше чем скрипт проинициализируется и повесит обработчик события `load` на img.
В таком случае нам обработчик не будет вызван и компонет останется в состоянии как будто изображение не згружено.

## Решение
При маунте компонента проверить не было ли изображение уже загружено через `img.complete`. Если уже было, то вручную вызвать событие `load`, чтобы обработать загрузку изображеня как задумано.