### PR TITLE
fix(Button): after/before padding for stretched

### DIFF
--- a/packages/vkui/src/components/Button/Button.e2e-playground.tsx
+++ b/packages/vkui/src/components/Button/Button.e2e-playground.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Icon16Add, Icon24Camera } from '@vkontakte/icons';
+import { Icon12Add, Icon12Tag, Icon16Add, Icon24Camera } from '@vkontakte/icons';
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { Counter } from '../Counter/Counter';
 import { Button, type ButtonProps } from './Button';
@@ -99,6 +99,34 @@ export const ButtonWithCounterPlayground = (props: ComponentPlaygroundProps) => 
         }
         return ButtonElement;
       }}
+    </ComponentPlayground>
+  );
+};
+
+export const ButtonWithPaddingsPlayground = (props: ComponentPlaygroundProps) => {
+  return (
+    <ComponentPlayground
+      {...props}
+      propSets={[
+        {
+          size: ['s', 'm', 'l'],
+          stretched: [true, false],
+          before: [<Icon12Add key="before" />],
+        },
+        {
+          size: ['s', 'm', 'l'],
+          stretched: [true, false],
+          after: [<Icon12Tag key="after" />],
+        },
+      ]}
+    >
+      {(props: ButtonProps) => (
+        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+          {(['primary', 'secondary', 'tertiary', 'outline', 'link'] as const).map((mode) => (
+            <Button key={mode} {...props} mode={mode} />
+          ))}
+        </div>
+      )}
     </ComponentPlayground>
   );
 };

--- a/packages/vkui/src/components/Button/Button.e2e.tsx
+++ b/packages/vkui/src/components/Button/Button.e2e.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { test } from '@vkui-e2e/test';
-import { ButtonPlayground, ButtonWithCounterPlayground } from './Button.e2e-playground';
+import { Appearance } from '../../helpers/appearance';
+import {
+  ButtonPlayground,
+  ButtonWithCounterPlayground,
+  ButtonWithPaddingsPlayground,
+} from './Button.e2e-playground';
 
 test('Button', async ({ mount, expectScreenshotClippedToContent, componentPlaygroundProps }) => {
   await mount(<ButtonPlayground {...componentPlaygroundProps} />);
@@ -10,6 +15,18 @@ test('Button', async ({ mount, expectScreenshotClippedToContent, componentPlaygr
 test.describe('Button', () => {
   test('counter', async ({ mount, expectScreenshotClippedToContent, componentPlaygroundProps }) => {
     await mount(<ButtonWithCounterPlayground {...componentPlaygroundProps} />);
+    await expectScreenshotClippedToContent();
+  });
+
+  test.use({
+    onlyForAppearances: [Appearance.LIGHT],
+  });
+  test('paddings', async ({
+    mount,
+    expectScreenshotClippedToContent,
+    componentPlaygroundProps,
+  }) => {
+    await mount(<ButtonWithPaddingsPlayground {...componentPlaygroundProps} />);
     await expectScreenshotClippedToContent();
   });
 });

--- a/packages/vkui/src/components/Button/Button.module.css
+++ b/packages/vkui/src/components/Button/Button.module.css
@@ -185,7 +185,9 @@
 .Button--mode-link .Button__after,
 .Button--mode-link .Button__before,
 .Button--mode-link .Button__content:first-child,
-.Button--mode-link .Button__content:last-child {
+.Button--mode-link .Button__content:last-child,
+.Button--stretched .Button__after:only-child,
+.Button--stretched .Button__before:only-child {
   padding-left: 0;
   padding-right: 0;
 }

--- a/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:410043251e72075b3770550add3972a69117931b791956c042f749470f222a6f
+size 57815

--- a/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-ios-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b9db31052c1f9ada6acf2df1bb12704db2e53220cfb4ecf9b84ad78bff71708
+size 55315

--- a/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-vkcom-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:471f20b6b6103d11ddd71750af972db45b3e352bc14666bfc5895860036e18e1
+size 57107

--- a/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-vkcom-firefox-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:489466045f170bc1c3c9b0335e897e9cdc4f7762027753c9928e0f8c7282e1e8
+size 62789

--- a/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Button/__image_snapshots__/button-paddings-vkcom-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e89cd9a03801d6ed0c19a719f04fb1517c3d014b39bee986fe32c7455b640ea9
+size 52611


### PR DESCRIPTION
- fix #4049
---
~~- [ ] Unit-тесты~~

- [x] e2e-тесты
- [x] Дизайн-ревью

## Описание

В режиме `stretched` у кнопок только с `after` или `before` сохранялись ненужные отступы 

## Изменения

Добавили класс для обнуления отступов + накинули `e2e`-тестов
