### PR TITLE
[BREAKING CHANGE] refactor: Избавляемся от `aria-label` в пользу визуально скрытого текста

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -180,7 +180,7 @@ export const Alert = ({
           onItemClick={onItemClick}
         />
         {isDismissButtonVisible && dismissButtonMode === 'outside' && (
-          <ModalDismissButton onClick={close} aria-label={dismissLabel} />
+          <ModalDismissButton onClick={close}>{dismissLabel}</ModalDismissButton>
         )}
       </FocusTrap>
     </PopoutWrapper>

--- a/packages/vkui/src/components/BaseGallery/types.ts
+++ b/packages/vkui/src/components/BaseGallery/types.ts
@@ -47,4 +47,12 @@ export interface BaseGalleryProps
   showArrows?: boolean;
   hasPointer?: boolean;
   arrowSize?: ScrollArrowProps['size'];
+  /**
+   * Текст для кнопки-стрелки влево (назад). Делает ее доступной для ассистивных технологий
+   */
+  arrowPrevLabel?: string;
+  /**
+   * Текст для кнопки-стрелки вправо (вперед). Делает ее доступной для ассистивных технологий
+   */
+  arrowNextLabel?: string;
 }

--- a/packages/vkui/src/components/Calendar/Calendar.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.tsx
@@ -14,13 +14,13 @@ import styles from './Calendar.module.css';
 
 export interface CalendarProps
   extends Omit<HTMLAttributesWithRootRef<HTMLDivElement>, 'onChange'>,
-    Pick<CalendarTimeProps, 'changeHoursAriaLabel' | 'changeMinutesAriaLabel'>,
+    Pick<CalendarTimeProps, 'changeHoursLabel' | 'changeMinutesLabel'>,
     Pick<
       CalendarHeaderProps,
-      | 'prevMonthAriaLabel'
-      | 'nextMonthAriaLabel'
-      | 'changeMonthAriaLabel'
-      | 'changeYearAriaLabel'
+      | 'prevMonthLabel'
+      | 'nextMonthLabel'
+      | 'changeMonthLabel'
+      | 'changeYearLabel'
       | 'onNextMonth'
       | 'onPrevMonth'
       | 'prevMonthIcon'
@@ -35,7 +35,7 @@ export interface CalendarProps
   enableTime?: boolean;
   disablePickers?: boolean;
   doneButtonText?: string;
-  changeDayAriaLabel?: string;
+  changeDayLabel?: string;
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   showNeighboringMonth?: boolean;
   size?: 's' | 'm';
@@ -77,14 +77,14 @@ export const Calendar = ({
   doneButtonText,
   weekStartsOn = 1,
   disablePickers,
-  changeHoursAriaLabel,
-  changeMinutesAriaLabel,
-  prevMonthAriaLabel,
-  nextMonthAriaLabel,
-  changeMonthAriaLabel,
-  changeYearAriaLabel,
+  changeHoursLabel = 'Изменить час',
+  changeMinutesLabel = 'Изменить минуту',
+  prevMonthLabel = 'Предыдущий месяц',
+  nextMonthLabel = 'Следующий месяц',
+  changeMonthLabel = 'Изменить месяц',
+  changeYearLabel = 'Изменить год',
   showNeighboringMonth,
-  changeDayAriaLabel = 'Изменить день',
+  changeDayLabel = 'Изменить день',
   size = 'm',
   viewDate: externalViewDate,
   onHeaderChange,
@@ -180,10 +180,10 @@ export const Calendar = ({
         onPrevMonth={setPrevMonth}
         disablePickers={disablePickers || size === 's'}
         className={styles['Calendar__header']}
-        prevMonthAriaLabel={prevMonthAriaLabel}
-        nextMonthAriaLabel={nextMonthAriaLabel}
-        changeMonthAriaLabel={changeMonthAriaLabel}
-        changeYearAriaLabel={changeYearAriaLabel}
+        prevMonthLabel={prevMonthLabel}
+        nextMonthLabel={nextMonthLabel}
+        changeMonthLabel={changeMonthLabel}
+        changeYearLabel={changeYearLabel}
         prevMonthIcon={prevMonthIcon}
         nextMonthIcon={nextMonthIcon}
         prevMonthProps={prevMonthProps}
@@ -195,7 +195,7 @@ export const Calendar = ({
         weekStartsOn={weekStartsOn}
         isDayFocused={isDayFocused}
         tabIndex={0}
-        aria-label={changeDayAriaLabel}
+        aria-label={changeDayLabel}
         onKeyDown={handleKeyDown}
         onDayChange={onDayChange}
         isDayActive={isDayActive}
@@ -215,8 +215,8 @@ export const Calendar = ({
             onChange={onChange}
             onClose={onClose}
             doneButtonText={doneButtonText}
-            changeHoursAriaLabel={changeHoursAriaLabel}
-            changeMinutesAriaLabel={changeMinutesAriaLabel}
+            changeHoursLabel={changeHoursLabel}
+            changeMinutesLabel={changeMinutesLabel}
             isDayDisabled={minDateTime || maxDateTime ? isDayDisabled : undefined}
           />
         </div>

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { ENABLE_KEYBOARD_INPUT_EVENT_NAME } from '../../hooks/useKeyboardInputTracker';
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';
 import { Tappable, TappableElementProps } from '../Tappable/Tappable';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './CalendarDay.module.css';
 
 export type CalendarDayElementProps = Omit<
@@ -50,13 +51,21 @@ export const CalendarDay = React.memo(
     sameMonth,
     size,
     className,
-    ...props
+    children,
+    ...restProps
   }: CalendarDayProps) => {
     const { locale } = useConfigProvider();
     const ref = React.useRef<HTMLElement>(null);
     const onClick = React.useCallback(() => onChange(day), [day, onChange]);
     const handleEnter = React.useCallback(() => onEnter?.(day), [day, onEnter]);
     const handleLeave = React.useCallback(() => onLeave?.(day), [day, onLeave]);
+
+    const label = new Intl.DateTimeFormat(locale, {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(day);
 
     React.useEffect(() => {
       if (focused && ref.current) {
@@ -66,7 +75,7 @@ export const CalendarDay = React.memo(
     }, [focused]);
 
     if (hidden) {
-      return <div className={styles['CalendarDay__hidden']}></div>;
+      return <div className={styles['CalendarDay__hidden']} />;
     }
 
     return (
@@ -86,18 +95,12 @@ export const CalendarDay = React.memo(
         hasActive={false}
         onClick={onClick}
         disabled={disabled}
-        aria-label={new Intl.DateTimeFormat(locale, {
-          weekday: 'long',
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        }).format(day)}
         tabIndex={-1}
         getRootRef={ref}
         focusVisibleMode={active ? 'outside' : 'inside'}
         onEnter={handleEnter}
         onLeave={handleLeave}
-        {...props}
+        {...restProps}
       >
         <div
           className={classNames(
@@ -113,7 +116,10 @@ export const CalendarDay = React.memo(
               active && !disabled && styles['CalendarDay__inner--active'],
             )}
           >
-            <div className={styles['CalendarDay__day-number']}>{day.getDate()}</div>
+            <div className={styles['CalendarDay__day-number']}>
+              <VisuallyHidden>{children ?? label}</VisuallyHidden>
+              <span aria-hidden>{day.getDate()}</span>
+            </div>
           </div>
         </div>
       </Tappable>

--- a/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
@@ -14,6 +14,7 @@ import { CustomSelect } from '../CustomSelect/CustomSelect';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { Tappable, TappableElementProps } from '../Tappable/Tappable';
 import { Paragraph } from '../Typography/Paragraph/Paragraph';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './CalendarHeader.module.css';
 
 type ArrowMonthProps = Omit<TappableElementProps, 'onClick' | 'aria-label'>;
@@ -24,10 +25,10 @@ export interface CalendarHeaderProps
   prevMonth?: boolean;
   nextMonth?: boolean;
   disablePickers?: boolean;
-  prevMonthAriaLabel?: string;
-  nextMonthAriaLabel?: string;
-  changeMonthAriaLabel?: string;
-  changeYearAriaLabel?: string;
+  prevMonthLabel?: string;
+  nextMonthLabel?: string;
+  changeMonthLabel?: string;
+  changeYearLabel?: string;
   prevMonthIcon?: React.ReactNode;
   nextMonthIcon?: React.ReactNode;
   prevMonthProps?: ArrowMonthProps;
@@ -53,10 +54,10 @@ export const CalendarHeader = ({
   onPrevMonth,
   prevMonthProps = {},
   nextMonthProps = {},
-  prevMonthAriaLabel = 'Предыдущий месяц',
-  nextMonthAriaLabel = 'Следующий месяц',
-  changeMonthAriaLabel = 'Изменить месяц',
-  changeYearAriaLabel = 'Изменить год',
+  prevMonthLabel = 'Предыдущий месяц',
+  nextMonthLabel = 'Следующий месяц',
+  changeMonthLabel = 'Изменить месяц',
+  changeYearLabel = 'Изменить год',
   prevMonthIcon = (
     <Icon20ChevronLeftOutline
       className={styles['CalendarHeader__nav-icon--accent']}
@@ -117,9 +118,11 @@ export const CalendarHeader = ({
               prevMonthClassName,
             )}
             onClick={onPrevMonth}
-            aria-label={`${prevMonthAriaLabel}, ${formatter.format(subMonths(viewDate, 1))}`}
             {...restPrevMonthProps}
           >
+            <VisuallyHidden>
+              {prevMonthLabel}, {formatter.format(subMonths(viewDate, 1))}
+            </VisuallyHidden>
             {prevMonthIcon}
           </Tappable>
         </AdaptivityProvider>
@@ -163,7 +166,7 @@ export const CalendarHeader = ({
               onChange={onMonthsChange}
               forceDropdownPortal={false}
               selectType="accent"
-              aria-label={changeMonthAriaLabel}
+              aria-label={changeMonthLabel}
             />
             <CustomSelect
               className={classNames(
@@ -178,7 +181,7 @@ export const CalendarHeader = ({
               onChange={onYearChange}
               forceDropdownPortal={false}
               selectType="accent"
-              aria-label={changeYearAriaLabel}
+              aria-label={changeYearLabel}
             />
           </div>
         </AdaptivityProvider>
@@ -192,9 +195,11 @@ export const CalendarHeader = ({
               nextMonthClassName,
             )}
             onClick={onNextMonth}
-            aria-label={`${nextMonthAriaLabel}, ${formatter.format(addMonths(viewDate, 1))}`}
             {...restNextMonthProps}
           >
+            <VisuallyHidden>
+              {nextMonthLabel}, {formatter.format(addMonths(viewDate, 1))}
+            </VisuallyHidden>
             {nextMonthIcon}
           </Tappable>
         </AdaptivityProvider>

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -21,10 +21,10 @@ export interface CalendarRangeProps
   extends Omit<HTMLAttributesWithRootRef<HTMLDivElement>, 'onChange'>,
     Pick<
       CalendarHeaderProps,
-      | 'prevMonthAriaLabel'
-      | 'nextMonthAriaLabel'
-      | 'changeMonthAriaLabel'
-      | 'changeYearAriaLabel'
+      | 'prevMonthLabel'
+      | 'nextMonthLabel'
+      | 'changeMonthLabel'
+      | 'changeYearLabel'
       | 'prevMonthIcon'
       | 'nextMonthIcon'
     >,
@@ -33,7 +33,7 @@ export interface CalendarRangeProps
   disablePast?: boolean;
   disableFuture?: boolean;
   disablePickers?: boolean;
-  changeDayAriaLabel?: string;
+  changeDayLabel?: string;
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   onChange?(value?: Array<Date | null>): void;
   shouldDisableDate?(value: Date): boolean;
@@ -60,11 +60,11 @@ export const CalendarRange = ({
   onClose,
   weekStartsOn = 1,
   disablePickers,
-  prevMonthAriaLabel,
-  nextMonthAriaLabel,
-  changeMonthAriaLabel,
-  changeYearAriaLabel,
-  changeDayAriaLabel = 'Изменить день',
+  prevMonthLabel = 'Предыдущий месяц',
+  nextMonthLabel = 'Следующий месяц',
+  changeMonthLabel = 'Изменить месяц',
+  changeYearLabel = 'Изменить год',
+  changeDayLabel = 'Изменить день',
   prevMonthIcon,
   nextMonthIcon,
   listenDayChangesForUpdate,
@@ -187,10 +187,10 @@ export const CalendarRange = ({
           onPrevMonth={setPrevMonth}
           disablePickers={disablePickers}
           className={styles['CalendarRange__header']}
-          prevMonthAriaLabel={prevMonthAriaLabel}
-          nextMonthAriaLabel={nextMonthAriaLabel}
-          changeMonthAriaLabel={changeMonthAriaLabel}
-          changeYearAriaLabel={changeYearAriaLabel}
+          prevMonthLabel={prevMonthLabel}
+          nextMonthLabel={nextMonthLabel}
+          changeMonthLabel={changeMonthLabel}
+          changeYearLabel={changeYearLabel}
           prevMonthIcon={prevMonthIcon}
         />
         <CalendarDays
@@ -211,7 +211,7 @@ export const CalendarRange = ({
           isHintedDaySelectionStart={isHintedDaySelectionStart}
           isDayDisabled={isDayDisabled}
           listenDayChangesForUpdate={listenDayChangesForUpdate}
-          aria-label={changeDayAriaLabel}
+          aria-label={changeDayLabel}
         />
       </div>
       <div className={styles['CalendarRange__inner']}>
@@ -222,17 +222,17 @@ export const CalendarRange = ({
           onNextMonth={setNextMonth}
           disablePickers={disablePickers}
           className={styles['CalendarRange__header']}
-          prevMonthAriaLabel={prevMonthAriaLabel}
-          nextMonthAriaLabel={nextMonthAriaLabel}
-          changeMonthAriaLabel={changeMonthAriaLabel}
-          changeYearAriaLabel={changeYearAriaLabel}
+          prevMonthLabel={prevMonthLabel}
+          nextMonthLabel={nextMonthLabel}
+          changeMonthLabel={changeMonthLabel}
+          changeYearLabel={changeYearLabel}
           nextMonthIcon={nextMonthIcon}
         />
         <CalendarDays
           viewDate={secondViewDate}
           value={value}
           weekStartsOn={weekStartsOn}
-          aria-label={changeDayAriaLabel}
+          aria-label={changeDayLabel}
           onKeyDown={handleKeyDown}
           isDayFocused={isDayFocused}
           onDayChange={onDayChange}

--- a/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
@@ -8,8 +8,8 @@ import styles from './CalendarTime.module.css';
 export interface CalendarTimeProps {
   value: Date;
   doneButtonText?: string;
-  changeHoursAriaLabel?: string;
-  changeMinutesAriaLabel?: string;
+  changeHoursLabel?: string;
+  changeMinutesLabel?: string;
   onChange?(value: Date): void;
   onClose?(): void;
   isDayDisabled?(day: Date, withTime?: boolean): boolean;
@@ -36,8 +36,8 @@ export const CalendarTime = ({
   doneButtonText = 'Готово',
   onChange,
   onClose,
-  changeHoursAriaLabel = 'Изменить час',
-  changeMinutesAriaLabel = 'Изменить минуту',
+  changeHoursLabel,
+  changeMinutesLabel,
   isDayDisabled,
 }: CalendarTimeProps) => {
   const localHours = isDayDisabled
@@ -72,7 +72,7 @@ export const CalendarTime = ({
             options={localHours}
             onChange={onHoursChange}
             forceDropdownPortal={false}
-            aria-label={changeHoursAriaLabel}
+            aria-label={changeHoursLabel}
           />
         </AdaptivityProvider>
       </div>
@@ -84,13 +84,13 @@ export const CalendarTime = ({
             options={localMinutes}
             onChange={onMinutesChange}
             forceDropdownPortal={false}
-            aria-label={changeMinutesAriaLabel}
+            aria-label={changeMinutesLabel}
           />
         </AdaptivityProvider>
       </div>
       <div className={styles['CalendarTime__button']}>
         <AdaptivityProvider sizeY="compact">
-          <Button mode="secondary" onClick={onClose} size="l" aria-label={doneButtonText}>
+          <Button mode="secondary" onClick={onClose} size="l">
             {doneButtonText}
           </Button>
         </AdaptivityProvider>

--- a/packages/vkui/src/components/Cell/Cell.tsx
+++ b/packages/vkui/src/components/Cell/Cell.tsx
@@ -40,7 +40,7 @@ export interface CellProps
    */
   onDragFinish?(swappedItemRange: SwappedItemRange): void;
   /**
-   * aria-label для кнопки перетаскивания ячейки
+   * Текст для кнопки перетаскивания ячейки
    */
   draggerLabel?: string;
 }
@@ -84,11 +84,12 @@ export const Cell = ({
     <CellDragger
       elRef={rootElRef}
       className={styles['Cell__dragger']}
-      aria-label={draggerLabel}
       disabled={disabled}
       onDragStateChange={setDragging}
       onDragFinish={onDragFinish}
-    />
+    >
+      {draggerLabel}
+    </CellDragger>
   ) : null;
 
   let checkbox;

--- a/packages/vkui/src/components/Cell/CellDragger/CellDragger.tsx
+++ b/packages/vkui/src/components/Cell/CellDragger/CellDragger.tsx
@@ -10,6 +10,7 @@ import { usePlatform } from '../../../hooks/usePlatform';
 import { useIsomorphicLayoutEffect } from '../../../lib/useIsomorphicLayoutEffect';
 import { HTMLAttributesWithRootRef } from '../../../types';
 import { Touch } from '../../Touch/Touch';
+import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import styles from './CellDragger.module.css';
 
 interface CellDraggerProps
@@ -25,6 +26,7 @@ export const CellDragger = ({
   className,
   onDragStateChange,
   onDragFinish,
+  children,
   ...restProps
 }: CellDraggerProps) => {
   const platform = usePlatform();
@@ -49,6 +51,7 @@ export const CellDragger = ({
       onEnd={disabled ? undefined : onDragEnd}
       {...restProps}
     >
+      {children && <VisuallyHidden>{children}</VisuallyHidden>}
       <Icon className={styles['CellDragger__icon']} />
     </Touch>
   );

--- a/packages/vkui/src/components/Chip/Chip.tsx
+++ b/packages/vkui/src/components/Chip/Chip.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Icon16Cancel } from '@vkontakte/icons';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
-import { getTitleFromChildren } from '../../lib/utils';
+import { getTextFromChildren } from '../../lib/children';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { Tappable } from '../Tappable/Tappable';
@@ -58,7 +58,7 @@ export const Chip = ({
     },
     [onRemove, value],
   );
-  const title = getTitleFromChildren(children);
+  const title = getTextFromChildren(children);
 
   return (
     <RootComponent

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -36,13 +36,13 @@ export interface DateInputProps
       | 'doneButtonText'
       | 'weekStartsOn'
       | 'disablePickers'
-      | 'changeHoursAriaLabel'
-      | 'changeMinutesAriaLabel'
-      | 'prevMonthAriaLabel'
-      | 'nextMonthAriaLabel'
-      | 'changeMonthAriaLabel'
-      | 'changeYearAriaLabel'
-      | 'changeDayAriaLabel'
+      | 'changeHoursLabel'
+      | 'changeMinutesLabel'
+      | 'prevMonthLabel'
+      | 'nextMonthLabel'
+      | 'changeMonthLabel'
+      | 'changeYearLabel'
+      | 'changeDayLabel'
       | 'showNeighboringMonth'
       | 'size'
       | 'viewDate'
@@ -56,8 +56,8 @@ export interface DateInputProps
     FormFieldProps {
   calendarPlacement?: PlacementWithAuto;
   closeOnChange?: boolean;
-  clearFieldAriaLabel?: string;
-  showCalendarAriaLabel?: string;
+  clearFieldLabel?: string;
+  showCalendarLabel?: string;
   disableCalendar?: boolean;
 }
 
@@ -123,17 +123,17 @@ export const DateInput = ({
   disabled,
   onClick,
   onFocus,
-  prevMonthAriaLabel,
-  nextMonthAriaLabel,
+  prevMonthLabel = 'Предыдущий месяц',
+  nextMonthLabel = 'Следующий месяц',
   showNeighboringMonth,
   size,
-  changeMonthAriaLabel = 'Изменить месяц',
-  changeYearAriaLabel = 'Изменить год',
-  changeDayAriaLabel = 'Изменить день',
-  changeHoursAriaLabel = 'Изменить час',
-  changeMinutesAriaLabel = 'Изменить минуту',
-  clearFieldAriaLabel = 'Очистить поле',
-  showCalendarAriaLabel = 'Показать календарь',
+  changeMonthLabel = 'Изменить месяц',
+  changeYearLabel = 'Изменить год',
+  changeDayLabel = 'Изменить день',
+  changeHoursLabel = 'Изменить час',
+  changeMinutesLabel = 'Изменить минуту',
+  clearFieldLabel = 'Очистить поле',
+  showCalendarLabel = 'Показать календарь',
   viewDate,
   onHeaderChange,
   onNextMonth,
@@ -223,11 +223,11 @@ export const DateInput = ({
       getRootRef={handleRootRef}
       after={
         value ? (
-          <IconButton hoverMode="opacity" aria-label={clearFieldAriaLabel} onClick={clear}>
+          <IconButton hoverMode="opacity" label={clearFieldLabel} onClick={clear}>
             <Icon16Clear />
           </IconButton>
         ) : (
-          <IconButton hoverMode="opacity" aria-label={showCalendarAriaLabel} onClick={openCalendar}>
+          <IconButton hoverMode="opacity" label={showCalendarLabel} onClick={openCalendar}>
             <Icon20CalendarOutline />
           </IconButton>
         )
@@ -249,7 +249,7 @@ export const DateInput = ({
           index={0}
           onElementSelect={setFocusedElement}
           value={internalValue[0]}
-          aria-label={changeDayAriaLabel}
+          label={changeDayLabel}
         />
         <InputLikeDivider>.</InputLikeDivider>
         <InputLike
@@ -258,7 +258,7 @@ export const DateInput = ({
           index={1}
           onElementSelect={setFocusedElement}
           value={internalValue[1]}
-          aria-label={changeMonthAriaLabel}
+          label={changeMonthLabel}
         />
         <InputLikeDivider>.</InputLikeDivider>
         <InputLike
@@ -267,7 +267,7 @@ export const DateInput = ({
           index={2}
           onElementSelect={setFocusedElement}
           value={internalValue[2]}
-          aria-label={changeYearAriaLabel}
+          label={changeYearLabel}
         />
         {enableTime && (
           <React.Fragment>
@@ -280,7 +280,7 @@ export const DateInput = ({
               index={3}
               onElementSelect={setFocusedElement}
               value={internalValue[3]}
-              aria-label={changeHoursAriaLabel}
+              label={changeHoursLabel}
             />
             <InputLikeDivider>:</InputLikeDivider>
             <InputLike
@@ -289,7 +289,7 @@ export const DateInput = ({
               index={4}
               onElementSelect={setFocusedElement}
               value={internalValue[4]}
-              aria-label={changeMinutesAriaLabel}
+              label={changeMinutesLabel}
             />
           </React.Fragment>
         )}
@@ -307,13 +307,13 @@ export const DateInput = ({
             getRootRef={calendarRef}
             doneButtonText={doneButtonText}
             disablePickers={disablePickers}
-            changeHoursAriaLabel={changeHoursAriaLabel}
-            changeMinutesAriaLabel={changeMinutesAriaLabel}
-            prevMonthAriaLabel={prevMonthAriaLabel}
-            nextMonthAriaLabel={nextMonthAriaLabel}
-            changeMonthAriaLabel={changeMonthAriaLabel}
-            changeYearAriaLabel={changeYearAriaLabel}
-            changeDayAriaLabel={changeDayAriaLabel}
+            changeHoursLabel={changeHoursLabel}
+            changeMinutesLabel={changeMinutesLabel}
+            prevMonthLabel={prevMonthLabel}
+            nextMonthLabel={nextMonthLabel}
+            changeMonthLabel={changeMonthLabel}
+            changeYearLabel={changeYearLabel}
+            changeDayLabel={changeDayLabel}
             showNeighboringMonth={showNeighboringMonth}
             size={size}
             viewDate={viewDate}

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -15,6 +15,7 @@ import { InputLike } from '../InputLike/InputLike';
 import { InputLikeDivider } from '../InputLike/InputLikeDivider';
 import { Popper } from '../Popper/Popper';
 import { Text } from '../Typography/Text/Text';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './DateRangeInput.module.css';
 import dateInputStyles from '../DateInput/DateInput.module.css';
 
@@ -34,11 +35,11 @@ export interface DateRangeInputProps
       | 'value'
       | 'weekStartsOn'
       | 'disablePickers'
-      | 'prevMonthAriaLabel'
-      | 'nextMonthAriaLabel'
-      | 'changeMonthAriaLabel'
-      | 'changeYearAriaLabel'
-      | 'changeDayAriaLabel'
+      | 'prevMonthLabel'
+      | 'nextMonthLabel'
+      | 'changeMonthLabel'
+      | 'changeYearLabel'
+      | 'changeDayLabel'
       | 'prevMonthIcon'
       | 'nextMonthIcon'
     >,
@@ -46,14 +47,14 @@ export interface DateRangeInputProps
     FormFieldProps {
   calendarPlacement?: PlacementWithAuto;
   closeOnChange?: boolean;
-  clearFieldAriaLabel?: string;
-  showCalendarAriaLabel?: string;
-  changeStartDayAriaLabel?: string;
-  changeStartMonthAriaLabel?: string;
-  changeStartYearAriaLabel?: string;
-  changeEndDayAriaLabel?: string;
-  changeEndMonthAriaLabel?: string;
-  changeEndYearAriaLabel?: string;
+  clearFieldLabel?: string;
+  showCalendarLabel?: string;
+  changeStartDayLabel?: string;
+  changeStartMonthLabel?: string;
+  changeStartYearLabel?: string;
+  changeEndDayLabel?: string;
+  changeEndMonthLabel?: string;
+  changeEndYearLabel?: string;
   disableCalendar?: boolean;
 }
 
@@ -117,19 +118,19 @@ export const DateRangeInput = ({
   disabled,
   onClick,
   onFocus,
-  prevMonthAriaLabel,
-  nextMonthAriaLabel,
-  changeDayAriaLabel,
-  changeMonthAriaLabel,
-  changeYearAriaLabel,
-  changeStartDayAriaLabel = 'Изменить день начала',
-  changeStartMonthAriaLabel = 'Изменить месяц начала',
-  changeStartYearAriaLabel = 'Изменить год начала',
-  changeEndDayAriaLabel = 'Изменить день окончания',
-  changeEndMonthAriaLabel = 'Изменить месяц окончания',
-  changeEndYearAriaLabel = 'Изменить год окончания',
-  clearFieldAriaLabel = 'Очистить поле',
-  showCalendarAriaLabel = 'Показать календарь',
+  prevMonthLabel = 'Предыдущий месяц',
+  nextMonthLabel = 'Следующий месяц',
+  changeDayLabel = 'Изменить день',
+  changeMonthLabel = 'Изменить месяц',
+  changeYearLabel = 'Изменить год',
+  changeStartDayLabel = 'Изменить день начала',
+  changeStartMonthLabel = 'Изменить месяц начала',
+  changeStartYearLabel = 'Изменить год начала',
+  changeEndDayLabel = 'Изменить день окончания',
+  changeEndMonthLabel = 'Изменить месяц окончания',
+  changeEndYearLabel = 'Изменить год окончания',
+  clearFieldLabel = 'Очистить поле',
+  showCalendarLabel = 'Показать календарь',
   prevMonthIcon,
   nextMonthIcon,
   disableCalendar = false,
@@ -236,11 +237,13 @@ export const DateRangeInput = ({
       getRootRef={handleRootRef}
       after={
         value ? (
-          <IconButton hoverMode="opacity" aria-label={clearFieldAriaLabel} onClick={clear}>
+          <IconButton hoverMode="opacity" onClick={clear}>
+            <VisuallyHidden>{clearFieldLabel}</VisuallyHidden>
             <Icon16Clear />
           </IconButton>
         ) : (
-          <IconButton hoverMode="opacity" aria-label={showCalendarAriaLabel} onClick={openCalendar}>
+          <IconButton hoverMode="opacity" onClick={openCalendar}>
+            <VisuallyHidden>{showCalendarLabel}</VisuallyHidden>
             <Icon20CalendarOutline />
           </IconButton>
         )
@@ -268,7 +271,7 @@ export const DateRangeInput = ({
           index={0}
           onElementSelect={setFocusedElement}
           value={internalValue[0]}
-          aria-label={changeStartDayAriaLabel}
+          label={changeStartDayLabel}
         />
         <InputLikeDivider>.</InputLikeDivider>
         <InputLike
@@ -277,7 +280,7 @@ export const DateRangeInput = ({
           index={1}
           onElementSelect={setFocusedElement}
           value={internalValue[1]}
-          aria-label={changeStartMonthAriaLabel}
+          label={changeStartMonthLabel}
         />
         <InputLikeDivider>.</InputLikeDivider>
         <InputLike
@@ -286,7 +289,7 @@ export const DateRangeInput = ({
           index={2}
           onElementSelect={setFocusedElement}
           value={internalValue[2]}
-          aria-label={changeStartYearAriaLabel}
+          label={changeStartYearLabel}
         />
         <InputLikeDivider>{' — '}</InputLikeDivider>
         <InputLike
@@ -295,7 +298,7 @@ export const DateRangeInput = ({
           index={3}
           onElementSelect={setFocusedElement}
           value={internalValue[3]}
-          aria-label={changeEndDayAriaLabel}
+          label={changeEndDayLabel}
         />
         <InputLikeDivider>.</InputLikeDivider>
         <InputLike
@@ -304,7 +307,7 @@ export const DateRangeInput = ({
           index={4}
           onElementSelect={setFocusedElement}
           value={internalValue[4]}
-          aria-label={changeEndMonthAriaLabel}
+          label={changeEndMonthLabel}
         />
         <InputLikeDivider>.</InputLikeDivider>
         <InputLike
@@ -313,7 +316,7 @@ export const DateRangeInput = ({
           index={5}
           onElementSelect={setFocusedElement}
           value={internalValue[5]}
-          aria-label={changeEndYearAriaLabel}
+          label={changeEndYearLabel}
         />
       </Text>
       {open && !disableCalendar && (
@@ -327,11 +330,11 @@ export const DateRangeInput = ({
             onClose={closeCalendar}
             getRootRef={calendarRef}
             disablePickers={disablePickers}
-            prevMonthAriaLabel={prevMonthAriaLabel}
-            nextMonthAriaLabel={nextMonthAriaLabel}
-            changeMonthAriaLabel={changeMonthAriaLabel}
-            changeYearAriaLabel={changeYearAriaLabel}
-            changeDayAriaLabel={changeDayAriaLabel}
+            prevMonthLabel={prevMonthLabel}
+            nextMonthLabel={nextMonthLabel}
+            changeMonthLabel={changeMonthLabel}
+            changeYearLabel={changeYearLabel}
+            changeDayLabel={changeDayLabel}
             prevMonthIcon={prevMonthIcon}
             nextMonthIcon={nextMonthIcon}
           />

--- a/packages/vkui/src/components/InputLike/InputLike.tsx
+++ b/packages/vkui/src/components/InputLike/InputLike.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
 import { callMultiple } from '../../lib/callMultiple';
 import { stopPropagation } from '../../lib/utils';
-import { HTMLAttributesWithRootRef } from '../../types';
-import { RootComponent } from '../RootComponent/RootComponent';
+import { RootComponent, type RootComponentProps } from '../RootComponent/RootComponent';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './InputLike.module.css';
 
-export interface InputLikeProps extends HTMLAttributesWithRootRef<HTMLSpanElement> {
+export interface InputLikeProps extends RootComponentProps<HTMLSpanElement> {
   length: number;
   index: number;
   value?: string;
+  label?: string;
   onElementSelect?(index: number): void;
 }
 
@@ -33,7 +34,8 @@ export const InputLike = ({
   onElementSelect,
   onClick,
   onFocus,
-  ...props
+  label,
+  ...restProps
 }: InputLikeProps) => {
   const handleElementSelect = React.useCallback(
     (event: React.MouseEvent<HTMLSpanElement>) => {
@@ -50,8 +52,9 @@ export const InputLike = ({
       tabIndex={0}
       onClick={callMultiple(onClick, handleElementSelect)}
       onFocus={callMultiple(stopPropagation, onFocus)}
-      {...props}
+      {...restProps}
     >
+      {label && <VisuallyHidden>{label}</VisuallyHidden>}
       {value?.slice(0, length - 1)}
       {value?.slice(length - 1) && (
         <span key={index} className={styles['InputLike__last_character']}>

--- a/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
+++ b/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
@@ -49,7 +49,7 @@ export interface ModalCardBaseProps extends HTMLAttributesWithRootRef<HTMLDivEle
   onClose?: VoidFunction;
 
   /**
-   * `aria-label` для кнопки закрытия. Необходим, чтобы кнопка была доступной.
+   * Текст кнопки закрытия. Делает ее доступной для ассистивных технологий
    */
   dismissLabel?: string;
 
@@ -150,11 +150,12 @@ export const ModalCardBase = ({
         {hasReactNode(actions) && <div className={styles['ModalCardBase__actions']}>{actions}</div>}
 
         <ModalCardBaseCloseButton
-          aria-label={dismissLabel}
           testId={modalDismissButtonTestId}
           onClose={onClose}
           mode={dismissButtonMode}
-        />
+        >
+          {dismissLabel}
+        </ModalCardBaseCloseButton>
       </div>
     </RootComponent>
   );

--- a/packages/vkui/src/components/ModalCardBase/ModalCardBaseCloseButton.tsx
+++ b/packages/vkui/src/components/ModalCardBase/ModalCardBaseCloseButton.tsx
@@ -3,18 +3,18 @@ import { Icon20Cancel, Icon24Dismiss } from '@vkontakte/icons';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { usePlatform } from '../../hooks/usePlatform';
 import { ModalDismissButton } from '../ModalDismissButton/ModalDismissButton';
-import { Tappable } from '../Tappable/Tappable';
+import { Tappable, TappableProps } from '../Tappable/Tappable';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './ModalCardBase.module.css';
 
-interface ModalCardBaseCloseButtonProps {
+interface ModalCardBaseCloseButtonProps extends Omit<TappableProps, 'mode' | 'onClose'> {
   onClose?: VoidFunction;
-  dismissLabel?: string;
   testId?: string;
   mode?: 'inside' | 'outside';
 }
 
 export function ModalCardBaseCloseButton({
-  dismissLabel,
+  children = 'Закрыть',
   testId,
   mode,
   onClose,
@@ -23,19 +23,23 @@ export function ModalCardBaseCloseButton({
   const { isDesktop } = useAdaptivityWithJSMediaQueries();
 
   if (isDesktop && mode === 'outside') {
-    return <ModalDismissButton aria-label={dismissLabel} data-testid={testId} onClick={onClose} />;
+    return (
+      <ModalDismissButton data-testid={testId} onClick={onClose}>
+        {children}
+      </ModalDismissButton>
+    );
   }
 
   if (mode === 'inside' || (platform === 'ios' && !isDesktop)) {
     return (
       <Tappable
-        aria-label={dismissLabel}
         className={styles['ModalCardBase__dismiss']}
         onClick={onClose}
         hoverMode="opacity"
         activeMode="opacity"
         data-testid={testId}
       >
+        <VisuallyHidden>{children}</VisuallyHidden>
         {platform === 'ios' ? <Icon24Dismiss /> : <Icon20Cancel />}
       </Tappable>
     );

--- a/packages/vkui/src/components/ModalCardBase/Readme.md
+++ b/packages/vkui/src/components/ModalCardBase/Readme.md
@@ -44,11 +44,16 @@
 Согласно нашим дизайн-гайдам, `dismissButtonMode=outside` отображается только для `compact`-режима (десктопная и планшетные версии).
 Для `iOS` всегда будет применяться `dismissButtonMode=inside` в `regular`-режиме (мобильная версия).
 
+## Цифровая доступность (a11y)
+
+Чтобы кнопка для закрытия была доступной для ассистивных технологий, мы передаем в нее скрытый визуально текст, который сможет прочитать скринридер. Чтобы заменить текст, передайте его в `dismissLabel`.
+
 ```jsx { "props": { "layout": false, "iframe": false } }
 <div style={{ margin: 20 }}>
   <AdaptivityProvider viewWidth={ViewWidth.TABLET}>
     <ModalCardBase
       dismissButtonMode="inside"
+      dismissLabel="Закрыть"
       style={{ width: 450, marginBottom: 20 }}
       header="Десктопная и планшетная версии с крестиком внутри"
       subheader="Сверху будет безопасный отступ до иконки"

--- a/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.tsx
+++ b/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { Icon20Cancel } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
-import { HTMLAttributesWithRootRef } from '../../types';
-import { Tappable } from '../Tappable/Tappable';
+import { Tappable, type TappableProps } from '../Tappable/Tappable';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './ModalDismissButton.module.css';
 
-export type ModalDismissButtonProps = HTMLAttributesWithRootRef<HTMLButtonElement>;
+export type ModalDismissButtonProps = Omit<TappableProps, 'mode' | 'onClose'>;
 
 /**
  * @see https://vkcom.github.io/VKUI/#/ModalDismissButton
  */
 export const ModalDismissButton = ({
-  'aria-label': ariaLabel = 'Закрыть',
+  children = 'Закрыть',
   className,
   ...restProps
 }: ModalDismissButtonProps) => {
@@ -19,10 +19,10 @@ export const ModalDismissButton = ({
     <Tappable
       className={classNames(styles['ModalDismissButton'], className)}
       {...restProps}
-      aria-label={ariaLabel}
       activeMode={styles['ModalDismissButton--active']}
       hoverMode={styles['ModalDismissButton--hover']}
     >
+      {children && <VisuallyHidden>{children}</VisuallyHidden>}
       <Icon20Cancel />
     </Tappable>
   );

--- a/packages/vkui/src/components/ModalDismissButton/Readme.md
+++ b/packages/vkui/src/components/ModalDismissButton/Readme.md
@@ -1,6 +1,10 @@
 Кнопка для закрытия модальных окон на широком экране.
 Для правильной отрисовки нужно расположить в контейнере с `position: "relative"` и отображать при достаточной ширине экрана (от `ViewWidth.SMALL_TABLET`)
 
+## Цифровая доступность (a11y)
+
+Чтобы кнопка была доступной для ассистивных технологий, мы передаем в нее скрытый визуально текст, который сможет прочитать скринридер. Сейчас по умолчанию это — "Закрыть". Чтобы заменить текст, передайте его в `children`.
+
 ```jsx { "props": { "layout": false, "adaptivity": true } }
 const CustomPopout = ({ onClose }) => {
   const { sizeX } = useAdaptivityConditionalRender();
@@ -17,7 +21,9 @@ const CustomPopout = ({ onClose }) => {
         <h4>Кастомное модальное окно</h4>
 
         {sizeX.regular && (
-          <ModalDismissButton className={sizeX.regular.className} onClick={onClose} />
+          <ModalDismissButton className={sizeX.regular.className} onClick={onClose}>
+            Закрыть кастомное модальное окно
+          </ModalDismissButton>
         )}
       </div>
     </PopoutWrapper>

--- a/packages/vkui/src/components/Pagination/Pagination.tsx
+++ b/packages/vkui/src/components/Pagination/Pagination.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { Icon24ChevronCompactLeft, Icon24ChevronCompactRight } from '@vkontakte/icons';
 import { PaginationPageType, usePagination } from '../../hooks/usePagination';
-import type { HTMLAttributesWithRootRef } from '../../types';
+import type { HasComponent, HTMLAttributesWithRootRef } from '../../types';
 import { Button } from '../Button/Button';
 import { RootComponent } from '../RootComponent/RootComponent';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { PaginationPageButton } from './PaginationPage/PaginationPageButton';
 import { PaginationPageEllipsis } from './PaginationPage/PaginationPageEllipsis';
-import { getPageAriaLabelDefault } from './utils';
+import { getPageLabelDefault } from './utils';
 import styles from './Pagination.module.css';
 
 export interface PaginationProps extends Omit<HTMLAttributesWithRootRef<HTMLElement>, 'onChange'> {
@@ -31,20 +32,26 @@ export interface PaginationProps extends Omit<HTMLAttributesWithRootRef<HTMLElem
    */
   disabled?: boolean;
   /**
-   * Переопределение `aria-label` для кнопки навигации назад.
+   * Переопределение текста для обозначения блока навигации.
    * По умолчанию используется текст на "ru_RU".
    */
-  prevButtonAriaLabel?: string;
+  navigationLabel?: string;
+  navigationLabelComponent?: HasComponent['Component'];
   /**
-   * Переопределение `aria-label` для кнопки навигации вперёд.
+   * Переопределение текста для кнопки навигации назад.
    * По умолчанию используется текст на "ru_RU".
    */
-  nextButtonAriaLabel?: string;
+  prevButtonLabel?: string;
   /**
-   * Функция для переопределения и/или локализации `aria-label` атрибута.
+   * Переопределение текста для кнопки навигации вперёд.
    * По умолчанию используется текст на "ru_RU".
    */
-  getPageAriaLabel?(page: number, isCurrent: boolean): string;
+  nextButtonLabel?: string;
+  /**
+   * Функция для переопределения и/или локализации текста кнопки страницы.
+   * По умолчанию используется текст на "ru_RU".
+   */
+  getPageLabel?(isCurrent: boolean): string;
   onChange?(page: number): void;
 }
 
@@ -57,9 +64,11 @@ export const Pagination = ({
   boundaryCount = 1,
   totalPages = 1,
   disabled,
-  getPageAriaLabel = getPageAriaLabelDefault,
-  prevButtonAriaLabel = 'Перейти на предыдущую страницу',
-  nextButtonAriaLabel = 'Перейти на следующую страницу',
+  getPageLabel = getPageLabelDefault,
+  navigationLabel = 'Навигация по страницам',
+  navigationLabelComponent = 'h2',
+  prevButtonLabel = 'Перейти на предыдущую страницу',
+  nextButtonLabel = 'Перейти на следующую страницу',
   onChange,
   ...resetProps
 }: PaginationProps) => {
@@ -107,7 +116,7 @@ export const Pagination = ({
           return (
             <li key={page}>
               <PaginationPageButton
-                getPageAriaLabel={getPageAriaLabel}
+                getPageLabel={getPageLabel}
                 isCurrent={isCurrent}
                 onClick={handleClick}
                 disabled={disabled}
@@ -119,25 +128,25 @@ export const Pagination = ({
         }
       }
     },
-    [currentPage, disabled, getPageAriaLabel, handleClick],
+    [currentPage, disabled, getPageLabel, handleClick],
   );
 
   return (
-    <RootComponent
-      Component="nav"
-      role="navigation"
-      aria-label="Навигация по страницам"
-      {...resetProps}
-    >
+    <RootComponent Component="nav" role="navigation" {...resetProps}>
+      <VisuallyHidden Component={navigationLabelComponent}>{navigationLabel}</VisuallyHidden>
       <ul className={styles['Pagination__list']}>
         <li className={styles['Pagination__prevButtonContainer']}>
           <Button
             size="l"
-            before={<Icon24ChevronCompactLeft width={24} />}
+            before={
+              <>
+                <VisuallyHidden>{prevButtonLabel}</VisuallyHidden>{' '}
+                <Icon24ChevronCompactLeft width={24} />
+              </>
+            }
             appearance="accent"
             mode="tertiary"
             disabled={isFirstPage || disabled}
-            aria-label={prevButtonAriaLabel}
             onClick={handlePrevClick}
           />
         </li>
@@ -145,11 +154,15 @@ export const Pagination = ({
         <li className={styles['Pagination__nextButtonContainer']}>
           <Button
             size="l"
-            after={<Icon24ChevronCompactRight width={24} />}
+            after={
+              <>
+                <VisuallyHidden>{nextButtonLabel}</VisuallyHidden>
+                <Icon24ChevronCompactRight width={24} />
+              </>
+            }
             appearance="accent"
             mode="tertiary"
             disabled={isLastPage || disabled}
-            aria-label={nextButtonAriaLabel}
             onClick={handleNextClick}
           />
         </li>

--- a/packages/vkui/src/components/Pagination/PaginationPage/PaginationPageButton.tsx
+++ b/packages/vkui/src/components/Pagination/PaginationPage/PaginationPageButton.tsx
@@ -3,25 +3,23 @@ import { classNames } from '@vkontakte/vkjs';
 import type { HasRootRef } from '../../../types';
 import { Tappable } from '../../Tappable/Tappable';
 import { Text } from '../../Typography/Text/Text';
-import { getPageAriaLabelDefault } from '../utils';
+import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
+import { PaginationProps } from '../Pagination';
+import { getPageLabelDefault } from '../utils';
 import { usePaginationPageClassNames } from './usePaginationPageClasses';
 import styles from './PaginationPage.module.css';
 
 export interface PaginationPageButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    HasRootRef<HTMLButtonElement> {
+    HasRootRef<HTMLButtonElement>,
+    Pick<PaginationProps, 'getPageLabel'> {
   isCurrent?: boolean;
-  /**
-   * Функция для переопределения и/или локализации `aria-label` атрибута.
-   * По умолчанию используется текст на "ru_RU".
-   */
-  getPageAriaLabel?(page: number, isCurrent: boolean): string;
   children: number;
 }
 
 export const PaginationPageButton = ({
   isCurrent = false,
-  getPageAriaLabel = getPageAriaLabelDefault,
+  getPageLabel = getPageLabelDefault,
   children,
   className,
   disabled,
@@ -39,11 +37,13 @@ export const PaginationPageButton = ({
       focusVisibleMode="outside"
       data-page={children}
       aria-current={isCurrent ? true : undefined}
-      aria-label={getPageAriaLabel(children, isCurrent)}
       disabled={disabled}
       {...restProps}
     >
-      <Text normalize={false}>{children}</Text>
+      <Text normalize={false}>
+        <VisuallyHidden>{getPageLabel(isCurrent)} </VisuallyHidden>
+        {children}
+      </Text>
     </Tappable>
   );
 };

--- a/packages/vkui/src/components/Pagination/utils.ts
+++ b/packages/vkui/src/components/Pagination/utils.ts
@@ -1,3 +1,3 @@
-export function getPageAriaLabelDefault(page: number, isCurrent: boolean): string {
-  return isCurrent ? `${page} страница` : `Перейти на ${page} страницу`;
+export function getPageLabelDefault(isCurrent: boolean): string {
+  return isCurrent ? `Cтраница` : `Перейти на страницу`;
 }

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.stories.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.stories.tsx
@@ -23,6 +23,7 @@ import { Search } from '../Search/Search';
 import { Tabs } from '../Tabs/Tabs';
 import { TabsItem } from '../TabsItem/TabsItem';
 import { View } from '../View/View';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { PanelHeader, PanelHeaderProps } from './PanelHeader';
 
 const story: Meta<PanelHeaderProps> = {
@@ -59,13 +60,14 @@ export const PanelHeaderWithCounter: Story = {
             before={<PanelHeaderBack label={platform === 'vkcom' ? 'Назад' : undefined} />}
             after={
               <PanelHeaderButton
-                aria-label="Изображения"
                 label={
-                  <Counter size="s" mode="prominent" aria-label="Обновлений: ">
+                  <Counter size="s" mode="prominent">
+                    <VisuallyHidden>Новых: </VisuallyHidden>
                     21
                   </Counter>
                 }
               >
+                <VisuallyHidden>Изображения</VisuallyHidden>
                 <AdaptiveIconRenderer
                   IconCompact={Icon24PictureOutline}
                   IconRegular={Icon28PictureOutline}
@@ -91,26 +93,26 @@ export const PanelHeaderWithMultipleIcons: Story = {
           after={
             <React.Fragment>
               <PanelHeaderButton
-                aria-label="Настройки"
                 label={
-                  <Counter size="s" mode="prominent" aria-label="Новые настройки: ">
-                    3
+                  <Counter size="s" mode="prominent">
+                    <VisuallyHidden>Новых: </VisuallyHidden>3
                   </Counter>
                 }
               >
+                <VisuallyHidden>Настройки</VisuallyHidden>
                 <AdaptiveIconRenderer
                   IconCompact={Icon24GearOutline}
                   IconRegular={Icon28SettingsOutline}
                 />
               </PanelHeaderButton>
               <PanelHeaderButton
-                aria-label="Уведомления"
                 label={
-                  <Counter size="s" mode="prominent" aria-label="Уведомлений: ">
+                  <Counter size="s" mode="prominent">
                     2
                   </Counter>
                 }
               >
+                <VisuallyHidden>Уведомления</VisuallyHidden>
                 <AdaptiveIconRenderer
                   IconCompact={Icon24NotificationOutline}
                   IconRegular={Icon28Notifications}

--- a/packages/vkui/src/components/PanelHeader/Readme.md
+++ b/packages/vkui/src/components/PanelHeader/Readme.md
@@ -46,7 +46,6 @@ const Example = () => {
             }
             after={
               <PanelHeaderButton
-                aria-label="Изображения"
                 label={
                   <Counter size="s" mode="prominent">
                     <VisuallyHidden>Обновлений: </VisuallyHidden>
@@ -54,6 +53,7 @@ const Example = () => {
                   </Counter>
                 }
               >
+                <VisuallyHidden>Изображения</VisuallyHidden>
                 <AdaptiveIconRenderer
                   IconCompact={Icon24PictureOutline}
                   IconRegular={Icon28PictureOutline}
@@ -73,20 +73,19 @@ const Example = () => {
             after={
               <React.Fragment>
                 <PanelHeaderButton
-                  aria-label="Настройки"
                   label={
                     <Counter size="s" mode="prominent">
                       <VisuallyHidden>Новых: </VisuallyHidden>3
                     </Counter>
                   }
                 >
+                  <VisuallyHidden>Настройки</VisuallyHidden>
                   <AdaptiveIconRenderer
                     IconCompact={Icon24GearOutline}
                     IconRegular={Icon28SettingsOutline}
                   />
                 </PanelHeaderButton>
                 <PanelHeaderButton
-                  aria-label="Уведомления"
                   label={
                     <Counter size="s" mode="prominent">
                       2
@@ -97,6 +96,7 @@ const Example = () => {
                     IconCompact={Icon24NotificationOutline}
                     IconRegular={Icon28Notifications}
                   />
+                  <VisuallyHidden>Уведомления</VisuallyHidden>
                 </PanelHeaderButton>
               </React.Fragment>
             }

--- a/packages/vkui/src/components/PanelHeaderBack/PanelHeaderBack.tsx
+++ b/packages/vkui/src/components/PanelHeaderBack/PanelHeaderBack.tsx
@@ -12,11 +12,12 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { PlatformType } from '../../lib/platform';
 import { AdaptiveIconRenderer } from '../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { PanelHeaderButton, PanelHeaderButtonProps } from '../PanelHeaderButton/PanelHeaderButton';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from '../PanelHeaderButton/PanelHeaderButton.module.css';
 
-export type PanelHeaderBackProps = PanelHeaderButtonProps & {
-  'aria-label'?: string;
-};
+export interface PanelHeaderBackProps extends Omit<PanelHeaderButtonProps, 'children'> {
+  children?: string;
+}
 
 const getBackIcon = (platform: PlatformType) => {
   switch (platform) {
@@ -44,13 +45,13 @@ const getBackIcon = (platform: PlatformType) => {
  */
 export const PanelHeaderBack = ({
   label,
-  'aria-label': ariaLabel = 'Назад',
   className,
+  children = 'Назад',
   ...restProps
 }: PanelHeaderButtonProps) => {
   const platform = usePlatform();
   const { sizeX = 'none' } = useAdaptivity();
-  // так-же label нужно скрывать при platform === 'ios' && sizeX === regular
+  // также label нужно скрывать при platform === 'ios' && sizeX === regular
   // https://github.com/VKCOM/VKUI/blob/master/src/components/PanelHeaderButton/PanelHeaderButton.css#L104
   const showLabel = platform === 'vkcom' || platform === 'ios';
 
@@ -65,8 +66,8 @@ export const PanelHeaderBack = ({
         className,
       )}
       label={showLabel && label}
-      aria-label={ariaLabel}
     >
+      {children && <VisuallyHidden>{children}</VisuallyHidden>}
       {getBackIcon(platform)}
     </PanelHeaderButton>
   );

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { classNames, isPrimitiveReactNode } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';
-import { getTitleFromChildren } from '../../lib/utils';
-import { warnOnce } from '../../lib/warnOnce';
+import { hasAccessibleName } from '../../lib/accessibility';
+import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
 import { Tappable, TappableProps } from '../Tappable/Tappable';
 import { Text } from '../Typography/Text/Text';
 import { Title } from '../Typography/Title/Title';
@@ -71,18 +71,14 @@ export const PanelHeaderButton = ({
   }
 
   if (process.env.NODE_ENV === 'development') {
-    const hasAccessibleName = Boolean(
-      getTitleFromChildren(children) ||
-        getTitleFromChildren(label) ||
-        restProps['aria-label'] ||
-        restProps['aria-labelledby'],
-    );
+    /* istanbul ignore next: проверка в dev mode, тест на hasAccessibleName() есть в lib/accessibility.test.tsx */
+    const isAccessible = hasAccessibleName({
+      children: [children, label],
+      ...restProps,
+    });
 
-    if (!hasAccessibleName) {
-      warn(
-        'a11y: У кнопки нет названия, которое может прочитать скринридер, и она недоступна для части пользователей. Замените содержимое на текст или добавьте описание действия с помощью пропа aria-label.',
-        'error',
-      );
+    if (!isAccessible) {
+      warn(COMMON_WARNINGS.a11y[restProps.href ? 'link-name' : 'button-name'], 'error');
     }
   }
 

--- a/packages/vkui/src/components/PanelHeaderClose/PanelHeaderClose.tsx
+++ b/packages/vkui/src/components/PanelHeaderClose/PanelHeaderClose.tsx
@@ -1,21 +1,28 @@
 import * as React from 'react';
 import { Icon24CancelOutline, Icon28CancelOutline } from '@vkontakte/icons';
 import { usePlatform } from '../../hooks/usePlatform';
-import { getTitleFromChildren } from '../../lib/utils';
 import { AdaptiveIconRenderer } from '../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { PanelHeaderButton, PanelHeaderButtonProps } from '../PanelHeaderButton/PanelHeaderButton';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
 /**
  * @see https://vkcom.github.io/VKUI/#/PanelHeaderButton
  */
 export const PanelHeaderClose = ({ children = 'Отмена', ...restProps }: PanelHeaderButtonProps) => {
   const platform = usePlatform();
+
   return (
-    <PanelHeaderButton aria-label={getTitleFromChildren(children)} {...restProps}>
+    <PanelHeaderButton {...restProps}>
       {platform === 'ios' ? (
         children
       ) : (
-        <AdaptiveIconRenderer IconCompact={Icon24CancelOutline} IconRegular={Icon28CancelOutline} />
+        <>
+          <VisuallyHidden>{children}</VisuallyHidden>
+          <AdaptiveIconRenderer
+            IconCompact={Icon24CancelOutline}
+            IconRegular={Icon28CancelOutline}
+          />
+        </>
       )}
     </PanelHeaderButton>
   );

--- a/packages/vkui/src/components/PanelHeaderEdit/PanelHeaderEdit.tsx
+++ b/packages/vkui/src/components/PanelHeaderEdit/PanelHeaderEdit.tsx
@@ -8,6 +8,7 @@ import {
 import { usePlatform } from '../../hooks/usePlatform';
 import { AdaptiveIconRenderer } from '../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { PanelHeaderButton, PanelHeaderButtonProps } from '../PanelHeaderButton/PanelHeaderButton';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
 export interface PanelHeaderEditProps extends PanelHeaderButtonProps {
   /**
@@ -15,11 +16,11 @@ export interface PanelHeaderEditProps extends PanelHeaderButtonProps {
    */
   isActive?: boolean;
   /**
-   * iOS only. Текст кнопки, когда режим редактирования не активен
+   * Текст кнопки, когда режим редактирования не активен. Визуально скрыт везде, кроме iOS
    */
   editLabel?: string;
   /**
-   * iOS only. Текст кнопки при активном режиме редактирования для выхода из него
+   * Текст кнопки при активном режиме редактирования для выхода из него. Визуально скрыт везде, кроме iOS
    */
   doneLabel?: string;
 }
@@ -33,18 +34,21 @@ export const PanelHeaderEdit = ({
   doneLabel = 'Готово',
   ...restProps
 }: PanelHeaderEditProps) => {
-  const iOSText = isActive ? doneLabel : editLabel;
   const platform = usePlatform();
+  const label = isActive ? doneLabel : editLabel;
 
   return (
-    <PanelHeaderButton aria-label={iOSText} {...restProps}>
+    <PanelHeaderButton {...restProps}>
       {platform === 'ios' ? (
-        iOSText
+        label
       ) : (
-        <AdaptiveIconRenderer
-          IconCompact={isActive ? Icon24DoneOutline : Icon24PenOutline}
-          IconRegular={isActive ? Icon28DoneOutline : Icon28EditOutline}
-        />
+        <>
+          <VisuallyHidden>{label}</VisuallyHidden>
+          <AdaptiveIconRenderer
+            IconCompact={isActive ? Icon24DoneOutline : Icon24PenOutline}
+            IconRegular={isActive ? Icon28DoneOutline : Icon28EditOutline}
+          />
+        </>
       )}
     </PanelHeaderButton>
   );

--- a/packages/vkui/src/components/PanelHeaderSubmit/PanelHeaderSubmit.tsx
+++ b/packages/vkui/src/components/PanelHeaderSubmit/PanelHeaderSubmit.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Icon24DoneOutline, Icon28DoneOutline } from '@vkontakte/icons';
 import { usePlatform } from '../../hooks/usePlatform';
-import { getTitleFromChildren } from '../../lib/utils';
 import { AdaptiveIconRenderer } from '../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { PanelHeaderButton, PanelHeaderButtonProps } from '../PanelHeaderButton/PanelHeaderButton';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
 /**
  * @see https://vkcom.github.io/VKUI/#/PanelHeaderButton
@@ -15,11 +15,14 @@ export const PanelHeaderSubmit = ({
   const platform = usePlatform();
 
   return (
-    <PanelHeaderButton aria-label={getTitleFromChildren(children)} primary {...restProps}>
+    <PanelHeaderButton primary {...restProps}>
       {platform === 'ios' ? (
         children
       ) : (
-        <AdaptiveIconRenderer IconCompact={Icon24DoneOutline} IconRegular={Icon28DoneOutline} />
+        <>
+          <VisuallyHidden>{children}</VisuallyHidden>
+          <AdaptiveIconRenderer IconCompact={Icon24DoneOutline} IconRegular={Icon28DoneOutline} />
+        </>
       )}
     </PanelHeaderButton>
   );

--- a/packages/vkui/src/components/Removable/Removable.tsx
+++ b/packages/vkui/src/components/Removable/Removable.tsx
@@ -3,8 +3,8 @@ import { Icon24Cancel } from '@vkontakte/icons';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 import { usePlatform } from '../../hooks/usePlatform';
+import { getTextFromChildren } from '../../lib/children';
 import { useDOM } from '../../lib/dom';
-import { getTitleFromChildren } from '../../lib/utils';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { IconButton } from '../IconButton/IconButton';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -170,7 +170,7 @@ export const Removable = ({
     onRemove(e);
   };
 
-  const removePlaceholderString: string = getTitleFromChildren(removePlaceholder);
+  const removePlaceholderString: string = getTextFromChildren(removePlaceholder);
 
   return (
     <RootComponent

--- a/packages/vkui/src/components/ScrollArrow/ScrollArrow.test.tsx
+++ b/packages/vkui/src/components/ScrollArrow/ScrollArrow.test.tsx
@@ -6,9 +6,7 @@ import { ScrollArrow } from './ScrollArrow';
 import styles from './ScrollArrow.module.css';
 
 describe(ScrollArrow, () => {
-  baselineComponent((props) => (
-    <ScrollArrow direction="left" aria-label="ScrollArrow" {...props} />
-  ));
+  baselineComponent((props) => <ScrollArrow direction="left" {...props} />);
 
   it('should have HTML style attribute for offsetY prop', () => {
     const offsetY = 10;

--- a/packages/vkui/src/components/ScrollArrow/ScrollArrow.tsx
+++ b/packages/vkui/src/components/ScrollArrow/ScrollArrow.tsx
@@ -3,6 +3,7 @@ import { Icon16Chevron, Icon24Chevron } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
 import { HasRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './ScrollArrow.module.css';
 
 const stylesSize = {
@@ -15,6 +16,13 @@ const stylesDirection = {
   right: styles['ScrollArrow--direction-right'],
   down: styles['ScrollArrow--direction-down'],
   left: styles['ScrollArrow--direction-left'],
+};
+
+const labelDirection = {
+  up: 'Назад',
+  right: 'Вперед',
+  down: 'Вперед',
+  left: 'Назад',
 };
 
 const ArrowIcon = ({ size }: Pick<ScrollArrowProps, 'size'>) => {
@@ -41,10 +49,11 @@ export interface ScrollArrowProps
    * Смещает иконку кнопки навигации по вертикали.
    */
   offsetY?: number | string;
+  label?: string;
 }
 
 /**
- * Компонент стрелки из HorizontalScroll
+ * Компонент стрелки. Используется в [HorizontalScroll](#/HorizontalScroll) и [Gallery](#/Gallery).
  *
  * @since 5.4.0
  * @see https://vkcom.github.io/VKUI/#/ScrollArrow
@@ -53,9 +62,12 @@ export const ScrollArrow = ({
   size = 'l',
   offsetY,
   direction,
+  label: labelProp,
   children = <ArrowIcon size={size} />,
   ...restProps
 }: ScrollArrowProps) => {
+  const label = labelProp ?? labelDirection[direction];
+
   return (
     <RootComponent
       Component="button"
@@ -67,6 +79,7 @@ export const ScrollArrow = ({
       )}
       {...restProps}
     >
+      {label && <VisuallyHidden>{label}</VisuallyHidden>}
       <span className={styles['ScrollArrow__icon']} style={offsetY ? { top: offsetY } : undefined}>
         {children}
       </span>

--- a/packages/vkui/src/components/Search/Readme.md
+++ b/packages/vkui/src/components/Search/Readme.md
@@ -46,7 +46,8 @@ const SimpleSearch = ({ goHeaderSearch }) => {
     <React.Fragment>
       <PanelHeader
         after={
-          <PanelHeaderButton aria-label="Добавить" onClick={goHeaderSearch}>
+          <PanelHeaderButton onClick={goHeaderSearch}>
+            <VisuallyHidden>Добавить</VisuallyHidden>
             <Icon28AddOutline />
           </PanelHeaderButton>
         }
@@ -131,14 +132,22 @@ const SearchExample = () => {
               <ModalPageHeader
                 before={
                   platform === 'android' && (
-                    <PanelHeaderButton aria-label="Отмена" onClick={hideModal}>
+                    <PanelHeaderButton onClick={hideModal}>
+                      <VisuallyHidden>Отмена</VisuallyHidden>
                       <Icon24Cancel />
                     </PanelHeaderButton>
                   )
                 }
                 after={
-                  <PanelHeaderButton aria-label="Готово" onClick={hideModal}>
-                    {platform === 'ios' ? 'Готово' : <Icon24Done />}
+                  <PanelHeaderButton onClick={hideModal}>
+                    {platform === 'ios' ? (
+                      'Готово'
+                    ) : (
+                      <>
+                        <VisuallyHidden>Готово</VisuallyHidden>
+                        <Icon24Done />
+                      </>
+                    )}
                   </PanelHeaderButton>
                 }
               >

--- a/packages/vkui/src/components/Search/Search.tsx
+++ b/packages/vkui/src/components/Search/Search.tsx
@@ -13,6 +13,7 @@ import { Button } from '../Button/Button';
 import { IconButton } from '../IconButton/IconButton';
 import { TouchEvent } from '../Touch/Touch';
 import { Headline } from '../Typography/Headline/Headline';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './Search.module.css';
 
 export interface SearchProps
@@ -27,8 +28,8 @@ export interface SearchProps
   icon?: React.ReactNode;
   onIconClick?(e: VKUITouchEvent): void;
   defaultValue?: string;
-  iconAriaLabel?: string;
-  clearAriaLabel?: string;
+  iconLabel?: string;
+  clearLabel?: string;
   /**
    * Удаляет отступы у компонента
    */
@@ -60,8 +61,8 @@ export const Search = ({
   autoComplete = 'off',
   onChange: onChangeProp,
   value: valueProp,
-  iconAriaLabel,
-  clearAriaLabel = 'Очистить',
+  iconLabel,
+  clearLabel = 'Очистить',
   noPadding,
   getRootRef,
   findButtonText = 'Найти',
@@ -173,8 +174,8 @@ export const Search = ({
               className={styles['Search__icon']}
               onFocus={setFocusedTrue}
               onBlur={setFocusedFalse}
-              label={iconAriaLabel}
             >
+              <VisuallyHidden>{iconLabel}</VisuallyHidden>
               {icon}
             </IconButton>
           )}
@@ -183,9 +184,9 @@ export const Search = ({
             onStart={onIconCancelClickStart}
             onClick={onCancel}
             className={styles['Search__icon']}
-            label={clearAriaLabel}
             tabIndex={value ? undefined : -1}
           >
+            <VisuallyHidden>{clearLabel}</VisuallyHidden>
             {platform === 'ios' ? <Icon16Clear /> : <Icon24Cancel />}
           </IconButton>
           {adaptiveSizeY.compact && onFindButtonClick && (

--- a/packages/vkui/src/components/TabbarItem/Readme.md
+++ b/packages/vkui/src/components/TabbarItem/Readme.md
@@ -1,5 +1,14 @@
 Элемент [Tabbar](#!/Tabbar). В качестве `children` рекомендуется использовать [иконку](https://vkcom.github.io/icons) 28 размера.
 
+## Цифровая доступность (a11y)
+
+Чтобы `TabbarItem` был доступным для ассистивных технологий, у него должен быть текст, который сможет прочитать скринридер. Если вы не передаете `text`, то передайте одновременно с иконкой текст, обернутый в компонент [VisuallyHidden](#!/VisuallyHidden).
+
+Как еще можно это сделать:
+
+- Передать `aria-label` или `title`.
+- Создать отдельный элемент с текстом и передать его `id` в `aria-labelledby` кнопки.
+
 ```jsx { "props": { "layout": false, "iframe": false } }
 const [simple, setSimple] = useState('one');
 const [text, setText] = useState('one');
@@ -14,10 +23,12 @@ const [indicator, setIndicator] = useState('one');
 >
   <div style={{ maxWidth: 768, margin: 'auto' }}>
     <Tabbar style={{ position: 'static', margin: '0 0 10px' }}>
-      <TabbarItem selected={simple === 'one'} onClick={() => setSimple('one')} aria-label="Новости">
+      <TabbarItem selected={simple === 'one'} onClick={() => setSimple('one')}>
+        <VisuallyHidden>Новости</VisuallyHidden>
         <Icon28NewsfeedOutline />
       </TabbarItem>
-      <TabbarItem selected={simple === 'two'} onClick={() => setSimple('two')} aria-label="Профиль">
+      <TabbarItem selected={simple === 'two'} onClick={() => setSimple('two')}>
+        <VisuallyHidden>Профиль</VisuallyHidden>
         <Icon28UserCircleOutline />
       </TabbarItem>
     </Tabbar>

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
-import { HasComponent, HasRootRef } from '../../types';
-import { RootComponent } from '../RootComponent/RootComponent';
+import { RootComponent, type RootComponentProps } from '../RootComponent/RootComponent';
 import styles from './VisuallyHidden.module.css';
 
-interface VisuallyHiddenProps
-  extends React.AllHTMLAttributes<HTMLElement>,
-    HasRootRef<HTMLElement>,
-    HasComponent {}
+export type VisuallyHiddenProps<T> = RootComponentProps<T>;
 
 /**
  * Компонент-обертка. Позволяет скрыть контент визуально, но оставить его
@@ -15,6 +11,9 @@ interface VisuallyHiddenProps
  * @since v5.4.0
  * @see https://vkcom.github.io/VKUI/#/VisuallyHidden
  */
-export const VisuallyHidden = ({ Component = 'span', ...restProps }: VisuallyHiddenProps) => (
+export const VisuallyHidden = <T,>({
+  Component = 'span',
+  ...restProps
+}: VisuallyHiddenProps<T>) => (
   <RootComponent Component={Component} {...restProps} baseClassName={styles['VisuallyHidden']} />
 );

--- a/packages/vkui/src/components/WriteBar/Readme.md
+++ b/packages/vkui/src/components/WriteBar/Readme.md
@@ -72,15 +72,11 @@ const WriteBarExample = (props) => {
             before={<WriteBarIcon mode="attach" />}
             after={
               <>
-                <WriteBarIcon aria-label="Эмоджи и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                <WriteBarIcon label="Эмоджи и стикеры">{SmileOutlineIcon}</WriteBarIcon>
 
-                <WriteBarIcon aria-label="Записать видео-сообщение">
-                  {CameraOutlineIcon}
-                </WriteBarIcon>
+                <WriteBarIcon label="Записать видео-сообщение">{CameraOutlineIcon}</WriteBarIcon>
 
-                <WriteBarIcon aria-label="Записать голосовое сообщение">
-                  {VoiceOutlineIcon}
-                </WriteBarIcon>
+                <WriteBarIcon label="Записать голосовое сообщение">{VoiceOutlineIcon}</WriteBarIcon>
               </>
             }
             placeholder="Сообщение"
@@ -95,22 +91,20 @@ const WriteBarExample = (props) => {
             inlineAfter={
               <>
                 {text2.length === 0 && (
-                  <WriteBarIcon aria-label="Открыть меню бота">
-                    {KeyboardBotsOutlineIcon}
-                  </WriteBarIcon>
+                  <WriteBarIcon label="Открыть меню бота">{KeyboardBotsOutlineIcon}</WriteBarIcon>
                 )}
                 {text2.length > 0 && (
-                  <WriteBarIcon aria-label="Эмоджи и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                  <WriteBarIcon label="Эмоджи и стикеры">{SmileOutlineIcon}</WriteBarIcon>
                 )}
               </>
             }
             after={
               <>
                 {text2.length === 0 && (
-                  <WriteBarIcon aria-label="Эмоджи и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                  <WriteBarIcon label="Эмоджи и стикеры">{SmileOutlineIcon}</WriteBarIcon>
                 )}
                 {text2.length === 0 && (
-                  <WriteBarIcon aria-label="Записать голосовое сообщение">
+                  <WriteBarIcon label="Записать голосовое сообщение">
                     {VoiceOutlineIcon}
                   </WriteBarIcon>
                 )}
@@ -128,13 +122,13 @@ const WriteBarExample = (props) => {
             before={<WriteBarIcon mode="attach" />}
             inlineAfter={
               text3.length > 0 && (
-                <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
               )
             }
             after={
               <>
                 {text3.length === 0 && (
-                  <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                  <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
                 )}
                 <WriteBarIcon mode="send" disabled={text3.length === 0} />
               </>
@@ -150,13 +144,13 @@ const WriteBarExample = (props) => {
             before={<WriteBarIcon mode="attach" />}
             inlineAfter={
               text4.length > 0 && (
-                <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
               )
             }
             after={
               <>
                 {text4.length === 0 && (
-                  <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                  <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
                 )}
                 <WriteBarIcon mode="done" disabled={text4.length === 0} />
               </>
@@ -188,16 +182,16 @@ const WriteBarExample = (props) => {
               }
               inlineAfter={
                 text.length > 0 && (
-                  <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                  <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
                 )
               }
               after={
                 <>
                   {text.length === 0 && (
-                    <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+                    <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
                   )}
                   {text.length === 0 && (
-                    <WriteBarIcon aria-label="Записать голосовое сообщение">
+                    <WriteBarIcon label="Записать голосовое сообщение">
                       {VoiceOutlineIcon}
                     </WriteBarIcon>
                   )}

--- a/packages/vkui/src/components/WriteBar/WriteBar.e2e-playground.tsx
+++ b/packages/vkui/src/components/WriteBar/WriteBar.e2e-playground.tsx
@@ -37,18 +37,16 @@ const WriteBarTestComponent = ({ value, ...restProps }: WriteBarProps) => {
       before={<WriteBarIcon mode="attach" count={5} />}
       inlineAfter={
         stringValue.length > 0 && (
-          <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+          <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
         )
       }
       after={
         <>
           {stringValue.length === 0 && (
-            <WriteBarIcon aria-label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
+            <WriteBarIcon label="Смайлы и стикеры">{SmileOutlineIcon}</WriteBarIcon>
           )}
           {stringValue.length === 0 && (
-            <WriteBarIcon aria-label="Записать голосовое сообщение">
-              {VoiceOutlineIcon}
-            </WriteBarIcon>
+            <WriteBarIcon label="Записать голосовое сообщение">{VoiceOutlineIcon}</WriteBarIcon>
           )}
           {stringValue.length > 0 && <WriteBarIcon mode="send" />}
         </>
@@ -77,7 +75,7 @@ export const WriteBarPlayground = (props: ComponentPlaygroundProps) => {
 };
 
 const WriteBarIosSmileIcon = (
-  <WriteBarIcon aria-label="Смайлы и стикеры">
+  <WriteBarIcon label="Смайлы и стикеры">
     <Icon28SmileOutline />
   </WriteBarIcon>
 );

--- a/packages/vkui/src/components/WriteBar/WriteBar.stories.tsx
+++ b/packages/vkui/src/components/WriteBar/WriteBar.stories.tsx
@@ -20,7 +20,7 @@ export const Playground: Story = {
     before: <WriteBarIcon count={10} mode="attach" />,
     placeholder: 'Сообщение',
     inlineAfter: (
-      <WriteBarIcon aria-label="Смайлы и стикеры">
+      <WriteBarIcon label="Смайлы и стикеры">
         <Icon28SmileOutline />
       </WriteBarIcon>
     ),

--- a/packages/vkui/src/components/WriteBarIcon/Readme.md
+++ b/packages/vkui/src/components/WriteBarIcon/Readme.md
@@ -1,11 +1,39 @@
-Компонент для отрисовки кнопок-иконок в `WriteBar`.
+Компонент для отрисовки кнопок-иконок внутри [WriteBar](#!/WriteBar).
 
 Надстройка над `<button />`. Компонент принимает все валидные для этого элемента свойства.
+
+## Цифровая доступность (a11y)
+
+Чтобы `WriteBarIcon` была доступной для ассистивных технологий, у нее должен быть текст, который сможет прочитать скринридер. Лучше всего передать этот текст в кастомное свойство `label`.
+
+Как еще можно это сделать:
+
+- Передать в `children` одновременно с иконкой текст, обернутый в компонент [VisuallyHidden](#!/VisuallyHidden).
+- Передать `aria-label` или `title`.
+- Создать отдельный элемент с текстом и передать его `id` в `aria-labelledby` кнопки.
 
 ```jsx static
 <WriteBarIcon mode="attach" />
 
+<WriteBarIcon label="Записать голосовое сообщение">
+  <Icon28VoiceOutline />
+</WriteBarIcon>
+
+<WriteBarIcon>
+  <VisuallyHidden>Записать голосовое сообщение</VisuallyHidden>
+  <Icon28VoiceOutline />
+</WriteBarIcon>
+
 <WriteBarIcon aria-label="Записать голосовое сообщение">
+  <Icon28VoiceOutline />
+</WriteBarIcon>
+
+<WriteBarIcon title="Записать голосовое сообщение">
+  <Icon28VoiceOutline />
+</WriteBarIcon>
+
+<VisuallyHidden id="write_bar_icon_voice">Записать голосовое сообщение</VisuallyHidden>
+<WriteBarIcon aria-labelledby="write_bar_icon_voice">
   <Icon28VoiceOutline />
 </WriteBarIcon>
 ```

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.test.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.test.tsx
@@ -4,12 +4,12 @@ import { baselineComponent } from '../../testing/utils';
 import { WriteBarIcon } from './WriteBarIcon';
 
 describe('WriteBarIcon', () => {
-  baselineComponent((props) => <WriteBarIcon aria-label="WriteBarIcon" {...props} />);
+  baselineComponent((props) => <WriteBarIcon label="WriteBarIcon" {...props} />);
 
-  it('a11y: adds default aria-label for assigned mode', () => {
+  it('a11y: adds default text context for assigned mode', () => {
     render(<WriteBarIcon data-testid="button" mode="send" />);
 
-    expect(screen.getByTestId('button')).toHaveAttribute('aria-label', 'Отправить');
+    expect(screen.getByTestId('button')).toHaveTextContent('Отправить');
   });
 
   it('shows counter when count={0} is provided', () => {

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.test.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.test.tsx
@@ -6,10 +6,17 @@ import { WriteBarIcon } from './WriteBarIcon';
 describe('WriteBarIcon', () => {
   baselineComponent((props) => <WriteBarIcon label="WriteBarIcon" {...props} />);
 
-  it('a11y: adds default text context for assigned mode', () => {
+  it('adds default text context for assigned mode', () => {
     render(<WriteBarIcon data-testid="button" mode="send" />);
 
     expect(screen.getByTestId('button')).toHaveTextContent('Отправить');
+  });
+
+  it('overrides mode default text content when label is provided', () => {
+    const label = 'Send Message';
+    render(<WriteBarIcon data-testid="button" mode="send" label={label} />);
+
+    expect(screen.getByTestId('button')).toHaveTextContent(label);
   });
 
   it('shows counter when count={0} is provided', () => {

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -29,11 +29,12 @@ const predefinedLabel = {
 export interface WriteBarIconProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * Предустановленные типы кнопок в WriteBar для отрисовки иконки и установки текста кнопки в зависимости от платформы.
-   * Если передать валидное значение для этого свойства, `children` и `label` игнорируются.
+   * Если передать валидное значение для этого свойства, `children` игнорируются, а для `label` по умолчанию используется текст на "ru_RU".
    *
-   * - `attach` – иконка прикрепления.
-   * - `send` – иконка отправки.
-   * - `done` – иконка отправки в режиме редактирования.
+   * Валидные значения:
+   * - `attach` – иконка прикрепления, текст по умолчанию — "Прикрепить файл";
+   * - `send` – иконка отправки, текст по умолчанию — "Отправить";
+   * - `done` – иконка отправки в режиме редактирования, текст по умолчанию — "Готово";
    */
   mode?: 'attach' | 'send' | 'done';
   /**
@@ -89,7 +90,7 @@ export const WriteBarIcon = ({
       break;
   }
 
-  const label = mode ? predefinedLabel[mode] : labelProp;
+  const label = labelProp ?? (mode && predefinedLabel[mode]);
 
   if (process.env.NODE_ENV === 'development') {
     /* istanbul ignore next: проверка в dev mode, тест на hasAccessibleName() есть в lib/accessibility.test.tsx */

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -12,16 +12,24 @@ import {
 } from '@vkontakte/icons';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';
+import { hasAccessibleName } from '../../lib/accessibility';
 import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
 import { AdaptiveIconRenderer } from '../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { Counter } from '../Counter/Counter';
 import { Tappable } from '../Tappable/Tappable';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './WriteBarIcon.module.css';
+
+const predefinedLabel = {
+  attach: 'Прикрепить файл',
+  send: 'Отправить',
+  done: 'Готово',
+};
 
 export interface WriteBarIconProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
-   * Предустановленные типы кнопок в WriteBar для отрисовки иконки в зависимости от платформы.
-   * Если передать валидное значение для этого свойства, `children` игнорируется.
+   * Предустановленные типы кнопок в WriteBar для отрисовки иконки и установки текста кнопки в зависимости от платформы.
+   * Если передать валидное значение для этого свойства, `children` и `label` игнорируются.
    *
    * - `attach` – иконка прикрепления.
    * - `send` – иконка отправки.
@@ -32,6 +40,10 @@ export interface WriteBarIconProps extends React.ButtonHTMLAttributes<HTMLButton
    * Значение счётчика для кнопки. Например, для количества прикреплённых файлов.
    */
   count?: number;
+  /**
+   * Текст кнопки. Необходим для ассистивных технологий.
+   */
+  label?: string;
 }
 
 const warn = warnOnce('WriteBarIcon');
@@ -44,19 +56,19 @@ export const WriteBarIcon = ({
   children,
   count,
   className,
+  label: labelProp,
   ...restProps
 }: WriteBarIconProps) => {
   const platform = usePlatform();
-  let modeLabel: string | undefined = undefined;
 
   let predefinedIcons;
+
   switch (mode) {
     case 'attach':
       predefinedIcons = {
         IconCompact: platform === 'ios' ? Icon28AddCircleOutline : Icon24Attach,
         IconRegular: platform === 'ios' ? Icon28AddCircleOutline : Icon28AttachOutline,
       };
-      modeLabel = 'Прикрепить файл';
       break;
 
     case 'send':
@@ -64,7 +76,6 @@ export const WriteBarIcon = ({
         IconCompact: platform === 'ios' ? Icon48WritebarSend : Icon24Send,
         IconRegular: platform === 'ios' ? Icon48WritebarSend : Icon28Send,
       };
-      modeLabel = 'Отправить';
       break;
 
     case 'done':
@@ -72,15 +83,20 @@ export const WriteBarIcon = ({
         IconCompact: platform === 'ios' ? Icon48WritebarDone : Icon24CheckCircleOutline,
         IconRegular: platform === 'ios' ? Icon48WritebarDone : Icon28CheckCircleOutline,
       };
-      modeLabel = 'Готово';
       break;
 
     default:
       break;
   }
 
+  const label = mode ? predefinedLabel[mode] : labelProp;
+
   if (process.env.NODE_ENV === 'development') {
-    const isAccessible = !modeLabel && (!restProps['aria-label'] || restProps['aria-labelledby']);
+    /* istanbul ignore next: проверка в dev mode, тест на hasAccessibleName() есть в lib/accessibility.test.tsx */
+    const isAccessible = hasAccessibleName({
+      children: [children, label],
+      ...restProps,
+    });
 
     if (!isAccessible) {
       warn(COMMON_WARNINGS.a11y['button-name'], 'error');
@@ -89,7 +105,6 @@ export const WriteBarIcon = ({
 
   return (
     <Tappable
-      aria-label={modeLabel}
       {...restProps}
       Component="button"
       hasHover={false}
@@ -103,6 +118,7 @@ export const WriteBarIcon = ({
       )}
     >
       <span className={styles['WriteBarIcon__in']}>
+        {label && <VisuallyHidden>{label}</VisuallyHidden>}
         {predefinedIcons ? <AdaptiveIconRenderer {...predefinedIcons} /> : children}
       </span>
       {hasReactNode(count) && (

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -309,6 +309,7 @@ export type { PanelHeaderEditProps } from './components/PanelHeaderEdit/PanelHea
 export { ModalCardBase } from './components/ModalCardBase/ModalCardBase';
 export type { ModalCardBaseProps } from './components/ModalCardBase/ModalCardBase';
 export { VisuallyHidden } from './components/VisuallyHidden/VisuallyHidden';
+export type { VisuallyHiddenProps } from './components/VisuallyHidden/VisuallyHidden';
 export { AdaptiveIconRenderer } from './components/AdaptiveIconRenderer/AdaptiveIconRenderer';
 export type { AdaptiveIconRendererProps } from './components/AdaptiveIconRenderer/AdaptiveIconRenderer';
 

--- a/packages/vkui/src/lib/select.ts
+++ b/packages/vkui/src/lib/select.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SelectType } from '../components/Select/Select';
-import { getTitleFromChildren } from './utils';
+import { getTextFromChildren } from './children';
 
 type Option = {
   label?: React.ReactElement | string;
@@ -28,7 +28,8 @@ try {
 
 type GetOptionLabel<T> = (option: Partial<T>) => string | undefined;
 
-const _getOptionLabel: GetOptionLabel<Option> = (option) => getTitleFromChildren(option.label);
+const _getOptionLabel: GetOptionLabel<Option> = ({ label }) =>
+  typeof label === 'string' ? label : getTextFromChildren(label);
 
 export const defaultFilterFn = <T>(
   query = '',

--- a/packages/vkui/src/lib/utils.ts
+++ b/packages/vkui/src/lib/utils.ts
@@ -39,18 +39,6 @@ export function multiRef<T>(...refs: Array<React.Ref<T> | undefined>): React.Ref
   };
 }
 
-export function getTitleFromChildren(children: React.ReactNode): string {
-  let label = '';
-
-  React.Children.map(children, (child) => {
-    if (typeof child === 'string') {
-      label += ' ' + child;
-    }
-  });
-
-  return label.trim();
-}
-
 export const stopPropagation = <T extends React.SyntheticEvent>(event: T) =>
   event.stopPropagation();
 

--- a/styleguide/Components/StyleGuide/StyleGuideMobile.js
+++ b/styleguide/Components/StyleGuide/StyleGuideMobile.js
@@ -9,6 +9,7 @@ import {
   SplitLayout,
   useAppearance,
   View,
+  VisuallyHidden,
 } from '@vkui';
 import { Logo } from '../Logo/Logo';
 import { StyleGuideModal } from './StyleGuideModal';
@@ -21,8 +22,18 @@ const StyleGuideMobileHeader = ({ before, switchStyleGuideAppearance }) => {
     <PanelHeader
       before={before}
       after={
-        <PanelHeaderButton onClick={switchStyleGuideAppearance} aria-label="Сменить тему">
-          {appearance === 'dark' ? <Icon28SunOutline /> : <Icon28MoonOutline />}
+        <PanelHeaderButton onClick={switchStyleGuideAppearance}>
+          {appearance === 'dark' ? (
+            <>
+              <VisuallyHidden>Переключить на светлую тему</VisuallyHidden>
+              <Icon28SunOutline />
+            </>
+          ) : (
+            <>
+              <VisuallyHidden>Переключить на темную тему</VisuallyHidden>
+              <Icon28MoonOutline />
+            </>
+          )}
         </PanelHeaderButton>
       }
     >
@@ -60,10 +71,8 @@ export const StyleGuideMobile = (props) => {
               <StyleGuideMobileHeader
                 switchStyleGuideAppearance={props.switchStyleGuideAppearance}
                 before={
-                  <PanelHeaderButton
-                    aria-label="Показать меню"
-                    onClick={() => setActivePanel('menu')}
-                  >
+                  <PanelHeaderButton onClick={() => setActivePanel('menu')}>
+                    <VisuallyHidden>Показать меню</VisuallyHidden>
                     <Icon28MenuOutline />
                   </PanelHeaderButton>
                 }
@@ -74,10 +83,9 @@ export const StyleGuideMobile = (props) => {
               <StyleGuideMobileHeader
                 switchStyleGuideAppearance={props.switchStyleGuideAppearance}
                 before={
-                  <PanelHeaderClose
-                    aria-label="Скрыть меню"
-                    onClick={() => setActivePanel('content')}
-                  />
+                  <PanelHeaderClose onClick={() => setActivePanel('content')}>
+                    Скрыть меню
+                  </PanelHeaderClose>
                 }
               />
               {props.toc}


### PR DESCRIPTION
- close https://github.com/VKCOM/VKUI/issues/2673

---

- [x] Unit-тесты
- [x] Документация фичи
- [x] Гайд миграции — см. https://github.com/VKCOM/VKUI/pull/6139#issuecomment-1840133929

## Описание

Отдельные пуллы в рамках этого:

- [x] https://github.com/VKCOM/VKUI/pull/6138
- [x] https://github.com/VKCOM/VKUI/pull/6167
- [x] https://github.com/VKCOM/VKUI/pull/6168
- [x] https://github.com/VKCOM/VKUI/pull/6190
- [x] https://github.com/VKCOM/VKUI/pull/6210 (в https://github.com/VKCOM/VKUI/pull/6206)

Что осталось тут:

- экспортировала `VisuallyHiddenProps`
- убрала остатки использования и удалила `getTitleFromChildren()`

- убрала `aria-label` и добавила скрытый текст:
  + `Calendar` — частично, не во всех местах получилось это удачно сделать; также переименовала пропсы
  + `CellDragger`
  + `WriteBarIcon` 
  + `PanelHeaderButton` и его вариаций
  + `ModalDismissButton` и `ModalCardBaseCloseButton`
  + `ScrollArrow`
  + `Pagination` — также переименовала пропсы
  + `Search` — также переименовала пропсы

- добавила документацию (relates to https://github.com/VKCOM/VKUI/issues/3035) и обновила примеры для:
  + `ModalCardBase`
  + `ModalDismissButton`
  + `PanelHeaderButton`
  + `WriteBarIcon`
  + `TabbarItem`