### PR TITLE
ci(pr-auto-add-label): rm v5; a.i. disable patch

### DIFF
--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -10,6 +10,8 @@ concurrency:
 
 jobs:
   labels:
+    # TODO [>=6]: удалить условие после релиза v6
+    if: false
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -25,19 +27,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ["patch"]
-            })
-
-      # TODO [>=6]: удалить после v6
-      - name: V5
-        if: ${{ !(startsWith(github.event.pull_request.title, 'BREAKING CHANGE') || contains(github.event.pull_request.title, 'v6') || startsWith(github.event.pull_request.title, 'patch'))}}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["v5"]
             })
 
   lint_codes_format:


### PR DESCRIPTION
## Описание

Зарелизили последнею минорную версию по **v5** [v5.10.0](https://github.com/VKCOM/VKUI/releases/tag/v5.10.0). Т.к. дальше пойдут только хотфиксы, то удаляем автодобавление метки `v5`, а также временно удаляем метку `patch`.

- related to #5953