### PR TITLE
fix(Select/CustomSelect): Allow to use custom options in renderOption prop

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -78,7 +78,7 @@ const handleOptionDown: MouseEventHandler = (e: React.MouseEvent<HTMLElement>) =
 };
 
 function findSelectedIndex<T extends CustomSelectOptionInterface>(
-  options: T[],
+  options: T[] = [],
   value: SelectValue,
   withClear: boolean,
 ) {
@@ -102,6 +102,8 @@ const filter = <T extends CustomSelectOptionInterface>(
     ? options.filter((option) => filterFn(inputValue, option))
     : options;
 };
+
+const defaultOptions: CustomSelectOptionInterface[] = [];
 
 type FilterFn<T> = (
   value: string,
@@ -226,9 +228,9 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     autoHideScrollbarDelay,
     searchable = false,
     renderOption: renderOptionProp = defaultRenderOptionFn,
-    options: optionsProp,
+    options: optionsProp = defaultOptions as OptionInterfaceT[],
     emptyText = 'Ничего не найдено',
-    filterFn: filterFnProp,
+    filterFn = defaultFilterFn,
     icon: iconProp,
     ClearButton = CustomSelectClearButton,
     allowClearButton = false,
@@ -237,8 +239,6 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     noMaxHeight = false,
     ...restProps
   } = props;
-
-  const filterFn: FilterFn<OptionInterfaceT> = filterFnProp || defaultFilterFn;
 
   if (process.env.NODE_ENV === 'development') {
     checkOptionsValueType(optionsProp);
@@ -490,7 +490,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
       const options =
         searchable && inputValue !== undefined
-          ? filter<OptionInterfaceT>(optionsProp, inputValue, filterFn)
+          ? filter(optionsProp, inputValue, filterFn)
           : optionsProp;
 
       setOptions(options);

--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -44,7 +44,7 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
 
   return (
     <React.Fragment>
-      {(hasPointer === undefined || hasPointer) && <CustomSelect<OptionT> {...props} />}
+      {(hasPointer === undefined || hasPointer) && <CustomSelect {...props} />}
       {(hasPointer === undefined || !hasPointer) && (
         <NativeSelect {...nativeProps}>
           {options.map(({ label, value }) => (

--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { useAdaptivityHasPointer } from '../../hooks/useAdaptivityHasPointer';
-import { CustomSelect, SelectProps } from '../CustomSelect/CustomSelect';
+import {
+  CustomSelect,
+  type CustomSelectOptionInterface,
+  type SelectProps,
+} from '../CustomSelect/CustomSelect';
 import { NativeSelect } from '../NativeSelect/NativeSelect';
 
 export type SelectType = 'default' | 'plain' | 'accent';
@@ -8,7 +12,10 @@ export type SelectType = 'default' | 'plain' | 'accent';
 /**
  * @see https://vkcom.github.io/VKUI/#/Select
  */
-export const Select = ({ children, ...props }: SelectProps) => {
+export const Select = <OptionT extends CustomSelectOptionInterface>({
+  children,
+  ...props
+}: SelectProps<OptionT>) => {
   const {
     options = [],
     searchable,
@@ -37,7 +44,7 @@ export const Select = ({ children, ...props }: SelectProps) => {
 
   return (
     <React.Fragment>
-      {(hasPointer === undefined || hasPointer) && <CustomSelect {...props} />}
+      {(hasPointer === undefined || hasPointer) && <CustomSelect<OptionT> {...props} />}
       {(hasPointer === undefined || !hasPointer) && (
         <NativeSelect {...nativeProps}>
           {options.map(({ label, value }) => (

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -271,6 +271,7 @@ export { CustomSelect } from './components/CustomSelect/CustomSelect';
 export type {
   SelectProps,
   CustomSelectOptionInterface,
+  CustomSelectRenderOption,
 } from './components/CustomSelect/CustomSelect';
 export { CustomSelectOption } from './components/CustomSelectOption/CustomSelectOption';
 export type { CustomSelectOptionProps } from './components/CustomSelectOption/CustomSelectOption';

--- a/packages/vkui/src/lib/select.ts
+++ b/packages/vkui/src/lib/select.ts
@@ -26,14 +26,14 @@ try {
   letterRegexp = new RegExp('\\p{L}', 'u');
 } catch (e) {}
 
-type GetOptionLabel = (option: Option) => string | undefined;
+type GetOptionLabel<T> = (option: Partial<T>) => string | undefined;
 
-const _getOptionLabel: GetOptionLabel = (option) => getTitleFromChildren(option.label);
+const _getOptionLabel: GetOptionLabel<Option> = (option) => getTitleFromChildren(option.label);
 
-export const defaultFilterFn = (
+export const defaultFilterFn = <T extends { label?: React.ReactElement | string }>(
   query = '',
-  option: Option,
-  getOptionLabel: GetOptionLabel = _getOptionLabel,
+  option: T,
+  getOptionLabel: GetOptionLabel<T> = _getOptionLabel,
 ) => {
   query = query.toLocaleLowerCase();
   let label = getOptionLabel(option)?.toLocaleLowerCase();

--- a/packages/vkui/src/lib/select.ts
+++ b/packages/vkui/src/lib/select.ts
@@ -30,7 +30,7 @@ type GetOptionLabel<T> = (option: Partial<T>) => string | undefined;
 
 const _getOptionLabel: GetOptionLabel<Option> = (option) => getTitleFromChildren(option.label);
 
-export const defaultFilterFn = <T extends { label?: React.ReactElement | string }>(
+export const defaultFilterFn = <T>(
   query = '',
   option: T,
   getOptionLabel: GetOptionLabel<T> = _getOptionLabel,


### PR DESCRIPTION
- close #6072

---

- [x] Unit-тесты - добавлен тест для проверки случаев использования CustomSelect с расширенными опциями. В основном, чтобы поймать ошибку типов.

## Описание
Мы вроде бы позволяем использовать опции любых типов, которые бы имели у себя обязательные свойста Select, 
https://github.com/VKCOM/VKUI/blob/3a844db48dea7a4d83d2b9020c2bf21ba18a3344/packages/vkui/src/components/CustomSelect/CustomSelect.tsx#L107-L112
но сейчас TS ругается если мы пытаемся использовать в `renderOption` опции со свойствами, которых нету в `CustomSelectOptionInterface`. 

## Изменения
Добавили дженерик для типа опций с constraint, чтобы можно было использовать расширинный тип опции с обязательными полями.
