### PR TITLE
fix(ModalRoot/ModalPage/PullToRefresh): Disable native pull-to-refresh

### DIFF
--- a/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
@@ -145,4 +145,29 @@ describe.each([
     clickFade();
     expect(onClose).toBeCalledTimes(1);
   });
+
+  it('disables native pull-to-refresh when modal is open', () => {
+    const modals = [<ModalPage id="m" key="m" />, <ModalPage id="other" key="o" />];
+
+    const component = render(<ModalRoot activeModal={null}>{modals}</ModalRoot>, {
+      baseElement: document.documentElement,
+    });
+    runAllTimers();
+
+    expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeFalsy();
+
+    component.rerender(<ModalRoot activeModal="m">{modals}</ModalRoot>);
+    runAllTimers();
+
+    if (name === 'ModalRootTouch') {
+      expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeTruthy();
+    } else {
+      expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeFalsy();
+    }
+
+    component.rerender(<ModalRoot activeModal={null}>{modals}</ModalRoot>);
+    runAllTimers();
+
+    expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeFalsy();
+  });
 });

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
@@ -154,20 +154,20 @@ describe.each([
     });
     runAllTimers();
 
-    expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeFalsy();
+    expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
 
     component.rerender(<ModalRoot activeModal="m">{modals}</ModalRoot>);
     runAllTimers();
 
     if (name === 'ModalRootTouch') {
-      expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeTruthy();
+      expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeTruthy();
     } else {
-      expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeFalsy();
+      expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
     }
 
     component.rerender(<ModalRoot activeModal={null}>{modals}</ModalRoot>);
     runAllTimers();
 
-    expect(document.querySelector('.vkui--modal-overscroll-behavior')).toBeFalsy();
+    expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
   });
 });

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -61,7 +61,6 @@ class ModalRootTouchComponent extends React.Component<
     };
 
     this.frameIds = {};
-    this.prevHtmlOverlayBehaviorValue = '';
   }
 
   private documentScrolling = false;
@@ -73,7 +72,6 @@ class ModalRootTouchComponent extends React.Component<
     [index: string]: number;
   };
   private restoreFocusTo: HTMLElement | undefined | null = undefined;
-  private prevHtmlOverlayBehaviorValue: CSSStyleDeclaration['overscrollBehavior'];
 
   get timeout(): number {
     return this.props.platform === Platform.IOS ? 400 : 320;
@@ -148,10 +146,9 @@ class ModalRootTouchComponent extends React.Component<
     this.documentScrolling = enabled;
 
     if (enabled) {
-      // восстанавливаем сохраненное значение overscroll behavior,
-      // чтобы вернуть нативный pull-to-refresh и bounce-эффект
-      this.document.documentElement.style.overscrollBehavior =
-        this.prevHtmlOverlayBehaviorValue || '';
+      // восстанавливаем значение overscroll behavior,
+      // eslint-disable-next-line no-restricted-properties
+      this.document.documentElement.classList.remove('vkui--modal-overscroll-behavior');
 
       // некоторые браузеры на странных вендорах типа Meizu не удаляют обработчик.
       // https://github.com/VKCOM/VKUI/issues/444
@@ -161,8 +158,9 @@ class ModalRootTouchComponent extends React.Component<
       });
     } else {
       // отключаем нативный pull-to-refresh при открытом модальном окне
-      this.prevHtmlOverlayBehaviorValue = this.document.documentElement.style['overscrollBehavior'];
-      this.document.documentElement.style.overscrollBehavior = 'none';
+      // чтобы он не срабатывал при закрытии модалки смахиванием вниз
+      // eslint-disable-next-line no-restricted-properties
+      this.document.documentElement.classList.add('vkui--modal-overscroll-behavior');
 
       this.window.addEventListener('touchmove', this.preventTouch, {
         passive: false,

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -146,7 +146,7 @@ class ModalRootTouchComponent extends React.Component<
     this.documentScrolling = enabled;
 
     if (enabled) {
-      // восстанавливаем значение overscroll behavior,
+      // восстанавливаем значение overscroll behavior
       // eslint-disable-next-line no-restricted-properties
       this.document.documentElement.classList.remove('vkui--modal-overscroll-behavior');
 

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -61,6 +61,7 @@ class ModalRootTouchComponent extends React.Component<
     };
 
     this.frameIds = {};
+    this.prevHtmlOverlayBehaviorValue = '';
   }
 
   private documentScrolling = false;
@@ -72,6 +73,7 @@ class ModalRootTouchComponent extends React.Component<
     [index: string]: number;
   };
   private restoreFocusTo: HTMLElement | undefined | null = undefined;
+  private prevHtmlOverlayBehaviorValue: CSSStyleDeclaration['overscrollBehavior'];
 
   get timeout(): number {
     return this.props.platform === Platform.IOS ? 400 : 320;
@@ -146,7 +148,11 @@ class ModalRootTouchComponent extends React.Component<
     this.documentScrolling = enabled;
 
     if (enabled) {
-      // Здесь нужен последний аргумент с такими же параметрами, потому что
+      // восстанавливаем сохраненное значение overscroll behavior,
+      // чтобы вернуть нативный pull-to-refresh и bounce-эффект
+      this.document.documentElement.style.overscrollBehavior =
+        this.prevHtmlOverlayBehaviorValue || '';
+
       // некоторые браузеры на странных вендорах типа Meizu не удаляют обработчик.
       // https://github.com/VKCOM/VKUI/issues/444
       this.window.removeEventListener('touchmove', this.preventTouch, {
@@ -154,6 +160,10 @@ class ModalRootTouchComponent extends React.Component<
         passive: false,
       });
     } else {
+      // отключаем нативный pull-to-refresh при открытом модальном окне
+      this.prevHtmlOverlayBehaviorValue = this.document.documentElement.style['overscrollBehavior'];
+      this.document.documentElement.style.overscrollBehavior = 'none';
+
       this.window.addEventListener('touchmove', this.preventTouch, {
         passive: false,
       });

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -148,7 +148,7 @@ class ModalRootTouchComponent extends React.Component<
     if (enabled) {
       // восстанавливаем значение overscroll behavior
       // eslint-disable-next-line no-restricted-properties
-      this.document.documentElement.classList.remove('vkui--modal-overscroll-behavior');
+      this.document.documentElement.classList.remove('vkui--disable-overscroll-behavior');
 
       // некоторые браузеры на странных вендорах типа Meizu не удаляют обработчик.
       // https://github.com/VKCOM/VKUI/issues/444
@@ -160,7 +160,7 @@ class ModalRootTouchComponent extends React.Component<
       // отключаем нативный pull-to-refresh при открытом модальном окне
       // чтобы он не срабатывал при закрытии модалки смахиванием вниз
       // eslint-disable-next-line no-restricted-properties
-      this.document.documentElement.classList.add('vkui--modal-overscroll-behavior');
+      this.document.documentElement.classList.add('vkui--disable-overscroll-behavior');
 
       this.window.addEventListener('touchmove', this.preventTouch, {
         passive: false,

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
@@ -149,4 +149,23 @@ describe('PullToRefresh', () => {
       expect(hasSpinner()).toBe(false);
     });
   });
+
+  test('disables native pull-to-refresh while pulling', () => {
+    const component = render(
+      <ConfigProvider platform={Platform.IOS}>
+        <PullToRefresh onRefresh={noop} data-testid="xxx" />
+      </ConfigProvider>,
+      { baseElement: document.documentElement },
+    );
+
+    expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
+
+    // класс присутствует пока пуллим
+    firePull(component.getByTestId('xxx'), { end: false });
+    expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeTruthy();
+
+    // класс удаляется когда отпускаем
+    fireEvent.mouseUp(component.getByTestId('xxx'), { clientY: 500 });
+    expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
+  });
 });

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
@@ -8,7 +8,7 @@ import { useTimeout } from '../../hooks/useTimeout';
 import { DOMProps, useDOM } from '../../lib/dom';
 import { Platform } from '../../lib/platform';
 import { runTapticImpactOccurred } from '../../lib/taptic';
-import { VKUITouchEvent } from '../../lib/touch';
+import { coordY, VKUITouchEvent } from '../../lib/touch';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { AnyFunction, HasChildren } from '../../types';
 import { ScrollContextInterface, useScroll } from '../AppRoot/ScrollContext';
@@ -191,11 +191,14 @@ export const PullToRefresh = ({
     runRefreshing,
   ]);
 
+  const startYRef = React.useRef(0);
+
   const onTouchStart = (e: TouchEvent) => {
     if (refreshing) {
       cancelEvent(e);
     }
     setTouchDown(true);
+    startYRef.current = e.startY;
 
     if (document) {
       // eslint-disable-next-line no-restricted-properties
@@ -203,8 +206,27 @@ export const PullToRefresh = ({
     }
   };
 
+  const shouldPreventTouchMove = (event: VKUITouchEvent) => {
+    if (watching || refreshing) {
+      return true;
+    }
+
+    /* Нам нужно запретить touchmove у документа как только стало понятно, что
+     * начинается pull.
+     * состояния watching и refreshing устанавливаются слишком поздно и браузер
+     * может успеть начать нативный pull to refresh.
+     *
+     * Этот код является запасным вариантом, на случай, если css свойство
+     * overscroll-behavior не поддерживается
+     * */
+    const shiftY = coordY(event) - startYRef.current;
+    const pageYOffset = scroll?.getScroll().y;
+    const isRefreshGestureStarted = pageYOffset === 0 && shiftY > 0 && touchDown;
+    return isRefreshGestureStarted;
+  };
+
   const onWindowTouchMove = (event: VKUITouchEvent) => {
-    if (refreshing) {
+    if (shouldPreventTouchMove(event)) {
       event.preventDefault();
       event.stopPropagation();
     }

--- a/packages/vkui/src/styles/common.css
+++ b/packages/vkui/src/styles/common.css
@@ -38,3 +38,13 @@
 .vkui--layout-plain {
   background: var(--vkui--color_background_content);
 }
+
+/* отключаем нативный pull-to-refresh при закрывании модалки */
+.vkui--modal-overscroll-behavior {
+  overscroll-behavior-y: contain;
+}
+
+/* отключаем нативный pull-to-refresh в PullToRefresh компоненте*/
+.vkui--disable-overscroll-behavior {
+  overscroll-behavior-y: none;
+}

--- a/packages/vkui/src/styles/common.css
+++ b/packages/vkui/src/styles/common.css
@@ -44,7 +44,7 @@
   overscroll-behavior-y: contain;
 }
 
-/* отключаем нативный pull-to-refresh в PullToRefresh компоненте*/
+/* отключаем нативный pull-to-refresh в PullToRefresh компоненте */
 .vkui--disable-overscroll-behavior {
   overscroll-behavior-y: none;
 }

--- a/packages/vkui/src/styles/common.css
+++ b/packages/vkui/src/styles/common.css
@@ -39,7 +39,7 @@
   background: var(--vkui--color_background_content);
 }
 
-/* отключаем нативный pull-to-refresh при закрывании модалки */
+/* отключаем нативный pull-to-refresh при открывании модалки */
 .vkui--modal-overscroll-behavior {
   overscroll-behavior-y: contain;
 }

--- a/packages/vkui/src/styles/common.css
+++ b/packages/vkui/src/styles/common.css
@@ -44,7 +44,7 @@
   overscroll-behavior-y: contain;
 }
 
-/* отключаем нативный pull-to-refresh в PullToRefresh компоненте */
+/* отключаем нативный pull-to-refresh при взаимодействии с компонентом PullToRefresh */
 .vkui--disable-overscroll-behavior {
   overscroll-behavior-y: none;
 }

--- a/packages/vkui/src/styles/common.css
+++ b/packages/vkui/src/styles/common.css
@@ -39,12 +39,8 @@
   background: var(--vkui--color_background_content);
 }
 
-/* отключаем нативный pull-to-refresh при открывании модалки */
-.vkui--modal-overscroll-behavior {
-  overscroll-behavior-y: contain;
-}
-
-/* отключаем нативный pull-to-refresh при взаимодействии с компонентом PullToRefresh */
+/* отключаем нативный pull-to-refresh при взаимодействии с компонентом
+ * PullToRefresh или при открывании модалки */
 .vkui--disable-overscroll-behavior {
   overscroll-behavior-y: none;
 }


### PR DESCRIPTION
- close #2806 
- related #5670 и #5967

---

- [x] Unit-тесты

## Описание
Ещё одна попытка победить нативный pull-to-refresh который периодически появляется при закрытии модалки или в PullToRefresh компоненте.

В целом событие `touchmove` на window уже игнорируется, но этого недостаточно, потому что для pull-to-refresh в мобильном Safari хватит и одного обработанного браузером`touchstart`. 

Используется css свойство [`overscroll-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) на `html` элементе.

Перепробывал кучу других вариантов с `touchstart/touchmove` событиями, но единственный действенный это превентить `touchstart`. Но тогда перестаёт работать скролл внутри PullToRefresh, а через JS имитировать скролл браузера неблагодарная задача.

## Изменения
добавил глобальный класс, которые в последствии будут вешаться на `html` элемент при открытии модалки или при взаимодействии с PullToRefresh.
Сейчас уже работает наверняка для `PullToRefresh` компонента и покрывает баг в модалках если закрывать окно потянув из `ModalPageHeader`.

Используем классы, а не напрямую меняем style, чтобы не думать и не сохранять предыдущие значения `overscroll-behavior`, это также позволяет избавиться от чтения/записи стилей, чтобы не заставлять браузер готовить и пересчитывать для нас CSSOM в момент чтения/записи style.

### ModalPage
- устанавливаем `overscroll-behavior-y: none` когда модалка открыта

### PullToRefresh
- класс вешается на `html` на событии `touchstart` и убирается в обработчике собитий `touchend/touchcancel`.

## Особенности PullToRefresh.
Так как убирается bounce-эффект, то страница становится менее отзывчивая (без эффекта) если это единственный компонент на странице и пользователь доскролил до конца страницы.
Но зато можно начать наш PullToRefresh даже если страница уже была чуть проскроллена вниз, а пользователь начал тянуть. Раньше можно было вызвать наш PullToRefresh только если страница имеет `scrollTop = 0` в момент начала жеста.

Есть вариант добиться `bounce` эффекта когда пользователь доскроли до конца страницы.
Например, добавить к уже имеющейся логику в `touchmove` и смотреть в какую сторону в пределах `PullToRefresh` пользователь скроллит, и если это скролл вниз (пальцем снизу вверх), то убирать класс, если снова скролл вверх, то добавлять класс. 
Но это так себе решение, потому что мы всегда в `touchstart` выставляем класс, и если пользователь сразу скроллит вниз, то получится, что класс добавиться и тут же убереться. Хотя, не сильно хуже чем сейчас, конечно, потому что мы сейчас и так всегда класс добавляем а на touchend/touchcancel убираем.
И ещё момент появится, что если пользователь уже доскроллил до конца страницы и попробует поскролить вниз ещё раз, то bounce-эффекта не будет, ведь на touchmove мы не поймём в какую сторону пользователь скролит. Хотя тут можно поиграться. И посмотреть scrollTop значение. 🤔 
Вопрос только стоит ли?

## Видео

### ModalPage

| До  | После |
| ------------- | ------------- |
| <video src="https://github.com/VKCOM/VKUI/assets/5443359/52498df0-b6f4-4ccd-856b-0da0b963e338" />  | <video src="https://github.com/VKCOM/VKUI/assets/5443359/82eaa646-6ea5-4122-88c7-ecaee8b77325" />  |


### PullToRefresh
https://github.com/VKCOM/VKUI/assets/5443359/ab242869-fbf0-4c2f-ba4a-1c31246474c7

