### PR TITLE
feat(ActionSheetItem): add `after`

### DIFF
--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.module.css
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.module.css
@@ -84,21 +84,16 @@
   color: var(--vkui--color_icon_negative);
 }
 
-.ActionSheetItem__radio {
-  display: none;
-}
-
-.ActionSheetItem__marker {
-  display: none;
-  align-items: center;
-  justify-content: center;
-  background-color: transparent;
-  color: var(--vkui--color_icon_accent);
-  margin-left: 16px;
-}
-
-.ActionSheetItem__radio:checked ~ .ActionSheetItem__marker {
+.ActionSheetItem__after {
   display: flex;
+  flex-direction: row;
+  margin-left: 16px;
+  color: var(--vkui--color_icon_accent);
+}
+
+/* stylelint-disable-next-line selector-max-universal -- gap 12px */
+.ActionSheetItem__after > *:not(:last-child) {
+  margin-right: 12px;
 }
 
 /**

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Icon20CheckCircleOn, Icon24CheckCircleOn } from '@vkontakte/icons';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { usePlatform } from '../../hooks/usePlatform';
@@ -10,6 +9,7 @@ import { Tappable } from '../Tappable/Tappable';
 import { Subhead } from '../Typography/Subhead/Subhead';
 import { Text } from '../Typography/Text/Text';
 import { Title } from '../Typography/Title/Title';
+import { Radio } from './subcomponents/Radio/Radio';
 import styles from './ActionSheetItem.module.css';
 
 export interface ActionSheetItemProps
@@ -18,6 +18,7 @@ export interface ActionSheetItemProps
     Pick<React.InputHTMLAttributes<HTMLInputElement>, 'name' | 'checked' | 'value'> {
   mode?: 'default' | 'destructive' | 'cancel';
   before?: React.ReactNode;
+  after?: React.ReactNode;
   meta?: React.ReactNode;
   subtitle?: React.ReactNode;
   autoClose?: boolean;
@@ -48,13 +49,14 @@ export interface ActionSheetItemProps
 /**
  * @see https://vkcom.github.io/VKUI/#/ActionSheetItem
  */
-const ActionSheetItem = ({
+export const ActionSheetItem = ({
   children,
   autoClose,
   mode = 'default',
   meta,
   subtitle,
   before,
+  after,
   selectable,
   value,
   name,
@@ -64,7 +66,7 @@ const ActionSheetItem = ({
   onClick,
   onImmediateClick,
   multiline = false,
-  iconChecked: iconCheckedProp,
+  iconChecked,
   className,
   isCancelItem,
   ...restProps
@@ -73,10 +75,6 @@ const ActionSheetItem = ({
   const { onItemClick = () => noop, isDesktop } =
     React.useContext<ActionSheetContextType<HTMLElement>>(ActionSheetContext);
   const { sizeY } = useAdaptivityWithJSMediaQueries();
-
-  const iconChecked =
-    iconCheckedProp ||
-    (sizeY === SizeType.COMPACT ? <Icon20CheckCircleOn /> : <Icon24CheckCircleOn />);
 
   let Component: React.ElementType = restProps.href ? 'a' : 'div';
 
@@ -142,29 +140,29 @@ const ActionSheetItem = ({
         </div>
         {subtitle && <Subhead className={styles['ActionSheetItem__subtitle']}>{subtitle}</Subhead>}
       </div>
-      {selectable && (
+      {(selectable || after) && (
         <div className={styles['ActionSheetItem__after']}>
-          <input
-            type="radio"
-            className={styles['ActionSheetItem__radio']}
-            name={name}
-            value={value}
-            onChange={onChange}
-            onClick={onItemClick({
-              action: noop,
-              immediateAction: noop,
-              autoClose: Boolean(autoClose),
-              isCancelItem: Boolean(isCancelItem),
-            })}
-            defaultChecked={defaultChecked}
-            checked={checked}
-            disabled={restProps.disabled}
-          />
-          <div className={styles['ActionSheetItem__marker']}>{iconChecked}</div>
+          {after}
+          {selectable && (
+            <Radio
+              name={name}
+              value={value}
+              onChange={onChange}
+              onClick={onItemClick({
+                action: noop,
+                immediateAction: noop,
+                autoClose: Boolean(autoClose),
+                isCancelItem: Boolean(isCancelItem),
+              })}
+              defaultChecked={defaultChecked}
+              checked={checked}
+              disabled={restProps.disabled}
+            >
+              {iconChecked}
+            </Radio>
+          )}
         </div>
       )}
     </Tappable>
   );
 };
-
-export { ActionSheetItem };

--- a/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.module.css
+++ b/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.module.css
@@ -1,0 +1,9 @@
+/* stylelint-disable-next-line selector-max-universal -- отключаем иконку */
+.ActionSheetItemRadio__input ~ * {
+  display: none;
+}
+
+/* stylelint-disable-next-line selector-max-universal -- включаем иконку если checked */
+.ActionSheetItemRadio__input:checked ~ * {
+  display: block;
+}

--- a/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Icon20CheckCircleOn, Icon24CheckCircleOn } from '@vkontakte/icons';
+import { HasRef, HasRootRef } from '../../../../types';
+import { AdaptiveIconRenderer } from '../../../AdaptiveIconRenderer/AdaptiveIconRenderer';
+import { RootComponent } from '../../../RootComponent/RootComponent';
+import { VisuallyHidden } from '../../../VisuallyHidden/VisuallyHidden';
+import styles from './Radio.module.css';
+
+const adaptiveIcon = (
+  <AdaptiveIconRenderer IconCompact={Icon20CheckCircleOn} IconRegular={Icon24CheckCircleOn} />
+);
+
+interface ActionSheetItemCheckedProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    HasRootRef<HTMLDivElement>,
+    HasRef<HTMLInputElement> {
+  /**
+   * Иконка для `checked` режима.
+   */
+  children?: React.ReactNode;
+}
+
+export const Radio = ({
+  children = adaptiveIcon,
+  getRootRef,
+  getRef,
+  className,
+  style,
+  ...restProps
+}: ActionSheetItemCheckedProps) => {
+  return (
+    <RootComponent getRootRef={getRootRef} className={className} style={style}>
+      <VisuallyHidden
+        Component="input"
+        getRootRef={getRef}
+        type="radio"
+        className={styles['ActionSheetItemRadio__input']}
+        {...restProps}
+      />
+      {children}
+    </RootComponent>
+  );
+};


### PR DESCRIPTION
- closed #2017

---

- ~[ ] Unit-тесты~
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~

## Описание

Добавлено свойство `after` для ActionSheetItem

## Изменения

Была вынесена Radio иконка как отдельный компонент, слегка пофиксил a11y.

Прокинул свойство `after` в нужное место
