### PR TITLE
fix(AspectRatio): children prop passing

### DIFF
--- a/packages/vkui/src/components/AspectRatio/AspectRatio.tsx
+++ b/packages/vkui/src/components/AspectRatio/AspectRatio.tsx
@@ -10,7 +10,6 @@ export interface AspectRatioProps extends HTMLAttributesWithRootRef<HTMLDivEleme
    * По умолчанию, вложенный контент будет растягиваться и заполнять весь блок.
    */
   mode?: 'stretch' | 'none';
-  children: React.ReactNode;
   /**
    * Например 16 / 9, 4 / 3, 1920 / 1080
    */
@@ -20,13 +19,12 @@ export interface AspectRatioProps extends HTMLAttributesWithRootRef<HTMLDivEleme
 /**
  * `AspectRatio` позволяет поддерживать постоянное соотношение ширины и высоты.
  * Его можно использовать для отображения изображений, карт, видео и других медиафайлов.
- 
+
  * @since 5.5.0
  * @see https://vkcom.github.io/VKUI/#/AspectRatio
  */
 export function AspectRatio({
   ratio,
-  children,
   mode = 'stretch',
   style: styleProp,
   ...props


### PR DESCRIPTION

## Описание
После fd4948219b59c41d1a61c2e629ac0a773c1dff54 мы перестали передавать `children` в `RootComponent`.
Проверил все изменения из того коммита - это единственное место.

В результате чего на странице [AspectRatio](https://vkcom.github.io/VKUI/5.8.0/#/AspectRatio) начиная с версии 5.8.0 мы не видим картинок.
<img width="1407" alt="Снимок экрана 2023-09-25 в 11 58 04" src="https://github.com/VKCOM/VKUI/assets/5443359/bbbd7d11-0c09-4f18-9039-5b2a72638881">


<!--
По возможности, напиши подробности о том, что делает PR.

Добавь ссылки на связанные задачи, если такие есть. Это позволит легче разобраться откуда росли
"ноги".

Пример:
- related to #123
-->

