### PR TITLE
ci(labels): ignore patch

### DIFF
--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -29,7 +29,7 @@ jobs:
 
       # TODO [>=6]: удалить после v6
       - name: V5
-        if: ${{ !(startsWith(github.event.pull_request.title, 'BREAKING CHANGE') || contains(github.event.pull_request.title, 'v6'))}}
+        if: ${{ !(startsWith(github.event.pull_request.title, 'BREAKING CHANGE') || contains(github.event.pull_request.title, 'v6') || startsWith(github.event.pull_request.title, 'patch'))}}
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
Не накладываем лейбл <kbd>v5</kbd> на PR-ы названия которых начинаются с `patch`