### PR TITLE
fix: rm default React imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pnpm add @vkontakte/vkui @vkontakte/vk-bridge
 ## Hello World
 
 ```jsx static
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {
   AdaptivityProvider,

--- a/packages/vkui/.eslintrc.js
+++ b/packages/vkui/.eslintrc.js
@@ -118,6 +118,10 @@ module.exports = {
         selector: 'CallExpression[callee.name="classNames"][arguments.length=1]',
         message: 'Do not use classNames with one argument',
       },
+      {
+        selector: 'ImportDefaultSpecifier[local.name="React"][parent.source.value="react"]',
+        message: 'Не используйте импорт React по умолчанию',
+      },
     ],
 
     'import/no-default-export': 'error',

--- a/packages/vkui/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Div } from '../Div/Div';

--- a/packages/vkui/src/components/Accordion/AccordionSummary.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionSummary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Icon24ChevronDown, Icon24ChevronUp } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
 import { SimpleCell, SimpleCellProps } from '../SimpleCell/SimpleCell';

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.stories.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { getIconArgBySize, getIconComponent, IconArgType, IconName } from '../../storybook/Icons';
 import { CanvasFullLayout, DisableCartesianParam, StringArg } from '../../storybook/constants';

--- a/packages/vkui/src/components/AdaptiveIconRenderer/AdaptiveIconRenderer.stories.tsx
+++ b/packages/vkui/src/components/AdaptiveIconRenderer/AdaptiveIconRenderer.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon24SmileOutline, Icon28SmileOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.stories.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditionalRender';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Alert/Alert.stories.tsx
+++ b/packages/vkui/src/components/Alert/Alert.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Button } from '../Button/Button';

--- a/packages/vkui/src/components/AppearanceProvider/AppearanceProvider.stories.tsx
+++ b/packages/vkui/src/components/AppearanceProvider/AppearanceProvider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { AppearanceProvider, AppearanceProviderProps } from './AppearanceProvider';

--- a/packages/vkui/src/components/AspectRatio/AspectRatio.stories.tsx
+++ b/packages/vkui/src/components/AspectRatio/AspectRatio.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout } from '../../storybook/constants';

--- a/packages/vkui/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../storybook/constants';

--- a/packages/vkui/src/components/Banner/Banner.stories.tsx
+++ b/packages/vkui/src/components/Banner/Banner.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/Button/Button.stories.tsx
+++ b/packages/vkui/src/components/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import {

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon16Add, Icon24Add } from '@vkontakte/icons';

--- a/packages/vkui/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Calendar, CalendarProps } from './Calendar';

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.stories.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { CalendarRange, CalendarRangeProps } from './CalendarRange';

--- a/packages/vkui/src/components/Card/Card.stories.tsx
+++ b/packages/vkui/src/components/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/CardGrid/CardGrid.stories.tsx
+++ b/packages/vkui/src/components/CardGrid/CardGrid.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/CardScroll/CardScroll.stories.tsx
+++ b/packages/vkui/src/components/CardScroll/CardScroll.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Cell/Cell.stories.tsx
+++ b/packages/vkui/src/components/Cell/Cell.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Cell/CellCheckbox/CellCheckbox.stories.tsx
+++ b/packages/vkui/src/components/Cell/CellCheckbox/CellCheckbox.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../../storybook/constants';

--- a/packages/vkui/src/components/CellButton/CellButton.stories.tsx
+++ b/packages/vkui/src/components/CellButton/CellButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28AddOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { baselineComponent } from '../../testing/utils';
@@ -9,7 +9,7 @@ describe('Checkbox', () => {
 
   it('handles change', () => {
     const CheckboxController = () => {
-      const [checked, setChecked] = useState(false);
+      const [checked, setChecked] = React.useState(false);
       return (
         <Checkbox checked={checked} onChange={(e) => setChecked(e.target.checked)}>
           check

--- a/packages/vkui/src/components/Chip/Chip.stories.tsx
+++ b/packages/vkui/src/components/Chip/Chip.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { getIconArgBySize, getIconComponent, IconName } from '../../storybook/Icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.stories.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon12Download } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Clickable/Clickable.test.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { noop } from '@vkontakte/vkjs';
 import { baselineComponent } from '../../testing/utils';
 import { Clickable } from './Clickable';

--- a/packages/vkui/src/components/Clickable/Clickable.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useFocusVisible } from '../../hooks/useFocusVisible';
 import { callMultiple } from '../../lib/callMultiple';

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { ConfigProvider, ConfigProviderProps } from './ConfigProvider';

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Appearance } from '../../helpers/appearance';
 import { generateVKUITokensClassName } from '../../helpers/generateVKUITokensClassName';
@@ -20,7 +20,7 @@ describe('ConfigProvider', () => {
       transitionMotionEnabled: false,
     };
     const ConfigUser = () => {
-      expect(useContext(ConfigProviderContext)).toEqual({
+      expect(React.useContext(ConfigProviderContext)).toEqual({
         platform: Platform.ANDROID,
         isWebView: false,
         locale: 'ru',
@@ -46,7 +46,7 @@ describe('ConfigProvider', () => {
         transitionMotionEnabled: false,
       };
       const ConfigUser = () => {
-        expect(useContext(ConfigProviderContext)).toEqual({
+        expect(React.useContext(ConfigProviderContext)).toEqual({
           platform: Platform.ANDROID,
           isWebView: false,
           locale: 'ru',
@@ -71,7 +71,7 @@ describe('ConfigProvider', () => {
         transitionMotionEnabled: false,
       };
       const ConfigUser = () => {
-        expect(useContext(ConfigProviderContext)).toEqual({
+        expect(React.useContext(ConfigProviderContext)).toEqual({
           platform: Platform.ANDROID,
           isWebView: false,
           locale: 'ru',
@@ -93,7 +93,7 @@ describe('ConfigProvider', () => {
   describe('inherits properties from parent ConfigProvider context', () => {
     let config: ConfigProviderContextInterface | undefined;
     const ReadConfig = () => {
-      config = useContext(ConfigProviderContext);
+      config = React.useContext(ConfigProviderContext);
       return null;
     };
 
@@ -168,7 +168,7 @@ describe('ConfigProvider', () => {
     };
 
     const TestComponent = () => {
-      const [isMounted, setIsMounted] = useState(true);
+      const [isMounted, setIsMounted] = React.useState(true);
 
       return (
         <ConfigProvider {...config}>

--- a/packages/vkui/src/components/ConfigProvider/ConfigProviderOverride.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProviderOverride.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
 import {
   ConfigProviderContext,

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.test.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { CustomSelectOption } from './CustomSelectOption';

--- a/packages/vkui/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { DateInput, DateInputProps } from './DateInput';

--- a/packages/vkui/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/vkui/src/components/DatePicker/DatePicker.test.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { baselineComponent } from '../../testing/utils';
@@ -15,7 +15,7 @@ describe('DatePicker', () => {
   });
 
   describe('custom', () => {
-    const forceCustom = (jsx: ReactNode) => (
+    const forceCustom = (jsx: React.ReactNode) => (
       <AdaptivityProvider hasPointer>{jsx}</AdaptivityProvider>
     );
     const getByName = (name: string) => document.getElementsByName(name)[0] as HTMLInputElement;
@@ -132,7 +132,7 @@ describe('DatePicker', () => {
   });
 
   describe('native', () => {
-    const forceNative = (jsx: ReactNode) => (
+    const forceNative = (jsx: React.ReactNode) => (
       <AdaptivityProvider hasPointer={false}>{jsx}</AdaptivityProvider>
     );
     const getInput = () => document.querySelector('input') as Element;

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.stories.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { DateRangeInput, DateRangeInputProps } from './DateRangeInput';

--- a/packages/vkui/src/components/Div/Div.stories.tsx
+++ b/packages/vkui/src/components/Div/Div.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Group } from '../Group/Group';

--- a/packages/vkui/src/components/Epic/Epic.stories.tsx
+++ b/packages/vkui/src/components/Epic/Epic.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import {
   Icon28ClipOutline,

--- a/packages/vkui/src/components/FixedLayout/FixedLayout.stories.tsx
+++ b/packages/vkui/src/components/FixedLayout/FixedLayout.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Footer/Footer.stories.tsx
+++ b/packages/vkui/src/components/Footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/FormField/FormField.stories.tsx
+++ b/packages/vkui/src/components/FormField/FormField.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon16Clear, Icon28MessageOutline } from '@vkontakte/icons';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/FormItem/FormItem.stories.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Input } from '../Input/Input';

--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { FormItem } from '../FormItem/FormItem';

--- a/packages/vkui/src/components/Gallery/Gallery.stories.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Gallery, GalleryProps } from './Gallery';

--- a/packages/vkui/src/components/Gradient/Gradient.stories.tsx
+++ b/packages/vkui/src/components/Gradient/Gradient.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Gradient, GradientProps } from './Gradient';

--- a/packages/vkui/src/components/GridAvatar/GridAvatar.stories.tsx
+++ b/packages/vkui/src/components/GridAvatar/GridAvatar.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon20GiftCircleFillRed } from '@vkontakte/icons';

--- a/packages/vkui/src/components/Group/Group.stories.tsx
+++ b/packages/vkui/src/components/Group/Group.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import {
   Icon28CheckShieldDeviceOutline,

--- a/packages/vkui/src/components/Header/Header.stories.tsx
+++ b/packages/vkui/src/components/Header/Header.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/HorizontalCell/HorizontalCell.stories.tsx
+++ b/packages/vkui/src/components/HorizontalCell/HorizontalCell.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { usePlatform } from '../../hooks/usePlatform';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/HorizontalCellShowMore/HorizontalCellShowMore.stories.tsx
+++ b/packages/vkui/src/components/HorizontalCellShowMore/HorizontalCellShowMore.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam, StringArg } from '../../storybook/constants';

--- a/packages/vkui/src/components/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
+++ b/packages/vkui/src/components/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { HorizontalCellShowMore } from './HorizontalCellShowMore';

--- a/packages/vkui/src/components/HorizontalCellShowMore/HorizontalCellShowMore.tsx
+++ b/packages/vkui/src/components/HorizontalCellShowMore/HorizontalCellShowMore.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Icon28ChevronRightCircle } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
 import { HasRef, HasRootRef, LiteralUnion } from '../../types';

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.stories.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/vkui/src/components/IconButton/IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon16Delete } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.stories.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../../storybook/constants';
 import { ImageBaseBadge, ImageBaseBadgeProps } from './ImageBaseBadge';

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.stories.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../../storybook/constants';
 import { ImageBaseOverlay, ImageBaseOverlayProps } from './ImageBaseOverlay';

--- a/packages/vkui/src/components/InfoRow/InfoRow.stories.tsx
+++ b/packages/vkui/src/components/InfoRow/InfoRow.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Link/Link.stories.tsx
+++ b/packages/vkui/src/components/Link/Link.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon24ExternalLinkOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/List/List.stories.tsx
+++ b/packages/vkui/src/components/List/List.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28PrivacyOutline, Icon28SettingsOutline, Icon28UserOutline } from '@vkontakte/icons';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/LocaleProvider/LocaleProvider.stories.tsx
+++ b/packages/vkui/src/components/LocaleProvider/LocaleProvider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';

--- a/packages/vkui/src/components/LocaleProvider/LocaleProvider.test.tsx
+++ b/packages/vkui/src/components/LocaleProvider/LocaleProvider.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';

--- a/packages/vkui/src/components/LocaleProvider/LocaleProvider.tsx
+++ b/packages/vkui/src/components/LocaleProvider/LocaleProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ConfigProviderContextInterface } from '../ConfigProvider/ConfigProviderContext';
 import { ConfigProviderOverride } from '../ConfigProvider/ConfigProviderOverride';
 

--- a/packages/vkui/src/components/MiniInfoCell/MiniInfoCell.stories.tsx
+++ b/packages/vkui/src/components/MiniInfoCell/MiniInfoCell.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon20ArticleOutline } from '@vkontakte/icons';

--- a/packages/vkui/src/components/ModalCard/ModalCard.stories.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon56MoneyTransferOutline, Icon56NotificationOutline } from '@vkontakte/icons';
 import { ModalWrapper } from '../../storybook/ModalWrapper';

--- a/packages/vkui/src/components/ModalCardBase/ModalCardBase.stories.tsx
+++ b/packages/vkui/src/components/ModalCardBase/ModalCardBase.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon56MoneyTransferOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.stories.tsx
+++ b/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { ModalDismissButton, ModalDismissButtonProps } from './ModalDismissButton';

--- a/packages/vkui/src/components/ModalPage/ModalPage.stories.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon24Dismiss, Icon56MoneyTransferOutline } from '@vkontakte/icons';
 import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditionalRender';

--- a/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.stories.tsx
+++ b/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon24Cancel, Icon24Done } from '@vkontakte/icons';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.stories.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { ModalWrapper } from '../../storybook/ModalWrapper';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/ModalRoot/useModalRootContext.tsx
+++ b/packages/vkui/src/components/ModalRoot/useModalRootContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ModalRootContext } from './ModalRootContext';
 
 export const useModalRootContext = () => React.useContext(ModalRootContext);

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { NativeSelect, NativeSelectProps } from './NativeSelect';

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.test.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { baselineComponent } from '../../testing/utils';
@@ -17,7 +17,7 @@ describe('NativeSelect', () => {
 
   it('works correctly with value and onChange', () => {
     const SelectController = () => {
-      const [value, setValue] = useState('0');
+      const [value, setValue] = React.useState('0');
       return (
         <NativeSelect data-testid="target" value={value} onChange={(e) => setValue(e.target.value)}>
           <option value="0">Mike</option>

--- a/packages/vkui/src/components/NavIdContext/NavIdContext.tsx
+++ b/packages/vkui/src/components/NavIdContext/NavIdContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export const NavViewIdContext = React.createContext<string | undefined>(undefined);
 export const NavPanelIdContext = React.createContext<string | undefined>(undefined);

--- a/packages/vkui/src/components/NavIdContext/useNavId.test.tsx
+++ b/packages/vkui/src/components/NavIdContext/useNavId.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { Panel } from '../Panel/Panel';
 import { View } from '../View/View';

--- a/packages/vkui/src/components/NavIdContext/useNavId.ts
+++ b/packages/vkui/src/components/NavIdContext/useNavId.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { NavPanelIdContext, NavViewIdContext } from './NavIdContext';
 
 export const useNavId = () => ({

--- a/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.test.tsx
+++ b/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { Panel } from '../Panel/Panel';

--- a/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.tsx
+++ b/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 type DirectionContextType = boolean | undefined;
 

--- a/packages/vkui/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/vkui/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Panel/Panel.stories.tsx
+++ b/packages/vkui/src/components/Panel/Panel.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28MusicOutline, Icon28UserOutline, Icon28UsersOutline } from '@vkontakte/icons';
 import { withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.stories.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28Notifications, Icon28PictureOutline, Icon28SettingsOutline } from '@vkontakte/icons';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.stories.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28AddOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/PanelHeaderContent/PanelHeaderContent.stories.tsx
+++ b/packages/vkui/src/components/PanelHeaderContent/PanelHeaderContent.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { usePlatform } from '../../hooks/usePlatform';
 import { Platform } from '../../lib/platform';

--- a/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.stories.tsx
+++ b/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import {
   Icon16Dropdown,

--- a/packages/vkui/src/components/Placeholder/Placeholder.stories.tsx
+++ b/packages/vkui/src/components/Placeholder/Placeholder.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon56UsersOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/PlatformProvider/PlatformProvider.stories.tsx
+++ b/packages/vkui/src/components/PlatformProvider/PlatformProvider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';

--- a/packages/vkui/src/components/PlatformProvider/PlatformProvider.test.tsx
+++ b/packages/vkui/src/components/PlatformProvider/PlatformProvider.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import {

--- a/packages/vkui/src/components/PlatformProvider/PlatformProvider.tsx
+++ b/packages/vkui/src/components/PlatformProvider/PlatformProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useAppearance } from '../../hooks/useAppearance';
 import { PlatformType } from '../../lib/platform';
 import { TokensClassProvider } from '../../lib/tokensClassProvider';

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.stories.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { SplitCol } from '../SplitCol/SplitCol';

--- a/packages/vkui/src/components/Popover/Popover.stories.tsx
+++ b/packages/vkui/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { DisableCartesianParam } from '../../storybook/constants';
 import { Button } from '../Button/Button';

--- a/packages/vkui/src/components/Popper/Popper.stories.tsx
+++ b/packages/vkui/src/components/Popper/Popper.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Button } from '../Button/Button';

--- a/packages/vkui/src/components/Popper/Popper.test.tsx
+++ b/packages/vkui/src/components/Popper/Popper.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { waitForFloatingPosition } from '../../testing/utils';
 import { Popper } from './Popper';

--- a/packages/vkui/src/components/Progress/Progress.stories.tsx
+++ b/packages/vkui/src/components/Progress/Progress.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Progress, ProgressProps } from './Progress';

--- a/packages/vkui/src/components/Progress/Progress.test.tsx
+++ b/packages/vkui/src/components/Progress/Progress.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { Progress } from './Progress';

--- a/packages/vkui/src/components/PromoBanner/PromoBanner.test.tsx
+++ b/packages/vkui/src/components/PromoBanner/PromoBanner.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { baselineComponent } from '../../testing/utils';

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { test } from '@vkui-e2e/test';
 import { Platform } from '../../lib/platform';
 import { PullToRefreshPlayground } from './PullToRefresh.e2e-playground';

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.stories.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/vkui/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/packages/vkui/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/RichCell/RichCell.stories.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/RichTooltip/RichTooltip.stories.tsx
+++ b/packages/vkui/src/components/RichTooltip/RichTooltip.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon16HelpOutline, Icon28UserAddOutline } from '@vkontakte/icons';
 import { DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Root/Root.stories.tsx
+++ b/packages/vkui/src/components/Root/Root.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/RootComponent/RootComponent.tsx
+++ b/packages/vkui/src/components/RootComponent/RootComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { HasComponent, HasRootRef } from '../../types';
 

--- a/packages/vkui/src/components/Search/Search.stories.tsx
+++ b/packages/vkui/src/components/Search/Search.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/vkui/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { SegmentedControl, SegmentedControlProps } from './SegmentedControl';

--- a/packages/vkui/src/components/SelectMimicry/SelectMimicry.stories.tsx
+++ b/packages/vkui/src/components/SelectMimicry/SelectMimicry.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { SelectMimicry, SelectMimicryProps } from './SelectMimicry';

--- a/packages/vkui/src/components/Separator/Separator.stories.tsx
+++ b/packages/vkui/src/components/Separator/Separator.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28Notifications, Icon28SlidersOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.stories.tsx
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon12Verified, Icon28MessageOutline } from '@vkontakte/icons';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/Slider/Slider.stories.tsx
+++ b/packages/vkui/src/components/Slider/Slider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { Meta, StoryContext, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon24ThumbsUpOutline, Icon28ErrorCircleOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam, StringArg } from '../../storybook/constants';

--- a/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { baselineComponent } from '../../testing/utils';

--- a/packages/vkui/src/components/Spacing/Spacing.stories.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28BlockOutline, Icon28UserOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/SplitCol/SplitCol.stories.tsx
+++ b/packages/vkui/src/components/SplitCol/SplitCol.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon56MentionOutline, Icon56UsersOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/SplitLayout/SplitLayout.stories.tsx
+++ b/packages/vkui/src/components/SplitLayout/SplitLayout.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import {
   Icon56MentionOutline,

--- a/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.stories.tsx
+++ b/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useArgs } from '@storybook/addons';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel, withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.stories.tsx
+++ b/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon24FavoriteOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Tabbar/Tabbar.stories.tsx
+++ b/packages/vkui/src/components/Tabbar/Tabbar.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import {
   Icon28ClipOutline,

--- a/packages/vkui/src/components/TabbarItem/TabbarItem.stories.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { getIconArgBySize, getIconComponent, IconName } from '../../storybook/Icons';
 import { withVKUILayout } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/react';
 import { withSinglePanel } from '../../storybook/VKUIDecorators';

--- a/packages/vkui/src/components/TabsItem/TabsItem.stories.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import {
   Icon16Dropdown,

--- a/packages/vkui/src/components/Tappable/Tappable.stories.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Tappable, TappableProps } from './Tappable';

--- a/packages/vkui/src/components/TextTooltip/TextTooltip.stories.tsx
+++ b/packages/vkui/src/components/TextTooltip/TextTooltip.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { DisableCartesianParam } from '../../storybook/constants';
 import { Button } from '../Button/Button';

--- a/packages/vkui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { withVKUILayout } from '../../storybook/VKUIDecorators';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/components/Touch/Touch.stories.tsx
+++ b/packages/vkui/src/components/Touch/Touch.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Touch, TouchEvent, TouchProps } from './Touch';

--- a/packages/vkui/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/vkui/src/components/Typography/Caption/Caption.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../../storybook/constants';

--- a/packages/vkui/src/components/Typography/Footnote/Footnote.stories.tsx
+++ b/packages/vkui/src/components/Typography/Footnote/Footnote.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../../storybook/constants';

--- a/packages/vkui/src/components/Typography/Headline/Headline.stories.tsx
+++ b/packages/vkui/src/components/Typography/Headline/Headline.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../../storybook/constants';

--- a/packages/vkui/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/vkui/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../../storybook/constants';

--- a/packages/vkui/src/components/Typography/Subhead/Subhead.stories.tsx
+++ b/packages/vkui/src/components/Typography/Subhead/Subhead.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../../storybook/constants';

--- a/packages/vkui/src/components/Typography/Text/Text.stories.tsx
+++ b/packages/vkui/src/components/Typography/Text/Text.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../../storybook/constants';

--- a/packages/vkui/src/components/Typography/Title/Title.stories.tsx
+++ b/packages/vkui/src/components/Typography/Title/Title.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../../storybook/constants';

--- a/packages/vkui/src/components/Typography/Typography.stories.tsx
+++ b/packages/vkui/src/components/Typography/Typography.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../storybook/constants';

--- a/packages/vkui/src/components/View/View.stories.tsx
+++ b/packages/vkui/src/components/View/View.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import vkBridge from '@vkontakte/vk-bridge';
 import { Platform } from '../../lib/platform';

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,11 +1,11 @@
-import React, { AllHTMLAttributes } from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { HasComponent, HasRootRef } from '../../types';
 import { VisuallyHidden } from './VisuallyHidden';
 
 interface VisuallyHiddenProps
-  extends AllHTMLAttributes<HTMLElement>,
+  extends React.AllHTMLAttributes<HTMLElement>,
     HasRootRef<HTMLElement>,
     HasComponent {}
 

--- a/packages/vkui/src/components/WriteBar/WriteBar.stories.tsx
+++ b/packages/vkui/src/components/WriteBar/WriteBar.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28SmileOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';

--- a/packages/vkui/src/hooks/useAdaptivityHasHover.test.tsx
+++ b/packages/vkui/src/hooks/useAdaptivityHasHover.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { AdaptivityProvider } from '../components/AdaptivityProvider/AdaptivityProvider';
 import { useAdaptivityHasHover } from './useAdaptivityHasHover';

--- a/packages/vkui/src/hooks/useAdaptivityHasPointer.test.tsx
+++ b/packages/vkui/src/hooks/useAdaptivityHasPointer.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { AdaptivityProvider } from '../components/AdaptivityProvider/AdaptivityProvider';
 import { useAdaptivityHasPointer } from './useAdaptivityHasPointer';

--- a/packages/vkui/src/hooks/useAutoFocus.ts
+++ b/packages/vkui/src/hooks/useAutoFocus.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
 
 export function useAutoFocus(

--- a/packages/vkui/src/hooks/useFocusWithin.ts
+++ b/packages/vkui/src/hooks/useFocusWithin.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useDOM } from '../lib/dom';
 import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
 import { useGlobalEventListener } from './useGlobalEventListener';

--- a/packages/vkui/src/hooks/useTodayDate.ts
+++ b/packages/vkui/src/hooks/useTodayDate.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { getMillisecondsToTomorrow, isSameDay } from '../lib/date';
 import { useDOM } from '../lib/dom';
 

--- a/packages/vkui/src/storybook/ModalWrapper.tsx
+++ b/packages/vkui/src/storybook/ModalWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Button } from '../components/Button/Button';
 import { ModalRoot } from '../components/ModalRoot/ModalRootAdaptive';
 import { Placeholder } from '../components/Placeholder/Placeholder';

--- a/packages/vkui/src/storybook/VKUIDecorators.tsx
+++ b/packages/vkui/src/storybook/VKUIDecorators.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Decorator } from '@storybook/react';
 import { AdaptivityProvider } from '../components/AdaptivityProvider/AdaptivityProvider';
 import { AppRoot } from '../components/AppRoot/AppRoot';

--- a/styleguide/Components/Code/CodeRenderer.js
+++ b/styleguide/Components/Code/CodeRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import './Code.css';
 
 export const CodeRenderer = ({ children }) => {

--- a/styleguide/Components/ComplexType/ComplexTypeRenderer.js
+++ b/styleguide/Components/ComplexType/ComplexTypeRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Icon16ErrorCircleOutline } from '@vkontakte/icons';
 import {
   classNames,

--- a/styleguide/Components/ComponentsList/ComponentsListRenderer.js
+++ b/styleguide/Components/ComponentsList/ComponentsListRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { SimpleCell } from '@vkui';
 
 export default ({ items }) => {

--- a/styleguide/Components/Frame/Frame.js
+++ b/styleguide/Components/Frame/Frame.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import ReactFrame, { useFrame } from 'react-frame-component';
 import { PanelSpinner } from '@vkui';

--- a/styleguide/Components/Frame/usePlatformStyle.js
+++ b/styleguide/Components/Frame/usePlatformStyle.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Platform } from '@vkui';
 
 /**

--- a/styleguide/Components/Heading/HeadingRenderer.js
+++ b/styleguide/Components/Heading/HeadingRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { classNames, Headline, Title } from '@vkui';
 import './Heading.css';
 

--- a/styleguide/Components/Link/LinkRenderer.js
+++ b/styleguide/Components/Link/LinkRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Link } from '@vkui';
 
 export const LinkRenderer = ({ href: _href, ...restProps }) => {

--- a/styleguide/Components/List/index.js
+++ b/styleguide/Components/List/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Text from '../Text';
 import './List.css';
 

--- a/styleguide/Components/Logo/Logo.js
+++ b/styleguide/Components/Logo/Logo.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export const Logo = (props) => {
   return (

--- a/styleguide/Components/Modals/Platforms.js
+++ b/styleguide/Components/Modals/Platforms.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Div, ModalPage, ModalPageHeader, PanelSpinner, Platform, SimpleCell } from '@vkui';
 import { StyleGuideContext } from '../StyleGuide/StyleGuideRenderer';
 import { useFetch } from './useFetch';

--- a/styleguide/Components/Modals/Versions.js
+++ b/styleguide/Components/Modals/Versions.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Div, ModalPage, ModalPageHeader, PanelSpinner, SimpleCell } from '@vkui';
 import { useFetch } from './useFetch';
 

--- a/styleguide/Components/Name/NameRenderer.js
+++ b/styleguide/Components/Name/NameRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { classNames, Text } from '@vkui';
 import './Name.css';
 

--- a/styleguide/Components/Para/ParaRenderer.js
+++ b/styleguide/Components/Para/ParaRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Text from '../Text/index';
 import './Para.css';
 

--- a/styleguide/Components/ReactComponent/ReactComponent.js
+++ b/styleguide/Components/ReactComponent/ReactComponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useStyleGuideContext } from '@rsg-components/Context';
 import Examples from '@rsg-components/Examples';
 import Markdown from '@rsg-components/Markdown';

--- a/styleguide/Components/Section/SectionRenderer.js
+++ b/styleguide/Components/Section/SectionRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Markdown from '@rsg-components/Markdown';
 import SectionHeading from '@rsg-components/SectionHeading';
 import PropTypes from 'prop-types';

--- a/styleguide/Components/Section/index.js
+++ b/styleguide/Components/Section/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Components from '@rsg-components/Components';
 import { useStyleGuideContext } from '@rsg-components/Context';
 import Examples from '@rsg-components/Examples';

--- a/styleguide/Components/SectionHeading/SectionHeadingRenderer.js
+++ b/styleguide/Components/SectionHeading/SectionHeadingRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Heading from '../Heading';
 
 export const SectionHeadingRenderer = ({ children, level = 1, ...restProps }) => {

--- a/styleguide/Components/Settings/AppearanceSelect.js
+++ b/styleguide/Components/Settings/AppearanceSelect.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Appearance, Link } from '@vkui';
 import { Setting } from '../Setting/Setting';
 

--- a/styleguide/Components/Settings/HasCustomPanelHeaderAfter.js
+++ b/styleguide/Components/Settings/HasCustomPanelHeaderAfter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Link, Switch } from '@vkui';
 import { Setting } from '../Setting/Setting';
 

--- a/styleguide/Components/Settings/HasPointerCheckbox.js
+++ b/styleguide/Components/Settings/HasPointerCheckbox.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Link, Switch } from '@vkui';
 import { Setting } from '../Setting/Setting';
 

--- a/styleguide/Components/Settings/LayoutSelect.js
+++ b/styleguide/Components/Settings/LayoutSelect.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Link } from '@vkui';
 import { Setting } from '../Setting/Setting';
 

--- a/styleguide/Components/Settings/PlatformSelect.js
+++ b/styleguide/Components/Settings/PlatformSelect.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Link, Platform } from '@vkui';
 import { Setting } from '../Setting/Setting';
 import { StyleGuideContext } from '../StyleGuide/StyleGuideRenderer';

--- a/styleguide/Components/Settings/ViewHeightSelect.js
+++ b/styleguide/Components/Settings/ViewHeightSelect.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { BREAKPOINTS } from '@vkui/lib/adaptivity';
 import { Setting } from '../Setting/Setting';
 

--- a/styleguide/Components/Settings/ViewWidthSelect.js
+++ b/styleguide/Components/Settings/ViewWidthSelect.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { BREAKPOINTS } from '@vkui/lib/adaptivity';
 import { Setting } from '../Setting/Setting';
 

--- a/styleguide/Components/StyleGuide/StyleGuideDesktop.js
+++ b/styleguide/Components/StyleGuide/StyleGuideDesktop.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { SplitCol, SplitLayout } from '@vkui';
 import { StyleGuideHeader } from './StyleGuideHeader';
 import { StyleGuideModal } from './StyleGuideModal';

--- a/styleguide/Components/StyleGuide/StyleGuideHeader.js
+++ b/styleguide/Components/StyleGuide/StyleGuideHeader.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Icon16Dropdown, Icon28MoonOutline, Icon28SunOutline } from '@vkontakte/icons';
 import { IconButton, Link, SplitCol, SplitLayout, Tappable, useAppearance } from '@vkui';
 import { VKUI_PACKAGE } from '../../../shared';

--- a/styleguide/Components/StyleGuide/StyleGuideModal.js
+++ b/styleguide/Components/StyleGuide/StyleGuideModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ModalRoot } from '@vkui';
 import { Platforms } from '../Modals/Platforms';
 import { Versions } from '../Modals/Versions';

--- a/styleguide/Components/Text/TextRenderer.js
+++ b/styleguide/Components/Text/TextRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { classNames } from '@vkui';
 import './Text.css';
 

--- a/styleguide/Components/TogglePropsButton/index.js
+++ b/styleguide/Components/TogglePropsButton/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { CellButton } from '@vkui';
 import './TogglePropsButton.css';
 

--- a/styleguide/Components/Type/TypeRenderer.js
+++ b/styleguide/Components/Type/TypeRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { classNames, Text } from '@vkui';
 import './Type.css';
 

--- a/styleguide/pages/adaptivity.md
+++ b/styleguide/pages/adaptivity.md
@@ -10,7 +10,7 @@
 > Учтите порядок подключения компонентов для конфигурации. `ConfigProvider` -> `AdaptivityProvider` -> `AppRoot`
 
 ```jsx static
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { ConfigProvider, AdaptivityProvider, AppRoot } from '@vkontakte/vkui';
 import '@vkontakte/vkui/dist/vkui.css';

--- a/styleguide/pages/integrations_vk_mini_apps.md
+++ b/styleguide/pages/integrations_vk_mini_apps.md
@@ -49,7 +49,7 @@ yarn add @vkontakte/vk-bridge @vkontakte/vk-bridge-react
 [@vkontakte/vk-bridge-react](https://www.npmjs.com/package/@vkontakte/vk-bridge).
 
 ```tsx static
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import vkBridge, { parseURLSearchParamsForGetLaunchParams } from '@vkontakte/vk-bridge';
 import { useAppearance, useInsets, useAdaptivity } from '@vkontakte/vk-bridge-react';

--- a/styleguide/pages/quick_start.md
+++ b/styleguide/pages/quick_start.md
@@ -42,7 +42,7 @@ pnpm add @vkontakte/vkui @vkontakte/icons @vkontakte/vk-bridge
 Соберите базовый app shell для VKUI.
 
 ```jsx static
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {
   AdaptivityProvider,

--- a/tools/storybook-addon-cartesian/README.md
+++ b/tools/storybook-addon-cartesian/README.md
@@ -7,7 +7,7 @@
 **Пример:**
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Component, ComponentProps } from './Component.path';

--- a/tools/storybook-addon-cartesian/src/preset/manager.tsx
+++ b/tools/storybook-addon-cartesian/src/preset/manager.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { addons, types } from '@storybook/manager-api';
 import { Tool } from '../Tool';
 import { ADDON_ID, TOOL_ID } from '../constants';


### PR DESCRIPTION
## Описание

Запрещаем использовать дефолтные импорты React, поскольку их должны [удалить в будущем](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

## Изменения

Слегка уменьшился бандл
