### PR TITLE
fix(Popper): mv to useLayoutEffect

### DIFF
--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -17,6 +17,7 @@ import {
   useFloating,
   type UseFloatingMiddleware,
 } from '../../lib/floating';
+import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import type { HasRef, HTMLAttributesWithRootRef } from '../../types';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
 import {
@@ -230,11 +231,11 @@ export const Popper = ({
   // TODO [>=6]: убрать getRef
   const handleRootRef = useExternRef<HTMLDivElement>(refs.setFloating, getRef, getRootRef);
 
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     refs.setReference(targetRef.current);
   }, [refs, targetRef]);
 
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (resolvedPlacement && onPlacementChange) {
       onPlacementChange({ placement: resolvedPlacement });
     }


### PR DESCRIPTION
- fix #5759 

## Описание

Т.к. `useIsClient` теперь обновляет состояние через `useLayoutEffect`, в **React 18** начало неправильно пересчитываться положение `Popper` при первом открытии.

Сначала думал это связано с двойным вызовом `useEffect` в **development** при оборачивание в `StrictMode`, но ни удаление этой обёртки, ни сборка в **production** не помогли.

Попробовал заменить `useEffect` также на `useLayoutEffect`, что помогло.

- caused by #5606
