### PR TITLE
ci(e2e): use playwright shard feature

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,5 @@ target/
 fixture/
 storybook-static/
 playwright-report/
+blob-report/
+all-blob-reports/

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -102,6 +102,9 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+
       - name: Download Playwright blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -88,6 +88,37 @@ jobs:
     with:
       ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
+  test_e2e_prepare_report:
+    needs: test_e2e
+    name: Prepare e2e's HTML report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+
+      - name: Download Playwright blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: all-blob-reports
+          path: all-blob-reports
+
+      - name: Merge Playwright blob reports into HTML Report
+        run: yarn run playwright:cmd:merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload Playwright HTML report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 1
+
   analyze_bundle_size:
     if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
     needs: changed_files
@@ -126,7 +157,7 @@ jobs:
       - changed_files
       - linters
       - test
-      - test_e2e
+      - test_e2e_prepare_report
     runs-on: ubuntu-latest
     name: Report CI results
     steps:
@@ -140,16 +171,12 @@ jobs:
         with:
           name: test-output
 
-      - name: Download Playwright blob reports from GitHub Actions Artifacts
-        # см. [Примечание 1]
+      - name: Download Playwright HTML report from GitHub Actions Artifacts
         if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
         uses: actions/download-artifact@v3
         with:
-          name: all-blob-reports
-          path: all-blob-reports
-
-      - name: Merge Playwright blob reports into HTML Report
-        run: yarn run playwright:cmd:merge-reports --reporter html ./all-blob-reports
+          name: playwright-report
+          path: playwright-report
 
       - name: Upload Playwright Report
         if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report
-          retention-days: 1
+          retention-days: 30
 
   analyze_bundle_size:
     if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -140,13 +140,16 @@ jobs:
         with:
           name: test-output
 
-      - name: Download Playwright Report artifact
+      - name: Download Playwright blob reports from GitHub Actions Artifacts
         # см. [Примечание 1]
         if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
         uses: actions/download-artifact@v3
         with:
-          name: playwright-report
-          path: playwright-report/
+          name: all-blob-reports
+          path: all-blob-reports
+
+      - name: Merge Playwright blob reports into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
 
       - name: Upload Playwright Report
         if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -149,7 +149,7 @@ jobs:
           path: all-blob-reports
 
       - name: Merge Playwright blob reports into HTML Report
-        run: npx playwright merge-reports --reporter html ./all-blob-reports
+        run: yarn run playwright:cmd:merge-reports --reporter html ./all-blob-reports
 
       - name: Upload Playwright Report
         if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}

--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -16,7 +16,12 @@ jobs:
       # см. https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.focal
       image: mcr.microsoft.com/playwright:v1.37.0-focal
       options: --ipc=host
-    name: Run visual (aka e2e) tests
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shardTotal: [10]
+    name: 'Run e2e tests for (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -54,32 +59,29 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
 
+      - name: Restore cached Playwright build
+        id: cache_playwright_build_restore
+        uses: actions/cache/restore@v3
+        with:
+          path: packages/vkui/playwright/.cache
+          key: playwright-build-cache-${{ github.event.pull_request.number }}-${{ github.run_id }}-${{ github.sha }}
+          restore-keys: playwright-build-cache-${{ github.event.pull_request.number }}-
+
       - name: Run e2e tests for @vkontakte/vkui workspace
         # Почему HOME=/root см. https://github.com/microsoft/playwright/issues/6500
-        run: HOME=/root yarn run test:e2e:ci
+        run: HOME=/root yarn run test:e2e:ci --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-      # TODO Playwright реализовать покрытие
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     flags: e2e-${{ matrix.browser }}-${{ matrix.platform }}-${{ matrix.appearance }}
-      #     files: .nyc_output/coverage.json
-      #     fail_ci_if_error: true
-
-      - name: Upload test artifact
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Save Playwright build cache
+        id: playwright-build-cache
+        uses: actions/cache/save@v3
         with:
-          name: e2e-output
-          path: |
-            packages/vkui/__diff_output__/
-            packages/vkui/e2e-results.json
+          path: packages/vkui/playwright/.cache
+          key: ${{ steps.cache_playwright_build_restore.outputs.cache-primary-key }}
 
-      - name: Upload Playwright HTML report
-        uses: actions/upload-artifact@v3
+      - name: Upload Playwright blob report to GitHub Actions Artifacts
         if: always()
+        uses: actions/upload-artifact@v3
         with:
-          name: playwright-report
-          path: packages/vkui/playwright-report/
-          retention-days: 30
+          name: all-blob-reports
+          path: packages/vkui/blob-report
+          retention-days: 1

--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -59,24 +59,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
 
-      - name: Restore cached Playwright build
-        id: cache_playwright_build_restore
-        uses: actions/cache/restore@v3
-        with:
-          path: packages/vkui/playwright/.cache
-          key: playwright-build-cache-${{ github.event.pull_request.number }}-${{ github.run_id }}-${{ github.sha }}
-          restore-keys: playwright-build-cache-${{ github.event.pull_request.number }}-
-
       - name: Run e2e tests for @vkontakte/vkui workspace
         # Почему HOME=/root см. https://github.com/microsoft/playwright/issues/6500
         run: HOME=/root yarn run test:e2e:ci --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-
-      - name: Save Playwright build cache
-        id: playwright-build-cache
-        uses: actions/cache/save@v3
-        with:
-          path: packages/vkui/playwright/.cache
-          key: ${{ steps.cache_playwright_build_restore.outputs.cache-primary-key }}
 
       - name: Upload Playwright blob report to GitHub Actions Artifacts
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ lint-results.json
 e2e-results.json
 yarn-error.log
 playwright-report/
+blob-report/
+all-blob-reports/
 
 # Caches
 .cache

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,5 @@ target/
 fixture/
 storybook-static/
 playwright-report/
+blob-report/
+all-blob-reports/

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "prepare": "husky install",
     "pre-commit": "lint-staged",
     "playwright:install": "playwright install --with-deps",
+    "playwright:cmd:merge-reports": "playwright merge-reports",
     "codesandbox:install": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install",
     "deduplicate": "yarn-deduplicate --list && yarn-deduplicate --fail"
   },

--- a/packages/vkui/playwright-ct.config.ts
+++ b/packages/vkui/playwright-ct.config.ts
@@ -22,10 +22,7 @@ const TS_CONFIG_ALIASES = Object.entries(tsconfig.compilerOptions.paths).reduce<
   return aliases;
 }, {});
 
-const DEFAULT_REPORTERS: ReporterDescription[] = [
-  ['html', { open: 'never' }],
-  ['json', { outputFile: 'e2e-results.json' }],
-];
+const DEFAULT_REPORTERS: ReporterDescription[] = [['json', { outputFile: 'e2e-results.json' }]];
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -56,16 +53,18 @@ export default defineConfig<VKUITestOptions>({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: 0,
+  /* Limit the number of failures on CI to save resources. */
+  maxFailures: process.env.CI ? 10 : undefined,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI
-    ? 4
+    ? 1
     : typeof process.env.PLAYWRIGHT_WORKERS === 'string'
     ? Number(process.env.PLAYWRIGHT_WORKERS)
     : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
-    ? [['github'], ['dot'], ...DEFAULT_REPORTERS]
-    : [['list'], ...DEFAULT_REPORTERS],
+    ? [['github'], ['dot'], ['blob'], ...DEFAULT_REPORTERS]
+    : [['list'], ['html', { open: 'never' }], ...DEFAULT_REPORTERS],
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {


### PR DESCRIPTION
Изменения в `reusable_workflow_test_e2e.yml`:
- Используем `strategy.matrix` и `--shard` для распараллеливания джоб.
- Объединяем отчёты через `npx playwright merge-reports` см. https://playwright.dev/docs/test-sharding#github-actions-example
- Удалили загрузку артефакта `e2e-output` за ненадобностью.
- Удалили `TODO Playwright реализовать покрытие`, т.к. покрытие мы уже собираем jest'ом.

Изменения в `playwright-ct.config.ts`:
- Так как в CI мы распараллеливаем тесты через `--shard`, то ставим `workers` на 1.
- Пробуем выставить `maxFailures: 10` в CI, чтобы в лишний раз не гонять все тесты, если 10 из них упали.
- Используем для CI blob для отчёта, чтобы потом можно было смержить.

## Результат

Стало в ~3.5 раза быстрее 🎉 

<img width="498" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/147e81ff-3463-4404-b219-fa4b2d27db55">

_До изменений_

<img width="498" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/2f94742a-1bb2-4d0f-b8d6-cb739e90cedf">

_После изменений_


## Нюанс про кэширование сборки перед запуском теста

Пробовал использовать `@actions/cache` для кеширования `playwright/.cache`, но из-за того, что все тесты идут практически параллельно, этот кэш не успевает создаться.

В будущем можно попробовать создать предварительный шаг, в котором будет создан `playwright/.cache` и закэширован через `@actions/cache`. Сейчас у Playwright нет команды, которая позволила бы только собрать сборку для создания `playwright/.cache`.

---

- close #5306
- related to #5308