### PR TITLE
feat(usePatchChildren): opportunity to provide props

### DIFF
--- a/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
+++ b/packages/vkui/src/components/HoverPopper/HoverPopper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useEventListener } from '../../hooks/useEventListener';
-import { usePatchChildrenRef } from '../../hooks/usePatchChildrenRef';
+import { usePatchChildren } from '../../hooks/usePatchChildren';
 import { useTimeout } from '../../hooks/useTimeout';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { Popper, PopperCommonProps } from '../Popper/Popper';
@@ -61,7 +61,7 @@ export const HoverPopper = ({
     setShown(false);
   }, hideDelay);
 
-  const [childRef, child] = usePatchChildrenRef(children);
+  const [childRef, child] = usePatchChildren(children);
 
   const onTargetEnter = () => {
     hideTimeout.clear();

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -3,7 +3,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { useEventListener } from '../../hooks/useEventListener';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
-import { usePatchChildrenRef } from '../../hooks/usePatchChildrenRef';
+import { usePatchChildren } from '../../hooks/usePatchChildren';
 import { useTimeout } from '../../hooks/useTimeout';
 import { useDOM } from '../../lib/dom';
 import { FocusTrap, FocusTrapProps } from '../FocusTrap/FocusTrap';
@@ -88,7 +88,7 @@ export const Popover = ({
 
   const patchedPopperRef = useExternRef<HTMLDivElement>(setPopperNode, getRef);
 
-  const [childRef, child] = usePatchChildrenRef(children);
+  const [childRef, child] = usePatchChildren(children);
 
   const setShown = (value: boolean) => {
     if (typeof shownProp !== 'boolean') {

--- a/packages/vkui/src/helpers/getMergedSameEventsByProps.test.ts
+++ b/packages/vkui/src/helpers/getMergedSameEventsByProps.test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { getMergedSameEventsByProps } from './getMergedSameEventsByProps';
+
+const getMockedArgs = () => ({
+  mainProps: {
+    someIntValue: 1,
+    onCallCommonDefinedFn: jest.fn(
+      (event: { stopPropagation?: boolean }) => event?.stopPropagation,
+    ),
+    onCallCommonUndefinedFn: jest.fn(),
+    onCallDefinedFn: jest.fn(),
+    onCallUndefinedFn: undefined,
+  },
+  secondProps: {
+    someIntValue: 1,
+    someBoolValue: false,
+    onCallCommonDefinedFn: jest.fn((event) => {
+      if (event) {
+        event.stopPropagation = true;
+      }
+    }),
+    onCallCommonUndefinedFn: undefined,
+    onCallOnlyInPropsFn: jest.fn(),
+  },
+});
+
+describe(getMergedSameEventsByProps, () => {
+  it('should call the same functions that correspond to the mainProps', () => {
+    const { mainProps: mainProps, secondProps: props } = getMockedArgs();
+    const { result } = renderHook(() => getMergedSameEventsByProps(mainProps, props));
+
+    act(() => {
+      if (result.current.onCallCommonDefinedFn) {
+        result.current.onCallCommonDefinedFn({});
+      }
+    });
+
+    expect(props.onCallCommonDefinedFn).toHaveBeenCalledTimes(1);
+    expect(mainProps.onCallCommonDefinedFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore undefined functions and not function props', () => {
+    const { mainProps: mainProps, secondProps: props } = getMockedArgs();
+    const { result } = renderHook(() => getMergedSameEventsByProps(mainProps, props));
+
+    expect(mainProps.onCallUndefinedFn).toBeUndefined();
+    expect(props.onCallCommonUndefinedFn).toBeUndefined();
+    expect(props).not.toHaveProperty('onCallDefinedFn');
+    expect(props).not.toHaveProperty('onCallUndefinedFn');
+
+    act(() => {
+      if (result.current.onCallDefinedFn) {
+        result.current.onCallDefinedFn();
+      }
+      if (result.current.onCallCommonUndefinedFn) {
+        result.current.onCallCommonUndefinedFn();
+      }
+    });
+
+    expect(result.current).not.toHaveProperty('someIntValue');
+    expect(mainProps.onCallDefinedFn).toHaveBeenCalledTimes(0);
+    expect(mainProps.onCallCommonUndefinedFn).toHaveBeenCalledTimes(0);
+  });
+
+  it('should ignore not exist in mainProps function', () => {
+    const { mainProps: mainProps, secondProps: props } = getMockedArgs();
+    const { result } = renderHook(() => getMergedSameEventsByProps(mainProps, props));
+
+    act(() => {
+      if (result.current.onCallCommonDefinedFn) {
+        result.current.onCallCommonDefinedFn({});
+      }
+    });
+
+    expect(props.onCallCommonDefinedFn).toHaveBeenCalledTimes(1);
+    expect(props.onCallOnlyInPropsFn).toHaveBeenCalledTimes(0);
+  });
+
+  it('should calls function by props first', () => {
+    const { mainProps: mainProps, secondProps: props } = getMockedArgs();
+    const { result } = renderHook(() => getMergedSameEventsByProps(mainProps, props));
+
+    act(() => {
+      if (result.current.onCallCommonDefinedFn) {
+        result.current.onCallCommonDefinedFn({ stopPropagation: false });
+      }
+    });
+
+    expect(mainProps.onCallCommonDefinedFn).toHaveReturnedWith(true);
+    expect(props.onCallCommonDefinedFn).toHaveBeenCalledWith({ stopPropagation: true });
+  });
+});

--- a/packages/vkui/src/helpers/getMergedSameEventsByProps.test.ts
+++ b/packages/vkui/src/helpers/getMergedSameEventsByProps.test.ts
@@ -73,7 +73,6 @@ describe(getMergedSameEventsByProps, () => {
     });
 
     expect(props.onCallCommonDefinedFn).toHaveBeenCalledTimes(1);
-    expect(props.onCallOnlyInPropsFn).toHaveBeenCalledTimes(0);
   });
 
   it('should calls function by props first', () => {

--- a/packages/vkui/src/helpers/getMergedSameEventsByProps.ts
+++ b/packages/vkui/src/helpers/getMergedSameEventsByProps.ts
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import type { AnyFunction } from '@vkontakte/vkjs';
+import type { PickOnlyFunctionProps } from '../types';
+
+const isFunctionExistInProps = <Props extends Record<PropertyKey, any>>(
+  props: Props,
+  key: PropertyKey,
+): key is Extract<keyof Props, AnyFunction> => typeof props[key] === 'function';
+
+/**
+ * Полезен, когда нужно сохранить пользовательские события.
+ *
+ * Приоритет даём пользовательскому событию. Например, можно будет отловить был ли вызван
+ * `event.preventDefault()` через `event.defaultPrevented`.
+ *
+ * @private
+ */
+export const getMergedSameEventsByProps = <
+  T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>,
+  MainProps extends React.ComponentProps<T>,
+  OnlyFnPropsByMain extends PickOnlyFunctionProps<MainProps>,
+>(
+  mainProps: MainProps,
+  secondProps: React.ComponentProps<T>,
+) => {
+  const result: {
+    [K in keyof OnlyFnPropsByMain]?:
+      | ((this: any, ...args: Parameters<OnlyFnPropsByMain[K]>) => void)
+      | undefined;
+  } = {};
+
+  for (const eventName in mainProps) {
+    if (
+      mainProps.hasOwnProperty(eventName) &&
+      secondProps.hasOwnProperty(eventName) &&
+      isFunctionExistInProps(mainProps, eventName) &&
+      isFunctionExistInProps(secondProps, eventName)
+    ) {
+      result[eventName] = function mergeSameEventsByProps(
+        ...args: Parameters<OnlyFnPropsByMain[typeof eventName]>
+      ) {
+        secondProps[eventName].apply(this, args);
+        mainProps[eventName].apply(this, args);
+      };
+    }
+  }
+  return result;
+};

--- a/packages/vkui/src/hooks/usePatchChildren.test.tsx
+++ b/packages/vkui/src/hooks/usePatchChildren.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { setRef } from '../lib/utils';
 import type { HasRootRef } from '../types';
-import { usePatchChildrenRef } from './usePatchChildrenRef';
+import { usePatchChildren } from './usePatchChildren';
 
 const ComponentWithGetRootRef = ({
   getRootRef,
@@ -22,7 +22,7 @@ const WrapperWithUsePatchChildrenRef = ({
   refHook,
   ...restProps
 }: WrapperWithUsePatchChildrenRefProps) => {
-  const [childRef, child] = usePatchChildrenRef<HTMLDivElement>(children, restProps, refHook);
+  const [childRef, child] = usePatchChildren<HTMLDivElement>(children, restProps, refHook);
 
   React.useEffect(() => {
     if (childRef.current && childRefProp) {
@@ -33,7 +33,7 @@ const WrapperWithUsePatchChildrenRef = ({
   return <div data-testid="child">{child}</div>;
 };
 
-describe(usePatchChildrenRef, () => {
+describe(usePatchChildren, () => {
   it.each([
     { type: 'element', refPropKey: 'childRef' },
     { type: 'element', refPropKey: 'refHook' },

--- a/packages/vkui/src/hooks/usePatchChildren.ts
+++ b/packages/vkui/src/hooks/usePatchChildren.ts
@@ -45,8 +45,10 @@ type ChildrenElement<T> =
  * const { ref } = useSomeHook();
  * const [childRef, child] = usePatchChildrenRef(children, undefined, ref);
  * ```
+ *
+ * @private
  */
-export const usePatchChildrenRef = <ElementType extends HTMLElement = HTMLElement>(
+export const usePatchChildren = <ElementType extends HTMLElement = HTMLElement>(
   children?: ChildrenElement<ElementType>,
   injectProps?: InjectProps<ElementType>,
   externRef?: React.Ref<ElementType>,

--- a/packages/vkui/src/hooks/usePatchChildrenRef.test.tsx
+++ b/packages/vkui/src/hooks/usePatchChildrenRef.test.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import { setRef } from '../lib/utils';
+import type { HasRootRef } from '../types';
+import { usePatchChildrenRef } from './usePatchChildrenRef';
+
+const ComponentWithGetRootRef = ({
+  getRootRef,
+  ...restProps
+}: HasRootRef<HTMLDivElement> & React.DOMAttributes<HTMLDivElement>) => (
+  <div ref={getRootRef} {...restProps}></div>
+);
+
+type WrapperWithUsePatchChildrenRefProps = {
+  childRef?: React.RefObject<HTMLDivElement>;
+  refHook?: React.RefObject<HTMLDivElement>;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const WrapperWithUsePatchChildrenRef = ({
+  children,
+  childRef: childRefProp,
+  refHook,
+  ...restProps
+}: WrapperWithUsePatchChildrenRefProps) => {
+  const [childRef, child] = usePatchChildrenRef<HTMLDivElement>(children, restProps, refHook);
+
+  React.useEffect(() => {
+    if (childRef.current && childRefProp) {
+      setRef<HTMLDivElement>(childRef.current, childRefProp);
+    }
+  }, [childRef, childRefProp]);
+
+  return <div data-testid="child">{child}</div>;
+};
+
+describe(usePatchChildrenRef, () => {
+  it.each([
+    { type: 'element', refPropKey: 'childRef' },
+    { type: 'element', refPropKey: 'refHook' },
+    { type: 'component', refPropKey: 'childRef' },
+    { type: 'component', refPropKey: 'refHook' },
+  ])('should get ref by $type with $refPropKey', ({ type, refPropKey }) => {
+    const refByTestingHook = React.createRef<HTMLDivElement>();
+    const refForCompare = React.createRef<HTMLDivElement>();
+
+    let reactElement: React.ReactNode = null;
+    switch (type) {
+      case 'element':
+        reactElement = <div ref={refForCompare} />;
+        break;
+      case 'component':
+        reactElement = <ComponentWithGetRootRef getRootRef={refForCompare} />;
+        break;
+    }
+
+    const result = render(
+      <WrapperWithUsePatchChildrenRef {...{ [refPropKey]: refByTestingHook }}>
+        {reactElement}
+      </WrapperWithUsePatchChildrenRef>,
+    );
+
+    act(() => {
+      expect(refByTestingHook).toEqual(refForCompare);
+    });
+
+    expect(result.getByTestId('child')).not.toBeEmptyDOMElement();
+  });
+
+  it.each([
+    { type: 'element', event: 'onMouseEnter', hasOwnEvent: false },
+    { type: 'element', event: 'onMouseEnter', hasOwnEvent: true },
+    { type: 'component', event: 'onMouseEnter', hasOwnEvent: false },
+    { type: 'component', event: 'onMouseEnter', hasOwnEvent: true },
+  ])(
+    'should inject $event event to $type (hasOwnEvent: $hasOwnEvent)',
+    ({ type, event, hasOwnEvent }) => {
+      const reactElementRef = React.createRef<HTMLDivElement>();
+      const ownEvent = {
+        someIntValue: 1,
+        someBoolValue: false,
+        onMouseEnter: jest.fn(),
+        onMouseLeave: jest.fn(),
+      };
+
+      let reactElement: React.ReactNode = null;
+      switch (type) {
+        case 'element': {
+          const props = hasOwnEvent ? ownEvent : {};
+          reactElement = <div ref={reactElementRef} {...props} />;
+          break;
+        }
+        case 'component': {
+          const props = hasOwnEvent ? ownEvent : {};
+          reactElement = <ComponentWithGetRootRef getRootRef={reactElementRef} {...props} />;
+          break;
+        }
+      }
+
+      const injectedEvents = {
+        [event]: jest.fn(),
+        onClick: jest.fn(),
+      };
+
+      render(
+        <WrapperWithUsePatchChildrenRef {...injectedEvents}>
+          {reactElement}
+        </WrapperWithUsePatchChildrenRef>,
+      );
+
+      act(() => {
+        fireEvent.mouseEnter(reactElementRef.current!);
+        fireEvent.click(reactElementRef.current!);
+      });
+
+      expect(ownEvent.someIntValue).toBe(1);
+      expect(ownEvent.someBoolValue).toBeFalsy();
+      expect(ownEvent.onMouseEnter).toHaveBeenCalledTimes(hasOwnEvent ? 1 : 0);
+      expect(ownEvent.onMouseLeave).toHaveBeenCalledTimes(0);
+      expect(injectedEvents.onMouseEnter).toHaveBeenCalledTimes(1);
+      expect(injectedEvents.onClick).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([{ type: 'fragment' }, { type: 'array' }])(
+    'should ignore invalid like $type',
+    ({ type }) => {
+      const refByTestingHook = React.createRef<HTMLDivElement>();
+
+      let reactElement: React.ReactNode = null;
+      switch (type) {
+        case 'fragment': {
+          reactElement = <React.Fragment>Fragment</React.Fragment>;
+          break;
+        }
+        case 'array': {
+          reactElement = [<div key="1" />, <div key="2" />];
+          break;
+        }
+      }
+
+      const result = render(
+        <WrapperWithUsePatchChildrenRef childRef={refByTestingHook}>
+          {reactElement}
+        </WrapperWithUsePatchChildrenRef>,
+      );
+
+      act(() => {
+        expect(refByTestingHook.current).toBeNull();
+      });
+
+      expect(result.getByTestId('child')).not.toBeEmptyDOMElement();
+    },
+  );
+});

--- a/packages/vkui/src/hooks/usePatchChildrenRef.ts
+++ b/packages/vkui/src/hooks/usePatchChildrenRef.ts
@@ -23,10 +23,33 @@ type ChildrenElement<T> =
   | null
   | undefined;
 
+/**
+ * Функция пытается прокинуть в переданный React-элемент хук для получения его ссылки на DOM этого
+ * элемента.
+ *
+ * @param children
+ * @param injectProps
+ * @param externRef – полезен когда нужно прокинуть `ref` элементу выше.
+ *
+ * 👎 Без параметра `externRef`
+ * ```ts
+ * const { ref } = useSomeHook();
+ * const [childRef, child] = usePatchChildrenRef(children);
+ * React.useLayoutEffect(() => {
+ *   ref.current = childRef.current; // или ref.current(childRef.current)
+ * }, [childRef]);
+ * ```
+ *
+ * 👍 С параметром `externRef`
+ * ```ts
+ * const { ref } = useSomeHook();
+ * const [childRef, child] = usePatchChildrenRef(children, undefined, ref);
+ * ```
+ */
 export const usePatchChildrenRef = <ElementType extends HTMLElement = HTMLElement>(
   children?: ChildrenElement<ElementType>,
   injectProps?: InjectProps<ElementType>,
-  refHook?: React.Ref<ElementType>,
+  externRef?: React.Ref<ElementType>,
 ): [React.MutableRefObject<ElementType | null>, ChildrenElement<ElementType> | undefined] => {
   const isValidElementResult = isValidNotReactFragmentElement(children);
   const isDOMTypeElementResult =
@@ -39,7 +62,7 @@ export const usePatchChildrenRef = <ElementType extends HTMLElement = HTMLElemen
       : isValidElementResult
       ? children.props.getRootRef
       : undefined,
-    refHook,
+    externRef,
   );
 
   const mergedEventsByInjectProps = getMergedSameEventsByProps(

--- a/packages/vkui/src/hooks/usePatchChildrenRef.ts
+++ b/packages/vkui/src/hooks/usePatchChildrenRef.ts
@@ -1,39 +1,66 @@
 import * as React from 'react';
+import { getMergedSameEventsByProps } from '../helpers/getMergedSameEventsByProps';
+import { isDOMTypeElement, isValidNotReactFragmentElement } from '../lib/utils';
 import { warnOnce } from '../lib/warnOnce';
+import type { HasRootRef } from '../types';
 import { useEffectDev } from './useEffectDev';
 import { useExternRef } from './useExternRef';
 
-type ChildrenElement<T> = React.ReactElement<{ getRootRef?: React.Ref<T> }>;
-
-const isDOMTypeElement = (element: React.ReactElement): element is React.DOMElement<any, any> => {
-  return typeof element.type === 'string';
-};
-
 const warn = warnOnce('usePatchChildrenRef');
 
-export const usePatchChildrenRef = <T = HTMLElement>(
-  children?: ChildrenElement<T>,
-): [React.MutableRefObject<T | null>, ChildrenElement<T> | undefined] => {
-  const childRef =
-    React.isValidElement(children) &&
-    (isDOMTypeElement(children) ? (children.ref as React.Ref<T>) : children.props.getRootRef);
-  const patchedRef = useExternRef<T>(childRef);
+type InjectProps<T> = Omit<React.HTMLAttributes<T>, keyof React.DOMAttributes<T>> & {
+  ref?: React.Ref<T>;
+};
+
+type ExpectedReactElement<T> = React.ReactElement<HasRootRef<T> & React.DOMAttributes<T>>;
+
+type ChildrenElement<T> =
+  | ExpectedReactElement<T>
+  | React.ReactText
+  | React.ReactFragment
+  | React.ReactPortal
+  | boolean
+  | null
+  | undefined;
+
+export const usePatchChildrenRef = <ElementType extends HTMLElement = HTMLElement>(
+  children?: ChildrenElement<ElementType>,
+  injectProps?: InjectProps<ElementType>,
+  refHook?: React.Ref<ElementType>,
+): [React.MutableRefObject<ElementType | null>, ChildrenElement<ElementType> | undefined] => {
+  const isValidElementResult = isValidNotReactFragmentElement(children);
+  const isDOMTypeElementResult =
+    isValidElementResult &&
+    isDOMTypeElement<React.HTMLAttributes<ElementType>, ElementType>(children);
+
+  const childRef = useExternRef<ElementType>(
+    isDOMTypeElementResult
+      ? children.ref
+      : isValidElementResult
+      ? children.props.getRootRef
+      : undefined,
+    refHook,
+  );
+
+  const mergedEventsByInjectProps = getMergedSameEventsByProps(
+    injectProps ? injectProps : {},
+    isValidElementResult ? children.props : {},
+  );
+
+  const props = isDOMTypeElementResult
+    ? { ref: childRef, ...injectProps, ...mergedEventsByInjectProps }
+    : isValidElementResult
+    ? { getRootRef: childRef, ...injectProps, ...mergedEventsByInjectProps }
+    : undefined;
 
   useEffectDev(() => {
-    if (!patchedRef.current) {
+    if (!childRef.current) {
       warn(
         'Кажется, в children передан компонент, который не поддерживает свойство getRootRef. Мы не можем получить ссылку на корневой dom-элемент этого компонента',
         'error',
       );
     }
-  }, [children?.type, patchedRef]);
+  }, [isValidElementResult ? children.type : null, childRef]);
 
-  return [
-    patchedRef,
-    React.isValidElement(children)
-      ? React.cloneElement(children, {
-          [isDOMTypeElement(children) ? 'ref' : 'getRootRef']: patchedRef,
-        })
-      : children,
-  ];
+  return [childRef, isValidElementResult ? React.cloneElement(children, props) : children];
 };

--- a/packages/vkui/src/lib/utils.ts
+++ b/packages/vkui/src/lib/utils.ts
@@ -89,3 +89,21 @@ export const excludeKeysWithUndefined = <T extends Record<string | number | symb
   }
   return filteredObj;
 };
+
+export const isDOMTypeElement = <
+  P extends React.HTMLAttributes<T> | React.SVGAttributes<T>,
+  T extends Element,
+>(
+  element: React.ReactElement,
+): element is Omit<React.DOMElement<P, T>, 'ref'> & { ref?: React.Ref<T> | undefined } =>
+  typeof element.type === 'string';
+
+export function isValidNotReactFragmentElement(
+  children: Parameters<typeof React.isValidElement>[0],
+): children is React.ReactElement<Record<PropertyKey, any>> {
+  return (
+    React.isValidElement(children) &&
+    // @ts-expect-error: TS2339 $$typeof всегда symbol, в отличии от type, благодаря этому пропускаем лишние проверки на тип.
+    children.$$typeof !== Symbol.for('react.fragment')
+  );
+}

--- a/packages/vkui/src/types.ts
+++ b/packages/vkui/src/types.ts
@@ -91,3 +91,9 @@ export type LiteralUnion<Union, Type> = Union | (Type & Nothing);
 export type HTMLAttributesWithRootRef<T> = React.HTMLAttributes<T> & HasRootRef<T>;
 
 export type ValuesOfObject<T> = T[keyof T];
+
+export type GetPropsWithFunctionKeys<T> = {
+  [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
+}[keyof T];
+
+export type PickOnlyFunctionProps<T> = Pick<T, GetPropsWithFunctionKeys<T>>;


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

Добавил два новых аргумента:
1. возможность прокидывать параметры помимо `ref`/`getRootRef`;
1. возможность прокинуть дополнительный обработчик `ref`.

- block #2523

## Изменения

- переименовал из `usePatchChildrenRef()` на `usePatchChildren()` (см. https://github.com/VKCOM/VKUI/pull/6135#discussion_r1405759461)
- `getMergedSameEventsByProps()` – функция, которая объединяет две схожие функции в одну из двух входных
параметров.
- в `lib/utils` добавились новые валидаторы `isDOMTypeElement()` и `isValidNotReactFragmentElement()`;