### PR TITLE
fix: IconButton is Primitives

### DIFF
--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -51,6 +51,8 @@ export type {
  */
 export { Button } from './components/Button/Button';
 export type { ButtonProps } from './components/Button/Button';
+export { IconButton } from './components/IconButton/IconButton';
+export type { IconButtonProps } from './components/IconButton/IconButton';
 
 /**
  * Layout
@@ -129,8 +131,6 @@ export { Badge } from './components/Badge/Badge';
 export type { BadgeProps } from './components/Badge/Badge';
 export { ButtonGroup } from './components/ButtonGroup/ButtonGroup';
 export type { ButtonGroupProps } from './components/ButtonGroup/ButtonGroup';
-export { IconButton } from './components/IconButton/IconButton';
-export type { IconButtonProps } from './components/IconButton/IconButton';
 export { Card } from './components/Card/Card';
 export type { CardProps } from './components/Card/Card';
 export { CardGrid } from './components/CardGrid/CardGrid';


### PR DESCRIPTION
- Fixes #6034

---

- ~[ ] Unit-тесты~
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~

На текущий момент не понятно как это отлавливать

## Описание

Стили IconButton перебивают другие стили в обычной сборке

## Изменения

Поднял IconButton выше других элементов