### PR TITLE
fix(PanelHeader): add z-index for visor={false}

### DIFF
--- a/packages/vkui/src/components/PanelHeader/PanelHeader.module.css
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.module.css
@@ -9,10 +9,12 @@
 
 .PanelHeader:not(.PanelHeader--vis):not(.PanelHeader--fixed) {
   height: 0;
+  /* см. https://github.com/VKCOM/VKUI/issues/5571 */
+  z-index: var(--vkui_internal--z_index_panel_header);
 }
 
 .PanelHeader__fixed {
-  z-index: var(--vkui_internal--z_index_panel_header_fixed);
+  z-index: var(--vkui_internal--z_index_panel_header);
 }
 
 .PanelHeader__in {
@@ -238,7 +240,7 @@
  */
 .PanelHeader--vkcom {
   position: relative;
-  z-index: var(--vkui_internal--z_index_panel_header_fixed);
+  z-index: var(--vkui_internal--z_index_panel_header);
 }
 
 .PanelHeader--vkcom.PanelHeader--sizeX-regular:not(:global(.vkuiInternalModalPageHeader__in)):not(

--- a/packages/vkui/src/styles/constants.css
+++ b/packages/vkui/src/styles/constants.css
@@ -37,7 +37,7 @@
   --vkui_internal--z_index_panel_header_context: 4;
   --vkui_internal--z_index_panel_header_fade: 5;
   --vkui_internal--z_index_pull_to_refresh: 9;
-  --vkui_internal--z_index_panel_header_fixed: 10;
+  --vkui_internal--z_index_panel_header: 10;
   --vkui_internal--z_index_split_layout_panel_header: 11;
 
   /* z_index Tappable isolate */


### PR DESCRIPTION
Заодно переименовал `--vkui_internal--z_index_panel_header_fixed` в `--vkui_internal--z_index_panel_header`, т.к.  используется не только для `fixed`.

---

- fix #5571