### PR TITLE
feat(Radio): Allow to pass data-* attributes to label element

### DIFF
--- a/packages/vkui/src/components/Radio/Radio.test.tsx
+++ b/packages/vkui/src/components/Radio/Radio.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { Radio } from './Radio';
@@ -12,4 +13,43 @@ describe('Radio', () => {
       <Radio aria-labelledby="radio" {...props} />
     </>
   ));
+
+  test('label and input can receive data-testid', () => {
+    render(
+      <React.Fragment>
+        <Radio
+          name="pay"
+          value="cash"
+          data-testid="input-cash-id"
+          labelProps={{ 'data-testid': 'label-cash-id' }}
+          defaultChecked
+        >
+          Оплата наличными
+        </Radio>
+        <Radio
+          name="pay"
+          value="card"
+          data-testid="input-card-id"
+          labelProps={{ 'data-testid': 'label-card-id' }}
+        >
+          Оплата картой
+        </Radio>
+      </React.Fragment>,
+    );
+
+    const inputCash = screen.getByTestId<HTMLInputElement>('input-cash-id');
+    const labelCash = screen.getByTestId<HTMLLabelElement>('label-cash-id');
+
+    expect(inputCash.checked).toBeTruthy();
+    expect(inputCash.matches('input')).toBeTruthy();
+    expect(labelCash.matches('label')).toBeTruthy();
+
+    const inputCard = screen.getByTestId<HTMLInputElement>('input-card-id');
+    expect(inputCard.checked).toBeFalsy();
+    const labelCard = screen.getByTestId<HTMLLabelElement>('label-card-id');
+
+    fireEvent.click(labelCard);
+    expect(inputCard.checked).toBeTruthy();
+    expect(inputCash.checked).toBeFalsy();
+  });
 });

--- a/packages/vkui/src/components/Radio/Radio.tsx
+++ b/packages/vkui/src/components/Radio/Radio.tsx
@@ -4,7 +4,7 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { usePlatform } from '../../hooks/usePlatform';
 import { SizeType } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';
-import { HasRef, HasRootRef } from '../../types';
+import { HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { ACTIVE_EFFECT_DELAY, Tappable } from '../Tappable/Tappable';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { Text } from '../Typography/Text/Text';
@@ -31,6 +31,10 @@ export interface RadioProps
     HasRootRef<HTMLLabelElement> {
   description?: React.ReactNode;
   titleAfter?: React.ReactNode;
+  /**
+   * Позволяет передавать data-* аттрибуты элементу label
+   **/
+  labelProps?: HasDataAttribute;
 }
 
 /**
@@ -44,6 +48,7 @@ export const Radio = ({
   getRootRef,
   titleAfter,
   getRef,
+  labelProps,
   ...restProps
 }: RadioProps) => {
   const platform = usePlatform();
@@ -61,6 +66,7 @@ export const Radio = ({
       activeEffectDelay={platform === Platform.IOS ? 100 : ACTIVE_EFFECT_DELAY}
       disabled={restProps.disabled}
       getRootRef={getRootRef}
+      {...labelProps}
     >
       <VisuallyHidden
         {...restProps}


### PR DESCRIPTION
- [x] Unit-тесты
- [x] Документация фичи

## Описание
Довольно сложно тестировать `Radio` элемент в e2e тестах с помощью `data-testid`. Из-за того, что мы передаём data-testid в input, реализованный с использованием [VisuallyHidden](https://vkcom.github.io/VKUI/#/VisuallyHidden). Известно, по крайне мере, о проблемах WebdriverIO, который не может нормально взаимодействовать с таким элементом.

## Изменения
Добавили возможность передавать `data-*` аттрибуты в `label` компонента `Radio` c помощью пропа `labelProps`.

На текущий момент ограничили типы `labelProps` до data-* аттрибутов, чтобы не было конфликтов с `Tappable` и не возникало желания переопределять пропы `Tappable`.