### PR TITLE
chore: Add prop mapping support for Storybook cartesian

### DIFF
--- a/packages/vkui/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.stories.tsx
@@ -75,9 +75,9 @@ export default story;
 type Story = StoryObj<AvatarStoryProps>;
 
 export const Playground: Story = {
-  render: ({ badge, overlay, children, ...args }) => (
-    <Avatar src={args.initials ? undefined : getAvatarUrl('user_id34')} {...args}>
-      {badge}
+  render: ({ badge, overlay, children, size = 48, ...args }) => (
+    <Avatar src={args.initials ? undefined : getAvatarUrl('user_id34')} {...args} size={size}>
+      {size >= 24 && badge}
       {overlay}
       {children}
     </Avatar>

--- a/packages/vkui/src/components/GridAvatar/GridAvatar.stories.tsx
+++ b/packages/vkui/src/components/GridAvatar/GridAvatar.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
-import { Icon20GiftCircleFillRed } from '@vkontakte/icons';
 import { CanvasFullLayout } from '../../storybook/constants';
+import { IconExampleForBadgeBasedOnImageBaseSize } from '../../testing/icons';
 import { getAvatarUrl } from '../../testing/mock';
 import { imageBaseSizes } from '../ImageBase/types';
 import { GridAvatar, GridAvatarProps } from './GridAvatar';
@@ -32,14 +32,19 @@ export default story;
 type Story = StoryObj<StoryGridAvatarProps>;
 
 export const Playground: Story = {
-  render: ({ badged, ...args }) => {
-    const badge = badged ? (
-      <GridAvatar.Badge>
-        <Icon20GiftCircleFillRed width={16} height={16} />
-      </GridAvatar.Badge>
-    ) : undefined;
+  render: ({ badged, size = 48, ...args }) => {
+    const badge =
+      size >= 24 && badged ? (
+        <GridAvatar.Badge>
+          <IconExampleForBadgeBasedOnImageBaseSize />
+        </GridAvatar.Badge>
+      ) : undefined;
 
-    return <GridAvatar {...args}>{badge}</GridAvatar>;
+    return (
+      <GridAvatar {...args} size={size}>
+        {badge}
+      </GridAvatar>
+    );
   },
   args: {
     src: [getAvatarUrl(), getAvatarUrl(), getAvatarUrl(), getAvatarUrl()],

--- a/tools/storybook-addon-cartesian/src/withCartesian.tsx
+++ b/tools/storybook-addon-cartesian/src/withCartesian.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Decorator, ReactRenderer } from '@storybook/react';
-import type { StoryContext, StrictArgs } from '@storybook/types';
+import type { StoryContext, StrictArgs, StrictArgTypes } from '@storybook/types';
 
 const CartesianContainerStyle: React.CSSProperties = {
   display: 'flex',
@@ -9,20 +9,29 @@ const CartesianContainerStyle: React.CSSProperties = {
   margin: '10px',
   gap: '5px',
   boxSizing: 'border-box',
-  alignItems: 'baseline',
+  height: '100%',
+  width: '100%',
+  alignItems: 'center',
+  justifyContent: 'center',
 };
 
 interface CartesianPropType extends StrictArgs {
   cartesian?: { [s: string]: unknown } | ArrayLike<unknown>;
 }
 
-function cartesianFunc(propDesc: CartesianPropType['cartesian'] = []) {
+function cartesianFunc(
+  propDesc: CartesianPropType['cartesian'] = [],
+  argTypes: StrictArgTypes<CartesianPropType>,
+) {
   return Object.entries(propDesc).reduce(
     (acc, [prop, values]: [string, any]) => {
       const res: any[] = [];
       acc.forEach((props) => {
         values.forEach((value: any) => {
-          res.push({ ...props, [prop]: value });
+          res.push({
+            ...props,
+            [prop]: argTypes[prop].mapping ? argTypes[prop].mapping[value] : value,
+          });
         });
       });
       return res;
@@ -33,11 +42,12 @@ function cartesianFunc(propDesc: CartesianPropType['cartesian'] = []) {
 
 export const withCartesian: Decorator = (StoryFn, context) => {
   const {
+    argTypes,
     args: { cartesian, ...restArgs },
   } = context as StoryContext<ReactRenderer, CartesianPropType>;
 
   if (cartesian) {
-    const variants = cartesianFunc(cartesian);
+    const variants = cartesianFunc(cartesian, argTypes);
 
     return (
       <div style={CartesianContainerStyle}>


### PR DESCRIPTION
~~- [ ] Unit-тесты~~
~~- [ ] e2e-тесты~~
~~- [ ] Дизайн-ревью~~

## Описание

Не подхватывались переопределения пропов через механизм [mapping](https://storybook.js.org/docs/react/essentials/controls#dealing-with-complex-values)

## Изменения

Поменяла отображения баджика в сторях компонентов `Avatar`/`GridAvatar`
