### PR TITLE
fix(SimpleCell): Get rid of selector complexity to define icon color

### DIFF
--- a/packages/vkui/src/components/CellButton/CellButton.module.css
+++ b/packages/vkui/src/components/CellButton/CellButton.module.css
@@ -41,16 +41,13 @@
 }
 
 .CellButton {
+  --vkui_internal--simple_cell_icon_color: var(--vkui--color_icon_accent);
+
   color: var(--vkui--color_text_accent);
 }
 
-.CellButton :global(.vkuiInternalSimpleCell__before),
-.CellButton :global(.vkuiInternalSimpleCell__after) {
-  color: var(--vkui--color_icon_accent);
-}
+.CellButton--mode-danger {
+  --vkui_internal--simple_cell_icon_color: var(--vkui--color_text_negative);
 
-.CellButton--mode-danger,
-.CellButton--mode-danger :global(.vkuiInternalSimpleCell__before),
-.CellButton--mode-danger :global(.vkuiInternalSimpleCell__after) {
   color: var(--vkui--color_text_negative);
 }

--- a/packages/vkui/src/components/CellButton/CellButton.module.css
+++ b/packages/vkui/src/components/CellButton/CellButton.module.css
@@ -41,13 +41,13 @@
 }
 
 .CellButton {
-  --vkui_internal--simple_cell_icon_color: var(--vkui--color_icon_accent);
+  --vkui_internal--icon_color: var(--vkui--color_icon_accent);
 
   color: var(--vkui--color_text_accent);
 }
 
 .CellButton--mode-danger {
-  --vkui_internal--simple_cell_icon_color: var(--vkui--color_text_negative);
+  --vkui_internal--icon_color: var(--vkui--color_text_negative);
 
   color: var(--vkui--color_text_negative);
 }

--- a/packages/vkui/src/components/CellButton/CellButton.module.css
+++ b/packages/vkui/src/components/CellButton/CellButton.module.css
@@ -44,14 +44,13 @@
   color: var(--vkui--color_text_accent);
 }
 
-.CellButton :global(.vkuiIcon) {
+.CellButton :global(.vkuiInternalSimpleCell__before),
+.CellButton :global(.vkuiInternalSimpleCell__after) {
   color: var(--vkui--color_icon_accent);
 }
 
-.CellButton--mode-danger {
+.CellButton--mode-danger,
+.CellButton--mode-danger :global(.vkuiInternalSimpleCell__before),
+.CellButton--mode-danger :global(.vkuiInternalSimpleCell__after) {
   color: var(--vkui--color_text_negative);
-}
-
-.CellButton--mode-danger :global(.vkuiIcon) {
-  color: var(--vkui--color_icon_negative);
 }

--- a/packages/vkui/src/components/CellButton/CellButton.tsx
+++ b/packages/vkui/src/components/CellButton/CellButton.tsx
@@ -23,9 +23,7 @@ export const CellButton = ({
       {...restProps}
       className={classNames(
         styles['CellButton'],
-        'vkuiInternalCellButton',
-        mode === 'danger' &&
-          classNames(styles['CellButton--mode-danger'], 'vkuiInternalCellButton--mode-danger'),
+        mode === 'danger' && styles['CellButton--mode-danger'],
         centered && styles['CellButton--centered'],
         className,
       )}

--- a/packages/vkui/src/components/ImageBase/ImageBase.module.css
+++ b/packages/vkui/src/components/ImageBase/ImageBase.module.css
@@ -5,7 +5,7 @@
   justify-content: center;
   flex-shrink: 0;
   box-sizing: border-box;
-  color: var(--vkui--color_icon_secondary);
+  color: var(--vkui_internal--icon_color, var(--vkui--color_icon_secondary));
   background-color: var(--vkui--color_background_secondary);
   background-size: cover;
   isolation: isolate;
@@ -48,14 +48,6 @@
   /* Расчитываем на ценитрирование через родительский `display: flex` */
   top: auto;
   left: auto;
-}
-
-/**
- * CMP:
- * CellButton
- */
-:global(.vkuiInternalCellButton) .ImageBase {
-  color: var(--vkui_internal--simple_cell_icon_color, var(--vkui--color_icon_accent));
 }
 
 /**

--- a/packages/vkui/src/components/ImageBase/ImageBase.module.css
+++ b/packages/vkui/src/components/ImageBase/ImageBase.module.css
@@ -54,12 +54,8 @@
  * CMP:
  * CellButton
  */
-:global(.vkuiInternalCellButton) > .ImageBase :global(.vkuiIcon) {
-  color: var(--vkui--color_icon_accent);
-}
-
-:global(.vkuiInternalCellButton--mode-danger) > .ImageBase :global(.vkuiIcon) {
-  color: var(--vkui--color_icon_negative);
+:global(.vkuiInternalCellButton) .ImageBase {
+  color: var(--vkui_internal--simple_cell_icon_color, var(--vkui--color_icon_accent));
 }
 
 /**

--- a/packages/vkui/src/components/Removable/Removable.module.css
+++ b/packages/vkui/src/components/Removable/Removable.module.css
@@ -10,10 +10,6 @@
   flex-grow: 0;
   flex-shrink: 0;
   border: 0;
-}
-
-/* Увеличиваем вес селектора */
-.Removable__action.Removable__action {
   color: var(--vkui--color_icon_secondary);
 }
 

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
@@ -23,13 +23,12 @@
   padding-top: 6px;
   padding-bottom: 6px;
   padding-right: 12px;
+  color: var(--vkui--color_icon_accent);
 }
 
-/* stylelint-disable-next-line @project-tools/stylelint-atomic */
+/* stylelint-disable-next-line @project-tools/stylelint-atomic -- добиваем отступ до 16px */
 .SimpleCell__before > :global(.vkuiIcon) {
-  /* добиваем отступ до 16px  */
   padding-right: 4px;
-  color: var(--vkui--color_icon_accent);
 }
 
 .SimpleCell__before:empty {

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
@@ -23,12 +23,13 @@
   padding-top: 6px;
   padding-bottom: 6px;
   padding-right: 12px;
-  color: var(--vkui--color_icon_accent);
 }
 
-/* stylelint-disable-next-line @project-tools/stylelint-atomic -- добиваем отступ до 16px */
+/* stylelint-disable-next-line @project-tools/stylelint-atomic */
 .SimpleCell__before > :global(.vkuiIcon) {
+  /* добиваем отступ до 16px  */
   padding-right: 4px;
+  color: var(--vkui--color_icon_accent);
 }
 
 .SimpleCell__before:empty {
@@ -115,11 +116,11 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  color: var(--vkui--color_icon_accent);
 }
 
 .SimpleCell__after > :global(.vkuiIcon) {
   padding-left: 8px;
+  color: var(--vkui--color_icon_accent);
 }
 
 .SimpleCell__after > :global(.vkuiIcon):last-child {

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
@@ -23,7 +23,7 @@
   padding-top: 6px;
   padding-bottom: 6px;
   padding-right: 12px;
-  color: var(--vkui_internal--simple_cell_icon_color, var(--vkui--color_icon_accent));
+  color: var(--vkui_internal--icon_color, var(--vkui--color_icon_accent));
 }
 
 /* stylelint-disable-next-line @project-tools/stylelint-atomic -- добиваем отступ до 16px */
@@ -115,7 +115,7 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  color: var(--vkui_internal--simple_cell_icon_color, var(--vkui--color_icon_accent));
+  color: var(--vkui_internal--icon_color, var(--vkui--color_icon_accent));
 }
 
 .SimpleCell__after > :global(.vkuiIcon) {
@@ -126,7 +126,7 @@
   padding-right: 2px;
 }
 
-.SimpleCell__after .SimpleCell__chevronIcon {
+.SimpleCell__chevronIcon {
   color: var(--vkui--color_icon_tertiary);
   padding-left: 12px;
 }

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
@@ -23,7 +23,7 @@
   padding-top: 6px;
   padding-bottom: 6px;
   padding-right: 12px;
-  color: var(--vkui--color_icon_accent);
+  color: var(--vkui_internal--simple_cell_icon_color, var(--vkui--color_icon_accent));
 }
 
 /* stylelint-disable-next-line @project-tools/stylelint-atomic -- добиваем отступ до 16px */
@@ -115,7 +115,7 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  color: var(--vkui--color_icon_accent);
+  color: var(--vkui_internal--simple_cell_icon_color, var(--vkui--color_icon_accent));
 }
 
 .SimpleCell__after > :global(.vkuiIcon) {

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.module.css
@@ -116,11 +116,11 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
+  color: var(--vkui--color_icon_accent);
 }
 
 .SimpleCell__after > :global(.vkuiIcon) {
   padding-left: 8px;
-  color: var(--vkui--color_icon_accent);
 }
 
 .SimpleCell__after > :global(.vkuiIcon):last-child {

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
@@ -128,7 +128,9 @@ export const SimpleCell = ({
         className,
       )}
     >
-      <div className={styles['SimpleCell__before']}>{before}</div>
+      <div className={classNames(styles['SimpleCell__before'], 'vkuiInternalSimpleCell__before')}>
+        {before}
+      </div>
       <div className={styles['SimpleCell__middle']}>
         {subhead && (
           <Subhead

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
@@ -128,9 +128,7 @@ export const SimpleCell = ({
         className,
       )}
     >
-      <div className={classNames(styles['SimpleCell__before'], 'vkuiInternalSimpleCell__before')}>
-        {before}
-      </div>
+      <div className={styles['SimpleCell__before']}>{before}</div>
       <div className={styles['SimpleCell__middle']}>
         {subhead && (
           <Subhead


### PR DESCRIPTION
## Описание

- related to #5794  [SimpleCell.module.css](https://github.com/VKCOM/VKUI/pull/5794/files#diff-cde505330a0123c800ac2efb02f954a76b39dfafaa0c5250dfb355bafddb7596)

Выставление `color` явно в `.SimpleCell__before` перебивает цвет заданный в вышестоящем компоненте, таком как `CellButton`. В итоге влияет иконку без класса `.vkuiIcon`.
https://github.com/VKCOM/VKUI/blob/e560f5306928f680ce8f060520edefae4fa7de83/packages/vkui/src/components/CellButton/CellButton.module.css#L51-L57

<img width="390" alt="Корзина должна быть красная, даже если нету класса vkuiIcon у иконки" src="https://github.com/VKCOM/VKUI/assets/5443359/9fb2114e-266a-4168-8077-dc27eeba661b">

## Изменения
- избавляемся от зависимости цвета от селекторов с .vkuiIcon классом
- используем css-переменную `--vkui_internal--icon_color` которую задаём в `CellButton` и использем в `.SimpleCell__before` и `.SimpleCell__after` с фоллбэком на цвета SimpleCell.
- это позволило также избавится от селекторов в `ImageBase` в случае когда `ImageBase` передается в `.CellButton `(что также было сломано, иконки внутри `ImageBase` в примере `CellButton` не принимали цвет заданный в `CellButton`).