### PR TITLE
fix: Do not use classNames with one argument

### DIFF
--- a/packages/vkui/.eslintrc.js
+++ b/packages/vkui/.eslintrc.js
@@ -110,6 +110,10 @@ module.exports = {
           'ImportDeclaration[source.value=/\\.css$/i] ~ ImportDeclaration[source.value!=/\\.css$/i]',
         message: 'CSS import must be last',
       },
+      {
+        selector: 'CallExpression[callee.name="classNames"][arguments.length=1]',
+        message: 'Do not use classNames with one argument',
+      },
     ],
 
     'import/no-default-export': 'error',

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -276,13 +276,12 @@ export function CustomSelect(props: SelectProps) {
 
   const openedClassNames = React.useMemo(
     () =>
-      classNames(
-        opened &&
-          dropdownOffsetDistance === 0 &&
-          (popperPlacement?.includes('top')
-            ? styles['CustomSelect--pop-up']
-            : styles['CustomSelect--pop-down']),
-      ),
+      (opened &&
+        dropdownOffsetDistance === 0 &&
+        (popperPlacement?.includes('top')
+          ? styles['CustomSelect--pop-up']
+          : styles['CustomSelect--pop-down'])) ||
+      undefined,
     [dropdownOffsetDistance, opened, popperPlacement],
   );
 

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -186,9 +186,7 @@ export const ImageBase = ({
             onError={handleImageError}
           />
         )}
-        {fallbackIcon && (
-          <div className={classNames(styles['ImageBase__fallback'])}>{fallbackIcon}</div>
-        )}
+        {fallbackIcon && <div className={styles['ImageBase__fallback']}>{fallbackIcon}</div>}
         {children}
         {withBorder && <div aria-hidden className={styles['ImageBase__border']} />}
       </div>

--- a/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
+++ b/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
@@ -57,7 +57,7 @@ export const SubnavigationBar = ({
         // и удалить применение селектора в `SubnavigationButton.module.css`.
         // 2. Заменить глобальный селектор на CSS Modules `styles['SubnavigationBar--mode-fixed']`
         // mode !== 'fixed' && classNames('vkuiInternalSubnavigationBar--mode-fixed')
-        mode === 'fixed' && classNames('vkuiInternalSubnavigationBar--mode-fixed'),
+        mode === 'fixed' && 'vkuiInternalSubnavigationBar--mode-fixed',
         className,
       )}
     >


### PR DESCRIPTION
Запрещаем использовать classNames с одним свойством