### PR TITLE
fix(ModalRoot): fix modal overlay 

### DIFF
--- a/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
@@ -6,8 +6,9 @@ import { ModalCard } from '../ModalCard/ModalCard';
 import { ModalPage } from '../ModalPage/ModalPage';
 import { ModalRootTouch } from './ModalRoot';
 import { ModalRootDesktop } from './ModalRootDesktop';
+import styles from './ModalRoot.module.css';
 
-const clickFade = () => userEvent.click(document.querySelector('.vkuiModalRoot__mask') as Element);
+const clickFade = () => userEvent.click(document.querySelector(`.${styles.ModalRoot__mask}`)!);
 let rafSpies: jest.SpyInstance[];
 
 describe.each([
@@ -136,7 +137,9 @@ describe.each([
     runAllTimers();
 
     // check if mask is present
-    expect((document.querySelector('.vkuiModalRoot__mask') as HTMLElement).style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>(`.${styles.ModalRoot__mask}`)?.style.opacity).toBe(
+      '1',
+    );
 
     // onClose is working
     clickFade();

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
@@ -121,4 +121,25 @@ describe.each([
       });
     }
   });
+
+  it('check modal mask with fast modal change', async () => {
+    const onClose = jest.fn();
+    const modals = [
+      <ModalPage id="m" key="m" />,
+      <ModalPage id="other" key="o" onClose={onClose} />,
+    ];
+
+    const h = render(<ModalRoot activeModal="m">{modals}</ModalRoot>);
+    runAllTimers();
+    h.rerender(<ModalRoot activeModal={null}>{modals}</ModalRoot>);
+    h.rerender(<ModalRoot activeModal="other">{modals}</ModalRoot>);
+    runAllTimers();
+
+    // check if mask is present
+    expect((document.querySelector('.vkuiModalRoot__mask') as HTMLElement).style.opacity).toBe('1');
+
+    // onClose is working
+    clickFade();
+    expect(onClose).toBeCalledTimes(1);
+  });
 });

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -122,6 +122,7 @@ class ModalRootTouchComponent extends React.Component<
           ? `${this.timeout}ms`
           : '';
         this.animateTranslate(enteringState, enteringState.translateY);
+        this.setMaskOpacity(enteringState, 1);
       }
     }
 
@@ -538,6 +539,8 @@ class ModalRootTouchComponent extends React.Component<
             ? 1 - (translateYCurrent - translateY) / (100 - translateY) || 0
             : forceOpacity;
         this.maskElementRef.current.style.opacity = clamp(opacity, 0, 100).toString();
+        this.maskElementRef.current.style.transitionDelay =
+          opacity && this.props.delayEnter ? `${this.timeout}ms` : '';
       }
     });
   }

--- a/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -109,6 +109,9 @@ export const ModalRootDesktop = ({
             timeout,
           );
           animateModalOpacity(enteringState, true);
+          if (enteringState) {
+            setMaskOpacity(enteringState, 1);
+          }
         }
       });
 
@@ -116,10 +119,13 @@ export const ModalRootDesktop = ({
     }
 
     // Переход между модальными окнами без анимации
-    if (enteringState?.innerElement) {
-      enteringState.innerElement.style.transition = 'none';
-      enteringState.innerElement.style.opacity = '1';
-    }
+    requestAnimationFrame(() => {
+      if (enteringState?.innerElement) {
+        enteringState.innerElement.style.transition = 'none';
+        enteringState.innerElement.style.opacity = '1';
+        setMaskOpacity(enteringState, 1);
+      }
+    });
 
     onEntered(enteringModal);
   };


### PR DESCRIPTION
---
- fix #5740
---
- [x] Unit-тесты
- ~[ ] e2e-тесты~ 
- ~[ ] Дизайн-ревью~

## Описание

Для случая, когда модальные окна сменяются (`modal1 - null - modal2`) достаточно быстро (в пределах длительности анимации закрытия), теряли подложку у модального окна (она оставалась в `opacity: 0`, а при появлении нового окна (из состояния `null`) мы всегда полагались на то, что компонент с подложкой будет замаунчен заново).

## Изменения

Теперь в `entering`-фазе всегда проставляем подложке `opacity: 1`. 
Для десктопной версии завернула изменение стилей в `requestAnimationFrame`, чтобы сохранить очередность событий
