### PR TITLE
fix(ChipsSelect): Use showSelected prop

### DIFF
--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -69,6 +69,12 @@ describe('ChipsSelect', () => {
       userEvent.click(queryListOption(colors[0]) as Element);
       expect(queryListOption(colors[1])).toBeNull();
     });
+    it('does not close options after select with showSelected and closeAfterSelect={false}', async () => {
+      render(<ChipsSelect options={colors} value={[]} showSelected closeAfterSelect={false} />);
+      await toggleDropdown();
+      userEvent.click(queryListOption(colors[0]) as Element);
+      expect(queryListOption(colors[1])).toBeTruthy();
+    });
     it('closes options on esc', async () => {
       render(<ChipsSelect options={colors} value={[]} />);
       await toggleDropdown();
@@ -105,8 +111,13 @@ describe('ChipsSelect', () => {
       expect(queryListOption(options[idx])).toBeNull();
       expect(value).toEqual([options[idx]]);
     });
+    it('does not hide selected option from list', async () => {
+      render(<ChipsSelect options={colors} value={[colors[0]]} showSelected />);
+      await toggleDropdown();
+      expect(queryListOption(colors[0])).toBeTruthy();
+    });
     it('hides selected option from list', async () => {
-      render(<ChipsSelect options={colors} value={[colors[0]]} />);
+      render(<ChipsSelect options={colors} value={[colors[0]]} showSelected={false} />);
       await toggleDropdown();
       expect(queryListOption(colors[0])).toBeNull();
     });

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -174,10 +174,8 @@ export const ChipsSelect = <Option extends ChipOption>(props: ChipsSelectProps<O
   };
 
   const handleClickOutside = (e: MouseEvent) => {
-    const isClickOutsideFormField =
-      e.target !== rootRef.current && !rootRef.current?.contains(e.target as Node);
-    const isClickOutsideDropdown =
-      e.target !== scrollBoxRef.current && !scrollBoxRef.current?.contains(e.target as Node);
+    const isClickOutsideFormField = !rootRef.current?.contains(e.target as Node);
+    const isClickOutsideDropdown = !scrollBoxRef.current?.contains(e.target as Node);
 
     if (isClickOutsideFormField && isClickOutsideDropdown) {
       setOpened(false);

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -174,7 +174,12 @@ export const ChipsSelect = <Option extends ChipOption>(props: ChipsSelectProps<O
   };
 
   const handleClickOutside = (e: MouseEvent) => {
-    if (e.target !== rootRef.current && !rootRef.current?.contains(e.target as Node)) {
+    const isClickOutsideFormField =
+      e.target !== rootRef.current && !rootRef.current?.contains(e.target as Node);
+    const isClickOutsideDropdown =
+      e.target !== scrollBoxRef.current && !scrollBoxRef.current?.contains(e.target as Node);
+
+    if (isClickOutsideFormField && isClickOutsideDropdown) {
       setOpened(false);
     }
   };

--- a/packages/vkui/src/hooks/useChipsSelect.ts
+++ b/packages/vkui/src/hooks/useChipsSelect.ts
@@ -6,7 +6,7 @@ import { useChipsInput } from './useChipsInput';
 export const useChipsSelect = <Option extends ChipOption>(
   props: Partial<ChipsSelectProps<Option>>,
 ) => {
-  const { options, filterFn, getOptionLabel, getOptionValue } = props;
+  const { options, filterFn, getOptionLabel, getOptionValue, showSelected } = props;
 
   const [opened, setOpened] = React.useState(false);
   const [focusedOptionIndex, setFocusedOptionIndex] = React.useState<number | null>(0);
@@ -32,22 +32,25 @@ export const useChipsSelect = <Option extends ChipOption>(
       : (options as Option[]);
   }, [options, filterFn, fieldValue, getOptionLabel]);
 
-  filteredOptions = React.useMemo(() => {
-    if (!filteredOptions.length) {
-      return filteredOptions;
-    }
-
-    const filteredSet = new Set(filteredOptions);
-    const selected = selectedOptions.map((item) => getOptionValue!(item));
-
-    for (const item of filteredSet) {
-      if (selected.includes(getOptionValue!(item))) {
-        filteredSet.delete(item);
+  filteredOptions = React.useMemo(
+    function filterOutSelectedIfNeeded() {
+      if (!filteredOptions.length || showSelected) {
+        return filteredOptions;
       }
-    }
 
-    return [...filteredSet];
-  }, [filteredOptions, selectedOptions, getOptionValue]);
+      const filteredSet = new Set(filteredOptions);
+      const selected = selectedOptions.map((item) => getOptionValue!(item));
+
+      for (const item of filteredSet) {
+        if (selected.includes(getOptionValue!(item))) {
+          filteredSet.delete(item);
+        }
+      }
+
+      return [...filteredSet];
+    },
+    [filteredOptions, selectedOptions, getOptionValue, showSelected],
+  );
 
   return {
     ...chipsInputState,


### PR DESCRIPTION
fixes: #5677 

## Описание
По какой-то причине мы вообще не использовали этот проп.

## Изменения
- при включенном пропе `showSelected` выбранные опции не отфильтровываются.
- поправил логику закрытия по клику мимо селекта. Оказалось, оттого, что дропдаунт рендерится через портал, click outside логика срабатывает при клике по опции и селект закрывается. Раньше это не было заметно, потому без правильно работающего showSelected пропа выбранные опции всегда удалялись из dropdown и событие клика по опции никак не обрабатывалось и не всплывало до body. А по какой опции был сделан клик мы определяли по `onMouseDown`.