### PR TITLE
ci(pull_request_dependabot): add write permissions

### DIFF
--- a/.github/workflows/pull_request_dependabot.yml
+++ b/.github/workflows/pull_request_dependabot.yml
@@ -5,6 +5,10 @@ on:
     types: [opened]
     branches: [master]
 
+permissions:
+  pull-requests: write
+  repository-projects: write
+
 concurrency:
   group: pr-dependabot-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
После https://github.com/VKCOM/VKUI/pull/5561 `.github/workflows/pull_request_dependabot.yml` теперь падает, т.к. не может запушить изменения.

В доке [Changing GITHUB_TOKEN permissions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions) сказано, что можно дать разрешение на запись для **Dependabot**, тем самым у бота появится возможность пушить.