### PR TITLE
docs: fix default layout for examples

### DIFF
--- a/styleguide/Components/Playground/PlaygroundRenderer.js
+++ b/styleguide/Components/Playground/PlaygroundRenderer.js
@@ -41,6 +41,7 @@ const PlaygroundRenderer = ({ name, preview, previewProps, tabBody, exampleIndex
           integration,
           config,
           exampleId,
+          showLayoutSelect,
         })}
       </div>
       {sizeX.regular && (

--- a/styleguide/Components/Preview.js
+++ b/styleguide/Components/Preview.js
@@ -87,6 +87,7 @@ class Preview extends PreviewParent {
       iframe = true,
       exampleId,
       viewWidth,
+      showLayoutSelect,
     } = this.props;
     const { error } = this.state;
 
@@ -112,6 +113,8 @@ class Preview extends PreviewParent {
           } else {
             width = viewWidth - 32;
           }
+
+          const appRootLayout = showLayoutSelect ? styleGuideContext.layout : undefined;
 
           return (
             <Profiler id={exampleId} onRender={logPerf}>
@@ -149,7 +152,11 @@ class Preview extends PreviewParent {
                           appearance={styleGuideContext.appearance}
                           platform={styleGuideContext.platform}
                         >
-                          <Config {...styleGuideContext} exampleId={exampleId}>
+                          <Config
+                            {...styleGuideContext}
+                            layout={appRootLayout}
+                            exampleId={exampleId}
+                          >
                             {layout ? <Layout>{example}</Layout> : example}
                           </Config>
                         </Frame>


### PR DESCRIPTION
## Изменения

Делаем по дефолту `layout=undefined`, чтобы изменение `layout` там, где он задан в настройках, не аффектило примеры без него
