### PR TITLE
fix(ActionSheet/SplitLayout): Make PopoutRoot fixed on desktop

### DIFF
--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.module.css
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.module.css
@@ -13,10 +13,6 @@
   height: 100%;
 }
 
-.PopoutRoot__popout--absolute {
-  position: absolute;
-}
-
 .PopoutRoot__modal {
   position: fixed;
   left: 0;

--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { blurActiveElement, useDOM } from '../../lib/dom';
 import { HasRootRef } from '../../types';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
@@ -11,18 +10,7 @@ interface PopoutRootPopoutProps {
 }
 
 const PopoutRootPopout = ({ children }: PopoutRootPopoutProps) => {
-  const { isDesktop } = useAdaptivityWithJSMediaQueries();
-
-  return (
-    <div
-      className={classNames(
-        styles['PopoutRoot__popout'],
-        isDesktop && styles['PopoutRoot__popout--absolute'],
-      )}
-    >
-      {children}
-    </div>
-  );
+  return <div className={classNames(styles['PopoutRoot__popout'])}>{children}</div>;
 };
 
 interface PopoutRootModalProps {


### PR DESCRIPTION
resolves: #5463 

В ситуации с m.vk.com/video из-за большого кол-ва компонентов на странице, если проскролить контент, и вызвать ActionSheet то получается, что абсолютно позиционированный `PopoutRoot` появлялся где-то наверху, в результате чего событие клика вне области `ActionSheet` может не всплыть до `body`, где у `ActionSheet` добавлен обработчик закрытия, особенно если клик был по контенту вне body.

Вне body в m.vk.com/video можно кликнуть потому, что контент на странице позиционирован через fixed/absolute, в результате чего, если чуть проскролить, то область где контента нету это область `html`, не `body`, потому что `body` на столько не растянут.

В этом изменении не должно быть проблем потому что мы уже давно такое используем для мобильных устройств. (см. https://github.com/VKCOM/VKUI/commit/91f5b01efff98eed8f42f5755faccdceccba2c3b#diff-310629b0806cf5a229d2859420471efd9c563b0c3e2422ecf8a1f82310952180L8-L16).