### PR TITLE
fix(ScrollArrow): Specify default type="button"

### DIFF
--- a/packages/vkui/src/components/ScrollArrow/ScrollArrow.test.tsx
+++ b/packages/vkui/src/components/ScrollArrow/ScrollArrow.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { baselineComponent } from '../../testing/utils';
 import { ScrollArrow } from './ScrollArrow';
@@ -15,5 +15,10 @@ describe(ScrollArrow, () => {
     const { container } = render(<ScrollArrow direction="left" offsetY={offsetY} onClick={noop} />);
     const elIcon = container.querySelector(`.${styles['ScrollArrow__icon']}`);
     expect(elIcon).toHaveStyle({ top: `${offsetY}px` });
+  });
+
+  it('should have type="button" by default', () => {
+    render(<ScrollArrow direction="left" onClick={noop} />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
   });
 });

--- a/packages/vkui/src/components/ScrollArrow/ScrollArrow.tsx
+++ b/packages/vkui/src/components/ScrollArrow/ScrollArrow.tsx
@@ -59,6 +59,7 @@ export const ScrollArrow = ({
   return (
     <RootComponent
       Component="button"
+      type="button"
       baseClassName={classNames(
         styles['ScrollArrow'],
         stylesSize[size],


### PR DESCRIPTION
- close #5852

---

## Описание
ScrollArrow это кнопка, и чтобы она не отправляла форму по умолчанию, ей следует задать тип `button`.

