### PR TITLE
fix(useAdaptivityHasPointer): two pass rendering

### DIFF
--- a/packages/vkui/src/hooks/useAdaptivityHasPointer.test.tsx
+++ b/packages/vkui/src/hooks/useAdaptivityHasPointer.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { AdaptivityProvider } from '../components/AdaptivityProvider/AdaptivityProvider';
+import { useAdaptivityHasPointer } from './useAdaptivityHasPointer';
+
+describe(useAdaptivityHasPointer, () => {
+  it('returns on client', () => {
+    const { result } = renderHook(useAdaptivityHasPointer, {});
+    expect(result.current).toEqual(true);
+  });
+
+  it('context hasPointer={true}', () => {
+    const { result } = renderHook(useAdaptivityHasPointer, {
+      wrapper: ({ children }) => (
+        <AdaptivityProvider hasPointer={true}>{children}</AdaptivityProvider>
+      ),
+    });
+    expect(result.current).toEqual(true);
+  });
+
+  it('context hasPointer={false}', () => {
+    const { result } = renderHook(useAdaptivityHasPointer, {
+      wrapper: ({ children }) => (
+        <AdaptivityProvider hasPointer={false}>{children}</AdaptivityProvider>
+      ),
+    });
+    expect(result.current).toEqual(false);
+  });
+});

--- a/packages/vkui/src/hooks/useAdaptivityHasPointer.ts
+++ b/packages/vkui/src/hooks/useAdaptivityHasPointer.ts
@@ -13,12 +13,13 @@ export function useAdaptivityHasPointer(deferDetect?: true): undefined | boolean
 export function useAdaptivityHasPointer(deferDetect?: false): boolean;
 export function useAdaptivityHasPointer(deferDetect = true): undefined | boolean {
   const { hasPointer: hasPointerContext } = React.useContext(AdaptivityContext);
-  const hasPointer = hasPointerContext === undefined ? hasPointerLib : hasPointerContext;
 
-  const isClient = useIsClient(!deferDetect);
-  if (!isClient) {
-    return undefined;
+  const needTwoPassRendering = !deferDetect || hasPointerContext !== undefined;
+
+  const isClient = useIsClient(needTwoPassRendering);
+  if (!isClient || hasPointerContext !== undefined) {
+    return hasPointerContext;
   }
 
-  return hasPointer;
+  return hasPointerLib;
 }


### PR DESCRIPTION
Не используем двойной рендер если
значение было проброшено через контекст