### PR TITLE
Remove overflow-x: hidden from body

### DIFF
--- a/packages/vkui/src/styles/common.css
+++ b/packages/vkui/src/styles/common.css
@@ -1,9 +1,4 @@
 /* stylelint-disable-next-line selector-max-type */
-.vkui > body {
-  overflow-x: hidden;
-}
-
-/* stylelint-disable-next-line selector-max-type */
 .vkui,
 .vkui > body,
 .vkui__root {


### PR DESCRIPTION
## Описание
Известно, что при `overflow-x: hidden` на `body` события скролла не всплывают до `window`. И библиотеки (реализующие виртуальные списки), которые слушают события скролла `window` ломаются.

Рекоммендуем пользователям библиотеки самим выставлять `overflow-x: hidden` на `body`, если это действительно нужно по какой-то причине.
Возможно, что выставим это же на `AppRoot`, если в этом будет необходимость, как в `embedded` режиме.