### PR TITLE
chore(ci): add latest tag support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ on:
         required: true
         type: boolean
         default: true
+      latest:
+        description: 'set latest tag'
+        required: true
+        type: boolean
+        default: true
 
 run-name: Publish ${{ inputs.type }} ${{ inputs.custom_version }}
 
@@ -102,11 +107,16 @@ jobs:
           yarn config set npmAlwaysAuth true
           yarn config set npmAuthToken $NODE_AUTH_TOKEN
 
-      - name: Publishing release
-        run: |
-          yarn workspace @vkontakte/vkui npm publish
+      - name: Publishing with latest tag
+        if: ${{ github.event.inputs.latest == 'true' }}
+        run: yarn workspace @vkontakte/vkui npm publish
+
+      - name: Publishing with legacy tag
+        if: ${{ github.event.inputs.latest != 'true' }}
+        run: yarn workspace @vkontakte/vkui npm publish --tag legacy
 
       - name: Creating doc for stable release
+        if: ${{ github.event.inputs.latest == 'true' }}
         run: |
           yarn run docs:styleguide:build
           yarn run docs:storybook:build
@@ -114,6 +124,12 @@ jobs:
           cp -R packages/vkui/storybook-static/* styleguide/dist/playground
           cp -R styleguide/dist/* styleguide/${{ steps.updated_version.outputs.version }}
           mv styleguide/${{ steps.updated_version.outputs.version }} styleguide/dist/${{ steps.updated_version.outputs.version }}
+
+      - name: Build styleguide and storybook for legacy release
+        if: ${{ github.event.inputs.latest != 'true' }}
+        run: |
+          yarn run docs:styleguide:build --dist dist/${{ steps.updated_version.outputs.version }}
+          yarn docs:storybook:build -o ../../styleguide/dist/${{ steps.updated_version.outputs.version }}/playground
 
       - name: Publishing doc
         uses: JamesIves/github-pages-deploy-action@v4
@@ -126,7 +142,7 @@ jobs:
 
   close_milestone:
     needs: ['publish']
-    if: ${{ github.event.inputs.close_milestone  }}
+    if: ${{ github.event.inputs.close_milestone == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Close milestone, comment on issues and release notes
@@ -134,3 +150,4 @@ jobs:
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           releaseTag: ${{ needs.publish.outputs.release_tag }}
+          latest: ${{ github.event.inputs.latest }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,10 @@ on:
         required: false
       close_milestone:
         description: 'whether to close associated milestone after publish'
-        required: true
         type: boolean
         default: true
       latest:
         description: 'set latest tag'
-        required: true
         type: boolean
         default: true
 

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -125,7 +125,7 @@ jobs:
 
   close_milestone:
     needs: ['publish']
-    if: ${{ github.event.inputs.close_milestone  }}
+    if: ${{ github.event.inputs.close_milestone == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Close milestone, comment on issues and release notes
@@ -133,3 +133,4 @@ jobs:
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           releaseTag: ${{ needs.publish.outputs.release_tag }}
+          latest: false


### PR DESCRIPTION
~~- [ ] Unit-тесты~~
~~- [ ] e2e-тесты~~
~~- [ ] Дизайн-ревью~~

## Описание

Добавила в параметры запуска `publish`'a булик, который отвечает за проставление тега `latest` при паблише пакета в `npm` и `release notes`.

При деплое сторибука и стайлгайда оставляем только файлики по пути версии (чтобы не затирались актуальные)

Если `latest=false`, то в `npm` сейчас будет запаблишена версия с тегом `legacy` (`npm` требует всегда пушить с каким-нибудь тегом). Пока кажется, что мы  хотим паблишить без `latest` только версии прошлого мажора, поэтому тег более-менее подходящий. Раньше мы паблишили с тегом мажора (например, `v4`), но `npm` так делать не [рекомендует](https://docs.npmjs.com/adding-dist-tags-to-packages#:~:text=Note%3A%20Since%20dist%2Dtags%20share%20a%20namespace%20with%20semantic%20versions%2C%20avoid%20dist%2Dtags%20that%20conflict%20with%20existing%20version%20numbers.%20We%20recommend%20avoiding%20dist%2Dtags%20that%20start%20with%20a%20number%20or%20the%20letter%20%22v%22.).

![image](https://github.com/VKCOM/VKUI/assets/7431217/a73d155e-ed56-4b44-9dc4-7d2143ac208a)


## Изменения

Дополнительно сделала изменения для джобы с `close_milestone`, потому что булики в экшонах на самом деле строки
