### PR TITLE
tech: Skip close milestone if needed with flag close_milestone

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,11 @@ on:
       custom_version:
         description: 'custom version: x.y.z (without "v")'
         required: false
+      close_milestone:
+        description: 'whether to close associated milestone after publish'
+        required: true
+        type: boolean
+        default: true
 
 run-name: Publish ${{ inputs.type }} ${{ inputs.custom_version }}
 
@@ -101,6 +106,7 @@ jobs:
 
   close_milestone:
     needs: ['publish']
+    if: ${{ github.event.inputs.close_milestone  }}
     runs-on: ubuntu-latest
     steps:
       - name: Close milestone, comment on issues and release notes

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -24,6 +24,11 @@ on:
       custom_version:
         description: 'custom version: x.y.z-beta.0 (without "v")'
         required: false
+      close_milestone:
+        description: 'whether to close associated milestone after publish'
+        required: true
+        type: boolean
+        default: true
 
 run-name: Publish pre-release ${{ inputs.type }} ${{ inputs.custom_version }} (tag ${{ inputs.tag }})
 
@@ -100,6 +105,7 @@ jobs:
 
   close_milestone:
     needs: ['publish']
+    if: ${{ github.event.inputs.close_milestone  }}
     runs-on: ubuntu-latest
     steps:
       - name: Close milestone, comment on issues and release notes


### PR DESCRIPTION
True by default.

Ингда при релизе может не быть майлстоуна, например во время теста `publish` workflow, или при публикации тестовой кастомной версии. Хочется, чтобы этот шаг можно было пропустить.