### PR TITLE
feat(modal): add modalDismissButtonTestId

### DIFF
--- a/packages/vkui/src/components/ModalCard/ModalCard.test.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.test.tsx
@@ -1,7 +1,35 @@
 import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
+import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { ModalCard } from './ModalCard';
 
 describe('ModalCard', () => {
   baselineComponent((p) => <ModalCard nav="id" {...p} />);
+
+  test('testid for modal card content', () => {
+    const { rerender } = render(<ModalCard nav="id" />);
+
+    expect(screen.queryByTestId('modal-page-id')).not.toBeTruthy();
+    expect(screen.queryByTestId('modal-dismiss-button')).not.toBeTruthy();
+
+    rerender(
+      <ModalCard
+        nav="id"
+        data-testid="modal-page-id"
+        modalDismissButtonTestId="modal-dismiss-button"
+      />,
+    );
+
+    expect(screen.queryByTestId('modal-page-id')).toBeTruthy();
+    expect(screen.queryByTestId('modal-dismiss-button')).not.toBeTruthy();
+
+    rerender(
+      <ConfigProvider platform="vkcom">
+        <ModalCard nav="id" modalDismissButtonTestId="modal-dismiss-button" />
+      </ConfigProvider>,
+    );
+
+    expect(screen.queryByTestId('modal-dismiss-button')).toBeTruthy();
+  });
 });

--- a/packages/vkui/src/components/ModalCard/ModalCard.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.tsx
@@ -33,6 +33,7 @@ export const ModalCard = ({
   nav,
   id,
   size,
+  modalDismissButtonTestId,
   ...restProps
 }: ModalCardProps) => {
   const { isDesktop } = useAdaptivityWithJSMediaQueries();
@@ -62,6 +63,7 @@ export const ModalCard = ({
         actions={actions}
         onClose={onClose || modalContext.onClose}
         size={size}
+        modalDismissButtonTestId={modalDismissButtonTestId}
       >
         {children}
       </ModalCardBase>

--- a/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
+++ b/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
@@ -57,6 +57,11 @@ export interface ModalCardBaseProps extends HTMLAttributesWithRootRef<HTMLDivEle
    * Задаёт контенту максимальную ширину для десктопной версии.
    */
   size?: number;
+
+  /**
+   * `data-testid` для кнопки закрытия
+   */
+  modalDismissButtonTestId?: string;
 }
 
 /**
@@ -72,6 +77,7 @@ export const ModalCardBase = ({
   dismissLabel = 'Скрыть',
   style,
   size: sizeProp,
+  modalDismissButtonTestId,
   ...restProps
 }: ModalCardBaseProps) => {
   const platform = usePlatform();
@@ -131,7 +137,9 @@ export const ModalCardBase = ({
 
         {hasReactNode(actions) && <div className={styles['ModalCardBase__actions']}>{actions}</div>}
 
-        {isDesktop && <ModalDismissButton onClick={onClose} />}
+        {isDesktop && (
+          <ModalDismissButton data-testid={modalDismissButtonTestId} onClick={onClose} />
+        )}
         {canShowCloseButtonIOS && (
           <PanelHeaderButton
             aria-label={dismissLabel}

--- a/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
+import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { ModalPage } from './ModalPage';
 
 describe('ModalPage', () => {
@@ -15,12 +16,27 @@ describe('ModalPage', () => {
 
     expect(screen.queryByTestId('modal-page-id')).not.toBeTruthy();
     expect(screen.queryByTestId('modal-content-id')).not.toBeTruthy();
+    expect(screen.queryByTestId('modal-dismiss-button')).not.toBeTruthy();
 
     rerender(
-      <ModalPage nav="id" data-testid="modal-page-id" modalContentTestId="modal-content-id" />,
+      <ModalPage
+        nav="id"
+        data-testid="modal-page-id"
+        modalContentTestId="modal-content-id"
+        modalDismissButtonTestId="modal-dismiss-button"
+      />,
     );
 
     expect(screen.queryByTestId('modal-page-id')).toBeTruthy();
     expect(screen.queryByTestId('modal-content-id')).toBeTruthy();
+    expect(screen.queryByTestId('modal-dismiss-button')).not.toBeTruthy();
+
+    rerender(
+      <ConfigProvider platform="vkcom">
+        <ModalPage nav="id" modalDismissButtonTestId="modal-dismiss-button" />
+      </ConfigProvider>,
+    );
+
+    expect(screen.queryByTestId('modal-dismiss-button')).toBeTruthy();
   });
 });

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -68,6 +68,10 @@ export interface ModalPageProps extends HTMLAttributesWithRootRef<HTMLDivElement
    */
   hideCloseButton?: boolean;
   modalContentTestId?: string;
+  /**
+   * `data-testid` для кнопки закрытия
+   */
+  modalDismissButtonTestId?: string;
 }
 
 const warn = warnOnce('ModalPage');
@@ -91,6 +95,7 @@ export const ModalPage = ({
   hideCloseButton = false,
   height,
   modalContentTestId,
+  modalDismissButtonTestId,
   ...restProps
 }: ModalPageProps) => {
   const generatingId = useId();
@@ -155,7 +160,12 @@ export const ModalPage = ({
               </div>
               <div ref={refs.bottomInset} className={styles['ModalPage__bottom-inset']} />
             </div>
-            {isCloseButtonShown && <ModalDismissButton onClick={onClose || modalContext.onClose} />}
+            {isCloseButtonShown && (
+              <ModalDismissButton
+                data-testid={modalDismissButtonTestId}
+                onClick={onClose || modalContext.onClose}
+              />
+            )}
           </div>
         </div>
       </RootComponent>


### PR DESCRIPTION

- [x] Unit-тесты
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- [x] Документация фичи

## Описание

Добавляем свойство `modalDismissButtonTestId` для ModalCard и ModalPage

## Изменения


Новое свойство `modalDismissButtonTestId` для ModalCard и ModalPage которое прокидывается в кнопку закрытия