### PR TITLE
fix(PullToRefresh): Detect pull to refresh gesture in the document's touchmove

### DIFF
--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
@@ -109,9 +109,11 @@ describe('PullToRefresh', () => {
 
   describe('touch prevention', () => {
     const expectEvents = (toHaveDefault: boolean) => {
-      const hasDefaultMove = fireEvent.touchMove(document.body);
+      const hasDefaultMove = fireEvent.touchMove(document.body, {
+        changedTouches: [{ clientY: 0 }],
+      });
       expect(hasDefaultMove).toBe(toHaveDefault);
-      const hasDefaultStart = fireEvent.mouseDown(screen.getByTestId('xxx'));
+      const hasDefaultStart = fireEvent.mouseDown(screen.getByTestId('xxx'), { clientY: 0 });
       expect(hasDefaultStart).toBe(toHaveDefault);
     };
     it('prevents during refresh', () => {
@@ -129,7 +131,9 @@ describe('PullToRefresh', () => {
       const { unmount } = renderRefresher();
       firePull(screen.getByTestId('xxx'));
       unmount();
-      const hasDefaultMove = fireEvent.touchMove(document.body);
+      const hasDefaultMove = fireEvent.touchMove(document.body, {
+        changedTouches: [{ clientY: 0 }],
+      });
       expect(hasDefaultMove).toBe(true);
     });
   });

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
@@ -201,18 +201,23 @@ export const PullToRefresh = ({
     startYRef.current = e.startY;
   };
 
-  const isRefreshGestureStarted = (event: VKUITouchEvent) => {
-    if (watching) {
+  const shouldPreventTouchMove = (event: VKUITouchEvent) => {
+    if (watching || refreshing) {
       return true;
     }
 
+    /* Нам нужно запретить touchmove у документа как только стало понятно, что
+     * начинается pull.
+     * состояния watching и refreshing устанавливаются слишком поздно и браузер
+     * может успеть начать нативный pull to refresh. */
     const shiftY = coordY(event) - startYRef.current;
     const pageYOffset = scroll?.getScroll().y;
-    return pageYOffset === 0 && shiftY > 0 && touchDown;
+    const isRefreshGestureStarted = pageYOffset === 0 && shiftY > 0 && touchDown;
+    return isRefreshGestureStarted;
   };
 
   const onWindowTouchMove = (event: VKUITouchEvent) => {
-    if (isRefreshGestureStarted(event)) {
+    if (shouldPreventTouchMove(event)) {
       event.preventDefault();
       event.stopPropagation();
     }


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #5670

---

- [x] Unit-тесты

## Описание
Иногда, вместе с pull to refresh в мобильном iOS также может тригерится нативный pull to refresh который обновляет всю страницу.
Происходит это при довольно быстром жесте. 
Проблема в том, что внутренние состояния компонента устанавливаются с небольшой задержкой, потому что мы сначала определяем направление, потом уже начинаем проверять сдвиг по оси Y для отрисовки смещения спинера. И всё это через состояния, которые зависят одно от другого и устанавливаются при разных вызовах рендер функции.

Пока внутренние состояния устанавливаются браузер успевает обработать событие `touchmove` и принять решение о том, что началcя нативный pull to refresh. 

То есть для решения этой проблемы мы должный как можно раньше отменять `touchmove` событие на `document.body`.
Причём сразу отменить это событие если состояние `touchDown = true` тоже нельзя, потому что тогда не будет работать скролл внутри списка.



## Изменения
Решение заключается в отмене события как только мы определили, что жест "cдвиг вниз" начался.
Для этого мы должны сохранить позицию по `y` у события `touchstart` и высчитать сдвиг по `y` в событии `touchmove`. Если сдвиг по `y` положительный и мы находимся в начале страницы - начался жест pull, а значит touchmove можно отключить.