### PR TITLE
fix(Group): Show only separator--separator (not space) in the separator force mode

### DIFF
--- a/packages/vkui/src/components/Group/Group.module.css
+++ b/packages/vkui/src/components/Group/Group.module.css
@@ -33,7 +33,7 @@
   display: none;
 }
 
-.Group:last-of-type ~ .Group__separator--force,
+.Group:last-of-type ~ .Group__separator--force.Group__separator--separator,
 .Group--mode-card:last-of-type + .Group__separator--spacing {
   display: block;
 }

--- a/packages/vkui/src/components/Group/Group.module.css
+++ b/packages/vkui/src/components/Group/Group.module.css
@@ -33,7 +33,7 @@
   display: none;
 }
 
-.Group:last-of-type ~ .Group__separator--force.Group__separator--separator,
+.Group:last-of-type ~ .Group__separator--force,
 .Group--mode-card:last-of-type + .Group__separator--spacing {
   display: block;
 }

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -87,11 +87,6 @@ export const Group = ({
 
   const tabIndex = isTabPanel && tabIndexProp === undefined ? 0 : tabIndexProp;
 
-  const separatorClassName = classNames(
-    styles['Group__separator'],
-    separator === 'show' && styles['Group__separator--force'],
-  );
-
   return (
     <>
       <section
@@ -127,11 +122,15 @@ export const Group = ({
       {separator !== 'hide' && (
         <React.Fragment>
           <Spacing
-            className={classNames(separatorClassName, styles['Group__separator--spacing'])}
+            className={classNames(styles['Group__separator'], styles['Group__separator--spacing'])}
             size={16}
           />
           <Separator
-            className={classNames(separatorClassName, styles['Group__separator--separator'])}
+            className={classNames(
+              styles['Group__separator'],
+              styles['Group__separator--separator'],
+              separator === 'show' && styles['Group__separator--force'],
+            )}
           />
         </React.Fragment>
       )}


### PR DESCRIPTION
fixes: #5603

Так как в `separator="force"` мы добавляли класс `Group__separator--force` и для компонента `Spacing` и для компонента `Separator` то оба компонента могут быть видны ( а значит слишком большой отступ добавляется после Group), если Group последний своего типа в родителе.
Нам же надо, чтобы видно было только `Separator`.

Поэтому добавляем модификатор только этому компоненту.