### PR TITLE
fix(ConfigProvider): do not remove token class from body if it is in use by another app

### DIFF
--- a/packages/vkui/global.d.ts
+++ b/packages/vkui/global.d.ts
@@ -29,6 +29,10 @@ interface Object {
   hasOwnProperty<T>(this: T, v: PropertyKey): v is keyof T;
 }
 
-interface Window {
+interface VKUIPrivateGlobalInterface {
+  __VKUI__: { globalTokensClassNameUsage: Record<string, number> };
+}
+
+interface Window extends VKUIPrivateGlobalInterface {
   __isVkuiTesting: boolean;
 }

--- a/packages/vkui/global.d.ts
+++ b/packages/vkui/global.d.ts
@@ -33,6 +33,6 @@ interface VKUIPrivateGlobalInterface {
   __VKUI__: { globalTokensClassNameUsage: Record<string, number> };
 }
 
-interface Window extends VKUIPrivateGlobalInterface {
+interface Window extends Partial<VKUIPrivateGlobalInterface> {
   __isVkuiTesting: boolean;
 }

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -29,10 +29,27 @@ describe('ConfigProvider', () => {
       });
       return null;
     };
-    render(
+    const { unmount } = render(
       <ConfigProvider {...config}>
         <ConfigUser />
       </ConfigProvider>,
+    );
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: {
+          'vkui--vkBase--light': 1,
+        },
+      }),
+    );
+
+    unmount();
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: {
+          'vkui--vkBase--light': 0,
+        },
+      }),
     );
   });
   describe('inherits properties from parent ConfigProvider context', () => {

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -1,6 +1,7 @@
-import React, { useContext } from 'react';
-import { render } from '@testing-library/react';
+import React, { useContext, useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Appearance } from '../../helpers/appearance';
+import { generateVKUITokensClassName } from '../../helpers/generateVKUITokensClassName';
 import { Platform } from '../../lib/platform';
 import { baselineComponent } from '../../testing/utils';
 import { ConfigProvider } from './ConfigProvider';
@@ -12,6 +13,12 @@ import {
 
 describe('ConfigProvider', () => {
   baselineComponent<any>(ConfigProvider, { forward: false, a11y: false });
+  beforeAll(() => {
+    window.__VKUI__ = undefined;
+  });
+  afterEach(() => {
+    window.__VKUI__ = undefined;
+  });
   it('provides config context', () => {
     const config = {
       appearance: Appearance.LIGHT,
@@ -86,5 +93,116 @@ describe('ConfigProvider', () => {
 
       expect(config).toEqual(expect.objectContaining({ ...defaultConfig, [prop]: value }));
     });
+  });
+
+  it('adds VKUITokenClassName to document.body on mount and removed on unmount', async () => {
+    const config = { appearance: Appearance.LIGHT, platform: Platform.VKCOM };
+    const ConfigUser = () => {
+      return null;
+    };
+    const { unmount } = render(
+      <ConfigProvider {...config}>
+        <ConfigUser />
+      </ConfigProvider>,
+    );
+
+    const vkuiBodySelector = generateVKUITokensClassName(config.platform, config.appearance);
+    // class name usage of ConfigProvider represents in the window.__VKUI__
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: {
+          [vkuiBodySelector]: 1,
+        },
+      }),
+    );
+
+    expect(document.querySelector(`body.${vkuiBodySelector}`)).toBeTruthy();
+
+    unmount();
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: {
+          [vkuiBodySelector]: 0,
+        },
+      }),
+    );
+    // removed on unmount
+    expect(document.querySelector(`body.${vkuiBodySelector}`)).toBeFalsy();
+  });
+
+  it('adds VKUITokenClassName to document.body on mount and not removes if child ConfigProvider is unmounted', async () => {
+    const config = { appearance: Appearance.LIGHT, platform: Platform.VKCOM };
+    const ConfigUser = () => {
+      return <div>User config</div>;
+    };
+
+    const ConfigUserWithOwnProvider = () => {
+      return (
+        <ConfigProvider {...config}>
+          <ConfigUser />
+        </ConfigProvider>
+      );
+    };
+
+    const TestComponent = () => {
+      const [isMounted, setIsMounted] = useState(true);
+
+      return (
+        <ConfigProvider {...config}>
+          <div>
+            <button onClick={() => setIsMounted(false)}>Unmount child context</button>
+            {isMounted && <ConfigUserWithOwnProvider />}
+          </div>
+        </ConfigProvider>
+      );
+    };
+
+    const { unmount, rerender } = render(<TestComponent />);
+
+    const vkuiBodySelector = generateVKUITokensClassName(config.platform, config.appearance);
+    rerender(<TestComponent />);
+
+    // class name usage of two ConfigProvider represents in the window.__VKUI__
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: {
+          [vkuiBodySelector]: 2,
+        },
+      }),
+    );
+
+    // class name is applied to body
+    expect(document.querySelector(`body.${vkuiBodySelector}`)).toBeTruthy();
+
+    // unmount child ConfigProvider
+    fireEvent.click(screen.getByRole('button'));
+
+    // class name usage counter is decreased in the window.__VKUI__
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: {
+          [vkuiBodySelector]: 1,
+        },
+      }),
+    );
+
+    // class from body is not removed on unmount of child context
+    expect(document.querySelector(`body.${vkuiBodySelector}`)).toBeTruthy();
+
+    // unmount parent context as well
+    unmount();
+
+    // class name usage counter is decreased in the window.__VKUI__
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: {
+          [vkuiBodySelector]: 0,
+        },
+      }),
+    );
+
+    // when last context that is using this class is unmounted the class is removed from body
+    expect(document.querySelector(`body.${vkuiBodySelector}`)).toBeFalsy();
   });
 });

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
@@ -6,6 +6,7 @@ import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { useDOM } from '../../lib/dom';
 import { TokensClassProvider } from '../../lib/tokensClassProvider';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { VKUIGlobalTokensClassNameUsage } from '../../lib/vkuiGlobalTokensClassNameUsage';
 import {
   ConfigProviderContext,
   ConfigProviderContextInterface,
@@ -39,17 +40,22 @@ export const ConfigProvider = (props: ConfigProviderProps) => {
 
   const appearance = useAutoDetectAppearance(appearanceProp, onDetectAppearanceByBridge);
 
-  const { document } = useDOM();
+  const { document, window } = useDOM();
 
   useIsomorphicLayoutEffect(() => {
     const VKUITokensClassName = generateVKUITokensClassName(platform, appearance);
+    const tokensClassNameUsage = new VKUIGlobalTokensClassNameUsage(window, VKUITokensClassName);
 
     // eslint-disable-next-line no-restricted-properties
     document!.body.classList.add(VKUITokensClassName);
+    tokensClassNameUsage.incrementUsageNumber();
 
     return () => {
-      // eslint-disable-next-line no-restricted-properties
-      document!.body.classList.remove(VKUITokensClassName);
+      tokensClassNameUsage.decrementUsageNumber();
+      if (!tokensClassNameUsage.isInUse()) {
+        // eslint-disable-next-line no-restricted-properties
+        document!.body.classList.remove(VKUITokensClassName);
+      }
     };
   }, [platform, appearance]);
 

--- a/packages/vkui/src/lib/vkuiGlobalTokensClassNameUsage.test.ts
+++ b/packages/vkui/src/lib/vkuiGlobalTokensClassNameUsage.test.ts
@@ -1,0 +1,223 @@
+import { VKUIGlobalTokensClassNameUsage } from './vkuiGlobalTokensClassNameUsage';
+
+describe('VKUIGlobalTokensClassNameUsage', () => {
+  beforeAll(() => (window.__VKUI__ = undefined));
+  afterEach(() => (window.__VKUI__ = undefined));
+
+  test('does not throw if window is undefined', () => {
+    expect(() => {
+      const className = 'vkui--vkBase--light';
+      new VKUIGlobalTokensClassNameUsage(undefined, className);
+    }).not.toThrowError();
+  });
+
+  test("creates window.__VKUI__ if it doesn't exist", () => {
+    window.__VKUI__ = undefined;
+
+    const className = 'vkui--vkBase--light';
+
+    expect(window.__VKUI__).toBeUndefined();
+    expect(window.__VKUI__).not.toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: { [className]: 0 },
+      }),
+    );
+
+    new VKUIGlobalTokensClassNameUsage(window, className);
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: { [className]: 0 },
+      }),
+    );
+  });
+  test("creates window.__VKUI__.globalTokensClassNameUsage if it doesn't exist", () => {
+    window.__VKUI__ = {} as any;
+
+    const className = 'vkui--vkBase--light';
+
+    expect(window.__VKUI__).toBeDefined();
+    expect(window.__VKUI__).not.toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: { [className]: 0 },
+      }),
+    );
+
+    new VKUIGlobalTokensClassNameUsage(window, className);
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        globalTokensClassNameUsage: { [className]: 0 },
+      }),
+    );
+  });
+
+  test("doesn't override existing window.__VKUI__", () => {
+    window.__VKUI__ = { isTesting: true } as any;
+
+    const className = 'vkui--vkBase--light';
+
+    expect(window.__VKUI__).toBeDefined();
+    expect(window.__VKUI__).not.toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { [className]: 0 },
+      }),
+    );
+
+    new VKUIGlobalTokensClassNameUsage(window, className);
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { [className]: 0 },
+      }),
+    );
+  });
+
+  test("doesn't override existing window.__VKUI__.globalTokensClassNameUsage", () => {
+    const className = 'vkui--vkBase--light';
+
+    window.__VKUI__ = {
+      isTesting: true,
+      globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 2 },
+    } as any;
+
+    expect(window.__VKUI__).toBeDefined();
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 2 },
+      }),
+    );
+
+    new VKUIGlobalTokensClassNameUsage(window, className);
+
+    // global object is not changed
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 2 },
+      }),
+    );
+  });
+
+  test("doesn't override existing window.__VKUI__.globalTokensClassNameUsage", () => {
+    const className = 'vkui--vkBase--light';
+
+    window.__VKUI__ = {
+      isTesting: true,
+      globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 2 },
+    } as any;
+
+    expect(window.__VKUI__).toBeDefined();
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 2 },
+      }),
+    );
+
+    new VKUIGlobalTokensClassNameUsage(window, className);
+
+    // global object is not changed
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 2 },
+      }),
+    );
+  });
+
+  test('properly updates window.__VKUI__.globalTokensClassNameUsage', () => {
+    const className = 'vkui--vkBase--light';
+
+    window.__VKUI__ = {
+      isTesting: true,
+      // checking that only className defined in the constructor is going to be updated and existing
+      // token className usage number will stay untouched
+      globalTokensClassNameUsage: { 'vkui--vkCom--light': 0 },
+    } as any;
+
+    expect(window.__VKUI__).toBeDefined();
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0 },
+      }),
+    );
+
+    const globalTokensClassNameUsage = new VKUIGlobalTokensClassNameUsage(window, className);
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 0 },
+      }),
+    );
+
+    expect(globalTokensClassNameUsage.isInUse()).toBeFalsy();
+
+    // increments
+    globalTokensClassNameUsage.incrementUsageNumber();
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 1 },
+      }),
+    );
+
+    expect(globalTokensClassNameUsage.isInUse()).toBeTruthy();
+
+    // increments
+    globalTokensClassNameUsage.incrementUsageNumber();
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 2 },
+      }),
+    );
+
+    expect(globalTokensClassNameUsage.isInUse()).toBeTruthy();
+
+    // decrements
+    globalTokensClassNameUsage.decrementUsageNumber();
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 1 },
+      }),
+    );
+
+    expect(globalTokensClassNameUsage.isInUse()).toBeTruthy();
+
+    // decrements
+    globalTokensClassNameUsage.decrementUsageNumber();
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 0 },
+      }),
+    );
+
+    expect(globalTokensClassNameUsage.isInUse()).toBeFalsy();
+
+    // decrements
+    globalTokensClassNameUsage.decrementUsageNumber();
+
+    expect(window.__VKUI__).toEqual(
+      expect.objectContaining({
+        isTesting: true,
+        // usage number should't go below 0
+        globalTokensClassNameUsage: { 'vkui--vkCom--light': 0, [className]: 0 },
+      }),
+    );
+
+    // should be treated as not in use
+    expect(globalTokensClassNameUsage.isInUse()).toBeFalsy();
+  });
+});

--- a/packages/vkui/src/lib/vkuiGlobalTokensClassNameUsage.ts
+++ b/packages/vkui/src/lib/vkuiGlobalTokensClassNameUsage.ts
@@ -1,9 +1,20 @@
+/*
+ * Специальная обертка для работы с window и глобальной переменной __VKUI__.
+ *
+ * Необходима для подсчёта колличества VKUI приложений
+ * которые используют одинаковый className на body.
+ * Необходима для того, чтобы приложения,
+ * при размотировании не удаляли класс, небходимый для токенов, с body,
+ * если этот класс ещё используется другими приложениями.
+ *
+ * см. https://github.com/VKCOM/VKUI/issues/5518
+ * */
 export class VKUIGlobalTokensClassNameUsage {
-  public window: VKUIPrivateGlobalInterface;
-  public className: string;
+  private readonly window: VKUIPrivateGlobalInterface;
+  private className: string;
 
   constructor(window: Window | undefined, className: string) {
-    const windowObject = extendWindowByVKUI(window || {});
+    const windowObject = extendWindowWithVKUIVariable(window || {});
     if (!windowObject.__VKUI__.globalTokensClassNameUsage[className]) {
       windowObject.__VKUI__.globalTokensClassNameUsage[className] = 0;
     }
@@ -19,8 +30,7 @@ export class VKUIGlobalTokensClassNameUsage {
 
   decrementUsageNumber(): void {
     const currentUsage = this.window.__VKUI__.globalTokensClassNameUsage[this.className] ?? 0;
-    this.window.__VKUI__.globalTokensClassNameUsage[this.className] = currentUsage + 1;
-    if (currentUsage) {
+    if (currentUsage > 0) {
       this.window.__VKUI__.globalTokensClassNameUsage[this.className] = currentUsage - 1;
     }
   }
@@ -38,7 +48,7 @@ function isExtendedByVKUI(
   );
 }
 
-function extendWindowByVKUI(
+function extendWindowWithVKUIVariable(
   windowInput: Partial<VKUIPrivateGlobalInterface>,
 ): VKUIPrivateGlobalInterface {
   const windowObject: Partial<VKUIPrivateGlobalInterface> = windowInput || {

--- a/packages/vkui/src/lib/vkuiGlobalTokensClassNameUsage.ts
+++ b/packages/vkui/src/lib/vkuiGlobalTokensClassNameUsage.ts
@@ -1,0 +1,62 @@
+export class VKUIGlobalTokensClassNameUsage {
+  public window: VKUIPrivateGlobalInterface;
+  public className: string;
+
+  constructor(window: Window | undefined, className: string) {
+    const windowObject = extendWindowByVKUI(window || {});
+    if (!windowObject.__VKUI__.globalTokensClassNameUsage[className]) {
+      windowObject.__VKUI__.globalTokensClassNameUsage[className] = 0;
+    }
+
+    this.window = windowObject;
+    this.className = className;
+  }
+
+  incrementUsageNumber(): void {
+    const currentUsage = this.window.__VKUI__.globalTokensClassNameUsage[this.className] ?? 0;
+    this.window.__VKUI__.globalTokensClassNameUsage[this.className] = currentUsage + 1;
+  }
+
+  decrementUsageNumber(): void {
+    const currentUsage = this.window.__VKUI__.globalTokensClassNameUsage[this.className] ?? 0;
+    this.window.__VKUI__.globalTokensClassNameUsage[this.className] = currentUsage + 1;
+    if (currentUsage) {
+      this.window.__VKUI__.globalTokensClassNameUsage[this.className] = currentUsage - 1;
+    }
+  }
+
+  isInUse(): boolean {
+    return Boolean(this.window.__VKUI__.globalTokensClassNameUsage[this.className]);
+  }
+}
+
+function isExtendedByVKUI(
+  windowInput: Partial<VKUIPrivateGlobalInterface>,
+): windowInput is VKUIPrivateGlobalInterface {
+  return Boolean(
+    windowInput && windowInput.__VKUI__ && windowInput.__VKUI__.globalTokensClassNameUsage,
+  );
+}
+
+function extendWindowByVKUI(
+  windowInput: Partial<VKUIPrivateGlobalInterface>,
+): VKUIPrivateGlobalInterface {
+  const windowObject: Partial<VKUIPrivateGlobalInterface> = windowInput || {
+    __VKUI__: { globalTokensClassNameUsage: {} },
+  };
+  if (!windowObject.__VKUI__) {
+    windowObject.__VKUI__ = {
+      globalTokensClassNameUsage: {},
+    };
+  }
+
+  if (!windowObject.__VKUI__.globalTokensClassNameUsage) {
+    windowObject.__VKUI__.globalTokensClassNameUsage = {};
+  }
+
+  if (!isExtendedByVKUI(windowObject)) {
+    throw new Error('Can not extend window with VKUI private variable');
+  }
+
+  return windowObject;
+}


### PR DESCRIPTION
resolves: #5518 

Так как на странице может быть много независимых приложений использующих VKUI и ConfigProvider, то каждое такое приложение, согласно коду `ConfigProvider`, будет вешать свой класс на `body` и удалять свой класс с `body` при размонтировании.
Проблема в том, что мы никак не можем из одного приложения узнать что сделало другое приложение, потому что приложения могут иметь разные точки монтирования, а значит они не связаны через контекст.

Единственное сколько-нибудь контролируемое решение этой проблемы на данные момент является обращение к глобальной переменной через `window`.