### PR TITLE
feat: add provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,8 @@ jobs:
     concurrency: ci-gh-pages
     outputs:
       release_tag: ${{ steps.updated_version.outputs.version }}
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -97,21 +99,23 @@ jobs:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           directory: packages/vkui/
 
-      - name: Setup NPM Auth Token to .yarnrc.yml
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
-        shell: bash
-        run: |
-          yarn config set npmAlwaysAuth true
-          yarn config set npmAuthToken $NODE_AUTH_TOKEN
+      - name: Generate archive
+        working-directory: ./packages/vkui
+        run: yarn pack
 
       - name: Publishing with latest tag
+        working-directory: ./packages/vkui
         if: ${{ github.event.inputs.latest == 'true' }}
-        run: yarn workspace @vkontakte/vkui npm publish
+        run: npm publish package.tgz
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: Publishing with legacy tag
+        working-directory: ./packages/vkui
         if: ${{ github.event.inputs.latest != 'true' }}
-        run: yarn workspace @vkontakte/vkui npm publish --tag legacy
+        run: npm publish package.tgz --tag legacy
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: Creating doc for stable release
         if: ${{ github.event.inputs.latest == 'true' }}

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -37,6 +37,8 @@ jobs:
     concurrency: ci-gh-pages
     outputs:
       release_tag: ${{ steps.updated_version.outputs.version }}
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -97,17 +99,16 @@ jobs:
           branch: ${{ github.ref }}
           tags: true
 
-      - name: Setup NPM Auth Token to .yarnrc.yml
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
-        shell: bash
-        run: |
-          yarn config set npmAlwaysAuth true
-          yarn config set npmAuthToken $NODE_AUTH_TOKEN
+      - name: Generate archive
+        working-directory: ./packages/vkui
+        run: yarn pack
 
       - name: Publishing release
+        working-directory: ./packages/vkui
         run: |
-          yarn workspace @vkontakte/vkui npm publish --tag ${{ github.event.inputs.tag }}
+          npm publish package.tgz --tag ${{ github.event.inputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: Build styleguide
         run: yarn run docs:styleguide:build --dist dist/${{ steps.updated_version.outputs.version }}

--- a/.github/workflows/publish_token_translator.yml
+++ b/.github/workflows/publish_token_translator.yml
@@ -15,7 +15,8 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/token-translator
-
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,14 +71,11 @@ jobs:
           branch: ${{ github.ref }}
           tags: true
 
-      - name: Setup NPM Auth Token to .yarnrc.yml
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
-        shell: bash
-        run: |
-          yarn config set npmAlwaysAuth true
-          yarn config set npmAuthToken $NODE_AUTH_TOKEN
+      - name: Generate archive
+        run: yarn pack
 
       - name: Publishing release
         run: |
-          yarn npm publish
+          npm publish package.tgz
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_vkui_floating_ui_react_dom.yml
+++ b/.github/workflows/publish_vkui_floating_ui_react_dom.yml
@@ -28,6 +28,8 @@ run-name: Publish @vkontakte/vkui-floating-ui ${{ inputs.custom_version }} ${{ i
 
 jobs:
   publish:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -89,20 +91,19 @@ jobs:
           branch: ${{ github.ref }}
           tags: true
 
-      - name: Setup NPM Auth Token to .yarnrc.yml
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
-        shell: bash
-        run: |
-          yarn config set npmAlwaysAuth true
-          yarn config set npmAuthToken $NODE_AUTH_TOKEN
+      - name: Generate archive
+        run: yarn pack
 
       - name: Publishing tagged release
         if: ${{ github.event.inputs.tag }}
         run: |
-          yarn npm publish --tag ${{ github.event.inputs.tag }}
+          npm publish package.tgz --tag ${{ github.event.inputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
       - name: Publishing release
         if: ${{ !github.event.inputs.tag }}
         run: |
-          yarn npm publish
+          npm publish package.tgz
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/packages/token-translator/package.json
+++ b/packages/token-translator/package.json
@@ -33,5 +33,8 @@
     "build": "tsc",
     "test": "jest",
     "test:ci": "yarn test"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/vkui-floating-ui/package.json
+++ b/packages/vkui-floating-ui/package.json
@@ -82,5 +82,8 @@
   "devDependencies": {
     "@swc/core": "^1.3.96"
   },
-  "packageManager": "yarn@3.6.3"
+  "packageManager": "yarn@3.6.3",
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -121,5 +121,8 @@
       "path": "dist/vkui.css",
       "webpack": false
     }
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }


### PR DESCRIPTION
## Описание

Добавляем подпись от ci для npm пакетов

- [блог](https://github.blog/2023-04-19-introducing-npm-package-provenance/)
- [документация](https://docs.npmjs.com/generating-provenance-statements)

## Изменения

На пакетах появится подпись от GitHub Actions с ссылкой на коммит, процесс ci и т.д.

UPD: сейчас не заработает, нужно чтобы yarn завез себе

- blocked by  [yarnpkg/berry#5430](https://togithub.com/yarnpkg/berry/issues/5430)

UPD 2: переписал на npm 
