### PR TITLE
feature(ModalPage/Alert) Allow to pass testid to inner components

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -73,4 +73,19 @@ describe('Alert', () => {
       });
     });
   });
+
+  it('passes data-testid to actions', () => {
+    render(
+      <Alert
+        onClose={jest.fn()}
+        actions={[
+          { 'title': 'Allow', 'mode': 'default', 'data-testid': 'allow-test-id' },
+          { 'title': 'Deny', 'mode': 'default', 'data-testid': 'deny-test-id' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('allow-test-id')).toHaveTextContent('Allow');
+    expect(screen.getByTestId('deny-test-id')).toHaveTextContent('Deny');
+  });
 });

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -28,6 +28,7 @@ export interface AlertActionInterface
   action?: VoidFunction;
   autoClose?: boolean;
   mode: AlertActionMode;
+  ['data-testid']?: string;
 }
 
 export interface AlertProps extends React.HTMLAttributes<HTMLElement> {

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -7,7 +7,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { useWaitTransitionFinish } from '../../hooks/useWaitTransitionFinish';
 import { Platform } from '../../lib/platform';
 import { stopPropagation } from '../../lib/utils';
-import { AlignType, AnchorHTMLAttributesOnly } from '../../types';
+import { AlignType, AnchorHTMLAttributesOnly, HasDataAttribute } from '../../types';
 import { useScrollLock } from '../AppRoot/ScrollContext';
 import { ButtonProps } from '../Button/Button';
 import { FocusTrap } from '../FocusTrap/FocusTrap';
@@ -23,12 +23,12 @@ type AlertActionMode = 'cancel' | 'destructive' | 'default';
 
 export interface AlertActionInterface
   extends Pick<ButtonProps, 'Component'>,
-    AnchorHTMLAttributesOnly {
+    AnchorHTMLAttributesOnly,
+    HasDataAttribute {
   title: string;
   action?: VoidFunction;
   autoClose?: boolean;
   mode: AlertActionMode;
-  ['data-testid']?: string;
 }
 
 export interface AlertProps extends React.HTMLAttributes<HTMLElement> {

--- a/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { ModalPage } from './ModalPage';
 
@@ -7,5 +8,19 @@ describe('ModalPage', () => {
     // TODO [a11y]: "ARIA dialog and alertdialog nodes should have an accessible name (aria-dialog-name)"
     //              https://dequeuniversity.com/rules/axe/4.5/aria-dialog-name?application=axeAPI
     a11y: false,
+  });
+
+  test('testid is for content', () => {
+    const { rerender } = render(<ModalPage nav="id" />);
+
+    expect(screen.queryByTestId('modal-page-id')).not.toBeTruthy();
+    expect(screen.queryByTestId('modal-content-id')).not.toBeTruthy();
+
+    rerender(
+      <ModalPage nav="id" data-testid="modal-page-id" modalContentTestId="modal-content-id" />,
+    );
+
+    expect(screen.queryByTestId('modal-page-id')).toBeTruthy();
+    expect(screen.queryByTestId('modal-content-id')).toBeTruthy();
   });
 });

--- a/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
@@ -10,7 +10,7 @@ describe('ModalPage', () => {
     a11y: false,
   });
 
-  test('testid is for content', () => {
+  test('testid for modal page content', () => {
     const { rerender } = render(<ModalPage nav="id" />);
 
     expect(screen.queryByTestId('modal-page-id')).not.toBeTruthy();

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -61,6 +61,7 @@ export interface ModalPageProps extends HTMLAttributesWithRootRef<HTMLDivElement
    * Скрывает кнопку закрытия (актуально для iOS, т.к. можно отрисовать кнопку закрытия внутри модалки)
    */
   hideCloseButton?: boolean;
+  modalContentTestId?: string;
 }
 
 const warn = warnOnce('ModalPage');
@@ -82,6 +83,7 @@ export const ModalPage = ({
   nav,
   id: idProp,
   hideCloseButton = false,
+  modalContentTestId,
   ...restProps
 }: ModalPageProps) => {
   const generatingId = useId();
@@ -139,6 +141,7 @@ export const ModalPage = ({
               <div
                 className={styles['ModalPage__content']}
                 ref={multiRef<HTMLDivElement>(refs.contentElement, getModalContentRef)}
+                {...(modalContentTestId && { 'data-testid': modalContentTestId })}
               >
                 <div className={styles['ModalPage__content-in']}>{children}</div>
               </div>

--- a/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.test.tsx
+++ b/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.test.tsx
@@ -1,7 +1,35 @@
 import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { ModalPageHeader } from './ModalPageHeader';
 
 describe('ModalPageHeader', () => {
   baselineComponent((props) => <ModalPageHeader {...props}>ModalPageHeader</ModalPageHeader>);
+
+  test('typographyProps can be partially overriden', () => {
+    const { rerender } = render(<ModalPageHeader>Стартовый экран</ModalPageHeader>);
+
+    expect(screen.queryByRole('heading', { level: 2, name: 'Стартовый экран' })).toBeTruthy();
+    expect(screen.queryByTestId('header-text-id')).toBeFalsy();
+
+    rerender(
+      <ModalPageHeader typographyProps={{ 'data-testid': 'header-text-id' }}>
+        Стартовый экран
+      </ModalPageHeader>,
+    );
+
+    // cвойства по-умолчанию не сбросились
+    expect(screen.queryByRole('heading', { level: 2, name: 'Стартовый экран' })).toBeTruthy();
+    expect(screen.queryByTestId('header-text-id')).toBeTruthy();
+
+    rerender(
+      <ModalPageHeader typographyProps={{ 'Component': 'h3', 'data-testid': 'header-text-id' }}>
+        Стартовый экран
+      </ModalPageHeader>,
+    );
+
+    expect(screen.queryByRole('heading', { level: 2, name: 'Стартовый экран' })).toBeFalsy();
+    expect(screen.queryByRole('heading', { level: 3, name: 'Стартовый экран' })).toBeTruthy();
+    expect(screen.queryByTestId('header-text-id')).toBeTruthy();
+  });
 });

--- a/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -22,6 +22,7 @@ export const ModalPageHeader = ({
   separator = true,
   getRef,
   className,
+  typographyProps,
   ...restProps
 }: ModalPageHeaderProps) => {
   const platform = usePlatform();
@@ -40,14 +41,15 @@ export const ModalPageHeader = ({
     >
       <PanelHeader
         className={classNames('vkuiInternalModalPageHeader__in', className)}
+        typographyProps={{
+          Component: 'h2',
+          id: labelId,
+          ...typographyProps,
+        }}
         {...restProps}
         fixed={false}
         separator={false}
         transparent
-        typographyProps={{
-          Component: 'h2',
-          id: labelId,
-        }}
       >
         {children}
       </PanelHeader>

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -52,7 +52,7 @@ export interface PanelHeaderProps
   /**
    * По умолчанию как `Component` используется `span`.
    */
-  typographyProps?: HasComponent & React.HTMLAttributes<HTMLDivElement> & HasDataAttribute;
+  typographyProps?: HasComponent & React.HTMLAttributes<HTMLElement> & HasDataAttribute;
 }
 
 const PanelHeaderIn = ({

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -52,7 +52,8 @@ export interface PanelHeaderProps
   /**
    * По умолчанию как `Component` используется `span`.
    */
-  typographyProps?: HasComponent & React.HTMLAttributes<HTMLElement>;
+  typographyProps?: HasComponent &
+    React.HTMLAttributes<HTMLDivElement> & { 'data-testid'?: string };
 }
 
 const PanelHeaderIn = ({

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -5,7 +5,7 @@ import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditi
 import { usePlatform } from '../../hooks/usePlatform';
 import { SizeType } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';
-import { HasComponent, HasRef, HTMLAttributesWithRootRef } from '../../types';
+import { HasComponent, HasDataAttribute, HasRef, HTMLAttributesWithRootRef } from '../../types';
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';
 import { FixedLayout } from '../FixedLayout/FixedLayout';
 import { ModalRootContext } from '../ModalRoot/ModalRootContext';
@@ -52,8 +52,7 @@ export interface PanelHeaderProps
   /**
    * По умолчанию как `Component` используется `span`.
    */
-  typographyProps?: HasComponent &
-    React.HTMLAttributes<HTMLDivElement> & { 'data-testid'?: string };
+  typographyProps?: HasComponent & React.HTMLAttributes<HTMLDivElement> & HasDataAttribute;
 }
 
 const PanelHeaderIn = ({


### PR DESCRIPTION
- [x] Unit-тесты
- [x] e2e-тесты (не нужны)
- [x] Дизайн-ревью (не требуется)

## Описание
Основано на вопросах по поводу того как писать наиболее стабильные E2E тесты используя vkui.

Мотивация:
- как можно меньше зависеть от внутренней реализации VKUI и уйти от селекторов в тестах.
- не всегда удобно завязываться на текст, хоть и может быть предпочтительнее.

### Почему не подождать подкомпонентного подхода https://github.com/VKCOM/VKUI/issues/4699?
В подкомпонентном подходе это, конечно, будет легче сделать, но мы всё равно оставим для пользователей возможность использовать уже собранный вариант компонента по умолчанию и хотелось бы поддержать возможность для пользователей прокидывать внутрь `data-testid`.
В https://github.com/VKCOM/VKUI/issues/2342 мы окончательно смогли бы решить эту проблему.

На данный момент просто хотелось бы дать возможность уже сейчас подготовиться пользователем к изменениям в css и отвязаться от классов в тестах.

## Изменения
- добавил проп `modalContentTestId` в ModalPage, чтобы можно было проще взаимодействовать с контейнером контента. Есть пара случаев где приходится в тестах контроллировать скролл. Поиск контейнера контента очень хрупок.
- добавил `['data-testid']?: string;` проп в интервейс `Alert actions`, чтобы можно было прокидывать `testid` каждому экшену в `Alert`.