### PR TITLE
fix(ci): create new workflow for report CI results

### DIFF
--- a/.github/workflows/branch_test_coverage.yml
+++ b/.github/workflows/branch_test_coverage.yml
@@ -26,6 +26,29 @@ jobs:
     with:
       workspace: '@vkontakte/vkui'
 
+  deploy_test_coverage:
+    if: ${{ !cancelled() && (success() || failure()) }}
+    needs: test
+    runs-on: ubuntu-latest
+    name: Deploy test coverage
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download test artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: test-output
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests
+          files: .nyc_output/coverage-final.json
+          fail_ci_if_error: true
+          verbose: true
+
   test_e2e:
     name: Call reusable e2e tests workflow
     # На текущий момент e2e так и так запускается только для @vkontakte/vkui

--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -11,19 +11,15 @@ on:
         required: true
 
 jobs:
-  undeploy_s3:
-    runs-on: ubuntu-latest
-    name: Undeploy S3
-    steps:
-      - name: Delete from S3
-        uses: VKCOM/gh-actions/VKUI/s3@main
-        with:
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
-          awsBucket: vkui-screenshot
-          awsEndpoint: https://hb.bizmrg.com
-          command: delete
-          commandDeletePrefix: pull/${{ inputs.pull_request_number || github.event.pull_request.number }}
+  upload_pr_workflow_payload:
+    # Не используем always(), т.к. он не учитывает отмену воркфлоу
+    # см. https://github.com/orgs/community/discussions/26303
+    if: ${{ !cancelled() }}
+    name: Call reusable workflow
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+    with:
+      action: upload
+      pr_number: ${{ inputs.pull_request_number || github.event.pull_request.number }}
 
   patch:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'patch')

--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
   workflow_dispatch:
     inputs:
-      pull_request_number:
+      pr_number_by_workflow_dispatch:
         description: 'Number of PR'
         type: number
         required: true
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
     with:
       action: upload
-      override_pr_number: ${{ inputs.pull_request_number }}
+      override_pr_number: ${{ inputs.pr_number_by_workflow_dispatch }}
 
   patch:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'patch')

--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
     with:
       action: upload
-      pr_number: ${{ inputs.pull_request_number || github.event.pull_request.number }}
+      override_pr_number: ${{ inputs.pull_request_number }}
 
   patch:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'patch')

--- a/.github/workflows/pr_close_undeploy.yml
+++ b/.github/workflows/pr_close_undeploy.yml
@@ -1,0 +1,31 @@
+name: 'Close Pull Request: Undeploy'
+# Note: display_title не задокументирован
+run-name: '${{ github.event.workflow_run.display_title }} • ${{ github.event.workflow_run.head_branch }} • ${{ github.event.workflow_run.id }}'
+
+on:
+  workflow_run:
+    workflows: ['Close Pull Request']
+    types: [completed]
+
+jobs:
+  pr_workflow_payload:
+    name: Call reusable workflow
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+    with:
+      action: download
+
+  undeploy_s3:
+    needs: pr_workflow_payload
+    if: ${{ needs.pr_workflow_payload.outputs.status == 'success' }}
+    runs-on: ubuntu-latest
+    name: Undeploy S3
+    steps:
+      - name: Delete from S3
+        uses: VKCOM/gh-actions/VKUI/s3@main
+        with:
+          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
+          awsBucket: ${{ vars.AWS_BUCKET }}
+          awsEndpoint: https://${{ vars.AWS_ENDPOINT }}
+          command: delete
+          commandDeletePrefix: pull/${{ needs.pr_workflow_payload.outputs.pr_number  }}

--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -19,17 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  upload_pr_workflow_payload:
-    # Дожидаемся выгрузки артефактов, на случай если вокрфлоу будет отменён или перезапушен
-    needs: [test, test_e2e_prepare_and_upload_report, docs_styleguide_upload, docs_storybook_upload]
-    # Не используем always(), т.к. он не учитывает отмену воркфлоу
-    # см. https://github.com/orgs/community/discussions/26303
-    if: ${{ !cancelled() }}
-    name: Call reusable workflow
-    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
-    with:
-      action: upload
-
   changed_files:
     runs-on: ubuntu-latest
     name: Detect what files changed
@@ -223,3 +212,14 @@ jobs:
         with:
           name: storybook-dist
           path: packages/vkui/storybook-static
+
+  upload_pr_workflow_payload:
+    # Дожидаемся выгрузки артефактов, на случай если вокрфлоу будет отменён или перезапушен
+    needs: [test, test_e2e_prepare_and_upload_report, docs_styleguide_upload, docs_storybook_upload]
+    # Не используем always(), т.к. он не учитывает отмену воркфлоу
+    # см. https://github.com/orgs/community/discussions/26303
+    if: ${{ !cancelled() }}
+    name: Call reusable workflow
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+    with:
+      action: upload

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -19,6 +19,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  upload_pr_workflow_payload:
+    # Дожидаемся выгрузки артефактов, на случай если вокрфлоу будет отменён или перезапушен
+    needs: [test, test_e2e_prepare_and_upload_report, docs_styleguide_upload, docs_storybook_upload]
+    # Не используем always(), т.к. он не учитывает отмену воркфлоу
+    # см. https://github.com/orgs/community/discussions/26303
+    if: ${{ !cancelled() }}
+    name: Call reusable workflow
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+    with:
+      action: upload
+
   changed_files:
     runs-on: ubuntu-latest
     name: Detect what files changed
@@ -28,13 +39,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
       - name: Find changes
         uses: dorny/paths-filter@v2
         id: changes
         with:
-          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           filters: .github/file-filters.yml
 
   linters:
@@ -43,8 +53,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -67,31 +75,38 @@ jobs:
       - name: Check if the generated files have been updated
         run: yarn run lint:generated-files
 
-      - name: Upload lint scripts artifact
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: lint-scripts-output
-          path: lint-results.json
+      - name: Report lint results
+        if: ${{ !cancelled() }}
+        uses: VKCOM/gh-actions/VKUI/reporter@main
 
   test:
-    name: Call reusable unit tests workflow
+    name: Call reusable workflow
     uses: ./.github/workflows/reusable_workflow_test.yml
-    with:
-      ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+  test_report:
+    if: ${{ !cancelled() && (success() || failure()) }}
+    needs: test
+    runs-on: ubuntu-latest
+    name: Report unit test results
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: test-output
+
+      - name: Report
+        uses: VKCOM/gh-actions/VKUI/reporter@main
 
   test_e2e:
     if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
     needs: changed_files
-    name: Call reusable e2e tests workflow
+    name: Call reusable workflow
     uses: ./.github/workflows/reusable_workflow_test_e2e.yml
-    with:
-      ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-  test_e2e_prepare_report:
-    if: always()
+  test_e2e_prepare_and_upload_report:
+    if: ${{ !cancelled() && (success() || failure()) }}
     needs: test_e2e
-    name: Prepare e2e's HTML report
+    name: Prepare and upload e2e's HTML report artifact
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -129,11 +144,12 @@ jobs:
     name: Analyze bundle size
     env:
       CI_JOB_NUMBER: 1
+    # Для Dependabot
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -154,66 +170,14 @@ jobs:
           # package_manager: yarn
           build_script: 'size:ci'
 
-  report_ci:
-    if: ${{ always() }}
-    needs:
-      - changed_files
-      - linters
-      - test
-      - test_e2e_prepare_report
-    runs-on: ubuntu-latest
-    name: Report CI results
-    steps:
-      - name: Download lint scripts artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: lint-scripts-output
-
-      - name: Download test artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: test-output
-
-      - name: Download Playwright HTML report from GitHub Actions Artifacts
-        if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: playwright-report
-          path: playwright-report
-
-      - name: Upload Playwright Report
-        if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
-        uses: VKCOM/gh-actions/VKUI/s3@main
-        with:
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
-          awsBucket: vkui-screenshot
-          awsEndpoint: https://hb.bizmrg.com
-          command: upload
-          commandUploadSrc: playwright-report/
-          commandUploadDist: pull/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/playwright-report
-
-      - name: Push reports (with Playwright Report comment)
-        if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
-        uses: VKCOM/gh-actions/VKUI/reporter@main
-        with:
-          playwrightReportURL: https://vkui-screenshot.hb.bizmrg.com/pull/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/playwright-report/index.html
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push reports (without Playwright Report comment)
-        if: ${{ needs.changed_files.outputs.package_vkui == 'false' }}
-        uses: VKCOM/gh-actions/VKUI/reporter@main
-
-  styleguide:
+  docs_styleguide_upload:
     if: ${{ needs.changed_files.outputs.docs_styleguide == 'true' }}
     needs: changed_files
     runs-on: ubuntu-latest
-    name: Deploy docs (styleguide)
+    name: Upload docs dist artifact (styleguide)
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -224,31 +188,23 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
 
-      - name: Build styleguide
+      - name: Build
         run: yarn run docs:styleguide:build
 
-      - name: Upload styleguide S3
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: VKCOM/gh-actions/VKUI/s3@main
+      - name: Upload dist
+        uses: actions/upload-artifact@v3
         with:
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
-          awsBucket: vkui-screenshot
-          awsEndpoint: https://hb.bizmrg.com
-          command: upload
-          commandUploadSrc: styleguide/dist/
-          commandUploadDist: pull/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/styleguide
+          name: styleguide-dist
+          path: styleguide/dist
 
-  storybook:
+  docs_storybook_upload:
     if: ${{ needs.changed_files.outputs.docs_styleguide == 'true' }}
     needs: changed_files
     runs-on: ubuntu-latest
-    name: Deploy docs (storybook)
+    name: Upload docs dist artifact (storybook)
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -259,48 +215,11 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
 
-      - name: Build storybook
+      - name: Build
         run: yarn docs:storybook:build
 
-      - name: Upload storybook S3
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: VKCOM/gh-actions/VKUI/s3@main
+      - name: Upload dist
+        uses: actions/upload-artifact@v3
         with:
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
-          awsBucket: vkui-screenshot
-          awsEndpoint: https://hb.bizmrg.com
-          command: upload
-          commandUploadSrc: packages/vkui/storybook-static
-          commandUploadDist: pull/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/storybook
-
-  docs_comment:
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    needs:
-      - storybook
-      - styleguide
-    runs-on: ubuntu-latest
-    name: Docs comment
-    steps:
-      - name: Find storybook URL comment
-        uses: peter-evans/find-comment@v2
-        id: find_url_comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: <!-- storybook_url -->
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          comment-id: ${{ steps.find_url_comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            <!-- storybook_url -->
-            ## 👀 Docs deployed
-
-            - [Styleguide](https://vkui-screenshot.hb.bizmrg.com/pull/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/styleguide/index.html)
-            - [Storybook](https://vkui-screenshot.hb.bizmrg.com/pull/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/storybook/index.html)
-
-            Commit ${{ github.event.pull_request.head.sha }}
-          edit-mode: replace
+          name: storybook-dist
+          path: packages/vkui/storybook-static

--- a/.github/workflows/pull_request_packages_deploy.yml
+++ b/.github/workflows/pull_request_packages_deploy.yml
@@ -1,0 +1,186 @@
+name: 'Pull Request / Packages: Deploy'
+# Note: display_title не задокументирован
+run-name: '${{ github.event.workflow_run.display_title }} • ${{ github.event.workflow_run.head_branch }} • ${{ github.event.workflow_run.id }}'
+
+on:
+  workflow_run:
+    workflows: ['Pull Request / Packages']
+    types: [completed]
+
+env:
+  PR_HEAD_REPOSITORY_FULL_NAME: ${{ github.event.workflow_run.head_repository.full_name }}
+  PR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+  AWS_S3_URL: https://${{ vars.AWS_BUCKET }}.${{ vars.AWS_ENDPOINT }}
+
+jobs:
+  pr_workflow_payload:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    name: Call reusable workflow
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+    with:
+      action: download
+
+  deploy_test_coverage:
+    needs: pr_workflow_payload
+    if: ${{ needs.pr_workflow_payload.outputs.status == 'success' }}
+    runs-on: ubuntu-latest
+    name: Deploy test coverage
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.PR_HEAD_REPOSITORY_FULL_NAME }}
+          ref: ${{ env.PR_HEAD_BRANCH }}
+          persist-credentials: false
+
+      - name: Download artifact
+        id: artifact
+        uses: VKCOM/gh-actions/shared/download-workflow-artifact@main
+        with:
+          name: test-output
+
+      - name: Upload coverage to Codecov
+        if: ${{ steps.artifact.outputs.found_artifact == 'true' }}
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests
+          files: .nyc_output/coverage-final.json
+          override_branch: ${{ env.PR_HEAD_BRANCH }}
+          override_commit: ${{ env.PR_HEAD_SHA }}
+          override_pr: ${{ needs.pr_workflow_payload.outputs.pr_number }}
+          fail_ci_if_error: true
+          verbose: true
+
+  deploy_playwright_report:
+    needs: pr_workflow_payload
+    if: ${{ needs.pr_workflow_payload.outputs.status == 'success' }}
+    runs-on: ubuntu-latest
+    name: Deploy Playwright Report and create comment
+    steps:
+      - name: Download artifact
+        id: artifact
+        uses: VKCOM/gh-actions/shared/download-workflow-artifact@main
+        with:
+          name: playwright-report
+          path: playwright-report/
+
+      - name: Deploy Playwright Report
+        if: ${{ steps.artifact.outputs.found_artifact == 'true' }}
+        id: deploy
+        uses: VKCOM/gh-actions/VKUI/s3@main
+        with:
+          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
+          awsBucket: ${{ vars.AWS_BUCKET }}
+          awsEndpoint: https://${{ vars.AWS_ENDPOINT }}
+          command: upload
+          commandUploadSrc: playwright-report/
+          commandUploadDist: pull/${{ needs.pr_workflow_payload.outputs.pr_number }}/${{ env.PR_HEAD_SHA }}/playwright-report
+
+      - name: Report
+        if: ${{ steps.deploy.outcome == 'success' }}
+        uses: VKCOM/gh-actions/VKUI/reporter@main
+        with:
+          prNumber: ${{ needs.pr_workflow_payload.outputs.pr_number }}
+          playwrightReportURL: ${{ env.AWS_S3_URL }}/pull/${{ needs.pr_workflow_payload.outputs.pr_number }}/${{ env.PR_HEAD_SHA }}/playwright-report/index.html
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy_styleguide:
+    needs: pr_workflow_payload
+    if: ${{ needs.pr_workflow_payload.outputs.status == 'success' }}
+    runs-on: ubuntu-latest
+    name: Deploy docs (styleguide)
+    outputs:
+      url: ${{ steps.url.outputs.value }}
+    steps:
+      - name: Download styleguide dist artifact
+        id: artifact
+        uses: VKCOM/gh-actions/shared/download-workflow-artifact@main
+        with:
+          name: styleguide-dist
+          path: styleguide-dist/
+
+      - name: Upload styleguide S3
+        if: ${{ steps.artifact.outputs.found_artifact == 'true' }}
+        id: deploy
+        uses: VKCOM/gh-actions/VKUI/s3@main
+        with:
+          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
+          awsBucket: ${{ vars.AWS_BUCKET }}
+          awsEndpoint: https://${{ vars.AWS_ENDPOINT }}
+          command: upload
+          commandUploadSrc: styleguide-dist/
+          commandUploadDist: pull/${{ needs.pr_workflow_payload.outputs.pr_number }}/${{ env.PR_HEAD_SHA }}/styleguide
+
+      - name: Create doc url
+        if: ${{ steps.deploy.outcome == 'success' }}
+        id: url
+        run: echo "value=${{ env.AWS_S3_URL }}/pull/${{ needs.pr_workflow_payload.outputs.pr_number }}/${{ env.PR_HEAD_SHA }}/styleguide/index.html" >> $GITHUB_OUTPUT
+
+  deploy_storybook:
+    needs: pr_workflow_payload
+    if: ${{ needs.pr_workflow_payload.outputs.status == 'success' }}
+    runs-on: ubuntu-latest
+    name: Deploy docs (storybook)
+    outputs:
+      url: ${{ steps.url.outputs.value }}
+    steps:
+      - name: Download dist artifact
+        id: artifact
+        uses: VKCOM/gh-actions/shared/download-workflow-artifact@main
+        with:
+          name: storybook-dist
+          path: storybook-dist/
+
+      - name: Upload
+        if: ${{ steps.artifact.outputs.found_artifact == 'true' }}
+        id: deploy
+        uses: VKCOM/gh-actions/VKUI/s3@main
+        with:
+          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
+          awsBucket: ${{ vars.AWS_BUCKET }}
+          awsEndpoint: https://${{ vars.AWS_ENDPOINT }}
+          command: upload
+          commandUploadSrc: storybook-dist/
+          commandUploadDist: pull/${{ needs.pr_workflow_payload.outputs.pr_number }}/${{ env.PR_HEAD_SHA }}/storybook
+
+      - name: Create doc url
+        if: ${{ steps.deploy.outcome == 'success' }}
+        id: url
+        run: echo "value=${{ env.AWS_S3_URL }}/pull/${{ needs.pr_workflow_payload.outputs.pr_number }}/${{ env.PR_HEAD_SHA }}/storybook/index.html" >> $GITHUB_OUTPUT
+
+  docs_comment:
+    needs:
+      - deploy_storybook
+      - deploy_styleguide
+      - pr_workflow_payload
+    if: ${{ needs.deploy_styleguide.outputs.url != '' || needs.deploy_storybook.outputs.url != '' }}
+    runs-on: ubuntu-latest
+    name: Docs comment
+    steps:
+      - name: Find docs URLs comment
+        uses: peter-evans/find-comment@v2
+        id: find_url_comment
+        with:
+          issue-number: ${{ needs.pr_workflow_payload.outputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: <!-- docs_urls -->
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.find_url_comment.outputs.comment-id }}
+          issue-number: ${{ needs.pr_workflow_payload.outputs.pr_number }}
+          body: |
+            <!-- docs_urls -->
+            ## 👀 Docs deployed
+
+            - ${{ (needs.deploy_styleguide.outputs.url != '' && '✅') || '❌' }} [Styleguide](${{ needs.deploy_styleguide.outputs.url }})
+            - ${{ (needs.deploy_storybook.outputs.url != '' && '✅') || '❌' }} [Storybook](${{ needs.deploy_storybook.outputs.url }})
+
+            Commit ${{ env.PR_HEAD_SHA }}
+          edit-mode: replace

--- a/.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+++ b/.github/workflows/reusable_workflow_pr_worfklow_payload.yml
@@ -1,0 +1,58 @@
+name: 'Reusable workflow / PR workflow payload'
+
+on:
+  workflow_call:
+    inputs:
+      action:
+        description: 'Use "upload" or "download"'
+        required: true
+        type: string
+    outputs:
+      status:
+        value: ${{ jobs.download.outputs.status }}
+      pr_number:
+        value: ${{ jobs.download.outputs.pr_number }}
+
+jobs:
+  download:
+    if: ${{ inputs.action == 'download' }}
+    runs-on: ubuntu-latest
+    name: Download PR workflow payload artifact
+    outputs:
+      status: ${{ steps.payload.outputs.status || steps.payload_fallback.outputs.status }}
+      pr_number: ${{ steps.payload.outputs.pr_number }}
+    steps:
+      - name: Download artifact
+        id: artifact
+        uses: VKCOM/gh-actions/shared/download-workflow-artifact@main
+        with:
+          name: pr_workflow_payload
+          path: pr_workflow_payload/
+
+      - name: Extract payload to GITHUB_OUTPUT
+        if: ${{ steps.artifact.outputs.found_artifact == 'true' }}
+        id: payload
+        run: |
+          echo "status=success" >> $GITHUB_OUTPUT
+          echo "pr_number=$(cat pr_workflow_payload/pr_number.txt)" >> $GITHUB_OUTPUT
+
+      - name: NO ARTEFACT
+        if: ${{ steps.artifact.outputs.found_artifact != 'true' }}
+        id: payload_fallback
+        run: echo "status=canceled" >> $GITHUB_OUTPUT
+
+  upload:
+    if: ${{ inputs.action == 'upload' }}
+    runs-on: ubuntu-latest
+    name: Upload PR workflow payload artifact
+    steps:
+      - name: Prepare data
+        run: |
+          mkdir pr_workflow_payload
+          echo ${{ github.event.pull_request.number }} > pr_workflow_payload/pr_number.txt
+
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr_workflow_payload
+          path: pr_workflow_payload/

--- a/.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+++ b/.github/workflows/reusable_workflow_pr_worfklow_payload.yml
@@ -7,9 +7,8 @@ on:
         description: 'Use "upload" or "download"'
         required: true
         type: string
-      pr_number:
-        default: ${{ github.event.pull_request.number }}
-        description: 'Helpful if trigger is not PR, example, worflow_dispatch'
+      override_pr_number:
+        description: 'Helpful if trigger is not PR (example, worflow_dispatch)'
         required: false
         type: string
     outputs:
@@ -54,7 +53,7 @@ jobs:
       - name: Prepare data
         run: |
           mkdir pr_workflow_payload
-          echo ${{ inputs.pr_number }} > pr_workflow_payload/pr_number.txt
+          echo ${{ inputs.override_pr_number || github.event.pull_request.number }} > pr_workflow_payload/pr_number.txt
 
       - name: Upload
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable_workflow_pr_worfklow_payload.yml
+++ b/.github/workflows/reusable_workflow_pr_worfklow_payload.yml
@@ -7,6 +7,11 @@ on:
         description: 'Use "upload" or "download"'
         required: true
         type: string
+      pr_number:
+        default: ${{ github.event.pull_request.number }}
+        description: 'Helpful if trigger is not PR, example, worflow_dispatch'
+        required: false
+        type: string
     outputs:
       status:
         value: ${{ jobs.download.outputs.status }}
@@ -49,7 +54,7 @@ jobs:
       - name: Prepare data
         run: |
           mkdir pr_workflow_payload
-          echo ${{ github.event.pull_request.number }} > pr_workflow_payload/pr_number.txt
+          echo ${{ inputs.pr_number }} > pr_workflow_payload/pr_number.txt
 
       - name: Upload
         uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable_workflow_test.yml
+++ b/.github/workflows/reusable_workflow_test.yml
@@ -35,17 +35,11 @@ jobs:
         if: ${{ inputs.workspace }}
         run: yarn workspace ${{ inputs.workspace }} run test:ci
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests
-          files: .nyc_output/coverage-final.json
-          fail_ci_if_error: true
-
       - name: Upload test artifact
-        uses: actions/upload-artifact@v3
         if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: test-output
-          path: test-results.json
+          path: |
+            test-results.json
+            .nyc_output/coverage-final.json


### PR DESCRIPTION
После #5561 потеряли возможность создавать отчёты для PR из форк-репозиторий.

Поэтому по мотивам статьи [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), создаём новый воркфлоу, который срабатывает на `worflow_run`. В таком воркфлоу будет доступ к кредам.

## Что было сделано?

- Вынес из `.github/workflows/pull_request_packages.yml` и из `.github/workflows/reusable_workflow_test.yml` шаги, где нужны креды, в отдельный воркфлоу `.github/workflows/pull_request_packages_deploy.yml`.

  Тем самым у `.github/workflows/branch_test_coverage.yml` появился шаг с выгрузкой отчёта в Codecov.
- Вынес из `.github/workflows/pr_close.yml` шаг, где нужны креды, в отдельный воркфлоу `.github/workflows/pr_close_undeploy.yml`
- Расширил `VKCOM/gh-actions/VKUI/reporter` параметром `prNumber` (https://github.com/VKCOM/gh-actions/pull/135).
- Использую условие `${{ !cancelled() && (success() || failure()) }}` вместо `${{ always() }}`, т.к. последний не учитывает отмену воркфлоу (см. https://github.com/orgs/community/discussions/26303).
  > **Note**
  >  `success()` и `failure()` нужны, чтобы исключить состояние `skipped`.
- Чтобы иметь доступ к артефактам из другого воркфлоу, используем кастомный экшен `VKCOM/gh-actions/shared/download-workflow-artifact` (https://github.com/VKCOM/gh-actions/pull/142).
- ~Для джобы `Analyze bundle size` пробуем дать разрешение на запись в PR, чтобы была возможность добавить комментарий.~ **UPD** не сработало. Пока оставляем как есть. `permissions` оставил для **Dependabot**.

## Нюансы

Логи воркфлоу, запущенные  `workflow_run`, не сыпятся в сам PR. Их можно найти на странице **Actions**.

<img width="480" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/65023f1f-b98d-4646-bd7f-b5dad4f234c9">

_Пример. Формирую названия на основе **заголовка PR** + **названия ветки** + **`run_id`** (привязан к PR, который вызвал `pull_request_package.yml`)._


## Тест

Так как воркфлоу с `worflow_run` работает только если файл находится в базовой ветке, то тестировал на своём форке https://github.com/inomdzhon/VKUI. А чтобы тестировать PR из форк реп, создал аккаунт, в котором форкнул свой форк https://github.com/inomdzhon-clone/VKUI :)

Ключи для S3 использовал свои.

<details><summary>Скриншоты результатов</summary>
<p>

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/bcd556db-fe62-4b22-b00b-366fcb9b75cc">

_1) Изменили `docs/ADAPTIVITY_GUIDE.md`, как и предполагается, запутилось только воркфлоу **Pull Request / Common** – **Pull Request / Packages: Deploy** на него не реагирует_

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/e6c5e1aa-a66c-4a1d-b837-d3668199c447">

_2) Изменили `styleguide/pages/adaptivity.md`, чтобы вызвать воркфлоу **Pull Request / Packages** (без запуска e2e) – после окончания воркфлоу, сработал **Pull Request / Packages: Deploy** и мы получили комментарии со ссылками на доки и отчёт Codecov_

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/caa7f042-d549-4b5f-bcf8-6b4af1c68629">

_3.1) Затронули `packages/vkui/src/components/Alert/Alert.tsx`, чтобы вызвать воркфлоу **Pull Request / Packages** с запуском e2e – после окончания воркфлоу, сработал **Pull Request / Packages: Deploy** и мы получили комментарий со ссылкой на отчёт Playwright, помимо него, обновились комментарии со ссылками на доку и отчёт Codecov_

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/f57f08c4-2e4b-41de-84e6-5cb2fb408629"> <img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/631d18b2-0a45-412e-9180-f49fcc3d1644">

_3.2) Специально сломали `packages/vkui/src/components/Alert/Alert.tsx`, убедиться, что `VKCOM/gh-actions/VKUI/reporter` работает_

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/1755595d-bd96-4d15-b855-5b6e18a5b3c9">

_4) Проверил, что **Pull Request / Packages: Deploy** нормально срабатывает и в случаях, когда PR не в `master` ветку (специально сломал e2e тест)_

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/28847144-5f2c-4373-be75-386d65c01b33"> <img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/02fd5cd2-395d-4e56-9f5d-b53295718f6b">

_5) Мержим PR – как видим, запустился **Close Pull Request: Undeploy** и очистил S3.

</p>
</details> 

## Чеклист перед релизом

- [x] Добавить `vars.AWS_BUCKET` в [настройки репозитория](https://github.com/VKCOM/VKUI/settings/variables/actions)
- [x] Добавить `vars. AWS_ENDPOINT ` в [настройки репозитория](https://github.com/VKCOM/VKUI/settings/variables/actions)

---

- caused by #5561