### PR TITLE
fix(SelectMimicry): useAutoFocus

### DIFF
--- a/packages/vkui/src/components/SelectMimicry/SelectMimicry.tsx
+++ b/packages/vkui/src/components/SelectMimicry/SelectMimicry.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
+import { useAutoFocus } from '../../hooks/useAutoFocus';
+import { useExternRef } from '../../hooks/useExternRef';
 import { SizeType } from '../../lib/adaptivity';
 import { getFormFieldModeFromSelectType } from '../../lib/select';
 import { HasAlign, HasRootRef } from '../../types';
@@ -42,10 +44,15 @@ export const SelectMimicry = ({
   selectType = 'default',
   status,
   className,
+  autoFocus,
   ...restProps
 }: SelectMimicryProps) => {
+  const rootRef = useExternRef(getRootRef);
+
   const { sizeY = 'none' } = useAdaptivity();
   const title = children || placeholder;
+
+  useAutoFocus(rootRef, autoFocus);
 
   return (
     <FormField
@@ -61,7 +68,7 @@ export const SelectMimicry = ({
         before && styles['Select--hasBefore'],
         className,
       )}
-      getRootRef={getRootRef}
+      getRootRef={rootRef}
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
       before={before}

--- a/packages/vkui/src/hooks/useAutoFocus.test.tsx
+++ b/packages/vkui/src/hooks/useAutoFocus.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useAutoFocus } from './useAutoFocus';
+
+const Playground = ({ autoFocus, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  useAutoFocus(ref, autoFocus);
+
+  return <div data-testid="div" ref={ref} tabIndex={0} {...props} />;
+};
+
+describe(useAutoFocus, () => {
+  it('autoFocus not set', () => {
+    const onFocus = jest.fn();
+    render(<Playground onFocus={onFocus} />);
+
+    expect(onFocus).not.toBeCalled();
+
+    const el = screen.getByTestId('div');
+    expect(document.activeElement).not.toBe(el);
+  });
+
+  it('set autoFocus', () => {
+    const onFocus = jest.fn();
+    render(<Playground onFocus={onFocus} autoFocus />);
+
+    expect(onFocus).toBeCalled();
+
+    const el = screen.getByTestId('div');
+    expect(document.activeElement).toBe(el);
+  });
+});

--- a/packages/vkui/src/hooks/useAutoFocus.ts
+++ b/packages/vkui/src/hooks/useAutoFocus.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
+
+export function useAutoFocus(
+  ref: React.RefObject<HTMLElement | null>,
+  autoFocus: boolean | undefined,
+) {
+  useIsomorphicLayoutEffect(() => {
+    if (!autoFocus || !ref.current) {
+      return;
+    }
+
+    ref.current.focus();
+  }, []);
+}


### PR DESCRIPTION
React в свойстве `autoFocus` обрабатывает только button, input, textarea и select
Добавляем хук для авто фокусировки элементов