### PR TITLE
feat(ScrollSaver): Add component to save scroll position of elements with scroll box

### DIFF
--- a/packages/vkui/src/components/ScrollSaver/Readme.md
+++ b/packages/vkui/src/components/ScrollSaver/Readme.md
@@ -1,0 +1,434 @@
+Компонент-обертка для сохранения позиции скролла элемента при переходах между View и Panel.
+По умолчанию позволяет восстановить значение скролла при возвращении назад.
+
+<br />
+
+Примеры использования **ScrollSaver**:
+
+- С компонентом Div.
+
+```jsx static
+<ScrollSaver id="div-scroll-saver">
+  <Div style={{ display: 'flex'; "max-width": "100px" }}>
+    <AlbumItems />
+  </Div>
+</ScrollSaver>
+```
+
+- С компонентом HorizontalScroll требуется задать проп withGetRef, потому что область скролла HorizontalScroll доступна не через getRootRef, а через getRef.
+
+```jsx static
+<ScrollSaver id="horizontal-scroll-saver-hook" useGetRef>
+  <HorizontalScroll>
+    <div style={{ display: 'flex' }}>
+      <AlbumItems />
+    </div>
+  </HorizontalScroll>
+</ScrollSaver>
+```
+
+- ScrollSaverWtihoutChildren берёт ref не из children а из пропа elementRef.
+
+```jsx static
+<ScrollSaverWithoutChildren id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
+  <HorizontalScroll getRef={horizontalRef}>
+    <div style={{ display: 'flex' }}>
+      <AlbumItems />
+    </div>
+  </HorizontalScroll>
+</ScrollSaverWithoutChildren>
+```
+
+- useScrollSaver хук
+
+```jsx static
+const ContentWithScrollSaverHook = () => {
+  const horizontalScrollRef = useRef();
+  useScrollSaver(horizontalScrollRef, 'horizontal-scroll-saver-hook');
+
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        With ScrollSaverHook
+      </Headline>
+      <HorizontalScroll getRef={horizontalScrollRef}>
+        <div style={{ display: 'flex' }}>
+          <AlbumItems />
+        </div>
+      </HorizontalScroll>
+    </Div>
+  );
+};
+```
+
+<br />
+
+## Хук useClearScrollSaverCache() позволяет получить функцию глобальной очистки кэша ScrollSaver.
+
+```jsx static
+const clearScrollCache = useClearScrollSaverCache();
+```
+
+<br />
+
+В примере ниже на View1 и View2 сохраняются позиции скролла HorizontalScroll используя **ScrollSaver**, **useScrollSaver** и **ScrollSaverWithoutChildren**.
+Позиция сохраняется как при переходе между View так и при переходе между Panel
+При возврате на View1 c других View мы сбрасываем весь кэш ScrollSaver.
+
+```jsx
+const albumItems = [
+  {
+    id: 1,
+    title: 'Команда <3',
+    size: 4,
+    thumb_src: 'https://sun9-33.userapi.com/ODk8khvW97c6aSx_MxHXhok5byDCsHEoU-3BwA/sO-lGf_NjN4.jpg',
+  },
+  {
+    id: 2,
+    title: 'Зингер',
+    size: 22,
+    thumb_src: 'https://sun9-60.userapi.com/bjwt581hETPAp4oY92bDcRvMymyfCaEsnojaUA/_KWQfS-MAd4.jpg',
+  },
+  {
+    id: 3,
+    title: 'Медиагалерея ВКонтакте',
+    size: 64,
+    thumb_src: 'https://sun9-26.userapi.com/YZ5-1A6cVgL7g1opJGQIWg1Bl5ynfPi8p41SkQ/IYIUDqGkkBE.jpg',
+  },
+];
+
+const largeImageStyles = {
+  width: 220,
+  height: 124,
+  borderRadius: 4,
+  boxSizing: 'border-box',
+  border: 'var(--vkui--size_border--regular) solid var(--vkui--color_image_border_alpha)',
+  objectFit: 'cover',
+};
+
+const AlbumItems = () => {
+  return albumItems.map(({ id, title, size, thumb_src }) => (
+    <HorizontalCell key={id} size="l" header={title} subtitle={`${size} фотографии`}>
+      <img style={largeImageStyles} src={thumb_src} />
+    </HorizontalCell>
+  ));
+};
+
+const Content = () => {
+  const direction = useNavDirection();
+
+  const [spinner, setSpinner] = useState(null);
+
+  React.useEffect(
+    function simulateDataLoadingWhenMovingForwards() {
+      let timerId = null;
+      const loadData = () => {
+        setSpinner(<Spinner size="large" style={{ margin: '20px 0' }} />);
+        timerId = setTimeout(() => setSpinner(null), 1000);
+      };
+
+      if (direction !== 'backwards') {
+        loadData();
+      }
+
+      return () => clearTimeout(timerId);
+    },
+    [direction],
+  );
+
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        Направление перехода:{' '}
+        {direction === 'forwards'
+          ? 'вперёд'
+          : direction === 'backwards'
+          ? 'назад'
+          : 'не определено'}
+      </Headline>
+      {spinner}
+    </Div>
+  );
+};
+
+const ContentWithScrollSaverComponent = () => {
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        With ScrollSaver component
+      </Headline>
+      <ScrollSaver id="horizontal-scroll-saver-hook" useGetRef>
+        <HorizontalScroll>
+          <div style={{ display: 'flex' }}>
+            <AlbumItems />
+          </div>
+        </HorizontalScroll>
+      </ScrollSaver>
+    </Div>
+  );
+};
+
+const ContentWithScrollSaverWithoutChildren = () => {
+  const horizontalRef = useRef();
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        With ScrollSaverWithoutChildren - doesn't look for children ref
+      </Headline>
+      <ScrollSaverWithoutChildren id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
+        <HorizontalScroll getRef={horizontalRef}>
+          <div style={{ display: 'flex' }}>
+            <AlbumItems />
+          </div>
+        </HorizontalScroll>
+      </ScrollSaverWithoutChildren>
+    </Div>
+  );
+};
+
+const ContentWithScrollSaverHook = () => {
+  const horizontalScrollRef = useRef();
+  useScrollSaver(horizontalScrollRef, 'horizontal-scroll-saver-hook');
+
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        With ScrollSaverHook
+      </Headline>
+      <HorizontalScroll getRef={horizontalScrollRef}>
+        <div style={{ display: 'flex' }}>
+          <AlbumItems />
+        </div>
+      </HorizontalScroll>
+    </Div>
+  );
+};
+
+const Example = () => {
+  const [activeView, setActiveView] = useState('view1');
+  const [activePanel, setActivePanel] = useState(1);
+
+  const [swipeViewHistory, setSwipeViewHistory] = useState([`swipeView.${activePanel}`]);
+  const pushSwipeViewHistory = React.useCallback((panel) => {
+    setSwipeViewHistory((prevHistory) => [...prevHistory, `swipeView.${panel}`]);
+  }, []);
+  const onSwipeBack = React.useCallback(() => {
+    const newHistory = swipeViewHistory.slice(0, -1);
+    setSwipeViewHistory(newHistory);
+
+    const newActiveSwipeViewPanel = newHistory[newHistory.length - 1];
+    const swipeViewPanel = +newActiveSwipeViewPanel.split('swipeView.')[1];
+    setActivePanel(swipeViewPanel);
+  }, [swipeViewHistory]);
+
+  handleActivePanelSet = React.useCallback(
+    (panel) => {
+      setActivePanel(panel);
+      if (activeView === 'swipeView') {
+        pushSwipeViewHistory(panel);
+      }
+    },
+    [pushSwipeViewHistory, activeView],
+  );
+
+  const cache = useScrollSaverCache();
+  const clearScrollCache = useClearScrollSaverCache();
+  handleActiveViewSet = React.useCallback(
+    (view) => {
+      if (view === 'view1') {
+        clearScrollCache();
+      }
+      console.log(cache);
+      if (view === 'swipeView') {
+        const defaultSwipeViewActivePanel = 1;
+        setSwipeViewHistory([`swipeView.${defaultSwipeViewActivePanel}`]);
+        setActivePanel(defaultSwipeViewActivePanel);
+      }
+      setActiveView(view);
+    },
+    [activePanel, clearScrollCache, cache],
+  );
+
+  const navigationButtons = (
+    <NavigationButtons
+      activePanel={activePanel}
+      activeView={activeView}
+      setActivePanel={handleActivePanelSet}
+      setActiveView={handleActiveViewSet}
+    />
+  );
+
+  const swipeViewActivePanel = swipeViewHistory[swipeViewHistory.length - 1];
+  return (
+    <ConfigProvider
+      {...(activeView === 'swipeView' ? { platform: Platform.IOS, isWebView: true } : {})}
+    >
+      <SplitLayout>
+        <SplitCol>
+          <Root activeView={activeView}>
+            <View activePanel={`panel1.${activePanel}`} id="view1">
+              <Panel id="panel1.1">
+                <PanelHeader>Панель 1.1</PanelHeader>
+                {navigationButtons}
+                <Content />
+                <ContentWithScrollSaverComponent />
+              </Panel>
+              <Panel id="panel1.2">
+                <PanelHeader>Панель 1.2</PanelHeader>
+                {navigationButtons}
+                <Content />
+                <ContentWithScrollSaverHook />
+              </Panel>
+              <Panel id="panel1.3">
+                <PanelHeader>Панель 1.3</PanelHeader>
+                {navigationButtons}
+                <Content />
+                <ContentWithScrollSaverWithoutChildren />
+              </Panel>
+            </View>
+            <View activePanel={`panel2.${activePanel}`} id="view2">
+              <Panel id="panel2.1">
+                <PanelHeader>Панель 2.1</PanelHeader>
+                {navigationButtons}
+                <Content />
+                <ContentWithScrollSaverComponent />
+              </Panel>
+              <Panel id="panel2.2">
+                <PanelHeader>Панель 2.2</PanelHeader>
+                {navigationButtons}
+                <Content />
+                <ContentWithScrollSaverHook />
+              </Panel>
+              <Panel id="panel2.3">
+                <PanelHeader>Панель 2.3</PanelHeader>
+                {navigationButtons}
+                <Content />
+                <ContentWithScrollSaverWithoutChildren />
+              </Panel>
+            </View>
+            <View
+              id="swipeView"
+              activePanel={swipeViewActivePanel}
+              history={swipeViewHistory}
+              onSwipeBack={onSwipeBack}
+            >
+              <Panel id="swipeView.1">
+                <PanelHeader>П.1 iOS Swipe Back</PanelHeader>
+                {navigationButtons}
+                <Content />
+              </Panel>
+              <Panel id="swipeView.2">
+                <PanelHeader>П.2 iOS Swipe Back</PanelHeader>
+                {navigationButtons}
+                <Content />
+              </Panel>
+              <Panel id="swipeView.3">
+                <PanelHeader>П.3 iOS Swipe Back</PanelHeader>
+                {navigationButtons}
+                <Content />
+              </Panel>
+            </View>
+          </Root>
+        </SplitCol>
+      </SplitLayout>
+    </ConfigProvider>
+  );
+};
+
+function NavigationButtons({ activePanel, activeView, setActiveView, setActivePanel }) {
+  return (
+    <>
+      <Spacing size={12} />
+      {activeView === 'view1' ? (
+        <>
+          <CellButton disabled>Перейти на View 1</CellButton>
+          <CellButton onClick={() => setActiveView('view2')}>Перейти на View 2</CellButton>
+          <CellButton onClick={() => setActiveView('swipeView')}>
+            Перейти на пример с iOS Swipe Back
+          </CellButton>
+        </>
+      ) : activeView === 'view2' ? (
+        <>
+          <CellButton onClick={() => setActiveView('view1')}>Назад View 1</CellButton>
+          <CellButton disabled>Перейти на View 2</CellButton>
+          <CellButton onClick={() => setActiveView('swipeView')}>
+            Перейти на пример с iOS Swipe Back
+          </CellButton>
+        </>
+      ) : (
+        activeView === 'swipeView' && (
+          <>
+            <CellButton onClick={() => setActiveView('view1')}>Назад на View 1</CellButton>
+            <CellButton onClick={() => setActiveView('view2')}>Назад на View 2</CellButton>
+            <CellButton disabled>Перейти на пример с iOS Swipe Back</CellButton>
+          </>
+        )
+      )}
+      <Spacing size={24}>
+        <Separator />
+      </Spacing>
+      <Group>
+        {activeView === 'view1' ? (
+          <>
+            {Array.from({ length: 3 }, (_, index) => (
+              <PanelNavigationButton
+                viewNumber={1}
+                panelNumber={index + 1}
+                activePanel={activePanel}
+                setActivePanel={setActivePanel}
+              />
+            ))}
+          </>
+        ) : activeView === 'view2' ? (
+          <>
+            {Array.from({ length: 3 }, (_, index) => (
+              <PanelNavigationButton
+                viewNumber={2}
+                panelNumber={index + 1}
+                activePanel={activePanel}
+                setActivePanel={setActivePanel}
+              />
+            ))}
+          </>
+        ) : (
+          activeView === 'swipeView' && (
+            <SwipeViewNavigationButton activePanel={activePanel} setActivePanel={setActivePanel} />
+          )
+        )}
+      </Group>
+      <Spacing size={24}>
+        <Separator />
+      </Spacing>
+    </>
+  );
+}
+
+function PanelNavigationButton({ activePanel, viewNumber, panelNumber, setActivePanel }) {
+  const goOrBack = activePanel <= panelNumber ? 'Перейти' : 'Назад';
+  return (
+    <CellButton disabled={activePanel === panelNumber} onClick={() => setActivePanel(panelNumber)}>
+      {goOrBack} на панель {viewNumber}.{panelNumber}
+    </CellButton>
+  );
+}
+
+function SwipeViewNavigationButton({ activePanel, setActivePanel }) {
+  return (
+    <>
+      {activePanel === 1 && (
+        <Placeholder>Перейдите на панель 2 чтобы можно было свайпнуть назад</Placeholder>
+      )}
+      {activePanel > 1 && (
+        <Placeholder>Теперь свайпните от левого края направо, чтобы вернуться</Placeholder>
+      )}
+      {activePanel < 3 && (
+        <CellButton onClick={() => setActivePanel(activePanel + 1)}>
+          Перейти на панель {activePanel + 1}
+        </CellButton>
+      )}
+    </>
+  );
+}
+
+<Example />;
+```

--- a/packages/vkui/src/components/ScrollSaver/Readme.md
+++ b/packages/vkui/src/components/ScrollSaver/Readme.md
@@ -27,16 +27,16 @@
 </ScrollSaver>
 ```
 
-- ScrollSaverWtihoutChildren берёт ref не из children а из пропа elementRef.
+- ScrollSaverWithCustomRef берёт ref не из children а из пропа elementRef.
 
 ```jsx static
-<ScrollSaverWithoutChildren id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
+<ScrollSaverWithCustomRef id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
   <HorizontalScroll getRef={horizontalRef}>
     <div style={{ display: 'flex' }}>
       <AlbumItems />
     </div>
   </HorizontalScroll>
-</ScrollSaverWithoutChildren>
+</ScrollSaverWithCustomRef>
 ```
 
 - useScrollSaver хук
@@ -71,7 +71,7 @@ const clearScrollCache = useClearScrollSaverCache();
 
 <br />
 
-В примере ниже на View1 и View2 сохраняются позиции скролла HorizontalScroll используя **ScrollSaver**, **useScrollSaver** и **ScrollSaverWithoutChildren**.
+В примере ниже на View1 и View2 сохраняются позиции скролла HorizontalScroll используя **ScrollSaver**, **useScrollSaver** и **ScrollSaverWithCustomRef**.
 Позиция сохраняется как при переходе между View так и при переходе между Panel
 При возврате на View1 c других View мы сбрасываем весь кэш ScrollSaver.
 
@@ -168,20 +168,20 @@ const ContentWithScrollSaverComponent = () => {
   );
 };
 
-const ContentWithScrollSaverWithoutChildren = () => {
+const ContentWithScrollSaverWithCustomRef = () => {
   const horizontalRef = useRef();
   return (
     <Div>
       <Headline level="1" style={{ marginBottom: 16 }}>
-        With ScrollSaverWithoutChildren - doesn't look for children ref
+        With ScrollSaverWithCustomRef - doesn't look for children ref
       </Headline>
-      <ScrollSaverWithoutChildren id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
+      <ScrollSaverWithCustomRef id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
         <HorizontalScroll getRef={horizontalRef}>
           <div style={{ display: 'flex' }}>
             <AlbumItems />
           </div>
         </HorizontalScroll>
-      </ScrollSaverWithoutChildren>
+      </ScrollSaverWithCustomRef>
     </Div>
   );
 };
@@ -283,7 +283,7 @@ const Example = () => {
                 <PanelHeader>Панель 1.3</PanelHeader>
                 {navigationButtons}
                 <Content />
-                <ContentWithScrollSaverWithoutChildren />
+                <ContentWithScrollSaverWithCustomRef />
               </Panel>
             </View>
             <View activePanel={`panel2.${activePanel}`} id="view2">
@@ -303,7 +303,7 @@ const Example = () => {
                 <PanelHeader>Панель 2.3</PanelHeader>
                 {navigationButtons}
                 <Content />
-                <ContentWithScrollSaverWithoutChildren />
+                <ContentWithScrollSaverWithCustomRef />
               </Panel>
             </View>
             <View

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { useNavDirection } from '../../components/NavTransitionDirectionContext/NavTransitionDirectionContext';
+export { useNavId } from '../../components/NavIdContext/useNavId';
+import { usePatchChildrenRef } from '../../hooks/usePatchChildrenRef';
+import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { HasRootRef } from '../../types';
+
+export interface ScrollSaverProps {
+  /*
+   * Уникальный идентификатор элемента скролл которого надо запомнить.
+   * Важно задавать id, так как на одной панели может понадобится запомнить позиции нескольких скролл-боксов.
+   **/
+  id: string;
+  /*
+   * Если передан реакт-компонент, то он должен поддерживать getRootRef.
+   **/
+  children: React.ReactElement<HasRootRef<any>> | React.ReactElement;
+  /*
+   * Режим для получения рефа на элемент для скролла через getRef проп, вместо getRootRef (актуально для компонента HorizontalScroll)
+   **/
+  useGetRef?: boolean;
+  /*
+   * Режим сохранения скролла: по умолчанию `forward`.
+   * `forward` - позиция скролла сохраняется только при переходе вперёд и восстанавливается при переходе назад.
+   * `always` - позиция скролла сохраняется и при переходе вперёд и при переходе назад.
+   **/
+  saveMode?: 'forward' | 'always';
+}
+
+let scrollSaverCache: { [key: string]: { inlineStart: number; blockStart: number } } = {};
+
+/**
+ * Компонент-обертка для сохранения позиции скролла элемента при переходах между View и Panel.
+ * По умолчанию позволяет восстановить значение скролла при возвращении назад.
+ */
+export function ScrollSaver({
+  id,
+  children: childrenProp,
+  saveMode = 'forward',
+  useGetRef,
+}: ScrollSaverProps) {
+  const uniqueId = useUniqueId(id);
+  const [childrenRef, children] = usePatchChildrenRef(childrenProp, useGetRef);
+  const direction = useNavDirection();
+
+  useIsomorphicLayoutEffect(
+    function handleScrollPosition() {
+      const scrollId = uniqueId;
+      const childrenNode = childrenRef.current;
+
+      function restoreScrollPosition() {
+        const scrollPosition = scrollSaverCache[scrollId];
+
+        const shouldRestoreMovingBackwards = direction === 'backwards' && saveMode === 'forward';
+        const shouldRestoreMovingForwards = saveMode === 'always';
+        const shouldRestore = shouldRestoreMovingBackwards || shouldRestoreMovingForwards;
+        if (!shouldRestore) {
+          // should I clean up the cache
+          return;
+        }
+
+        if (!scrollPosition) {
+          return;
+        }
+
+        const { inlineStart, blockStart } = scrollSaverCache[scrollId];
+        if (inlineStart) {
+          childrenNode.scrollLeft = inlineStart;
+        }
+        if (blockStart) {
+          childrenNode.scrollTop = blockStart;
+        }
+      }
+
+      restoreScrollPosition();
+
+      return function saveScrollPositionOnUnmount() {
+        scrollSaverCache[scrollId] = {
+          inlineStart: childrenNode.scrollLeft,
+          blockStart: childrenNode.scrollTop,
+        };
+      };
+    },
+    [direction, uniqueId, saveMode, childrenRef],
+  );
+
+  return children;
+}
+
+function useUniqueId(id: string) {
+  const { view: viewId, panel: panelId } = useNavId();
+  const uniqueId = `${viewId}-${panelId}-${id}`;
+  return uniqueId;
+}

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { useNavId } from '../../components/NavIdContext/useNavId';
 import { useNavDirection } from '../../components/NavTransitionDirectionContext/NavTransitionDirectionContext';
-export { useNavId } from '../../components/NavIdContext/useNavId';
 import { usePatchChildrenRef } from '../../hooks/usePatchChildrenRef';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { HasRootRef } from '../../types';

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
@@ -6,49 +6,37 @@ import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { HasRootRef } from '../../types';
 import { useScrollSaverCache } from './ScrollSaverContext';
 
-export interface ScrollSaverProps {
+interface ScrollSaverHookProps<T = HTMLElement> {
   /*
    * Уникальный идентификатор элемента скролл которого надо запомнить.
    * Важно задавать id, так как на одной панели может понадобится запомнить позиции нескольких скролл-боксов.
    **/
   id: string;
   /*
-   * Если передан реакт-компонент, то он должен поддерживать getRootRef.
-   **/
-  children: React.ReactElement<HasRootRef<any>> | React.ReactElement;
-  /*
-   * Режим для получения рефа на элемент для скролла через getRef проп, вместо getRootRef (актуально для компонента HorizontalScroll)
-   **/
-  useGetRef?: boolean;
-  /*
    * Режим сохранения скролла: по умолчанию `forward`.
    * `forward` - позиция скролла сохраняется только при переходе вперёд и восстанавливается при переходе назад.
    * `always` - позиция скролла сохраняется и при переходе вперёд и при переходе назад.
    **/
   saveMode?: 'forward' | 'always';
+  /* Ref элемента, скроллом которого надо управлять */
+  ref: React.RefObject<T>;
 }
 
-/**
- * Компонент-обертка для сохранения позиции скролла элемента при переходах между View и Panel.
- * По умолчанию позволяет восстановить значение скролла при возвращении назад.
- */
-export function ScrollSaver({
-  id,
-  children: childrenProp,
-  saveMode = 'forward',
-  useGetRef,
-}: ScrollSaverProps) {
+function useScrollSaver({ ref, id, saveMode = 'forward' }: ScrollSaverHookProps) {
   const uniqueId = useUniqueId(id);
-  const [childrenRef, children] = usePatchChildrenRef(childrenProp, useGetRef);
   const direction = useNavDirection();
   const scrollSaverCache = useScrollSaverCache();
 
   useIsomorphicLayoutEffect(
     function handleScrollPosition() {
       const scrollId = uniqueId;
-      const childrenNode = childrenRef.current;
+      const refNode = ref.current;
 
       function restoreScrollPosition() {
+        if (!refNode) {
+          return;
+        }
+
         const scrollPosition = scrollSaverCache[scrollId];
 
         const shouldRestoreMovingBackwards = direction === 'backwards' && saveMode === 'forward';
@@ -64,26 +52,63 @@ export function ScrollSaver({
 
         const { inlineStart, blockStart } = scrollSaverCache[scrollId];
         if (inlineStart) {
-          childrenNode.scrollLeft = inlineStart;
+          refNode.scrollLeft = inlineStart;
         }
         if (blockStart) {
-          childrenNode.scrollTop = blockStart;
+          refNode.scrollTop = blockStart;
         }
       }
 
       restoreScrollPosition();
 
       return function saveScrollPositionOnUnmount() {
+        if (!refNode) {
+          return;
+        }
         scrollSaverCache[scrollId] = {
-          inlineStart: childrenNode.scrollLeft,
-          blockStart: childrenNode.scrollTop,
+          inlineStart: refNode.scrollLeft,
+          blockStart: refNode.scrollTop,
         };
       };
     },
-    [direction, uniqueId, saveMode, childrenRef],
+    [direction, uniqueId, saveMode, ref],
   );
 
+  return ref;
+}
+
+interface ScrollSaverProps extends Omit<ScrollSaverHookProps, 'ref'> {
+  /*
+   * Если передан реакт-компонент, то он должен поддерживать getRootRef.
+   **/
+  children: React.ReactElement<HasRootRef<any>> | React.ReactElement;
+  /*
+   * Режим для получения рефа на элемент для скролла через getRef проп, вместо getRootRef (актуально для компонента HorizontalScroll)
+   **/
+  useGetRef?: boolean;
+}
+
+/**
+ * Компонент-обертка для сохранения позиции скролла элемента при переходах между View и Panel.
+ * По умолчанию позволяет восстановить значение скролла при возвращении назад.
+ */
+export function ScrollSaver(props: ScrollSaverProps) {
+  const [childrenRef, children] = usePatchChildrenRef(props.children, props.useGetRef);
+  useScrollSaver({ ref: childrenRef, id: props.id, saveMode: props.saveMode });
+
   return children;
+}
+
+interface ScrollSaverWithoutChildren<T = HTMLElement> extends Omit<ScrollSaverHookProps, 'ref'> {
+  elementRef: React.RefObject<T>;
+  children?: React.ReactElement | null;
+}
+
+/* Компонентный Вариант useScrollSaver хука для динамического рендеринга, чтобы можно было пробросить и использовать любой ref */
+export function ScrollSaverWithoutChildren(props: ScrollSaverWithoutChildren) {
+  useScrollSaver({ ref: props.elementRef, id: props.id, saveMode: props.saveMode });
+
+  return props.children;
 }
 
 function useUniqueId(id: string) {

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import { useNavId } from '../../components/NavIdContext/useNavId';
-import { useNavDirection } from '../../components/NavTransitionDirectionContext/NavTransitionDirectionContext';
 import { usePatchChildrenRef } from '../../hooks/usePatchChildrenRef';
-import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { HasRootRef } from '../../types';
-import { useScrollSaverCache } from './ScrollSaverContext';
+import { ScrollSaveModeType } from './types';
+import { useScrollSaver } from './useScrollSaver';
 
-interface ScrollSaverProps {
+export interface ScrollSaverProps {
   /*
    * Уникальный идентификатор элемента скролл которого надо запомнить.
    * Важно задавать id, так как на одной панели может понадобится запомнить позиции нескольких скролл-боксов.
@@ -17,7 +15,7 @@ interface ScrollSaverProps {
    * `forward` - позиция скролла сохраняется только при переходе вперёд и восстанавливается при переходе назад.
    * `always` - позиция скролла сохраняется и при переходе вперёд и при переходе назад.
    **/
-  saveMode?: 'forward' | 'always';
+  saveMode?: ScrollSaveModeType;
   /*
    * Если передан реакт-компонент, то он должен поддерживать getRootRef.
    **/
@@ -34,82 +32,9 @@ interface ScrollSaverProps {
  *
  * @see https://vkcom.github.io/VKUI/#/ScrollSaver
  */
-export function ScrollSaver(props: ScrollSaverProps) {
+export const ScrollSaver = (props: ScrollSaverProps) => {
   const [childrenRef, children] = usePatchChildrenRef(props.children, props.useGetRef);
   useScrollSaver(childrenRef, props.id, props.saveMode);
 
   return children;
-}
-
-export function useScrollSaver<T extends HTMLElement>(
-  elementRef: React.RefObject<T>,
-  id: ScrollSaverProps['id'],
-  saveMode: ScrollSaverProps['saveMode'] = 'forward',
-) {
-  const uniqueId = useUniqueId(id);
-  const direction = useNavDirection();
-  const scrollSaverCache = useScrollSaverCache();
-
-  useIsomorphicLayoutEffect(
-    function handleScrollPosition() {
-      const scrollId = uniqueId;
-      const refNode = elementRef.current;
-
-      function restoreScrollPosition() {
-        if (!refNode) {
-          return;
-        }
-
-        const scrollPosition = scrollSaverCache[scrollId];
-        if (!scrollPosition) {
-          return;
-        }
-
-        const shouldRestoreMovingBackwards = direction === 'backwards' && saveMode === 'forward';
-        const shouldRestoreMovingForwards = saveMode === 'always';
-        const shouldRestore = shouldRestoreMovingBackwards || shouldRestoreMovingForwards;
-        if (!shouldRestore) {
-          return;
-        }
-
-        const { inlineStart, blockStart } = scrollSaverCache[scrollId];
-        refNode.scrollLeft = inlineStart;
-        refNode.scrollTop = blockStart;
-      }
-
-      restoreScrollPosition();
-
-      return function saveScrollPositionOnUnmount() {
-        if (!refNode) {
-          return;
-        }
-        scrollSaverCache[scrollId] = {
-          inlineStart: refNode.scrollLeft,
-          blockStart: refNode.scrollTop,
-        };
-      };
-    },
-    [direction, uniqueId, saveMode, elementRef],
-  );
-
-  return elementRef;
-}
-
-interface ScrollSaverWithoutChildrenProps<T = HTMLElement>
-  extends Omit<ScrollSaverProps, 'useGetRef'> {
-  elementRef: React.RefObject<T>;
-}
-
-/* Компонентный Вариант useScrollSaver хука для динамического рендеринга, чтобы можно было пробросить и использовать любой ref
- * children проп можно передать, но ref из него браться не будет */
-export function ScrollSaverWithoutChildren(props: ScrollSaverWithoutChildrenProps) {
-  useScrollSaver(props.elementRef, props.id, props.saveMode);
-
-  return props.children;
-}
-
-function useUniqueId(id: string) {
-  const { view: viewId, panel: panelId } = useNavId();
-  const uniqueId = `${viewId}-${panelId}-${id}`;
-  return uniqueId;
-}
+};

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
@@ -4,6 +4,7 @@ export { useNavId } from '../../components/NavIdContext/useNavId';
 import { usePatchChildrenRef } from '../../hooks/usePatchChildrenRef';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { HasRootRef } from '../../types';
+import { useScrollSaverCache } from './ScrollSaverContext';
 
 export interface ScrollSaverProps {
   /*
@@ -27,8 +28,6 @@ export interface ScrollSaverProps {
   saveMode?: 'forward' | 'always';
 }
 
-let scrollSaverCache: { [key: string]: { inlineStart: number; blockStart: number } } = {};
-
 /**
  * Компонент-обертка для сохранения позиции скролла элемента при переходах между View и Panel.
  * По умолчанию позволяет восстановить значение скролла при возвращении назад.
@@ -42,6 +41,7 @@ export function ScrollSaver({
   const uniqueId = useUniqueId(id);
   const [childrenRef, children] = usePatchChildrenRef(childrenProp, useGetRef);
   const direction = useNavDirection();
+  const scrollSaverCache = useScrollSaverCache();
 
   useIsomorphicLayoutEffect(
     function handleScrollPosition() {
@@ -55,7 +55,6 @@ export function ScrollSaver({
         const shouldRestoreMovingForwards = saveMode === 'always';
         const shouldRestore = shouldRestoreMovingBackwards || shouldRestoreMovingForwards;
         if (!shouldRestore) {
-          // should I clean up the cache
           return;
         }
 

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaver.tsx
@@ -31,6 +31,8 @@ interface ScrollSaverProps {
 /**
  * Компонент-обертка для сохранения позиции скролла элемента при переходах между View и Panel.
  * По умолчанию позволяет восстановить значение скролла при возвращении назад.
+ *
+ * @see https://vkcom.github.io/VKUI/#/ScrollSaver
  */
 export function ScrollSaver(props: ScrollSaverProps) {
   const [childrenRef, children] = usePatchChildrenRef(props.children, props.useGetRef);

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaverContext.tsx
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaverContext.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+export type ScrollSaverCache = {
+  [key: string]: {
+    inlineStart: number;
+    blockStart: number;
+  };
+};
+
+export const ScrollSaverContext = React.createContext<React.MutableRefObject<ScrollSaverCache>>({
+  current: {},
+});
+export const ScrollSaverContextProvider = ({
+  value,
+  children,
+}: React.PropsWithChildren<{ value?: ScrollSaverCache }>) => {
+  const valueRef = {
+    current: value || {},
+  };
+
+  return <ScrollSaverContext.Provider value={valueRef}>{children}</ScrollSaverContext.Provider>;
+};
+
+export const useScrollSaverCache = () => {
+  const contextCacheRef = React.useContext(ScrollSaverContext);
+  return contextCacheRef.current;
+};
+
+export const useClearScrollSaverCache = () => {
+  const cacheRef = React.useContext(ScrollSaverContext);
+  return () => {
+    cacheRef.current = {};
+  };
+};

--- a/packages/vkui/src/components/ScrollSaver/ScrollSaverWithCustomRef.ts
+++ b/packages/vkui/src/components/ScrollSaver/ScrollSaverWithCustomRef.ts
@@ -1,0 +1,15 @@
+import { ScrollSaverProps } from './ScrollSaver';
+import { useScrollSaver } from './useScrollSaver';
+
+export interface ScrollSaverWithCustomRefProps<T = HTMLElement>
+  extends Omit<ScrollSaverProps, 'useGetRef'> {
+  elementRef: React.RefObject<T>;
+}
+
+/* Компонентный Вариант useScrollSaver хука для динамического рендеринга, чтобы можно было пробросить и использовать любой ref
+ * children проп можно передать, но ref из него браться не будет */
+export function ScrollSaverWithCustomRef(props: ScrollSaverWithCustomRefProps) {
+  useScrollSaver(props.elementRef, props.id, props.saveMode);
+
+  return props.children;
+}

--- a/packages/vkui/src/components/ScrollSaver/types.ts
+++ b/packages/vkui/src/components/ScrollSaver/types.ts
@@ -1,0 +1,1 @@
+export type ScrollSaveModeType = 'forward' | 'always';

--- a/packages/vkui/src/components/ScrollSaver/useScrollSaver.ts
+++ b/packages/vkui/src/components/ScrollSaver/useScrollSaver.ts
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { useNavId } from '../../components/NavIdContext/useNavId';
+import { useNavDirection } from '../../components/NavTransitionDirectionContext/NavTransitionDirectionContext';
+import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { useScrollSaverCache } from './ScrollSaverContext';
+import { ScrollSaveModeType } from './types';
+
+export function useScrollSaver<T extends HTMLElement>(
+  elementRef: React.RefObject<T>,
+  id: string,
+  saveMode: ScrollSaveModeType = 'forward',
+) {
+  const uniqueId = useUniqueId(id);
+  const direction = useNavDirection();
+  const scrollSaverCache = useScrollSaverCache();
+
+  useIsomorphicLayoutEffect(
+    function handleScrollPosition() {
+      const scrollId = uniqueId;
+      const refNode = elementRef.current;
+
+      function restoreScrollPosition() {
+        if (!refNode) {
+          return;
+        }
+
+        const scrollPosition = scrollSaverCache[scrollId];
+        if (!scrollPosition) {
+          return;
+        }
+
+        const shouldRestoreMovingBackwards = direction === 'backwards' && saveMode === 'forward';
+        const shouldRestoreMovingForwards = saveMode === 'always';
+        const shouldRestore = shouldRestoreMovingBackwards || shouldRestoreMovingForwards;
+        if (!shouldRestore) {
+          return;
+        }
+
+        const { inlineStart, blockStart } = scrollSaverCache[scrollId];
+        refNode.scrollLeft = inlineStart;
+        refNode.scrollTop = blockStart;
+      }
+
+      restoreScrollPosition();
+
+      return function saveScrollPositionOnUnmount() {
+        if (!refNode) {
+          return;
+        }
+        scrollSaverCache[scrollId] = {
+          inlineStart: refNode.scrollLeft,
+          blockStart: refNode.scrollTop,
+        };
+      };
+    },
+    [direction, uniqueId, saveMode, elementRef],
+  );
+
+  return elementRef;
+}
+
+function useUniqueId(id: string) {
+  const { view: viewId, panel: panelId } = useNavId();
+  const uniqueId = `${viewId}-${panelId}-${id}`;
+  return uniqueId;
+}

--- a/packages/vkui/src/components/View/Readme.md
+++ b/packages/vkui/src/components/View/Readme.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 Базовый компонент для создания панелей.
 
 - В качестве `children` принимает коллекцию [Panel](#/Panel). У каждой [Panel](#/Panel) должен быть
@@ -263,7 +264,49 @@ Xук возвращает правильное значение даже есл
 
 На третьем `View` пример со свайпом в iOS от левого края назад, где видно, что панель на которую идёт переход определяет его тип в самом начале свайпа.
 
+=======
+## <a id="usenavdirection_example" style="position: relative; top: -100px;"></a>[useNavDirection(): определение типа перехода (вперёд/назад), с которым была отрисована панель.](#/View?id=usenavdirection_example)
+
+>>>>>>> ffd276e66 (Update View Readme to use ScrollSaver with HorizontalScroll)
 ```jsx
+const albumItems = [
+  {
+    id: 1,
+    title: 'Команда <3',
+    size: 4,
+    thumb_src: 'https://sun9-33.userapi.com/ODk8khvW97c6aSx_MxHXhok5byDCsHEoU-3BwA/sO-lGf_NjN4.jpg',
+  },
+  {
+    id: 2,
+    title: 'Зингер',
+    size: 22,
+    thumb_src: 'https://sun9-60.userapi.com/bjwt581hETPAp4oY92bDcRvMymyfCaEsnojaUA/_KWQfS-MAd4.jpg',
+  },
+  {
+    id: 3,
+    title: 'Медиагалерея ВКонтакте',
+    size: 64,
+    thumb_src: 'https://sun9-26.userapi.com/YZ5-1A6cVgL7g1opJGQIWg1Bl5ynfPi8p41SkQ/IYIUDqGkkBE.jpg',
+  },
+];
+
+const largeImageStyles = {
+  width: 220,
+  height: 124,
+  borderRadius: 4,
+  boxSizing: 'border-box',
+  border: 'var(--vkui--size_border--regular) solid var(--vkui--color_image_border_alpha)',
+  objectFit: 'cover',
+};
+
+const AlbumItems = () => {
+  return albumItems.map(({ id, title, size, thumb_src }) => (
+    <HorizontalCell key={id} size="l" header={title} subtitle={`${size} фотографии`}>
+      <img style={largeImageStyles} src={thumb_src} />
+    </HorizontalCell>
+  ));
+};
+
 const Content = () => {
   const direction = useNavDirection();
 
@@ -297,6 +340,13 @@ const Content = () => {
           : 'не определено'}
       </Headline>
       {spinner}
+      <ScrollSaver id="horizontal-scroll" useGetRef>
+        <HorizontalScroll>
+          <div style={{ display: 'flex' }}>
+            <AlbumItems />
+          </div>
+        </HorizontalScroll>
+      </ScrollSaver>
     </Div>
   );
 };

--- a/packages/vkui/src/components/View/Readme.md
+++ b/packages/vkui/src/components/View/Readme.md
@@ -372,28 +372,26 @@ const ContentWithScrollSaverComponent = () => {
 };
 
 const ContentWithScrollSaverWithoutChildren = () => {
-  const horizontalScrollRef = useRef();
-
   const horizontalRef = useRef();
   return (
     <Div>
       <Headline level="1" style={{ marginBottom: 16 }}>
         With ScrollSaverWithoutChildren - doesn't look for children ref
       </Headline>
-      <ScrollSaver id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
-        <HorizontalScroll getRef={horizontalScrollRef} getRef={horizontalRef}>
+      <ScrollSaverWithoutChildren id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
+        <HorizontalScroll getRef={horizontalRef}>
           <div style={{ display: 'flex' }}>
             <AlbumItems />
           </div>
         </HorizontalScroll>
-      </ScrollSaver>
+      </ScrollSaverWithoutChildren>
     </Div>
   );
 };
 
 const ContentWithScrollSaverHook = () => {
   const horizontalScrollRef = useRef();
-  useScrollSaver({ elementRef: horizontalScrollRef, id: 'horizontal-scroll-saver-hook' });
+  useScrollSaver(horizontalScrollRef, 'horizontal-scroll-saver-hook');
 
   return (
     <Div>

--- a/packages/vkui/src/components/View/Readme.md
+++ b/packages/vkui/src/components/View/Readme.md
@@ -1,4 +1,5 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 Базовый компонент для создания панелей.
 
 - В качестве `children` принимает коллекцию [Panel](#/Panel). У каждой [Panel](#/Panel) должен быть
@@ -266,6 +267,13 @@ Xук возвращает правильное значение даже есл
 
 =======
 ## <a id="usenavdirection_example" style="position: relative; top: -100px;"></a>[useNavDirection(): определение типа перехода (вперёд/назад), с которым была отрисована панель.](#/View?id=usenavdirection_example)
+=======
+В примере ниже на View1 и View2 сохраняются позиции скролла HorizontalScroll используя ScrollSaver, useScrollSaver и ScrollSaverWithoutChildren.
+Позиция сохраняется как при переходе между View так и при переходе между Panel
+При возврате на View1 c других View мы сбрасываем весь кэш ScrollSaver.
+
+ScrollSaverWtihoutChildren - это версия useScrollSaver обёрнутая в компонент для динамического рендеринга, но она требудет преедачи пропа elementRef.
+>>>>>>> cffef2295 (Update Readme to show only ScrollSaver Example)
 
 >>>>>>> ffd276e66 (Update View Readme to use ScrollSaver with HorizontalScroll)
 ```jsx
@@ -340,13 +348,63 @@ const Content = () => {
           : 'не определено'}
       </Headline>
       {spinner}
-      <ScrollSaver id="horizontal-scroll" useGetRef>
-        <HorizontalScroll>
+    </Div>
+  );
+};
+
+const ContentWithScrollSaverComponent = () => {
+  const horizontalScrollRef = useRef();
+
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        With ScrollSaver component
+      </Headline>
+      <ScrollSaver id="horizontal-scroll-saver-hook" useGetRef>
+        <HorizontalScroll getRef={horizontalScrollRef}>
           <div style={{ display: 'flex' }}>
             <AlbumItems />
           </div>
         </HorizontalScroll>
       </ScrollSaver>
+    </Div>
+  );
+};
+
+const ContentWithScrollSaverWithoutChildren = () => {
+  const horizontalScrollRef = useRef();
+
+  const horizontalRef = useRef();
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        With ScrollSaverWithoutChildren - doesn't look for children ref
+      </Headline>
+      <ScrollSaver id="horizontal-scroll-saver-hook" elementRef={horizontalRef}>
+        <HorizontalScroll getRef={horizontalScrollRef} getRef={horizontalRef}>
+          <div style={{ display: 'flex' }}>
+            <AlbumItems />
+          </div>
+        </HorizontalScroll>
+      </ScrollSaver>
+    </Div>
+  );
+};
+
+const ContentWithScrollSaverHook = () => {
+  const horizontalScrollRef = useRef();
+  useScrollSaver({ elementRef: horizontalScrollRef, id: 'horizontal-scroll-saver-hook' });
+
+  return (
+    <Div>
+      <Headline level="1" style={{ marginBottom: 16 }}>
+        With ScrollSaverHook
+      </Headline>
+      <HorizontalScroll getRef={horizontalScrollRef}>
+        <div style={{ display: 'flex' }}>
+          <AlbumItems />
+        </div>
+      </HorizontalScroll>
     </Div>
   );
 };
@@ -378,8 +436,14 @@ const Example = () => {
     [pushSwipeViewHistory, activeView],
   );
 
+  const cache = useScrollSaverCache();
+  const clearScrollCache = useClearScrollSaverCache();
   handleActiveViewSet = React.useCallback(
     (view) => {
+      if (view === 'view1') {
+        clearScrollCache();
+      }
+      console.log(cache);
       if (view === 'swipeView') {
         const defaultSwipeViewActivePanel = 1;
         setSwipeViewHistory([`swipeView.${defaultSwipeViewActivePanel}`]);
@@ -387,7 +451,7 @@ const Example = () => {
       }
       setActiveView(view);
     },
-    [activePanel],
+    [activePanel, clearScrollCache, cache],
   );
 
   const navigationButtons = (
@@ -410,16 +474,19 @@ const Example = () => {
                 <PanelHeader>Панель 1.1</PanelHeader>
                 {navigationButtons}
                 <Content />
+                <ContentWithScrollSaverComponent />
               </Panel>
               <Panel id="panel1.2">
                 <PanelHeader>Панель 1.2</PanelHeader>
                 {navigationButtons}
                 <Content />
+                <ContentWithScrollSaverHook />
               </Panel>
               <Panel id="panel1.3">
                 <PanelHeader>Панель 1.3</PanelHeader>
                 {navigationButtons}
                 <Content />
+                <ContentWithScrollSaverWithoutChildren />
               </Panel>
             </View>
             <View activePanel={`panel2.${activePanel}`} id="view2">
@@ -427,16 +494,19 @@ const Example = () => {
                 <PanelHeader>Панель 2.1</PanelHeader>
                 {navigationButtons}
                 <Content />
+                <ContentWithScrollSaverComponent />
               </Panel>
               <Panel id="panel2.2">
                 <PanelHeader>Панель 2.2</PanelHeader>
                 {navigationButtons}
                 <Content />
+                <ContentWithScrollSaverHook />
               </Panel>
               <Panel id="panel2.3">
                 <PanelHeader>Панель 2.3</PanelHeader>
                 {navigationButtons}
                 <Content />
+                <ContentWithScrollSaverWithoutChildren />
               </Panel>
             </View>
             <View

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -343,7 +343,11 @@ export type {
   PopoverOnShownChange,
   PopoverContentRenderProp,
 } from './components/Popover/Popover';
-export { ScrollSaver } from './components/ScrollSaver/ScrollSaver';
+export {
+  ScrollSaver,
+  ScrollSaverWithoutChildren,
+  useScrollSaver,
+} from './components/ScrollSaver/ScrollSaver';
 export {
   ScrollSaverContextProvider,
   useScrollSaverCache,

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -343,11 +343,13 @@ export type {
   PopoverOnShownChange,
   PopoverContentRenderProp,
 } from './components/Popover/Popover';
+export { ScrollSaver, type ScrollSaverProps } from './components/ScrollSaver/ScrollSaver';
 export {
-  ScrollSaver,
-  ScrollSaverWithoutChildren,
-  useScrollSaver,
-} from './components/ScrollSaver/ScrollSaver';
+  ScrollSaverWithCustomRef,
+  type ScrollSaverWithCustomRefProps,
+} from './components/ScrollSaver/ScrollSaverWithCustomRef';
+export { useScrollSaver } from './components/ScrollSaver/useScrollSaver';
+export { type ScrollSaveModeType } from './components/ScrollSaver/types';
 export {
   ScrollSaverContextProvider,
   useScrollSaverCache,

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -344,6 +344,12 @@ export type {
   PopoverContentRenderProp,
 } from './components/Popover/Popover';
 export { ScrollSaver } from './components/ScrollSaver/ScrollSaver';
+export {
+  ScrollSaverContextProvider,
+  useScrollSaverCache,
+  useClearScrollSaverCache,
+  type ScrollSaverCache,
+} from './components/ScrollSaver/ScrollSaverContext';
 
 /**
  * HOCs

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -343,6 +343,7 @@ export type {
   PopoverOnShownChange,
   PopoverContentRenderProp,
 } from './components/Popover/Popover';
+export { ScrollSaver } from './components/ScrollSaver/ScrollSaver';
 
 /**
  * HOCs

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -314,6 +314,7 @@ const baseConfig = {
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/PlatformProvider/PlatformProvider.tsx`,
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/AppearanceProvider/AppearanceProvider.tsx`,
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/VisuallyHidden/VisuallyHidden.tsx`,
+            `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/ScrollSaver/ScrollSaver.tsx`,
           ],
         },
       ],


### PR DESCRIPTION
- close #3750 

---

- [ ] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи

## Описание
Добавлен новый компонент-обёртка **ScrollSaver** и его разновидности: хук **useScrollSaver** и **ScrollSaverWithoutChildren**.
Основная цель компонента **ScrollSaver** сохранять позицию скролла дочернего элемента при переходах между `View` и `Panel`.

## Изменения

<!--
Перечисли изменения и причины по которым они сделаны, если это по какой-то причине не очевидно.
В будущем это поможет ответить почему было сделано именно так.

Если всё прозрачно, то игнорируй этот заголовок.
-->
