### PR TITLE
Header a11y

### DIFF
--- a/packages/vkui/src/components/Header/Header.test.tsx
+++ b/packages/vkui/src/components/Header/Header.test.tsx
@@ -9,9 +9,9 @@ import { Header } from './Header';
 const getTypographyTagNameByText = (text: string) => screen.getByText(text).tagName.toLowerCase();
 
 describe('Header', () => {
-  baselineComponent(Header);
+  baselineComponent((props) => <Header {...props}>Title</Header>);
 
-  it('[typography] HeaderContent is span on ANDROID regardless of mode and size', () => {
+  it('[typography] HeaderContent is h2 on ANDROID regardless of mode and size', () => {
     render(
       <ConfigProvider platform={Platform.ANDROID}>
         <Header mode="primary">Русский</Header>
@@ -28,15 +28,15 @@ describe('Header', () => {
         </Header>
       </ConfigProvider>,
     );
-    expect(screen.getByText('Русский').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('English').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Espanõl').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Français').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Deutsch').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('中國人').parentElement?.tagName.toLowerCase()).toMatch('span');
+    expect(screen.getByText('Русский').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('English').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Espanõl').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Français').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Deutsch').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('中國人').parentElement?.tagName.toLowerCase()).toMatch('h2');
   });
 
-  it('[typography] HeaderContent is span on IOS regardless of mode and size', () => {
+  it('[typography] HeaderContent is h2 on IOS regardless of mode and size', () => {
     render(
       <ConfigProvider platform={Platform.IOS}>
         <Header mode="primary">Русский</Header>
@@ -53,15 +53,15 @@ describe('Header', () => {
         </Header>
       </ConfigProvider>,
     );
-    expect(screen.getByText('Русский').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('English').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Espanõl').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Français').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Deutsch').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('中國人').parentElement?.tagName.toLowerCase()).toMatch('span');
+    expect(screen.getByText('Русский').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('English').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Espanõl').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Français').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Deutsch').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('中國人').parentElement?.tagName.toLowerCase()).toMatch('h2');
   });
 
-  it('[typography] HeaderContent is span on VKCOM regardless of mode and size', () => {
+  it('[typography] HeaderContent is h2 on VKCOM regardless of mode and size', () => {
     render(
       <ConfigProvider platform={Platform.VKCOM}>
         <Header mode="primary">Русский</Header>
@@ -78,12 +78,12 @@ describe('Header', () => {
         </Header>
       </ConfigProvider>,
     );
-    expect(screen.getByText('Русский').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('English').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Espanõl').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Français').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('Deutsch').parentElement?.tagName.toLowerCase()).toMatch('span');
-    expect(screen.getByText('中國人').parentElement?.tagName.toLowerCase()).toMatch('span');
+    expect(screen.getByText('Русский').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('English').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Espanõl').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Français').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('Deutsch').parentElement?.tagName.toLowerCase()).toMatch('h2');
+    expect(screen.getByText('中國人').parentElement?.tagName.toLowerCase()).toMatch('h2');
   });
 
   it('[typography] HeaderSubtitle is span regardless of mode', () => {

--- a/packages/vkui/src/components/Header/Header.tsx
+++ b/packages/vkui/src/components/Header/Header.tsx
@@ -84,7 +84,6 @@ export const Header = ({
 }: HeaderProps) => {
   return (
     <RootComponent
-      Component="header"
       {...restProps}
       baseClassName={classNames(
         styles['Header'],

--- a/packages/vkui/src/components/Header/Header.tsx
+++ b/packages/vkui/src/components/Header/Header.tsx
@@ -11,7 +11,7 @@ import { Subhead } from '../Typography/Subhead/Subhead';
 import { Title } from '../Typography/Title/Title';
 import styles from './Header.module.css';
 
-export interface HeaderProps extends HTMLAttributesWithRootRef<HTMLElement> {
+export interface HeaderProps extends HTMLAttributesWithRootRef<HTMLElement>, HasComponent {
   mode?: 'primary' | 'secondary' | 'tertiary';
   size?: 'regular' | 'large';
   subtitle?: React.ReactNode;
@@ -75,6 +75,7 @@ const stylesMode = {
 export const Header = ({
   mode = 'primary',
   size = 'regular',
+  Component = 'h2',
   children,
   subtitle,
   indicator,
@@ -96,7 +97,7 @@ export const Header = ({
       <div className={styles['Header__main']}>
         <HeaderContent
           className={styles['Header__content']}
-          Component="span"
+          Component={Component}
           mode={mode}
           size={size}
         >


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи

## Описание

Повышение доступности.

Есть компонент `Header`, широко используемый везде. Внутри компонента зашито несколько комбинаций `Title`, `Headline`, `Footnote`. Это все завернуто во внутренний компонент `HeaderContent`.

Для доступности, быстрой навигации по h-заголовкам, таким пользователям необходимо иметь возможность навигироваться по реальным h-заголовкам, вместо span-ов.

Планируется ли такая поддержка h-заголовков внутри `Header`? Варианты по обратной совместимости значение по умолчанию / от режима `mode` / полностью опциональный вариант (т.е. по месту использования руками передавать)?

Другие мысли из чата:

Пару мыслей о доступности Header:
1. Правильно ли впихивать индикатор в h-заголовок (Счетчик всегда должен попадать на ссылку, на кнопку и на заголовок.)
2. Увидел Component="header", кажется нужно выпилить, ибо
- внутри Group превращается в generic, что бесполезно
- за пределами превратится в banner, что плохо

## Изменения

- удалил `Component="header"` с `RootComponent`
- добавил атрибут `Component="h2"` на `HeaderContent`