### PR TITLE
tech(dependabot): add v5 label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,6 +76,11 @@ updates:
           - '@vkontakte/prettier-config'
     versioning-strategy: increase
     open-pull-requests-limit: 20
+    labels:
+      - 'javascript'
+      - 'dependencies'
+      # По умолчанию должно отправляться в ветку с v5
+      - 'v5'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'
@@ -88,6 +93,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    labels:
+      - 'github_actions'
+      - 'dependencies'
+      # По умолчанию должно отправляться в ветку с v5
+      - 'v5'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'


### PR DESCRIPTION
- related to #5723

По умолчанию выставляем метку `v5` для PR от Dependabot, чтобы не приходилось это делать вручную. Договорились обновление зависимостей пока тоже мержить в ветку **v5**.

> **Note**
>
> Указание `labels` перебивает метки, который выставляет Dependabot по умолчанию в зависимости от `package-ecosystem`, поэтому вручную указал их.

