### PR TITLE
fix(build): rm single quote from floating-ui regex

### DIFF
--- a/packages/vkui-floating-ui/index.mjs
+++ b/packages/vkui-floating-ui/index.mjs
@@ -24,7 +24,7 @@ const FLOATING_UI_SUB_PACKAGES_NAMES_REGEX_GROUP = FLOATING_UI_SUB_PACKAGES_ENTR
   .join('|')
   .replace('/', '\\/');
 const FLOATING_UI_SUB_PACKAGES_NAME_REGEX = RegExp(
-  `"@floating-ui\\/('${FLOATING_UI_SUB_PACKAGES_NAMES_REGEX_GROUP}')"`,
+  `"@floating-ui\\/(${FLOATING_UI_SUB_PACKAGES_NAMES_REGEX_GROUP})"`,
   'g',
 );
 


### PR DESCRIPTION
## Описание

Из-за ошибки в регулярке (группа обёрнута в одинарные кавычки) импорт `@floating/core` не заменялся на ту, что собрана под ES5.

- related to #5958