### PR TITLE
Fix ModalDismissButton appearance in the doc

### DIFF
--- a/packages/vkui/src/components/ModalDismissButton/Readme.md
+++ b/packages/vkui/src/components/ModalDismissButton/Readme.md
@@ -10,6 +10,7 @@ const CustomPopout = ({ onClose }) => {
         style={{
           backgroundColor: 'var(--vkui--color_background_content)',
           borderRadius: 8,
+          position: 'relative',
           padding: '12px',
         }}
       >


### PR DESCRIPTION
## Описание
Кнопка пропала из документации https://vkcom.github.io/VKUI/#/ModalDismissButton

Пропажа связана с 
https://github.com/VKCOM/VKUI/commit/b5aa644c1d5a45d28a8c9240110829e4e7ca4a59
потому что мы стали полагаться на `position: relative` `PopoutWrapper__content`, но в примере он имеет ширину на всю страницу.

Вернул position: relative в пример.

## Изображения
До
![5337-dab1-d9b5-4640](https://github.com/VKCOM/VKUI/assets/5443359/55fd5e90-f592-4c47-81be-c1c4e1ffb991)

После
<img width="1020" alt="Снимок экрана 2023-09-08 в 19 35 53" src="https://github.com/VKCOM/VKUI/assets/5443359/6c3414c8-661a-47c6-b9a7-b3e41339e38d">
