### PR TITLE
fix(useAdaptivityHasHover): two pass rendering

### DIFF
--- a/packages/vkui/src/hooks/useAdaptivityHasHover.test.tsx
+++ b/packages/vkui/src/hooks/useAdaptivityHasHover.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { AdaptivityProvider } from '../components/AdaptivityProvider/AdaptivityProvider';
+import { useAdaptivityHasHover } from './useAdaptivityHasHover';
+
+describe(useAdaptivityHasHover, () => {
+  it('returns on client', () => {
+    const { result } = renderHook(useAdaptivityHasHover, {});
+    expect(result.current).toEqual(true);
+  });
+
+  it('context hasHover={true}', () => {
+    const { result } = renderHook(useAdaptivityHasHover, {
+      wrapper: ({ children }) => (
+        <AdaptivityProvider hasHover={true}>{children}</AdaptivityProvider>
+      ),
+    });
+    expect(result.current).toEqual(true);
+  });
+
+  it('context hasHover={false}', () => {
+    const { result } = renderHook(useAdaptivityHasHover, {
+      wrapper: ({ children }) => (
+        <AdaptivityProvider hasHover={false}>{children}</AdaptivityProvider>
+      ),
+    });
+    expect(result.current).toEqual(false);
+  });
+});

--- a/packages/vkui/src/hooks/useAdaptivityHasHover.ts
+++ b/packages/vkui/src/hooks/useAdaptivityHasHover.ts
@@ -15,9 +15,11 @@ export function useAdaptivityHasHover(deferDetect = true): undefined | boolean {
   const { hasHover: hasHoverContext } = React.useContext(AdaptivityContext);
   const hasHover = hasHoverContext === undefined ? hasHoverLib : hasHoverContext;
 
-  const isClient = useIsClient(!deferDetect);
-  if (!isClient) {
-    return undefined;
+  const needTwoPassRendering = deferDetect || hasHoverContext === undefined;
+
+  const isClient = useIsClient(!needTwoPassRendering);
+  if (!isClient || hasHoverContext !== undefined) {
+    return hasHoverContext;
   }
 
   return hasHover;

--- a/packages/vkui/src/hooks/useAdaptivityHasPointer.ts
+++ b/packages/vkui/src/hooks/useAdaptivityHasPointer.ts
@@ -14,9 +14,9 @@ export function useAdaptivityHasPointer(deferDetect?: false): boolean;
 export function useAdaptivityHasPointer(deferDetect = true): undefined | boolean {
   const { hasPointer: hasPointerContext } = React.useContext(AdaptivityContext);
 
-  const needTwoPassRendering = !deferDetect || hasPointerContext !== undefined;
+  const needTwoPassRendering = deferDetect || hasPointerContext === undefined;
 
-  const isClient = useIsClient(needTwoPassRendering);
+  const isClient = useIsClient(!needTwoPassRendering);
   if (!isClient || hasPointerContext !== undefined) {
     return hasPointerContext;
   }


### PR DESCRIPTION
Не используем двойной рендер если
значение было проброшено через контекст

## `useAdaptivityHasPointer`

Поправили условие из PR #5666

- caused by #5666