### PR TITLE
fix(WriteBar): icons shift

### DIFF
--- a/packages/vkui/src/components/WriteBar/WriteBar.e2e-playground.tsx
+++ b/packages/vkui/src/components/WriteBar/WriteBar.e2e-playground.tsx
@@ -76,3 +76,39 @@ export const WriteBarPlayground = (props: ComponentPlaygroundProps) => {
     </ComponentPlayground>
   );
 };
+
+const WriteBarIosSmileIcon = (
+  <WriteBarIcon aria-label="Смайлы и стикеры">
+    <Icon28SmileOutline />
+  </WriteBarIcon>
+);
+
+export const WriteBarIosIconsPlayground = (props: ComponentPlaygroundProps) => {
+  return (
+    <ComponentPlayground
+      {...props}
+      propSets={[
+        {
+          value: ['', 'Сообщение'],
+        },
+      ]}
+    >
+      {(props: WriteBarProps) => {
+        const value = String(props.value);
+        return (
+          <WriteBar
+            {...props}
+            inlineAfter={value.length > 0 && WriteBarIosSmileIcon}
+            after={
+              <>
+                {value.length === 0 && WriteBarIosSmileIcon}
+                <WriteBarIcon disabled={!value.length} mode="send" />
+              </>
+            }
+            placeholder="Сообщение"
+          />
+        );
+      }}
+    </ComponentPlayground>
+  );
+};

--- a/packages/vkui/src/components/WriteBar/WriteBar.e2e.tsx
+++ b/packages/vkui/src/components/WriteBar/WriteBar.e2e.tsx
@@ -1,8 +1,26 @@
 import * as React from 'react';
 import { test } from '@vkui-e2e/test';
-import { WriteBarPlayground } from './WriteBar.e2e-playground';
+import { Platform } from '../../lib/platform';
+import { WriteBarIosIconsPlayground, WriteBarPlayground } from './WriteBar.e2e-playground';
+
+test.use({
+  toMatchSnapshot: {
+    threshold: 0.04,
+  },
+});
 
 test('WriteBar', async ({ mount, expectScreenshotClippedToContent, componentPlaygroundProps }) => {
   await mount(<WriteBarPlayground {...componentPlaygroundProps} />);
   await expectScreenshotClippedToContent();
+});
+
+test.describe('WriteBar', () => {
+  test.use({
+    onlyForPlatforms: [Platform.IOS],
+  });
+  // Проверяем, что иконки в iOS не сдвигаются при изменении value
+  test('icons', async ({ mount, expectScreenshotClippedToContent, componentPlaygroundProps }) => {
+    await mount(<WriteBarIosIconsPlayground {...componentPlaygroundProps} />);
+    await expectScreenshotClippedToContent();
+  });
 });

--- a/packages/vkui/src/components/WriteBar/__image_snapshots__/writebar-icons-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/WriteBar/__image_snapshots__/writebar-icons-ios-webkit-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57b389e6761d6067bddb2808c48103a09c5680b71a47d2e62a03892872e4f4ee
+size 11501

--- a/packages/vkui/src/components/WriteBar/__image_snapshots__/writebar-icons-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/WriteBar/__image_snapshots__/writebar-icons-ios-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:600193f200619f109da3c4203b02b47fb2b7a1e792cc5118b987f15c8c12854d
+size 11708

--- a/packages/vkui/src/components/WriteBar/__image_snapshots__/writebar-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/WriteBar/__image_snapshots__/writebar-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a216796d09bfa713bffa4b9be2c4f568924c9a19e52a1ce5eb38063244f12be5
-size 29252
+oid sha256:d6bd23575f8f664ebce416aeb8c16c1b1e0a53f5f69708030bf8d7d5af60f99a
+size 28272

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.module.css
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.module.css
@@ -35,6 +35,10 @@
   box-shadow: 0 0 0 2px var(--vkui--color_background_modal);
 }
 
+.WriteBarIcon--ios .WriteBarIcon__counter {
+  box-shadow: 0 0 0 2px var(--vkui--color_background_content);
+}
+
 .WriteBarIcon.WriteBarIcon--mode-send,
 .WriteBarIcon.WriteBarIcon--mode-done {
   color: var(--vkui--color_icon_accent);
@@ -55,10 +59,15 @@
   padding-right: 0;
 }
 
+.WriteBarIcon--ios.WriteBarIcon--mode-send,
+.WriteBarIcon--ios.WriteBarIcon--mode-done {
+  /* компенсируем отступ WriteBar__after справа */
+  margin-right: -4px;
+}
+
 .WriteBarIcon--ios.WriteBarIcon--mode-send:only-child,
 .WriteBarIcon--ios.WriteBarIcon--mode-done:only-child {
-  /* для одной иконки нужно компенсировать отступы */
-  margin-right: -4px;
+  /* для одной иконки нужно компенсировать отступ WriteBar__after слева */
   margin-left: -4px;
 }
 


### PR DESCRIPTION
~- [ ] Unit-тесты~

- [x] e2e-тесты

~- [ ] Дизайн-ревью~

## Описание

В `iOS` "прыгала" `after` часть в случае, когда иконка и кнопка располагались вместе, а должны оставаться на своих местах

https://github.com/VKCOM/VKUI/assets/7431217/a655f037-2e2f-49bf-a95f-286e5d3b431d

## Изменения


https://github.com/VKCOM/VKUI/assets/7431217/7fd6fb87-693d-456a-b839-3fbfbf3c0817


Добавила компенсацию отступа для случая, когда в `after` части находится и кнопка, и иконки вместе.

И исправила обводку в `IOS` компонента `Counter`, чтобы она совпадала с фоном (пришлось ещё потрогать threshold, чтобы изменения на скриншотах появились)
