### PR TITLE
fix(ModalRoot/ModalPage): Fix flacky expanding and scrolling

### DIFF
--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -646,7 +646,7 @@ function initModal(modalState: ModalsStateEntry) {
 
 function initPageModal(modalState: ModalsStateEntry) {
   const { contentElement, bottomInset } = modalState;
-  const contentElementHeight = (contentElement?.firstElementChild as HTMLElement).offsetHeight;
+  const contentElementHeight = (contentElement?.firstElementChild as HTMLElement).scrollHeight;
   const bottomInsetHeight = bottomInset?.offsetHeight || 0;
   const contentHeight = contentElementHeight + bottomInsetHeight;
   let prevTranslateY = modalState.translateY;


### PR DESCRIPTION
- close #5793

## Описание

related to #4625, #4689, #5402

Иногда, если достаточно быстро свайпнуть вниз `ModalPage`, то состояние `collapsed` останется `false`, что в 
свою очередь означает, что сработает 
https://github.com/VKCOM/VKUI/blob/9309f383d991ac81469a4b4cf81450085fd10d84/packages/vkui/src/components/ModalRoot/ModalRoot.tsx#L606-L607
и у контента модалки высота будет выставлена как `height: 100%`.
https://github.com/VKCOM/VKUI/blob/9309f383d991ac81469a4b4cf81450085fd10d84/packages/vkui/src/components/ModalPage/ModalPage.module.css#L118-L124

В таком случае при следующем открытии модалки высота контента `.ModalPage__content-in` будет равна высоте родителя `.ModalPage__content` и проверка состояния expanded вернёт false, что в свою очередь заставит модалку открыться на всю высоту.
https://github.com/VKCOM/VKUI/blob/9309f383d991ac81469a4b4cf81450085fd10d84/packages/vkui/src/components/ModalRoot/ModalRoot.tsx#L654-L655
Но при этом другие проверки будут считать, что контент будто бы ещё можно развернуть на 100% в результате чего скролл внутри будет отсутствовать, пока модалку не развернут.

То есть получается сразу две проблемы. Модалка раскрыта полность, хотя не должна быть и отсутствует скролл контента.

Для того чтобы логика `expanded` не зависила от `height` контента, нам достаточно смотреть не на `offsetHeight` контента, а на `scrollHeigh`, тогда высота контента, особенно при большом количестве контента, не будет зависеть от height: 100% и мы стабильно будем знать, что контент стоит ещё развернуть. При этом мы не ломаем поведение при небольшом количестве контента, потому что `scrollHeight` значения будут почти эквивалентны `offsetHeight`, достаточно для наших задач.

## Изменения
- используем `scrollHeight` вместо `offsetHeight` чтобы получить высоту контента модалки для принятия решения по поводу состояния `expanded`.
