### PR TITLE
fix(ModalPage): Fix scrolling behaviour in the collapsed state of ModalPage

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPage.module.css
+++ b/packages/vkui/src/components/ModalPage/ModalPage.module.css
@@ -116,10 +116,7 @@
 }
 
 .ModalPage--desktop .ModalPage__content-in,
-:global(.vkuiInternalModalRoot__modal--expandable):not(
-    :global(.vkuiInternalModalRoot__modal--collapsed)
-  )
-  .ModalPage__content-in {
+:global(.vkuiInternalModalRoot__modal--expandable) .ModalPage__content-in {
   height: 100%;
 }
 

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -402,7 +402,7 @@ class ModalRootTouchComponent extends React.Component<
 
       modalState.translateY = translateY;
       modalState.translateYCurrent = translateY;
-      modalState.collapsed = translateY > 0 && translateY < shiftYEndPercent;
+      modalState.collapsed = numberInRange(translateY, modalState.collapsedRange);
       modalState.expanded = translateY === 0;
       modalState.hidden = translateY === 100;
 
@@ -661,9 +661,10 @@ function initPageModal(modalState: ModalsStateEntry) {
   let translateYFrom;
   let translateY;
   let expandedRange: TranslateRange;
-  let collapsedRange: TranslateRange;
+  let collapsedRange: TranslateRange | undefined;
   let hiddenRange: TranslateRange;
 
+  const hasCollapsedState = Boolean(modalState.expandable && modalState.settlingHeight !== 100);
   if (modalState.expandable) {
     translateYFrom = 100 - (modalState.settlingHeight ?? 0);
 
@@ -671,10 +672,10 @@ function initPageModal(modalState: ModalsStateEntry) {
     const visiblePart = 100 - translateYFrom;
 
     expandedRange = [0, shiftHalf];
-    collapsedRange = [shiftHalf, translateYFrom + visiblePart / 4];
+    collapsedRange = hasCollapsedState ? [shiftHalf, translateYFrom + visiblePart / 4] : undefined;
     hiddenRange = [translateYFrom + visiblePart / 4, 100];
 
-    collapsed = translateYFrom > 0;
+    collapsed = hasCollapsedState && translateYFrom > 0;
     expanded = translateYFrom <= 0;
     translateY = translateYFrom;
   } else {
@@ -686,7 +687,7 @@ function initPageModal(modalState: ModalsStateEntry) {
     translateY = translateYFrom;
 
     expandedRange = [translateY, translateY + 25];
-    collapsedRange = [translateY + 25, translateY + 25];
+    collapsedRange = undefined;
     hiddenRange = [translateY + 25, translateY + 100];
   }
 


### PR DESCRIPTION
- close #5901 
----
## Описание
В идеале, в состоянии `collapsed` (когда модульное окно не до конца раскрыто) скроллить контент невозможно.
Но, если перевести модальное окно из состояния `expanded` (полностью раскрыто) в состояние `collapsed` коротким, лёгким движением вниз, то визуально модальное окно будет в состоянии collapsed, но внутреннее состояние модалки будет `collapsed=false`, а значит скролл будет разрешен.

То же будет если из состоянии collapsed чуть поднять модальное окно за "челку" и отпустить. Скролл также снова будет доступен, хотя визуально модальное окно осталось в состоянии `collapsed`, но внутреннее состояние будет `collapsed=false`.
Особенно легко воспроизвести, если у `ConfigProvider` `hasCustomPanelHeaderAfter=true`.

Проблема тут в логике определяющей внутреннее состояние модального окна.
https://github.com/VKCOM/VKUI/blob/b15428df97b48a988cd932f1f179861f43824826/packages/vkui/src/components/ModalRoot/ModalRoot.tsx#L405

А именн в переменной `shiftYEndPercent`.
https://github.com/VKCOM/VKUI/blob/b15428df97b48a988cd932f1f179861f43824826/packages/vkui/src/components/ModalRoot/ModalRoot.tsx#L371
`shiftYEndPercent` представляет из себя позицию указателя по `y` в которой закончилось событие `touchMove` в процентном выражении относительно высоты экрана.
В идеале оно должно быть близко к `tranlsateY`, значению на которое нужо опустить/поднять модальное окно.
Но оно, в отличии `translateY`, не учитывает смещение модалки из-за `hasCustomPanelHeaderAfter=true` или из-за инсета. 
Плюс в условии не учитывается вариант, когда `shiftYEndPercent < translateY` как раз когда пользователь совсем немного опустил модальное окно, но достаточно, чтобы попасть в пределы `collapsedRange`.
https://github.com/VKCOM/VKUI/blob/b15428df97b48a988cd932f1f179861f43824826/packages/vkui/src/components/ModalRoot/ModalRoot.tsx#L674

## Изменения
- высчитываем `collapsed` состояние проверяя попадает ли `translateY` в `collapsedRange`.
- но для того, чтобы использовать `collapsedRange` нам надо поправить `collapsedRange` и не использовать его в том случае, если настройками модального окна это состояние не предусмотренно. Поэтому теперь мы устанавливаем `collapsedRange` в `undefined`, если такого состояния у модального окна не может быть.

  А состояние `collapsed`  может быть  у модального окна только если:  
  - модальное окно `expandable` то есть имеет контент, больший возможной высоты модалки для данного экрана
  - и `settlingHeight` не равно 100%, то есть у режима `collapsed` установлена определённая высота в процентном выражении от высоты модалки.

  В противном случае состояния `collapsed` нет, а значит в учитывании `collapsedRange` нету смысла.

  Раньше мы устанавливали `collapsedRange` равным `expandedRange`, если этого режима у модалки не предусмотрено, что неправильно с новой логикой, иначе флаг `collapsed=true` когда модалка открыта полностью, а значит scroll будет отключен.

- убрали css селектор где устанавливали `.ModalPage__content-in` `height: 100%`. в режиме `expanded` и `not collapsed`. Сейчас в этом нету смысла так как модальное окно в режиме `expanded` не может быть `collapsed`.

⚠️ ℹ️  Note: `height: 100%` у `.ModalPage__content-in` нужно, потому что иногда требуется растянуть контент модального окна на всю высоту. (смотри #4689, #4625).
Но устанавливаем мы `height: 100%` либо у модального окна на десктопе, либо у модального окна в режиме `expanded` (развернутого на 100%) c помощью [такого селектора](https://github.com/VKCOM/VKUI/blob/3d64b113837bb501dd19462801d62b416f7b9190/packages/vkui/src/components/ModalPage/ModalPage.module.css#L118-L121):
```css
.ModalPage--desktop .ModalPage__content-in,
:global(.vkuiInternalModalRoot__modal--expandable) .ModalPage__content-in {
  height: 100%;
}
```

Мы не можем напрямую всегда задавать `height: 100%` для `.ModalPage__content-in`
c помощью просто
```css
.ModalPage__content-in {
  height: 100%;
}
```
потому что это сломает поведение модального окна в режиме `dynamicContentHeight`
https://github.com/VKCOM/VKUI/blob/3d64b113837bb501dd19462801d62b416f7b9190/packages/vkui/src/components/ModalRoot/Readme.md?plain=1#L223
И оно всегда будет открываться на всю высоту окна.
