### PR TITLE
ci(pr_close): add workflow_dispatch

### DIFF
--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -3,6 +3,12 @@ name: 'Close Pull Request'
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: 'Number of PR'
+        type: number
+        required: true
 
 jobs:
   undeploy_s3:
@@ -17,7 +23,7 @@ jobs:
           awsBucket: vkui-screenshot
           awsEndpoint: https://hb.bizmrg.com
           command: delete
-          commandDeletePrefix: pull/${{ github.event.pull_request.number }}
+          commandDeletePrefix: pull/${{ inputs.pull_request_number || github.event.pull_request.number }}
 
   patch:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'patch')


### PR DESCRIPTION
При закрытии PR через воркфлоу [inactive_contributions.yml](https://github.com/VKCOM/VKUI/blob/master/.github/workflows/inactive_contributions.yml), не вызывается событие `closed`. Тем самым не очищается S3 от артефактов (stylegude, storybook, playwrgiht) загруженных в рамках PR.

Для таких случаев вызываем воркфлоу вручную.

Можно завязаться на `pull_request_target`, но мы недавно отказались от этого события в связи с рисками pwn-атак (см. https://github.com/orgs/community/discussions/26657).