### PR TITLE
[Temp PR] Deprecate @vkontakte/vkui-floating-ui-react-dom

### DIFF
--- a/.github/workflows/unpublish.yml
+++ b/.github/workflows/unpublish.yml
@@ -15,6 +15,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Unpublish
-        run: npm unpublish @vkontakte/vkui-floating-ui-react-dom -f
+        run: npm deprecate @vkontakte/vkui-floating-ui-react-dom "This package has been deprecated and is no longer maintained. Please use @vkontakte/vkui-floating-ui."
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Описание

`.github/workflows/unpublish.yml`, добавленный в PR https://github.com/VKCOM/VKUI/pull/5963, не сработал, т.к. успело набежать > 300 загрузок.

<img width="320" src="https://github.com/VKCOM/VKUI/assets/5850354/42bc1076-a977-4c7c-97a3-7ae2fc5b8168" />

_По правилам должно быть меньше 300 загрузок_

Поэтому в этой ветке в `.github/workflows/unpublish.yml` заменил **unpublish** на **deprecate** с сообщением `"This package has been deprecated and is no longer maintained. Please use @vkontakte/vkui-floating-ui."`.

