### PR TITLE
tech: provide custom port to storybook dev server

### DIFF
--- a/packages/vkui/.env.development.local
+++ b/packages/vkui/.env.development.local
@@ -23,3 +23,6 @@ PLAYWRIGHT_TEST_MATCH='[
 #
 # @type number – на самом деле при парсинге будет строка, но в коде преобразуем в число.
 PLAYWRIGHT_WORKERS=4
+
+# Порт для DevServer'а Storybook
+STORYBOOK_DEV_PORT=6006

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -60,7 +60,7 @@
     "test:e2e:ci": "yarn run -T playwright test --config playwright-ct.config.ts",
     "test:e2e-update:ci": "yarn run test:e2e:ci --update-snapshots",
     "lint:generated-files": "yarn run generate:css-custom-medias && git diff --exit-code src/styles/customMedias.generated.css",
-    "storybook": "yarn run -T cross-env SANDBOX=\\.storybook storybook dev -p 6006",
+    "storybook": "bash -c 'source .env >/dev/null 2>&1 && yarn run -T cross-env SANDBOX=\\.storybook storybook dev -p ${STORYBOOK_DEV_PORT:=6006}'",
     "storybook:build": "yarn run -T cross-env SANDBOX=\\.storybook FROM_STORYBOOK=1 storybook build",
     "generate:css-custom-medias": "node scripts/generateCSSCustomMedias.js"
   },

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -60,7 +60,7 @@
     "test:e2e:ci": "yarn run -T playwright test --config playwright-ct.config.ts",
     "test:e2e-update:ci": "yarn run test:e2e:ci --update-snapshots",
     "lint:generated-files": "yarn run generate:css-custom-medias && git diff --exit-code src/styles/customMedias.generated.css",
-    "storybook": "bash -c 'source .env >/dev/null 2>&1 && yarn run -T cross-env SANDBOX=\\.storybook storybook dev -p ${STORYBOOK_DEV_PORT:=6006}'",
+    "storybook": "bash -c 'source .env && yarn run -T cross-env SANDBOX=\\.storybook storybook dev -p ${STORYBOOK_DEV_PORT:=6006}'",
     "storybook:build": "yarn run -T cross-env SANDBOX=\\.storybook FROM_STORYBOOK=1 storybook build",
     "generate:css-custom-medias": "node scripts/generateCSSCustomMedias.js"
   },


### PR DESCRIPTION
## Описание

Добавил возможность задавать порт для девсервера Storybook через файлик `.env`, чтобы не приходилось менять в `package.json`.

## Изменения

- Для скрипта `yarn run storybook` в `packages/vkui` добавил импорт переменных окружения `.env` с последующим прокидыванием порта в команду `storybook dev -p`.
  - _Почему `bash -c`?_ в `@yarnpkg/shell` нет команды `source`, поэтому нужно запускать через `bash -c` (см. https://github.com/yarnpkg/berry/issues/2088#issuecomment-723953394).
  - _Что за равно в `${STORYBOOK_DEV_PORT:=6006}`?_ здесь мы задаём значение по умолчанию, если в `.env` вдруг не будет нужной переменной.
  > **Note**
  > Хотел сделать так, чтобы файл `.env` был не обязателен, но из-за проблемы в `yarn` не смог это реализовать (https://github.com/yarnpkg/berry/issues/4033). Поэтому локально надо себе создавать файлик `.env`.
- Добавил `.env.development.local` новую переменную `STORYBOOK_DEV_PORT`.
