### PR TITLE
feat(HorizontalScroll): disable scroll arrows for screen readers

### DIFF
--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -291,6 +291,7 @@ export const HorizontalScroll = ({
           size={arrowSize}
           offsetY={arrowOffsetY}
           direction="left"
+          aria-hidden
           className={classNames(
             styles['HorizontalScroll__arrow'],
             styles['HorizontalScroll__arrowLeft'],
@@ -303,6 +304,7 @@ export const HorizontalScroll = ({
           size={arrowSize}
           offsetY={arrowOffsetY}
           direction="right"
+          aria-hidden
           className={classNames(
             styles['HorizontalScroll__arrow'],
             styles['HorizontalScroll__arrowRight'],


### PR DESCRIPTION
## Описание

Скрывает стрелки навигации в компоненте `HorizontalScroll` от screen reader (например, NVDA). Данная утилита позволяет устанавливать фокус на любой элемент внутри прокручиваемого содержимого, что в свою очередь избавляет такого пользователя от необходимости управлять кнопками прокрутки.

## Изменения

Добавлен атрибут `aria-hidden` на кнопки стрелок навигации.