### PR TITLE
feat(Spacing,Separator): add vertical mode

### DIFF
--- a/packages/vkui/src/components/Separator/Readme.md
+++ b/packages/vkui/src/components/Separator/Readme.md
@@ -1,4 +1,9 @@
-Используется для разделения какого-либо контента. Отступы справа и слева контролируются свойством `wide`.
+Используется для разделения какого-либо контента.
+
+Свойство `wide` по дефолту позволяет контролировать отступы слева/справа, для `mode=vertical` отступы сверху/снизу.
+
+> Обратите внимание, если вы используете `Spacing` с вложенным компонентом `Separator` в режиме `vertical`,
+> то родительский элемент должен быть `flex`-контейнером.
 
 ```jsx
 <View activePanel="separator">
@@ -14,7 +19,19 @@
       </Spacing>
 
       <Cell before={<Icon28UserOutline />}>Учётная запись</Cell>
-      <Cell before={<Icon28SlidersOutline />}>Основные</Cell>
+    </Group>
+    <Group header={<Header mode="secondary">Вертикальный сепаратор</Header>}>
+      <Div style={{ display: 'flex' }}>
+        <Link>Новости</Link>
+        <Spacing size={16} mode="vertical">
+          <Separator mode="vertical" wide />
+        </Spacing>
+        <Link>Звонки</Link>
+        <Spacing size={16} mode="vertical">
+          <Separator mode="vertical" wide />
+        </Spacing>
+        <Link>Друзья</Link>
+      </Div>
     </Group>
   </Panel>
 </View>

--- a/packages/vkui/src/components/Separator/Separator.module.css
+++ b/packages/vkui/src/components/Separator/Separator.module.css
@@ -8,26 +8,40 @@
   background: currentColor;
   color: inherit;
   border: 0;
-  transform-origin: center top;
 }
 
-.Separator--padded .Separator__in {
+.Separator--mode-vertical {
+  display: inline-flex;
+}
+
+.Separator--mode-vertical .Separator__in {
+  width: var(--vkui--size_border--regular);
+  height: auto;
+  align-self: stretch;
+}
+
+.Separator--mode-horizontal.Separator--padded .Separator__in {
   margin-left: var(--vkui--size_base_padding_horizontal--regular);
   margin-right: var(--vkui--size_base_padding_horizontal--regular);
+}
+
+.Separator--mode-vertical.Separator--padded .Separator__in {
+  margin-top: var(--vkui--size_base_padding_vertical--regular);
+  margin-bottom: var(--vkui--size_base_padding_vertical--regular);
 }
 
 /*
  * CMP:
  * ModalPage
  */
-:global(.vkuiInternalModalPage--sizeX-regular) .Separator--padded {
+:global(.vkuiInternalModalPage--sizeX-regular) .Separator--mode-horizontal.Separator--padded {
   padding-left: 8px;
   padding-right: 8px;
 }
 
 /* FIXME: Мертвый код */
 @media (--sizeX-regular) {
-  :global(.vkuiInternalModalPage--sizeX-none) .Separator--padded {
+  :global(.vkuiInternalModalPage--sizeX-none) .Separator--mode-horizontal.Separator--padded {
     padding-left: 8px;
     padding-right: 8px;
   }

--- a/packages/vkui/src/components/Separator/Separator.stories.tsx
+++ b/packages/vkui/src/components/Separator/Separator.stories.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Icon28Notifications, Icon28SlidersOutline } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
+import { Div } from '../Div/Div';
 import { Group } from '../Group/Group';
+import { Link } from '../Link/Link';
 import { SimpleCell } from '../SimpleCell/SimpleCell';
 import { Spacing } from '../Spacing/Spacing';
 import { Separator, SeparatorProps } from './Separator';
@@ -18,28 +20,37 @@ export default story;
 type Story = StoryObj<SeparatorProps>;
 
 export const Playground: Story = {
-  decorators: [
-    (Component) => (
-      <div>
-        Before Separator
-        <Component />
-        After Separator
-      </div>
-    ),
-  ],
+  render: (props) => (
+    <div style={{ display: props.mode === 'vertical' ? 'flex' : undefined, height: 50 }}>
+      Before Separator
+      <Separator {...props} />
+      After Separator
+    </div>
+  ),
 };
 
-export const Example: Story = {
-  ...Playground,
-  decorators: [
-    (Component) => (
-      <Group>
-        <SimpleCell before={<Icon28Notifications />}>Уведомления</SimpleCell>
-        <Spacing>
-          <Component />
+export const Default: Story = {
+  render: () => (
+    <Group>
+      <SimpleCell before={<Icon28Notifications />}>Уведомления</SimpleCell>
+      <Spacing>
+        <Separator />
+      </Spacing>
+      <SimpleCell before={<Icon28SlidersOutline />}>Основные</SimpleCell>
+    </Group>
+  ),
+};
+
+export const VerticalMode: Story = {
+  render: () => (
+    <Group>
+      <Div style={{ display: 'flex' }}>
+        <Link href="#">Before</Link>
+        <Spacing mode="vertical">
+          <Separator wide mode="vertical" />
         </Spacing>
-        <SimpleCell before={<Icon28SlidersOutline />}>Основные</SimpleCell>
-      </Group>
-    ),
-  ],
+        <Link href="#">After</Link>
+      </Div>
+    </Group>
+  ),
 };

--- a/packages/vkui/src/components/Separator/Separator.tsx
+++ b/packages/vkui/src/components/Separator/Separator.tsx
@@ -9,15 +9,28 @@ export interface SeparatorProps extends HTMLAttributesWithRootRef<HTMLDivElement
    * С этим свойством компонент не будет иметь отступы слева и справа
    */
   wide?: boolean;
+  /**
+   * Направление отображения (горизональное/вертикальное)
+   */
+  mode?: 'horizontal' | 'vertical';
 }
+
+const modeClassNames = {
+  vertical: styles['Separator--mode-vertical'],
+  horizontal: styles['Separator--mode-horizontal'],
+};
 
 /**
  * @see https://vkcom.github.io/VKUI/#/Separator
  */
-export const Separator = ({ wide, ...restProps }: SeparatorProps) => (
+export const Separator = ({ wide, mode = 'horizontal', ...restProps }: SeparatorProps) => (
   <RootComponent
     {...restProps}
-    baseClassName={classNames(styles['Separator'], !wide && styles['Separator--padded'])}
+    baseClassName={classNames(
+      styles['Separator'],
+      !wide && styles['Separator--padded'],
+      modeClassNames[mode],
+    )}
   >
     <hr className={styles['Separator__in']} />
   </RootComponent>

--- a/packages/vkui/src/components/Spacing/Readme.md
+++ b/packages/vkui/src/components/Spacing/Readme.md
@@ -23,6 +23,11 @@
 <Spacing size={20} />
 ```
 
+Есть возможность задать `mode=vertical` для создания вертикального отступа между элементами.
+
+> Обратите внимание, если вы используете `Spacing` с вложенным компонентом `Separator` в режиме `vertical`,
+> то родительский элемент должен быть `flex`-контейнером.
+
 ```jsx
 <View activePanel="separator">
   <Panel id="separator">
@@ -86,6 +91,15 @@
 
       <SimpleCell before={<Icon28UserOutline />}>Учётная запись</SimpleCell>
       <SimpleCell before={<Icon28SlidersOutline />}>Основные</SimpleCell>
+    </Group>
+    <Group header={<Header mode="secondary">Vertical Spacings</Header>}>
+      <Div style={{ display: 'flex' }}>
+        <Link>Новости</Link>
+        <Spacing size={24} mode="vertical" />
+        <Link>Звонки</Link>
+        <Spacing size={24} mode="vertical" />
+        <Link>Друзья</Link>
+      </Div>
     </Group>
   </Panel>
 </View>

--- a/packages/vkui/src/components/Spacing/Spacing.module.css
+++ b/packages/vkui/src/components/Spacing/Spacing.module.css
@@ -2,3 +2,7 @@
   position: relative;
   box-sizing: border-box;
 }
+
+.Spacing--mode-vertical {
+  display: inline-flex;
+}

--- a/packages/vkui/src/components/Spacing/Spacing.stories.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.stories.tsx
@@ -29,14 +29,11 @@ export const Playground: Story = {
 };
 
 export const Example: Story = {
-  ...Playground,
-  decorators: [
-    (Component) => (
-      <Group>
-        <SimpleCell before={<Icon28BlockOutline />}>Не беспокоить</SimpleCell>
-        <Component />
-        <SimpleCell before={<Icon28UserOutline />}>Учётная запись</SimpleCell>
-      </Group>
-    ),
-  ],
+  render: () => (
+    <Group>
+      <SimpleCell before={<Icon28BlockOutline />}>Не беспокоить</SimpleCell>
+      <Spacing />
+      <SimpleCell before={<Icon28UserOutline />}>Учётная запись</SimpleCell>
+    </Group>
+  ),
 };

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { classNames } from '@vkontakte/vkjs';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Spacing.module.css';
@@ -8,17 +9,35 @@ export interface SpacingProps extends HTMLAttributesWithRootRef<HTMLDivElement> 
    * Высота спэйсинга
    */
   size?: number;
+  /**
+   * Направление отображения (горизональное/вертикальное)
+   */
+  mode?: 'horizontal' | 'vertical';
 }
 
 /**
  * @see https://vkcom.github.io/VKUI/#/Spacing
  */
-export const Spacing = ({ size = 8, style: styleProp, ...restProps }: SpacingProps) => {
-  const style: React.CSSProperties = {
-    height: size,
-    padding: `${size / 2}px 0`,
+export const Spacing = ({
+  size = 8,
+  style: styleProp,
+  mode = 'horizontal',
+  ...restProps
+}: SpacingProps) => {
+  let style: React.CSSProperties = {
+    padding: mode === 'vertical' ? `0 ${size / 2}px` : `${size / 2}px 0`,
+    ...(mode === 'vertical' ? { width: size } : { height: size }),
     ...styleProp,
   };
 
-  return <RootComponent {...restProps} baseClassName={styles['Spacing']} style={style} />;
+  return (
+    <RootComponent
+      {...restProps}
+      baseClassName={classNames(
+        styles['Spacing'],
+        mode === 'vertical' && styles['Spacing--mode-vertical'],
+      )}
+      style={style}
+    />
+  );
 };


### PR DESCRIPTION
- resolve #5636
---

~~- [ ] Unit-тесты~~
- [ ] e2e-тесты
- [ ] Дизайн-ревью

## Описание

Мы в свое время ушли от этой концепции, но, возможно, нужно подумать о том, чтобы все-таки вернуться к компоненту, который объединяет возможности `Spacing` и `Separator`. 

Кажется, в таком апи страдает DX:
```
<Spacing size={16} mode="vertical">
   <Separator mode="vertical" wide />
</Spacing>
```

Если используется `vertical` в `Spacing`, то `Separator` не может быть `horizontal` (и наоборот)

Ну и с точки зрения кода, кажется, проще прописать необходимые отступы непосредственно компоненту `Separator`, вместо оберток в `Spacing`