### PR TITLE
tech: Добавляем команду `size:ci` в package.json монорепы

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
     "playwright:install": "playwright install --with-deps",
     "playwright:cmd:merge-reports": "playwright merge-reports",
     "codesandbox:install": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install",
-    "deduplicate": "yarn-deduplicate --list && yarn-deduplicate --fail"
+    "deduplicate": "yarn-deduplicate --list && yarn-deduplicate --fail",
+    "size:ci": "yarn workspace @vkontakte/vkui run size:ci"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [


### PR DESCRIPTION
Связяна с: https://github.com/VKCOM/VKUI/pull/5717

Для обновления yarn до v3 надо удалить пустой `yarn.lock` файл из `/packages/vkui/`, потому что этот файл мешает yarn 3 без ошибок установить зависимости.
Этот пустой файл нужен для того, чтобы помочь экшену `andresz1/size-limit-action` правильно понять какой пакетный мереджер использовать.
https://github.com/andresz1/size-limit-action/blob/v1.7.0/src/Term.ts#L18-L22

Чтобы продолжить пользоваться экшеном без ошибок придётся удалить `packages/vkui/yarn.lock` и отказаться от свойства `directory`, потому что
именно по нему экшен попадает в `packages/vkui` и пытается найти `yarn.lock` чтобы определить пакетный менеджер. Если `yarn.lock` нет, то переключившись на ветку master и перейдя в папку `packages/vkui` он пытается установить зависимости используя `npm`, отчего тоже падает.

Как решение мы можем дать этому экшену комманду в корне репозитория. За счёт того, что команда в корне репозитория, экшен правильно установит зависимости используя `yarn`, а потом вызовет эту команду, которая укажет правильную папку для дальнейших действий.

Сразу в одном PR с обновлением yarn это не сделать, потому что экшен для сравнения размера пакета переключается на ветку `master`, а в этой ветке пока что в корне репозитория нету такой команды.