### PR TITLE
feat(Input): disable controls for type="number"

### DIFF
--- a/packages/vkui/src/components/Input/Input.module.css
+++ b/packages/vkui/src/components/Input/Input.module.css
@@ -28,6 +28,20 @@
   background: transparent;
 }
 
+/*
+ * Отключаем нативные элементы для <input type="number" />
+ *
+ * см. https://www.w3schools.com/howto/howto_css_hide_arrow_number.asp
+ */
+.Input__el::-webkit-outer-spin-button,
+.Input__el::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.Input__el[type='number'] {
+  -moz-appearance: textfield;
+}
+
 .Input--sizeY-compact .Input__el {
   height: var(--vkui--size_field_height--compact);
 }


### PR DESCRIPTION
Отключаем нативные элементы для `<input type="number" />` при передаче `type="number"` в [Input](https://vkcom.github.io/VKUI/5.7.1/#/Input).

Иначе приходится использовать кастомный `<input type="number" />` внутри [FormField](https://vkcom.github.io/VKUI/5.7.1/#/FormField) и сбрасывать ему стили.