### PR TITLE
fix(ConfigProvider) Allow duplicated classes in the body created by ConfigProvider

### DIFF
--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -180,10 +180,9 @@ describe('ConfigProvider', () => {
       );
     };
 
-    const { unmount, rerender } = render(<TestComponent />);
+    const { unmount } = render(<TestComponent />);
 
     const vkuiBodySelector = generateVKUITokensClassName(config.platform, config.appearance);
-    rerender(<TestComponent />);
 
     // class name is applied to body
     expect(document.querySelector(`body.${vkuiBodySelector}`)).toBeTruthy();

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
@@ -6,6 +6,7 @@ import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { useDOM } from '../../lib/dom';
 import { TokensClassProvider } from '../../lib/tokensClassProvider';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { addClassNameToElement, removeClassNameFromElement } from '../../lib/utils';
 import { warnOnce } from '../../lib/warnOnce';
 import {
   ConfigProviderContext,
@@ -83,12 +84,9 @@ ${webviewTypeRule}
   useIsomorphicLayoutEffect(() => {
     const VKUITokensClassName = generateVKUITokensClassName(platform, appearance);
 
-    // eslint-disable-next-line no-restricted-properties
-    document!.body.classList.add(VKUITokensClassName);
-
+    addClassNameToElement(document!.body, VKUITokensClassName);
     return () => {
-      // eslint-disable-next-line no-restricted-properties
-      document!.body.classList.remove(VKUITokensClassName);
+      removeClassNameFromElement(document!.body, VKUITokensClassName);
     };
   }, [platform, appearance]);
 

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
@@ -82,11 +82,15 @@ ${webviewTypeRule}
   const { document } = useDOM();
 
   useIsomorphicLayoutEffect(() => {
+    if (!document) {
+      return;
+    }
+
     const VKUITokensClassName = generateVKUITokensClassName(platform, appearance);
 
-    addClassNameToElement(document!.body, VKUITokensClassName);
+    addClassNameToElement(document.body, VKUITokensClassName);
     return () => {
-      removeClassNameFromElement(document!.body, VKUITokensClassName);
+      removeClassNameFromElement(document.body, VKUITokensClassName);
     };
   }, [platform, appearance]);
 

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
@@ -81,18 +81,22 @@ ${webviewTypeRule}
 
   const { document } = useDOM();
 
-  useIsomorphicLayoutEffect(() => {
-    if (!document) {
-      return;
-    }
+  // TODO [>=6]: переместить хук в AppRoot (см. https://github.com/VKCOM/VKUI/issues/4810).
+  useIsomorphicLayoutEffect(
+    function attachVKUITokensClassNameToBody() {
+      if (!document) {
+        return;
+      }
 
-    const VKUITokensClassName = generateVKUITokensClassName(platform, appearance);
+      const VKUITokensClassName = generateVKUITokensClassName(platform, appearance);
 
-    addClassNameToElement(document.body, VKUITokensClassName);
-    return () => {
-      removeClassNameFromElement(document.body, VKUITokensClassName);
-    };
-  }, [platform, appearance]);
+      addClassNameToElement(document.body, VKUITokensClassName);
+      return () => {
+        removeClassNameFromElement(document.body, VKUITokensClassName);
+      };
+    },
+    [platform, appearance],
+  );
 
   const configContext = useObjectMemo({
     webviewType,

--- a/packages/vkui/src/lib/utils.test.ts
+++ b/packages/vkui/src/lib/utils.test.ts
@@ -29,7 +29,7 @@ describe('removeClassNameFromElement', () => {
 
     // remove not existing class
     removeClassNameFromElement(div, 'unknown-class');
-    expect(div.getAttribute('class')).toEqual('b-class a-class a-class');
+    expect(div.getAttribute('class')).toEqual('a-class b-class a-class');
 
     removeClassNameFromElement(div, 'a-class');
     expect(div.getAttribute('class')).toEqual('b-class a-class');

--- a/packages/vkui/src/lib/utils.test.ts
+++ b/packages/vkui/src/lib/utils.test.ts
@@ -1,0 +1,39 @@
+import { addClassNameToElement, removeClassNameFromElement } from './utils';
+
+describe('addClassNameToElement', () => {
+  test('adds className to element', () => {
+    const div = document.createElement('div');
+    addClassNameToElement(div, 'a-class');
+
+    expect(div.getAttribute('class')).toEqual('a-class');
+
+    // allows to add duplicated class name
+    addClassNameToElement(div, 'a-class');
+    expect(div.getAttribute('class')).toEqual('a-class a-class');
+
+    addClassNameToElement(div, 'b-class');
+    expect(div.getAttribute('class')).toEqual('a-class a-class b-class');
+  });
+});
+
+describe('removeClassNameFromElement', () => {
+  test('removes className from element', () => {
+    const div = document.createElement('div');
+    div.setAttribute('class', 'a-class');
+
+    removeClassNameFromElement(div, 'a-class');
+    expect(div.getAttribute('class')).toEqual('');
+
+    // allows to remove duplicated class name
+    div.setAttribute('class', 'a-class b-class a-class');
+
+    removeClassNameFromElement(div, 'a-class');
+    expect(div.getAttribute('class')).toEqual('b-class a-class');
+
+    removeClassNameFromElement(div, 'b-class');
+    expect(div.getAttribute('class')).toEqual('a-class');
+
+    removeClassNameFromElement(div, 'a-class');
+    expect(div.getAttribute('class')).toEqual('');
+  });
+});

--- a/packages/vkui/src/lib/utils.test.ts
+++ b/packages/vkui/src/lib/utils.test.ts
@@ -30,7 +30,13 @@ describe('removeClassNameFromElement', () => {
     removeClassNameFromElement(div, 'a-class');
     expect(div.getAttribute('class')).toEqual('b-class a-class');
 
+    // allows to remove duplicated class name
+    div.setAttribute('class', 'a-class b-class a-class');
+
     removeClassNameFromElement(div, 'b-class');
+    expect(div.getAttribute('class')).toEqual('a-class a-class');
+
+    removeClassNameFromElement(div, 'a-class');
     expect(div.getAttribute('class')).toEqual('a-class');
 
     removeClassNameFromElement(div, 'a-class');

--- a/packages/vkui/src/lib/utils.test.ts
+++ b/packages/vkui/src/lib/utils.test.ts
@@ -27,6 +27,10 @@ describe('removeClassNameFromElement', () => {
     // allows to remove duplicated class name
     div.setAttribute('class', 'a-class b-class a-class');
 
+    // remove not existing class
+    removeClassNameFromElement(div, 'unknown-class');
+    expect(div.getAttribute('class')).toEqual('b-class a-class a-class');
+
     removeClassNameFromElement(div, 'a-class');
     expect(div.getAttribute('class')).toEqual('b-class a-class');
 

--- a/packages/vkui/src/lib/utils.ts
+++ b/packages/vkui/src/lib/utils.ts
@@ -53,3 +53,23 @@ export function getTitleFromChildren(children: React.ReactNode): string {
 
 export const stopPropagation = <T extends React.SyntheticEvent>(event: T) =>
   event.stopPropagation();
+
+export function addClassNameToElement(element: HTMLElement, className: string) {
+  const elementClassName = element.getAttribute('class') || '';
+  const updatedClassName = `${elementClassName}${elementClassName ? ' ' : ''}${className}`;
+
+  element.setAttribute('class', updatedClassName);
+}
+
+export function removeClassNameFromElement(element: HTMLElement, classNameToRemove: string) {
+  const classNamesArray = (element.getAttribute('class') || '').split(/\s+/);
+  const elementIndexToRemove = classNamesArray.findIndex(
+    (className) => className === classNameToRemove,
+  );
+  if (elementIndexToRemove === -1) {
+    return;
+  }
+  classNamesArray.splice(elementIndexToRemove, 1);
+
+  element.setAttribute('class', classNamesArray.join(' '));
+}


### PR DESCRIPTION
resolves: #5518 

Для того чтобы независимые приложения не удаляли класс главного приложений из body при размонтировании мы позволяем каждому приложению на странице добавить свой класс в body с помощью `ConfigProvider`, даже если такой класс уже есть.
Работа с классами `body` ведётся с помощь `className` а не `classList` (который не допускает дубликатов).