### PR TITLE
fix(lib/floating): Use compatible with old browsers version of floating-ui/react-dom using @vkontakte/floating-ui-react-dom

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,3 +9,7 @@ plugins:
     spec: '@yarnpkg/plugin-workspace-tools'
 
 yarnPath: .yarn/releases/yarn-3.6.3.cjs
+
+# specially for @vkontakte/floating-ui-react-dom package
+# to use published version instead of workspace by default
+enableTransparentWorkspaces: false

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "@project-tools/postcss-restructure-variable": "1.0.0",
     "@project-tools/storybook-addon-cartesian": "1.0.0",
     "@project-tools/stylelint-atomic": "1.0.0",
-    "@project-tools/stylelint-bad-multiplication": "1.0.0",
-    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0"
+    "@project-tools/stylelint-bad-multiplication": "1.0.0"
   },
   "devDependencies": {
     "@csstools/postcss-global-data": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.0",
   "name": "@vkontakte/vkui-monorepo",
   "dependencies": {
-    "@project-docs/styleguide": "1.0.0",
-    "@project-tools/eslint-plugin-vkui": "1.0.0",
-    "@project-tools/postcss-restructure-variable": "1.0.0",
-    "@project-tools/storybook-addon-cartesian": "1.0.0",
-    "@project-tools/stylelint-atomic": "1.0.0",
-    "@project-tools/stylelint-bad-multiplication": "1.0.0"
+    "@project-docs/styleguide": "workspace:1.0.0",
+    "@project-tools/eslint-plugin-vkui": "workspace:1.0.0",
+    "@project-tools/postcss-restructure-variable": "workspace:1.0.0",
+    "@project-tools/storybook-addon-cartesian": "workspace:1.0.0",
+    "@project-tools/stylelint-atomic": "workspace:1.0.0",
+    "@project-tools/stylelint-bad-multiplication": "workspace:1.0.0"
   },
   "devDependencies": {
     "@csstools/postcss-global-data": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "@project-tools/postcss-restructure-variable": "1.0.0",
     "@project-tools/storybook-addon-cartesian": "1.0.0",
     "@project-tools/stylelint-atomic": "1.0.0",
-    "@project-tools/stylelint-bad-multiplication": "1.0.0"
+    "@project-tools/stylelint-bad-multiplication": "1.0.0",
+    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0"
   },
   "devDependencies": {
     "@csstools/postcss-global-data": "2.1.0",

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -73,7 +73,7 @@
     "@swc/helpers": "^0.5.2",
     "@vkontakte/icons": "^2.62.0",
     "@vkontakte/vkjs": "^1.1.0",
-    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0",
+    "@vkontakte/vkui-floating-ui-react-dom": "0.0.2-alpha.0",
     "dayjs": "^1.11.10",
     "mitt": "^3.0.1"
   },

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -73,7 +73,7 @@
     "@swc/helpers": "^0.5.2",
     "@vkontakte/icons": "^2.62.0",
     "@vkontakte/vkjs": "^1.1.0",
-    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom0.0.2-alpha.0",
+    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0",
     "dayjs": "^1.11.10",
     "mitt": "^3.0.1"
   },

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -70,10 +70,10 @@
     "react-dom": "^17.0.0 || ^18.1.0"
   },
   "dependencies": {
-    "@floating-ui/react-dom": "^2.0.2",
     "@swc/helpers": "^0.5.2",
     "@vkontakte/icons": "^2.62.0",
     "@vkontakte/vkjs": "^1.1.0",
+    "@vkontakte/vkui-floating-ui-react-dom": "npm:0.0.2-alpha.0",
     "dayjs": "^1.11.10",
     "mitt": "^3.0.1"
   },

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -73,7 +73,7 @@
     "@swc/helpers": "^0.5.2",
     "@vkontakte/icons": "^2.62.0",
     "@vkontakte/vkjs": "^1.1.0",
-    "@vkontakte/vkui-floating-ui-react-dom": "npm:0.0.2-alpha.0",
+    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom0.0.2-alpha.0",
     "dayjs": "^1.11.10",
     "mitt": "^3.0.1"
   },

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -73,7 +73,7 @@
     "@swc/helpers": "^0.5.2",
     "@vkontakte/icons": "^2.62.0",
     "@vkontakte/vkjs": "^1.1.0",
-    "@vkontakte/vkui-floating-ui-react-dom": "0.0.2-alpha.0",
+    "@vkontakte/vkui-floating-ui-react-dom": "0.1.0",
     "dayjs": "^1.11.10",
     "mitt": "^3.0.1"
   },

--- a/packages/vkui/src/lib/floating/adapters.ts
+++ b/packages/vkui/src/lib/floating/adapters.ts
@@ -3,7 +3,7 @@ import {
   type AutoUpdateOptions,
   type FloatingElement,
   type ReferenceType,
-} from '@floating-ui/react-dom';
+} from '@vkontakte/vkui-floating-ui-react-dom';
 
 const defaultOptions = {
   ancestorScroll: true,

--- a/packages/vkui/src/lib/floating/index.ts
+++ b/packages/vkui/src/lib/floating/index.ts
@@ -8,7 +8,7 @@ export {
   size as sizeMiddleware,
   hide as hideMiddleware,
   getOverflowAncestors,
-} from '@floating-ui/react-dom';
+} from '@vkontakte/vkui-floating-ui-react-dom';
 
 export type {
   Placement,

--- a/packages/vkui/src/lib/floating/types.ts
+++ b/packages/vkui/src/lib/floating/types.ts
@@ -1,4 +1,4 @@
-import type { Placement } from '@floating-ui/react-dom';
+import type { Placement } from '@vkontakte/vkui-floating-ui-react-dom';
 
 export type AutoPlacementType = 'auto' | 'auto-start' | 'auto-end';
 
@@ -9,4 +9,4 @@ export type {
   Middleware as UseFloatingMiddleware,
   UseFloatingData,
   Strategy as FloatingPositionStrategy,
-} from '@floating-ui/react-dom';
+} from '@vkontakte/vkui-floating-ui-react-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,7 +2531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@project-docs/styleguide@1.0.0, @project-docs/styleguide@workspace:styleguide":
+"@project-docs/styleguide@workspace:1.0.0, @project-docs/styleguide@workspace:styleguide":
   version: 0.0.0-use.local
   resolution: "@project-docs/styleguide@workspace:styleguide"
   dependencies:
@@ -2542,19 +2542,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@project-tools/eslint-plugin-vkui@1.0.0, @project-tools/eslint-plugin-vkui@workspace:tools/eslint-plugin-vkui":
+"@project-tools/eslint-plugin-vkui@workspace:1.0.0, @project-tools/eslint-plugin-vkui@workspace:tools/eslint-plugin-vkui":
   version: 0.0.0-use.local
   resolution: "@project-tools/eslint-plugin-vkui@workspace:tools/eslint-plugin-vkui"
   languageName: unknown
   linkType: soft
 
-"@project-tools/postcss-restructure-variable@1.0.0, @project-tools/postcss-restructure-variable@workspace:tools/postcss-restructure-variable":
+"@project-tools/postcss-restructure-variable@workspace:1.0.0, @project-tools/postcss-restructure-variable@workspace:tools/postcss-restructure-variable":
   version: 0.0.0-use.local
   resolution: "@project-tools/postcss-restructure-variable@workspace:tools/postcss-restructure-variable"
   languageName: unknown
   linkType: soft
 
-"@project-tools/storybook-addon-cartesian@1.0.0, @project-tools/storybook-addon-cartesian@workspace:tools/storybook-addon-cartesian":
+"@project-tools/storybook-addon-cartesian@workspace:1.0.0, @project-tools/storybook-addon-cartesian@workspace:tools/storybook-addon-cartesian":
   version: 0.0.0-use.local
   resolution: "@project-tools/storybook-addon-cartesian@workspace:tools/storybook-addon-cartesian"
   dependencies:
@@ -2579,13 +2579,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@project-tools/stylelint-atomic@1.0.0, @project-tools/stylelint-atomic@workspace:tools/stylelint-atomic":
+"@project-tools/stylelint-atomic@workspace:1.0.0, @project-tools/stylelint-atomic@workspace:tools/stylelint-atomic":
   version: 0.0.0-use.local
   resolution: "@project-tools/stylelint-atomic@workspace:tools/stylelint-atomic"
   languageName: unknown
   linkType: soft
 
-"@project-tools/stylelint-bad-multiplication@1.0.0, @project-tools/stylelint-bad-multiplication@workspace:tools/stylelint-bad-multiplication":
+"@project-tools/stylelint-bad-multiplication@workspace:1.0.0, @project-tools/stylelint-bad-multiplication@workspace:tools/stylelint-bad-multiplication":
   version: 0.0.0-use.local
   resolution: "@project-tools/stylelint-bad-multiplication@workspace:tools/stylelint-bad-multiplication"
   languageName: unknown
@@ -5498,7 +5498,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0, @vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom":
+"@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0":
+  version: 0.0.2-alpha.0
+  resolution: "@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0"
+  dependencies:
+    "@floating-ui/react-dom": ^2.0.2
+    "@swc/helpers": ^0.5.2
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 1e2b3f5d6226933078b24cfd90a50bceb4c29f67564093fa4d4773b1676ae71faecc5eeb1765d9463a383a3aa5fe4d689c9517d6eea5b7cb0c548df360a1fc49
+  languageName: node
+  linkType: hard
+
+"@vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom":
   version: 0.0.0-use.local
   resolution: "@vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom"
   dependencies:
@@ -5518,12 +5531,12 @@ __metadata:
     "@csstools/postcss-global-data": 2.1.0
     "@playwright/experimental-ct-react17": 1.38.1
     "@playwright/test": 1.38.1
-    "@project-docs/styleguide": 1.0.0
-    "@project-tools/eslint-plugin-vkui": 1.0.0
-    "@project-tools/postcss-restructure-variable": 1.0.0
-    "@project-tools/storybook-addon-cartesian": 1.0.0
-    "@project-tools/stylelint-atomic": 1.0.0
-    "@project-tools/stylelint-bad-multiplication": 1.0.0
+    "@project-docs/styleguide": "workspace:1.0.0"
+    "@project-tools/eslint-plugin-vkui": "workspace:1.0.0"
+    "@project-tools/postcss-restructure-variable": "workspace:1.0.0"
+    "@project-tools/storybook-addon-cartesian": "workspace:1.0.0"
+    "@project-tools/stylelint-atomic": "workspace:1.0.0"
+    "@project-tools/stylelint-bad-multiplication": "workspace:1.0.0"
     "@size-limit/file": ^9.0.0
     "@size-limit/webpack": ^9.0.0
     "@size-limit/webpack-css": ^9.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,7 +5498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vkontakte/vkui-floating-ui-react-dom@npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0, @vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom":
+"@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0, @vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom":
   version: 0.0.0-use.local
   resolution: "@vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom"
   dependencies:
@@ -5547,7 +5547,6 @@ __metadata:
     "@vkontakte/prettier-config": ^0.1.0
     "@vkontakte/stylelint-config": ^3.4.0
     "@vkontakte/vk-bridge": ^2.1.3
-    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0"
     "@vkontakte/vkui-tokens": 4.40.0
     autoprefixer: ^10.4.16
     concurrently: ^8.2.1
@@ -5644,7 +5643,7 @@ __metadata:
     "@swc/helpers": ^0.5.2
     "@vkontakte/icons": ^2.62.0
     "@vkontakte/vkjs": ^1.1.0
-    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0"
+    "@vkontakte/vkui-floating-ui-react-dom": 0.0.2-alpha.0
     dayjs: ^1.11.10
     mitt: ^3.0.1
     storybook: 7.4.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,20 +5498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0":
-  version: 0.0.2-alpha.0
-  resolution: "@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0"
-  dependencies:
-    "@floating-ui/react-dom": ^2.0.2
-    "@swc/helpers": ^0.5.2
-  peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
-  checksum: 1e2b3f5d6226933078b24cfd90a50bceb4c29f67564093fa4d4773b1676ae71faecc5eeb1765d9463a383a3aa5fe4d689c9517d6eea5b7cb0c548df360a1fc49
-  languageName: node
-  linkType: hard
-
-"@vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom":
+"@vkontakte/vkui-floating-ui-react-dom@npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0, @vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom":
   version: 0.0.0-use.local
   resolution: "@vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom"
   dependencies:
@@ -5656,7 +5643,7 @@ __metadata:
     "@swc/helpers": ^0.5.2
     "@vkontakte/icons": ^2.62.0
     "@vkontakte/vkjs": ^1.1.0
-    "@vkontakte/vkui-floating-ui-react-dom": "npm:0.0.2-alpha.0"
+    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0"
     dayjs: ^1.11.10
     mitt: ^3.0.1
     storybook: 7.4.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -5547,6 +5547,7 @@ __metadata:
     "@vkontakte/prettier-config": ^0.1.0
     "@vkontakte/stylelint-config": ^3.4.0
     "@vkontakte/vk-bridge": ^2.1.3
+    "@vkontakte/vkui-floating-ui-react-dom": "npm:@vkontakte/vkui-floating-ui-react-dom@0.0.2-alpha.0"
     "@vkontakte/vkui-tokens": 4.40.0
     autoprefixer: ^10.4.16
     concurrently: ^8.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,16 +5498,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0":
-  version: 0.0.2-alpha.0
-  resolution: "@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0"
+"@vkontakte/vkui-floating-ui-react-dom@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@vkontakte/vkui-floating-ui-react-dom@npm:0.1.0"
   dependencies:
     "@floating-ui/react-dom": ^2.0.2
     "@swc/helpers": ^0.5.2
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 1e2b3f5d6226933078b24cfd90a50bceb4c29f67564093fa4d4773b1676ae71faecc5eeb1765d9463a383a3aa5fe4d689c9517d6eea5b7cb0c548df360a1fc49
+  checksum: 59242b3c3cd6d4130bc8a8872c2ddaf05632634ad143cf461929459be559c1482acea2035c674ad4a5d8b738d8d89a5b4abd059fd57f71ebeea5603d178d28e5
   languageName: node
   linkType: hard
 
@@ -5656,7 +5656,7 @@ __metadata:
     "@swc/helpers": ^0.5.2
     "@vkontakte/icons": ^2.62.0
     "@vkontakte/vkjs": ^1.1.0
-    "@vkontakte/vkui-floating-ui-react-dom": 0.0.2-alpha.0
+    "@vkontakte/vkui-floating-ui-react-dom": 0.1.0
     dayjs: ^1.11.10
     mitt: ^3.0.1
     storybook: 7.4.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,6 +5498,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0":
+  version: 0.0.2-alpha.0
+  resolution: "@vkontakte/vkui-floating-ui-react-dom@npm:0.0.2-alpha.0"
+  dependencies:
+    "@floating-ui/react-dom": ^2.0.2
+    "@swc/helpers": ^0.5.2
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 1e2b3f5d6226933078b24cfd90a50bceb4c29f67564093fa4d4773b1676ae71faecc5eeb1765d9463a383a3aa5fe4d689c9517d6eea5b7cb0c548df360a1fc49
+  languageName: node
+  linkType: hard
+
 "@vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom":
   version: 0.0.0-use.local
   resolution: "@vkontakte/vkui-floating-ui-react-dom@workspace:packages/vkui-floating-ui-react-dom"
@@ -5640,10 +5653,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vkontakte/vkui@workspace:packages/vkui"
   dependencies:
-    "@floating-ui/react-dom": ^2.0.2
     "@swc/helpers": ^0.5.2
     "@vkontakte/icons": ^2.62.0
     "@vkontakte/vkjs": ^1.1.0
+    "@vkontakte/vkui-floating-ui-react-dom": "npm:0.0.2-alpha.0"
     dayjs: ^1.11.10
     mitt: ^3.0.1
     storybook: 7.4.5


### PR DESCRIPTION
- [x] Unit-тесты - проходят
- [x] e2e-тесты - проходят
- [x] элементы на floating-ui через lib/floating работают корректно.

## Описание
Стало известно, что в старых барузерах, типа Firefox 52 приложения на VKUI падают, потому что в коде не преобразуются [spread syntax in object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).

Выяснилось, что проблема в том, что начиная с версии [v5.2.0](https://github.com/VKCOM/VKUI/releases/tag/v5.2.0) мы [перешли](https://vk.com/away.php?to=https%3A%2F%2Fgithub.com%2FVKCOM%2FVKUI%2Fcommit%2F0d05eb958c8f1e3c981a462da2ff7988f6c10aae&utf=1) с popperjs на floating-ui. Оказалось, что floating-ui [поддерживают более новые браузеры](https://github.com/floating-ui/floating-ui/commit/ee5d9dd22655cf52de9a7ab337e4cf7c6415b025) чем мы и теперь в нашу сборку попадает код, нарушающий контракт нашего [.browseslistrc](https://github.com/VKCOM/VKUI/blob/v5.7.2/.browserslistrc).

## Изменения
- в #5905 мы добавили новый пакет [@vkontakte/floating-ui-react-dom](https://www.npmjs.com/package/@vkontakte/vkui-floating-ui-react-dom), который является скомпилированной под es5 версией [@floating-ui/react-dom](https://www.npmjs.com/package/@floating-ui/react-dom/v/2.0.2)
- теперь мы используем этот новый пакет, вместо @floating-ui/react-dom, чтобы поддержать старые браузеры.
- По умолчанию yarn всегда пытается использовать локальный пакет из имеющихся воркспейсов, если версия пакета из package.json совпадает с версией в воркспейсе. Нам это не подходит, конкретно версию `@vkontakte/floating-ui-react-dom` мы хотим брать из npm, уже опубликованную.
  - Чтобы отключить поведение yarn по умолчанию в конфигурационном файле .yarnrc.yml выключен параметр [enableTransparentWorkspaces](https://yarnpkg.com/configuration/yarnrc#enableTransparentWorkspaces). 
Мы не ссылаемся на воркспейс специально, чтобы при локальной разработке не надо было каждый раз билдить пакет, чтобы не билдить его специально в воклфлоу CI при сборке VKUI а также чтобы случайно не задепоить `vkui`, забыв до этого задеплоить `@vkontakte/floating-ui-react-dom`.
Каждый раз при обновлении `floating-ui` мы будем отдельно билдить и релизить `@vkontakte/floating-ui-react-dom`, а потом обновлять `VKUI`.
  - так как [enableTransparentWorkspaces](https://yarnpkg.com/configuration/yarnrc#enableTransparentWorkspaces) теперь выключен, ссылки на остальные вокрспейсы, которые мы используем внутри монорепы, теперь явно заданы с помощью `workspace:` протокола.

## Уточнение
Надеюсь после тестирования выпустить новый минор `@vkontakte/floating-ui-react-dom`, чтобы использовать его, а не alpha версию, как сейчас.