### PR TITLE
BREAKING CHANGE(ActionSheet, Alert): remove autoClose

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.stories.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.stories.tsx
@@ -39,7 +39,7 @@ export const Base: Story = {
     const popout = visible ? (
       <ActionSheet {...args} onClose={() => setVisible(false)} toggleRef={baseToggleRef}>
         {items.map(({ children, ...rest }, index) => (
-          <ActionSheetItem autoClose key={index} {...rest}>
+          <ActionSheetItem key={index} {...rest}>
             {children}
           </ActionSheetItem>
         ))}

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -48,9 +48,9 @@ describe('ActionSheet', () => {
       it.each([
         {},
         { selectable: true },
-        { autoClose: true },
-        { autoClose: true, selectable: true },
-        { autoClose: true, isCancelItem: true },
+        { autoCloseDisabled: true },
+        { autoCloseDisabled: true, selectable: true },
+        { isCancelItem: true },
       ])('when %s', async (props) => {
         const onCloseHandler = jest.fn();
         const handlers = { onClick: jest.fn(), onChange: jest.fn() };
@@ -72,12 +72,13 @@ describe('ActionSheet', () => {
         expect(handlers.onClick).toBeCalled();
         props.selectable && expect(handlers.onChange).toBeCalled();
 
-        if (!props.autoClose) {
+        if (props.autoCloseDisabled) {
           expect(onCloseHandler).not.toBeCalled();
-        } else if (props.autoClose && props.isCancelItem) {
+        } else if (!props.autoCloseDisabled && props.isCancelItem) {
           expect(onCloseHandler).toBeCalledWith({ closedBy: 'cancel-item' });
         } else {
-          props.autoClose && expect(onCloseHandler).toBeCalledWith({ closedBy: 'action-item' });
+          !props.autoCloseDisabled &&
+            expect(onCloseHandler).toBeCalledWith({ closedBy: 'action-item' });
         }
       });
     });
@@ -106,17 +107,6 @@ describe('ActionSheet', () => {
       render(<ActionSheetDesktop onClose={onClose} />);
       await waitForFloatingPosition();
       await userEvent.click(document.body);
-      expect(onClose).toBeCalledTimes(1);
-      expect(onClose).toBeCalledWith({ closedBy: 'other' });
-    });
-    it('closes on item click with autoClose', async () => {
-      const onClose = jest.fn();
-      render(<ActionSheetDesktop onClose={onClose} />);
-      await waitForFloatingPosition();
-      runAllTimers();
-      await userEvent.click(document.body);
-      runAllTimers();
-
       expect(onClose).toBeCalledTimes(1);
       expect(onClose).toBeCalledWith({ closedBy: 'other' });
     });

--- a/packages/vkui/src/components/ActionSheet/ActionSheetDefaultIosCloseItem.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetDefaultIosCloseItem.tsx
@@ -3,7 +3,7 @@ import { ActionSheetItem, ActionSheetItemProps } from '../ActionSheetItem/Action
 
 export const ActionSheetDefaultIosCloseItem = (props: ActionSheetItemProps) => {
   return (
-    <ActionSheetItem autoClose mode="cancel" isCancelItem {...props}>
+    <ActionSheetItem mode="cancel" isCancelItem {...props}>
       Отмена
     </ActionSheetItem>
   );

--- a/packages/vkui/src/components/ActionSheet/Readme.md
+++ b/packages/vkui/src/components/ActionSheet/Readme.md
@@ -26,13 +26,11 @@ const baseTopTargetRef = React.useRef();
 const openBase = () =>
   setPopout(
     <ActionSheet onClose={onClose} toggleRef={baseTargetRef}>
-      <ActionSheetItem autoClose>Сохранить в закладках</ActionSheetItem>
-      <ActionSheetItem autoClose>Закрепить запись</ActionSheetItem>
-      <ActionSheetItem autoClose>Выключить комментирование</ActionSheetItem>
-      <ActionSheetItem autoClose>Закрепить запись</ActionSheetItem>
-      <ActionSheetItem autoClose mode="destructive">
-        Удалить запись
-      </ActionSheetItem>
+      <ActionSheetItem>Сохранить в закладках</ActionSheetItem>
+      <ActionSheetItem>Закрепить запись</ActionSheetItem>
+      <ActionSheetItem>Выключить комментирование</ActionSheetItem>
+      <ActionSheetItem>Закрепить запись</ActionSheetItem>
+      <ActionSheetItem mode="destructive">Удалить запись</ActionSheetItem>
     </ActionSheet>,
   );
 
@@ -40,7 +38,6 @@ const openIcons = () =>
   setPopout(
     <ActionSheet onClose={onClose} toggleRef={iconsTargetRef}>
       <ActionSheetItem
-        autoClose
         before={
           <AdaptiveIconRenderer IconCompact={Icon20WriteOutline} IconRegular={Icon28EditOutline} />
         }
@@ -48,7 +45,6 @@ const openIcons = () =>
         Редактировать профиль
       </ActionSheetItem>
       <ActionSheetItem
-        autoClose
         before={
           <AdaptiveIconRenderer
             IconCompact={Icon20ListPlayOutline}
@@ -59,7 +55,6 @@ const openIcons = () =>
         Слушать далее
       </ActionSheetItem>
       <ActionSheetItem
-        autoClose
         before={
           <AdaptiveIconRenderer IconCompact={Icon20ShareOutline} IconRegular={Icon28ShareOutline} />
         }
@@ -67,7 +62,6 @@ const openIcons = () =>
         Поделиться
       </ActionSheetItem>
       <ActionSheetItem
-        autoClose
         before={
           <AdaptiveIconRenderer IconCompact={Icon20CopyOutline} IconRegular={Icon28CopyOutline} />
         }
@@ -75,7 +69,6 @@ const openIcons = () =>
         Скопировать ссылку
       </ActionSheetItem>
       <ActionSheetItem
-        autoClose
         before={
           <AdaptiveIconRenderer
             IconCompact={platform === 'ios' ? Icon20DeleteOutline : Icon20DeleteOutlineAndroid}
@@ -99,7 +92,6 @@ const openSubtitle = () =>
             IconRegular={Icon28SettingsOutline}
           />
         }
-        autoClose
         subtitle="Авто"
       >
         Качество
@@ -111,7 +103,6 @@ const openSubtitle = () =>
             IconRegular={Icon28SubtitlesOutline}
           />
         }
-        autoClose
         subtitle="Отсутствуют"
         disabled
       >
@@ -121,7 +112,6 @@ const openSubtitle = () =>
         before={
           <AdaptiveIconRenderer IconCompact={Icon20Play} IconRegular={Icon28PlaySpeedOutline} />
         }
-        autoClose
         subtitle="Обычная"
       >
         Скорость воспроизведения
@@ -137,7 +127,6 @@ const openSelectable = () =>
         checked={filter === 'best'}
         name="filter"
         value="best"
-        autoClose
         selectable
       >
         Лучшие друзья
@@ -147,7 +136,6 @@ const openSelectable = () =>
         checked={filter === 'relatives'}
         name="filter"
         value="relatives"
-        autoClose
         selectable
       >
         Родственники
@@ -157,7 +145,6 @@ const openSelectable = () =>
         checked={filter === 'collegues'}
         name="filter"
         value="collegues"
-        autoClose
         selectable
       >
         Коллеги
@@ -167,7 +154,6 @@ const openSelectable = () =>
         checked={filter === 'school'}
         name="filter"
         value="school"
-        autoClose
         selectable
       >
         Друзья по школе
@@ -177,7 +163,6 @@ const openSelectable = () =>
         checked={filter === 'university'}
         name="filter"
         value="university"
-        autoClose
         selectable
       >
         Друзья по вузу
@@ -192,22 +177,18 @@ const openTitle = () =>
       header="Вы действительно хотите удалить это видео из Ваших видео?"
       toggleRef={titleTargetRef}
     >
-      <ActionSheetItem autoClose mode="destructive">
-        Удалить видео
-      </ActionSheetItem>
+      <ActionSheetItem mode="destructive">Удалить видео</ActionSheetItem>
     </ActionSheet>,
   );
 
 const openBaseTop = () =>
   setPopout(
     <ActionSheet onClose={onClose} toggleRef={baseTopTargetRef} placement="top-end">
-      <ActionSheetItem autoClose>Сохранить в закладках</ActionSheetItem>
-      <ActionSheetItem autoClose>Закрепить запись</ActionSheetItem>
-      <ActionSheetItem autoClose>Выключить комментирование</ActionSheetItem>
-      <ActionSheetItem autoClose>Закрепить запись</ActionSheetItem>
-      <ActionSheetItem autoClose mode="destructive">
-        Удалить запись
-      </ActionSheetItem>
+      <ActionSheetItem>Сохранить в закладках</ActionSheetItem>
+      <ActionSheetItem>Закрепить запись</ActionSheetItem>
+      <ActionSheetItem>Выключить комментирование</ActionSheetItem>
+      <ActionSheetItem>Закрепить запись</ActionSheetItem>
+      <ActionSheetItem mode="destructive">Удалить запись</ActionSheetItem>
     </ActionSheet>,
   );
 

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -19,7 +19,11 @@ export interface ActionSheetItemProps
   after?: React.ReactNode;
   meta?: React.ReactNode;
   subtitle?: React.ReactNode;
-  autoClose?: boolean;
+  /**
+   * По умолчанию клик на опцию вызывает переданную в `ActionSheet` функцию `onClose`, данное свойство
+   * позволяет отключить такое поведение
+   */
+  autoCloseDisabled?: boolean;
   selectable?: boolean;
   disabled?: boolean;
   /**
@@ -27,7 +31,7 @@ export interface ActionSheetItemProps
    */
   multiline?: boolean;
   /**
-   * Если autoClose === true, onClick будет вызван после завершения анимации скрытия и после вызова onClose.
+   * По умолчанию onClick будет вызван после завершения анимации скрытия и после вызова onClose.
    * Из этого следует, что в объекте события значения полей типа `currentTarget` будут не определены.
    * Если вам нужен объект события именно на момент клика, используйте `onImmediateClick`.
    */
@@ -49,7 +53,7 @@ export interface ActionSheetItemProps
  */
 export const ActionSheetItem = ({
   children,
-  autoClose,
+  autoCloseDisabled = false,
   mode = 'default',
   meta,
   subtitle,
@@ -93,7 +97,7 @@ export const ActionSheetItem = ({
           : onItemClick({
               action: onClick,
               immediateAction: onImmediateClick,
-              autoClose: Boolean(autoClose),
+              autoClose: !autoCloseDisabled,
               isCancelItem: Boolean(isCancelItem),
             })
       }
@@ -149,7 +153,7 @@ export const ActionSheetItem = ({
               onClick={onItemClick({
                 action: noop,
                 immediateAction: noop,
-                autoClose: Boolean(autoClose),
+                autoClose: !autoCloseDisabled,
                 isCancelItem: Boolean(isCancelItem),
               })}
               defaultChecked={defaultChecked}

--- a/packages/vkui/src/components/ActionSheetItem/Readme.md
+++ b/packages/vkui/src/components/ActionSheetItem/Readme.md
@@ -1,2 +1,1 @@
-Элемент списка `ActionSheet`. Если в `ActionSheetItem` передать `autoClose={true}`, то `ActionSheet` сам вызовет
-переданный в него `onClose`.
+Элемент списка `ActionSheet`. Если в `ActionSheetItem` передать `autoCloseDisabled={true}`, то при клике на эту опцию `ActionSheet` не будет автоматически вызывать переданный в него `onClose`, закрыть его будет необходимо самостоятельно.

--- a/packages/vkui/src/components/Alert/Alert.stories.tsx
+++ b/packages/vkui/src/components/Alert/Alert.stories.tsx
@@ -34,12 +34,10 @@ export const Playground: StoryObj<AlertProps> = {
     actions: [
       {
         title: 'Отмена',
-        autoClose: true,
         mode: 'cancel',
       },
       {
         title: 'Удалить',
-        autoClose: true,
         mode: 'destructive',
       },
     ],

--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -32,18 +32,24 @@ describe('Alert', () => {
   });
   describe('calls actions', () => {
     describe.each(['android', 'ios'])('on %s', (platform) => {
-      it('calls action', async () => {
+      it('calls action and do not calls onClose with autoCloseDisabled=true', async () => {
         const action = jest.fn();
         const onClose = jest.fn();
         render(
           <ConfigProvider platform={platform}>
-            <Alert onClose={onClose} actions={[{ action, title: '__action__', mode: 'default' }]} />
+            <Alert
+              onClose={onClose}
+              actions={[{ action, title: '__action__', autoCloseDisabled: true, mode: 'default' }]}
+            />
           </ConfigProvider>,
         );
         await userEvent.click(screen.getByText('__action__'));
         expect(action).toBeCalledTimes(1);
+        expect(onClose).not.toBeCalled();
+        runAllTimers();
+        expect(onClose).not.toBeCalled();
       });
-      it('calls action after close when autoClose=true', async () => {
+      it('calls action after close by default', async () => {
         const action = jest.fn();
         const onClose = jest.fn();
         render(
@@ -55,7 +61,6 @@ describe('Alert', () => {
                   action,
                   title: '__action__',
                   mode: 'default',
-                  autoClose: true,
                 },
               ]}
             />

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -105,7 +105,6 @@ export const Alert = ({
     (item: AlertActionInterface) => {
       const { action, autoCloseDisabled = false } = item;
 
-      console.log(autoCloseDisabled);
       if (!autoCloseDisabled) {
         setClosing(true);
         waitTransitionFinish(

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -25,7 +25,11 @@ export interface AlertActionInterface
     HasDataAttribute {
   title: string;
   action?: VoidFunction;
-  autoClose?: boolean;
+  /**
+   * По умолчанию клик на опцию вызывает переданную в `Alert` функцию `onClose`, данное свойство
+   * позволяет отключить такое поведение
+   */
+  autoCloseDisabled?: boolean;
   mode: AlertActionMode;
 }
 
@@ -99,9 +103,10 @@ export const Alert = ({
 
   const onItemClick = React.useCallback(
     (item: AlertActionInterface) => {
-      const { action, autoClose } = item;
+      const { action, autoCloseDisabled = false } = item;
 
-      if (autoClose) {
+      console.log(autoCloseDisabled);
+      if (!autoCloseDisabled) {
         setClosing(true);
         waitTransitionFinish(
           elementRef.current,

--- a/packages/vkui/src/components/Alert/AlertActions.tsx
+++ b/packages/vkui/src/components/Alert/AlertActions.tsx
@@ -43,7 +43,7 @@ export const AlertActions = ({
     >
       {actions.map((action, i) => {
         // Убираем
-        const { title: children, action: _, autoClose, ...restProps } = action;
+        const { title: children, action: _, autoCloseDisabled, ...restProps } = action;
 
         return (
           <React.Fragment key={i}>

--- a/packages/vkui/src/components/Alert/Readme.md
+++ b/packages/vkui/src/components/Alert/Readme.md
@@ -42,12 +42,10 @@ const Example = () => {
           {
             title: 'Лишить права',
             mode: 'destructive',
-            autoClose: true,
             action: () => addActionLogItem('Право на модерацию контента убрано.'),
           },
           {
             title: 'Отмена',
-            autoClose: true,
             mode: 'cancel',
           },
         ]}
@@ -65,12 +63,10 @@ const Example = () => {
         actions={[
           {
             title: 'Отмена',
-            autoClose: true,
             mode: 'cancel',
           },
           {
             title: 'Удалить',
-            autoClose: true,
             mode: 'destructive',
             action: () => addActionLogItem('Документ удален.'),
           },
@@ -132,11 +128,9 @@ const Example = () => {
           {
             title: 'Лишить права',
             mode: 'destructive',
-            autoClose: true,
           },
           {
             title: 'Отмена',
-            autoClose: true,
             mode: 'cancel',
           },
         ]}

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
@@ -20,7 +20,7 @@ import { View } from '../View/View';
 import { FocusTrap, FocusTrapProps } from './FocusTrap';
 
 const _children = ['first', 'middle', 'last'].map((item) => (
-  <ActionSheetItem key={item} autoClose data-testid={item}>
+  <ActionSheetItem key={item} data-testid={item}>
     {item} Item
   </ActionSheetItem>
 ));

--- a/styleguide/Components/Setting/Setting.js
+++ b/styleguide/Components/Setting/Setting.js
@@ -63,12 +63,7 @@ export const Setting = ({
                   const option = isPrimitive ? item : item.value;
                   const title = isPrimitive ? item : item.title;
                   return (
-                    <ActionSheetItem
-                      autoClose
-                      key={option}
-                      value={option}
-                      onClick={() => onChange(option)}
-                    >
+                    <ActionSheetItem key={option} value={option} onClick={() => onChange(option)}>
                       {title}
                     </ActionSheetItem>
                   );

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -132,7 +132,7 @@
 
 ```diff
  <ActionSheet>
--  <ActionSheetItem autoСlose>Сохранить в закладках</ActionSheetItem>
+-  <ActionSheetItem autoClose>Сохранить в закладках</ActionSheetItem>
 +  <ActionSheetItem>Сохранить в закладках</ActionSheetItem>
 -  <ActionSheetItem autoСlose={false}>Закрепить запись</ActionSheetItem>
 +  <ActionSheetItem autoCloseDisabled>Закрепить запись</ActionSheetItem>

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -97,3 +97,44 @@
 - `SizeType`
 - `ViewWidth`
 - `ViewHeight`
+
+<br/><br/>
+
+## [`Alert`](#/Alert)
+
+- Свойство `autoClose` удалено, теперь это поведение по-умолчанию
+
+```diff
+ <Alert
+   actions={[
+     {
+       title: "Лишить права",
+       mode: "destructive",
+-      autoClose: false,
++      autoCloseDisabled: true,
+     },
+     {
+       title: "Отмена",
+-      autoClose: true,
+       mode: "cancel",
+     },
+   ]}
+   header="Подтвердите действие"
+   text="Вы уверены, что хотите лишить пользователя права на модерацию контента?"
+ />
+```
+
+<br/><br/>
+
+## [`ActionSheetItem`](#/ActionSheetItem)
+
+- Свойство `autoClose` удалено, теперь это поведение по-умолчанию
+
+```diff
+ <ActionSheet>
+-  <ActionSheetItem autoСlose>Сохранить в закладках</ActionSheetItem>
++  <ActionSheetItem>Сохранить в закладках</ActionSheetItem>
+-  <ActionSheetItem autoСlose={false}>Закрепить запись</ActionSheetItem>
++  <ActionSheetItem autoCloseDisabled>Закрепить запись</ActionSheetItem>
+ </ActionSheet>
+```

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -134,7 +134,7 @@
  <ActionSheet>
 -  <ActionSheetItem autoClose>Сохранить в закладках</ActionSheetItem>
 +  <ActionSheetItem>Сохранить в закладках</ActionSheetItem>
--  <ActionSheetItem autoСlose={false}>Закрепить запись</ActionSheetItem>
+-  <ActionSheetItem autoClose={false}>Закрепить запись</ActionSheetItem>
 +  <ActionSheetItem autoCloseDisabled>Закрепить запись</ActionSheetItem>
  </ActionSheet>
 ```


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

~~- [ ] e2e-тесты~~

~~- [ ] Дизайн-ревью~~

- [x] Документация фичи

## Описание

Сейчас в айтемы `ActionSheet` и `Alert` необходимо каждый раз пробрасывать `autoClose=true`, чтобы при клике на айтем элемент скрывался, кажется, логичнее будет сделать это поведением по-умолчанию.

## Изменения

Добавлен проп `autoCloseDisabled`, который наоборот позволяет отключить автоматический вызов `onClose` у родительского элемента
