### PR TITLE
fix(ActionSheet): iOS Remove extra shadow padding

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.e2e.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.e2e.tsx
@@ -11,6 +11,9 @@ test.describe('ActionSheet', () => {
       sizeY: SizeType.REGULAR,
     },
     onlyForPlatforms: [Platform.IOS, Platform.ANDROID],
+    toMatchSnapshot: {
+      threshold: 0.02,
+    },
   });
   test('ViewWidth.MOBILE sizeY=regular', async ({
     mount,
@@ -29,6 +32,9 @@ test.describe('ActionSheet', () => {
       sizeY: SizeType.REGULAR,
     },
     onlyForPlatforms: [Platform.VKCOM],
+    toMatchSnapshot: {
+      threshold: 0.02,
+    },
   });
   test('ViewWidth.DESKTOP sizeY=regular', async ({
     mount,

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
@@ -1,16 +1,16 @@
 .ActionSheet {
-  overflow: hidden;
-  box-shadow: var(--vkui--elevation3);
-  width: calc(100% - 20px);
+  width: 100%;
   max-width: var(--vkui--size_popup_small--regular);
-  align-items: stretch;
-  display: flex;
-  flex-direction: column;
+  padding: 10px;
   box-sizing: border-box;
   animation: animation-actionsheet-intro 0.2s var(--vkui--animation_easing_platform);
+}
+
+.ActionSheet__content-wrapper {
   padding: 8px 0;
-  margin: 10px;
+  overflow: hidden;
   border-radius: 12px;
+  box-shadow: var(--vkui--elevation3);
   background: var(--vkui--color_background_modal);
 }
 
@@ -34,9 +34,21 @@
 .ActionSheet--ios {
   width: 100%;
   animation: animation-actionsheet-intro 0.3s var(--vkui--animation_easing_platform);
-  padding: 8px;
-  margin: unset;
   background: transparent;
+}
+
+.ActionSheet--ios .ActionSheet__content-wrapper {
+  border-radius: 14px;
+  padding: 0;
+}
+
+.ActionSheet__close-item-wrapper--ios {
+  margin-top: 8px;
+  margin-bottom: var(--vkui_internal--safe_area_inset_bottom);
+  overflow: hidden;
+  border-radius: 14px;
+  box-shadow: var(--vkui--elevation3);
+  background: var(--vkui--color_background_modal);
 }
 
 .ActionSheet--ios.ActionSheet--closing {
@@ -46,8 +58,6 @@
 
 .ActionSheet--ios .ActionSheet__header {
   position: relative;
-  overflow: hidden;
-  border-radius: 14px 14px 0 0;
   text-align: center;
 }
 
@@ -85,11 +95,11 @@
   width: auto;
   height: auto;
   animation: none;
-  margin: 0;
+  padding: 0;
   max-width: 100%;
 }
 
-.ActionSheet--desktop.ActionSheet--ios {
+.ActionSheet--desktop.ActionSheet--ios .ActionSheet__content-wrapper {
   border-radius: 14px;
   padding: 0;
 }

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
@@ -32,7 +32,6 @@
  * iOS
  */
 .ActionSheet--ios {
-  width: 100%;
   padding: 8px;
   animation: animation-actionsheet-intro 0.3s var(--vkui--animation_easing_platform);
   background: transparent;

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
@@ -1,7 +1,7 @@
 .ActionSheet {
   width: 100%;
   max-width: var(--vkui--size_popup_small--regular);
-  padding: 8px;
+  padding: 10px;
   box-sizing: border-box;
   animation: animation-actionsheet-intro 0.2s var(--vkui--animation_easing_platform);
 }
@@ -33,6 +33,7 @@
  */
 .ActionSheet--ios {
   width: 100%;
+  padding: 8px;
   animation: animation-actionsheet-intro 0.3s var(--vkui--animation_easing_platform);
   background: transparent;
 }

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
@@ -1,7 +1,7 @@
 .ActionSheet {
   width: 100%;
   max-width: var(--vkui--size_popup_small--regular);
-  padding: 10px;
+  padding: 8px;
   box-sizing: border-box;
   animation: animation-actionsheet-intro 0.2s var(--vkui--animation_easing_platform);
 }

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -134,4 +134,56 @@ describe('ActionSheet', () => {
       expect(onClose).toBeCalledWith({ closedBy: 'other' });
     });
   });
+
+  test('renders header and text', () => {
+    render(<ActionSheetMobile header="The header title" text="Text footnote" />);
+    expect(screen.queryByText('The header title')).toBeTruthy();
+    expect(screen.queryByText('Text footnote')).toBeTruthy();
+  });
+
+  test('renders close button only on mobile iOS', () => {
+    const { rerender } = render(
+      <ConfigProvider platform={Platform.IOS}>
+        <AdaptivityProvider viewWidth={ViewWidth.MOBILE} hasPointer>
+          <ActionSheet onClose={jest.fn()} />
+        </AdaptivityProvider>
+      </ConfigProvider>,
+    );
+
+    // mobile iOS
+    expect(screen.queryByText('Отмена')).toBeTruthy();
+
+    rerender(
+      <ConfigProvider platform={Platform.IOS}>
+        <AdaptivityProvider viewWidth={ViewWidth.DESKTOP} hasPointer>
+          <ActionSheet onClose={jest.fn()} />
+        </AdaptivityProvider>
+      </ConfigProvider>,
+    );
+
+    // desktop iOS
+    expect(screen.queryByText('Отмена')).toBeFalsy();
+
+    rerender(
+      <ConfigProvider platform={Platform.ANDROID}>
+        <AdaptivityProvider viewWidth={ViewWidth.MOBILE} hasPointer>
+          <ActionSheet onClose={jest.fn()} />
+        </AdaptivityProvider>
+      </ConfigProvider>,
+    );
+
+    // mobile Android
+    expect(screen.queryByText('Отмена')).toBeFalsy();
+
+    rerender(
+      <ConfigProvider platform={Platform.ANDROID}>
+        <AdaptivityProvider viewWidth={ViewWidth.DESKTOP} hasPointer>
+          <ActionSheet onClose={jest.fn()} />
+        </AdaptivityProvider>
+      </ConfigProvider>,
+    );
+
+    // desktop Android
+    expect(screen.queryByText('Отмена')).toBeFalsy();
+  });
 });

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -124,20 +124,24 @@ export const ActionSheet = ({
         className={isDesktop ? className : undefined}
         style={isDesktop ? style : undefined}
       >
-        {(header || text) && (
-          <header className={styles['ActionSheet__header']}>
-            {header && (
-              <Footnote weight="2" className={styles['ActionSheet__title']}>
-                {header}
-              </Footnote>
-            )}
-            {text && <Footnote className={styles['ActionSheet__text']}>{text}</Footnote>}
-          </header>
+        <div className={styles['ActionSheet__content-wrapper']}>
+          {(header || text) && (
+            <header className={styles['ActionSheet__header']}>
+              {header && (
+                <Footnote weight="2" className={styles['ActionSheet__title']}>
+                  {header}
+                </Footnote>
+              )}
+              {text && <Footnote className={styles['ActionSheet__text']}>{text}</Footnote>}
+            </header>
+          )}
+          {children}
+        </div>
+        {platform === Platform.IOS && !isDesktop && (
+          <div className={styles['ActionSheet__close-item-wrapper--ios']}>
+            {iosCloseItem ?? <ActionSheetDefaultIosCloseItem />}
+          </div>
         )}
-        {children}
-        {platform === Platform.IOS &&
-          !isDesktop &&
-          (iosCloseItem ?? <ActionSheetDefaultIosCloseItem />)}
       </DropdownComponent>
     </ActionSheetContext.Provider>
   );

--- a/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-desktop-sizey-regular-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-desktop-sizey-regular-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53b58e5688cc654b71593a0e249753e20b171d26d8f653435935d349d8b26ab2
-size 56529
+oid sha256:a7fdfd0f26ca511f4589f5d65a5cbe5413398b8444c6aa3b4818f8cd001f6bb2
+size 52887

--- a/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-desktop-sizey-regular-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-desktop-sizey-regular-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cce913df1b6bb4b3a0d693e1ef8c45d381b88bd8f6e04f7ff02534a9e65aa16c
-size 84688
+oid sha256:05d6c94310644bee4e3c3f241e4ae210e07fa9d4809eef6a0d5b3e17bee207b8
+size 81206

--- a/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-desktop-sizey-regular-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-desktop-sizey-regular-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6e08a4f9c4c9d58c7bcd0c6995754bcda867f93939340fe3c7ae70c97d59eae
-size 52057
+oid sha256:4ef9eea6833abbc7eeca56b944ec01503c683272c1ed8d5b4577895d183fbf7a
+size 49051

--- a/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df181ad881f334c47cd265743db2f7084ceae413620231b7963a14d2443adcc7
-size 47548
+oid sha256:d01fa65bf07c338bf39b358be5c42abfc0fe7b8edcbfb8b49ffda3fbefcbc995
+size 46037

--- a/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3353295c484fab5ca14d8d253e7950c3d8dfb38257e44cc038fff958e6ab425
-size 47307
+oid sha256:7f702fc5e761a1685d56d97f805e0d2d1645935d5af364f96a19d5dda854a109
+size 48332

--- a/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:465e1e0f3ba4e4366479d04dd4f128c80857b59b599cd90c3bdf1de3ea2b2e6d
-size 49637
+oid sha256:a3e9ca1c22b26ba0663a167ca93f1425d6f6f7b82e3a838c2317b90e7a4a7582
+size 47653

--- a/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ActionSheet/__image_snapshots__/actionsheet-viewwidth-mobile-sizey-regular-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10a2140f09fbf1e58a68fab813ce448a46afe4a116f299aa09d030258a47df4e
-size 49119
+oid sha256:3267686d652bcb854820c38d20bee10841ae63b3ca15d06803a6a828145e60a8
+size 49713

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.module.css
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.module.css
@@ -7,7 +7,6 @@
   color: var(--vkui--color_text_primary);
   padding: 0 20px;
   min-height: 48px;
-  border-radius: 0;
   box-sizing: border-box;
 }
 
@@ -109,7 +108,6 @@
 .ActionSheetItem--ios {
   padding: 14px 18px;
   min-height: 56px;
-  border-radius: 0;
   color: var(--vkui--color_text_accent_themed);
   background: var(--vkui--color_background_modal);
 }
@@ -124,17 +122,6 @@
 
 .ActionSheetItem--ios.ActionSheetItem--mode-destructive {
   color: var(--vkui--color_text_negative);
-}
-
-.ActionSheetItem--ios:first-child {
-  border-top-left-radius: 14px;
-  border-top-right-radius: 14px;
-}
-
-.ActionSheetItem--ios:not(.ActionSheetItem--desktop):nth-last-child(2),
-.ActionSheetItem--ios:last-child {
-  border-bottom-left-radius: 14px;
-  border-bottom-right-radius: 14px;
 }
 
 .ActionSheetItem--ios::before {
@@ -192,9 +179,6 @@
 }
 
 .ActionSheetItem--mode-cancel {
-  margin-top: 8px;
-  margin-bottom: var(--vkui_internal--safe_area_inset_bottom);
-  border-radius: 14px;
   min-height: 52px;
 }
 


### PR DESCRIPTION
- close #3866

---

- [x] Unit-тесты - добавил парочку в основном чтобы не ругался codecov
- [x] e2e-тесты - проходят
~- [ ] Дизайн-ревью~ (не требуется, ничего не поменялось)

## Описание

Тень имеет лишний отступ потому что ActionSheet имеет паддинг при прозрачном фоне.
Плюс ко всему этот отступ заметен не только сверху но и между списком опций и кнопкой "Отмена".

Пришлось разделить и обернуть список опций и кнопку отмена в отдельные обертки

## Изменения
- добавляется отдельная обертка вокруг списка опций и кнопки отмена в iOS
  - обертки отвечают за тень.
- убраны стили `ActionSheetItem` отвечающие за border-radius, потому что за это теперь отвечают обертки в  `ActionSheet`.
- отступ в Android и iOS задается теперь задаётся только через паддинг. 
- увеличили точность алгоритма в скриншотном тестировании в ActionSheet e2e тестах. По причине того, что точность по умолчанию не позволяла заметить изменения в тени ActionSheet.

## Скриншоты
До
<img width="349" alt="Снимок экрана 2023-09-13 в 16 25 23" src="https://github.com/VKCOM/VKUI/assets/5443359/4844718d-08b9-4050-a95d-0b8764110b6b">

После
<img width="368" alt="Снимок экрана 2023-09-13 в 16 26 59" src="https://github.com/VKCOM/VKUI/assets/5443359/52e52c4f-4f89-4823-9685-b3c7e3cc75b0">

