### PR TITLE
fix: `vk-bridge` insets deprecation

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -107,7 +107,8 @@ export const AppRoot = ({
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   const [portalRoot, setPortalRoot] = React.useState<HTMLElement | null>(null);
   const { document } = useDOM();
-  const deprecatedInsets = useInsets(!safeAreaInsets);
+  const deprecatedInsetsDisabled = Boolean(safeAreaInsets);
+  const deprecatedInsets = useInsets(deprecatedInsetsDisabled);
   const insets = safeAreaInsets ? safeAreaInsets : deprecatedInsets;
   const appearance = useAppearance();
 

--- a/packages/vkui/src/hoc/withInsets.tsx
+++ b/packages/vkui/src/hoc/withInsets.tsx
@@ -1,10 +1,22 @@
 import * as React from 'react';
 import { useInsets } from '../hooks/useInsets';
+import { warnOnce } from '../lib/warnOnce';
 import { HasInsets } from '../types';
 
+const warn = warnOnce('withInsets');
+
+/**
+ * TODO [>=6]: удалить HOC (#5049)
+ *
+ * @deprecated v5.10.0
+ */
 export function withInsets<T extends HasInsets>(
   Component: React.ComponentType<T>,
 ): React.ComponentType<Omit<T, keyof HasInsets>> {
+  if (process.env.NODE_ENV === 'development') {
+    warn("[@vkontakte/vk-bridge] Интеграция VKUI с @vkontakte/vk-bridge устарела и будет удалена в v6. Используйте хук `useInsets()` из @vkontakte/vk-bridge-react, для получения инсетов (см. https://github.com/VKCOM/VKUI/issues/5049)"); // prettier-ignore
+  }
+
   function WithInsets(props: Omit<T, keyof HasInsets>) {
     const insets = useInsets();
     return <Component {...(props as T)} insets={insets} />;

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -53,6 +53,10 @@
   - `webviewType={WebviewType.INTERNAL}` -> `hasCustomPanelHeaderAfter={false}`.
   - `webviewType={WebviewType.VKAPPS}` -> `hasCustomPanelHeaderAfter={true}`. При необходимости передайте `customPanelHeaderAfterMinWidth={<value>}` (по умолчанию `90`).
 
+## ~`withInsets`~
+
+Используйте вместо него хук `useInsets()` из [@vkontakte/vk-bridge-react](https://www.npmjs.com/package/@vkontakte/vk-bridge-react).
+
 ## Поддержка браузеров
 
 Библиотека по умолчанию компилируется в [ES2015 (ES6)](https://262.ecma-international.org/6.0/).


### PR DESCRIPTION
## Описание

- Для аргумента `useInsets(disabled: boolean)` некорректно определялся предикат.
- В PR #5496 пропустил депрекейт хока `withInsets()`. Обновил документ по миграции на **v6**.

---

- related to #5049