### PR TITLE
fix: bad env NODE_ENVIRONMENT

### DIFF
--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -33,7 +33,7 @@ export const AdaptivityProvider = ({
   const LEGACY_bridge = useBridgeAdaptivity(LEGACY_disableInternalUseBridgeAdaptivity);
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  if (process.env.NODE_ENVIRONMENT === 'development') {
+  if (process.env.NODE_ENV === 'development') {
     // TODO [>=6]: удалить warn
     if (!LEGACY_disableInternalUseBridgeAdaptivity) {
       warn("[@vkontakte/vk-bridge] Интеграция VKUI с @vkontakte/vk-bridge устарела и будет удалена в v6. Используйте хук `useAdaptivity()` из @vkontakte/vk-bridge-react и результат передайте в компонент (см. https://github.com/VKCOM/VKUI/issues/5049)"); // prettier-ignore

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -100,7 +100,7 @@ export const AppRoot = ({
 
   const { hasPointer, sizeX = 'none' } = useAdaptivity();
 
-  if (process.env.NODE_ENVIRONMENT === 'development') {
+  if (process.env.NODE_ENV === 'development') {
     if (!safeAreaInsets) {
       // TODO [>=6]: удалить warn
       warn("[@vkontakte/vk-bridge] Интеграция VKUI с @vkontakte/vk-bridge устарела и будет удалена в v6. Используйте хук `useInsets()` из @vkontakte/vk-bridge-react и результат передайте в параметр `safeAreaInsets` (см. https://github.com/VKCOM/VKUI/issues/5049)"); // prettier-ignore

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
@@ -57,7 +57,7 @@ export const ConfigProvider = (props: ConfigProviderProps) => {
       ? props.webviewType === WebviewType.VKAPPS
       : hasCustomPanelHeaderAfterMerged;
 
-  if (process.env.NODE_ENVIRONMENT === 'development') {
+  if (process.env.NODE_ENV === 'development') {
     // TODO [>=6]: удалить warn
     let webviewTypeRule = '';
     if (props.webviewType) {

--- a/packages/vkui/types/env.d.ts
+++ b/packages/vkui/types/env.d.ts
@@ -5,3 +5,16 @@ declare module '*.module.css' {
 }
 
 declare module '*.svg';
+
+// Фиксируем process.env, так как vite передает только NODE_ENV
+declare module 'process' {
+  declare global {
+    namespace NodeJS {
+      interface Process {
+        env: {
+          NODE_ENV: 'development' | 'production' | 'test';
+        };
+      }
+    }
+  }
+}


### PR DESCRIPTION
Сломалась сборка в vite из-за переменной.
Переименовываем `NODE_ENVIRONMENT` в `NODE_ENV` и фиксируем в типах

- fixed #5767