### PR TITLE
feat: extend lib/floating

### DIFF
--- a/packages/vkui/src/lib/dom.test.ts
+++ b/packages/vkui/src/lib/dom.test.ts
@@ -192,11 +192,7 @@ describe(contains, () => {
     { args: [undefined, document.createElement('div')] },
     { args: [null, document.createElement('div')] },
   ])('should be always false ($args)', (props) => {
-    if (props.args.length === 0) {
-      expect(contains()).toBeFalsy();
-    } else {
-      expect(contains(...props.args)).toBeFalsy();
-    }
+    expect(contains(...props.args)).toBeFalsy();
   });
 
   it('should return true if parent contain child', () => {

--- a/packages/vkui/src/lib/dom.test.ts
+++ b/packages/vkui/src/lib/dom.test.ts
@@ -1,4 +1,6 @@
 import {
+  contains,
+  getActiveElementByAnotherElement,
   getBoundingClientRect,
   getDocumentBody,
   getScrollHeight,
@@ -155,5 +157,52 @@ describe(getDocumentBody, () => {
     const el = document.createElement('div');
     document.body.appendChild(el);
     expect(getDocumentBody(el)).toBe(document.body);
+  });
+});
+
+describe(getActiveElementByAnotherElement, () => {
+  it('should return null if the argument is null', () => {
+    expect(getActiveElementByAnotherElement(null)).toBeNull();
+  });
+
+  it('should return activeElement by another element', () => {
+    const [elFocused, elBase] = [document.createElement('input'), document.createElement('div')];
+    document.body.append(elFocused, elBase);
+
+    expect(getActiveElementByAnotherElement(elBase)).toBe(document.body);
+
+    elFocused.focus();
+    expect(getActiveElementByAnotherElement(elBase)).toBe(elFocused);
+  });
+});
+
+describe(contains, () => {
+  it.each([
+    { args: [] },
+    { args: [undefined] },
+    { args: [undefined, undefined] },
+    { args: [null] },
+    { args: [null, null] },
+    { args: [undefined, null] },
+    { args: [null, undefined] },
+    { args: [document.createElement('div')] },
+    { args: [document.createElement('div'), undefined] },
+    { args: [document.createElement('div'), null] },
+    { args: [document.createElement('div'), document.createElement('div')] },
+    { args: [undefined, document.createElement('div')] },
+    { args: [null, document.createElement('div')] },
+  ])('should be always false ($args)', (props) => {
+    if (props.args.length === 0) {
+      expect(contains()).toBeFalsy();
+    } else {
+      expect(contains(...props.args)).toBeFalsy();
+    }
+  });
+
+  it('should return true if parent contain child', () => {
+    const [elParent, elChild] = [document.createElement('input'), document.createElement('div')];
+    elParent.append(elChild);
+    document.body.append(elParent);
+    expect(contains(elParent, elChild)).toBeTruthy();
   });
 });

--- a/packages/vkui/src/lib/dom.tsx
+++ b/packages/vkui/src/lib/dom.tsx
@@ -8,7 +8,12 @@ import {
   isHTMLElement,
 } from '@vkontakte/vkui-floating-ui/utils/dom';
 
-export { getWindow, getNodeScroll, isElement } from '@vkontakte/vkui-floating-ui/utils/dom';
+export {
+  getWindow,
+  getNodeScroll,
+  isHTMLElement,
+  isElement,
+} from '@vkontakte/vkui-floating-ui/utils/dom';
 
 export { canUseDOM, canUseEventListeners, onDOMLoaded } from '@vkontakte/vkjs';
 export interface DOMContextInterface {
@@ -143,3 +148,10 @@ export const getScrollRect = (node: Element | Window) => {
 };
 
 export const getDocumentBody = (node?: any) => getWindow(node).document.body;
+
+export const getActiveElementByAnotherElement = (el: Element | null) =>
+  el ? el.ownerDocument.activeElement : null;
+
+export const contains = (parent?: Element | null, child?: Element | null) => {
+  return parent && child ? parent.contains(child) : false;
+};

--- a/packages/vkui/src/lib/floating/adapters.ts
+++ b/packages/vkui/src/lib/floating/adapters.ts
@@ -4,6 +4,19 @@ import {
   type FloatingElement,
   type ReferenceType,
 } from '@vkontakte/vkui-floating-ui/react-dom';
+import { isHTMLElement } from '../dom';
+
+export {
+  useFloating,
+  offset as offsetMiddleware,
+  flip as flipMiddleware,
+  shift as shiftMiddleware,
+  autoPlacement as autoPlacementMiddleware,
+  arrow as arrowMiddleware,
+  size as sizeMiddleware,
+  hide as hideMiddleware,
+  getOverflowAncestors,
+} from '@vkontakte/vkui-floating-ui/react-dom';
 
 const defaultOptions = {
   ancestorScroll: true,
@@ -44,7 +57,7 @@ export function autoUpdateFloatingElement(
       initialUpdate = false;
     });
 
-    if (reference instanceof Element) {
+    if (isHTMLElement(reference)) {
       observer.observe(reference, {
         childList: true,
         subtree: true,

--- a/packages/vkui/src/lib/floating/index.ts
+++ b/packages/vkui/src/lib/floating/index.ts
@@ -1,16 +1,5 @@
-export {
-  useFloating,
-  offset as offsetMiddleware,
-  flip as flipMiddleware,
-  shift as shiftMiddleware,
-  autoPlacement as autoPlacementMiddleware,
-  arrow as arrowMiddleware,
-  size as sizeMiddleware,
-  hide as hideMiddleware,
-  getOverflowAncestors,
-} from '@vkontakte/vkui-floating-ui/react-dom';
-
 export type {
+  UseFloatingOptions,
   Placement,
   PlacementWithAuto,
   AutoPlacementType,
@@ -23,4 +12,22 @@ export {
   convertFloatingDataToReactCSSProperties,
 } from './functions';
 
-export { autoUpdateFloatingElement } from './adapters';
+export {
+  useFloating,
+  offsetMiddleware,
+  flipMiddleware,
+  shiftMiddleware,
+  autoPlacementMiddleware,
+  arrowMiddleware,
+  sizeMiddleware,
+  hideMiddleware,
+  getOverflowAncestors,
+  autoUpdateFloatingElement,
+} from './adapters';
+
+export {
+  type UseFloatingMiddlewaresBootstrapOptions,
+  useFloatingMiddlewaresBootstrap,
+} from './useFloatingMiddlewaresBootstrap';
+
+export * from './useFloatingWithInteractions';

--- a/packages/vkui/src/lib/floating/types.ts
+++ b/packages/vkui/src/lib/floating/types.ts
@@ -5,6 +5,9 @@ export type AutoPlacementType = 'auto' | 'auto-start' | 'auto-end';
 export type PlacementWithAuto = AutoPlacementType | Placement;
 
 export type {
+  UseFloatingOptions,
+  ReferenceType,
+  ArrowOptions,
   Placement,
   Middleware as UseFloatingMiddleware,
   UseFloatingData,

--- a/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
+++ b/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import {
+  arrowMiddleware,
+  autoPlacementMiddleware,
+  flipMiddleware,
+  hideMiddleware,
+  offsetMiddleware,
+  shiftMiddleware,
+  sizeMiddleware,
+} from '../adapters';
+import { checkIsNotAutoPlacement, getAutoPlacementAlign } from '../functions';
+import type { ArrowOptions, PlacementWithAuto, UseFloatingMiddleware } from '../types';
+
+export interface UseFloatingMiddlewaresBootstrapOptions {
+  /**
+   * По умолчанию компонент выберет наилучшее расположение сам. Но его можно задать извне с помощью этого свойства.
+   */
+  placement?: PlacementWithAuto;
+  /**
+   * Отступ по главной оси.
+   */
+  offsetByMainAxis?: number;
+  /**
+   * Отступ по вспомогательной оси.
+   */
+  offsetByCrossAxis?: number;
+  arrowRef?: ArrowOptions['element'];
+  /**
+   * Отображать ли стрелку, указывающую на якорный элемент.
+   */
+  arrow?: boolean;
+  /**
+   * Высота стрелки. Складывается с `mainAxis`, чтобы стрелка не залезала на якорный элемент..
+   */
+  arrowHeight?: number;
+  /**
+   * Безопасная зона вокруг стрелки, чтобы та не выходила за края контента..
+   */
+  arrowPadding?: number;
+  /**
+   * Выставлять ширину равной target элементу.
+   */
+  sameWidth?: boolean;
+  /**
+   * Массив кастомных модификаторов для Popper (необходимо мемоизировать).
+   */
+  customMiddlewares?: UseFloatingMiddleware[];
+  /**
+   * Принудительно скрывает компонет если целевой элемент исчез.
+   */
+  hideWhenReferenceHidden?: boolean;
+}
+
+export const useFloatingMiddlewaresBootstrap = ({
+  placement = 'bottom-start',
+  arrowRef = null,
+  arrow,
+  arrowHeight,
+  arrowPadding,
+  sameWidth,
+  offsetByMainAxis = 0,
+  offsetByCrossAxis = 0,
+  customMiddlewares,
+  hideWhenReferenceHidden,
+}: UseFloatingMiddlewaresBootstrapOptions) => {
+  return React.useMemo(() => {
+    const isNotAutoPlacement = checkIsNotAutoPlacement(placement);
+    const middlewares: UseFloatingMiddleware[] = [
+      offsetMiddleware({
+        crossAxis: offsetByCrossAxis,
+        mainAxis: arrow && arrowHeight ? offsetByMainAxis + arrowHeight : offsetByMainAxis,
+      }),
+    ];
+
+    // см. https://floating-ui.com/docs/flip#conflict-with-autoplacement
+    if (isNotAutoPlacement) {
+      middlewares.push(
+        flipMiddleware({
+          fallbackAxisSideDirection: 'start',
+        }),
+      );
+    } else {
+      middlewares.push(autoPlacementMiddleware({ alignment: getAutoPlacementAlign(placement) }));
+    }
+
+    middlewares.push(shiftMiddleware());
+
+    if (sameWidth) {
+      middlewares.push(
+        sizeMiddleware({
+          apply({ rects, elements }) {
+            Object.assign(elements.floating.style, {
+              width: `${rects.reference.width}px`,
+            });
+          },
+        }),
+      );
+    }
+
+    if (customMiddlewares) {
+      middlewares.push(...customMiddlewares);
+    }
+
+    // см. https://floating-ui.com/docs/arrow#order
+    if (arrow) {
+      middlewares.push(
+        arrowMiddleware({
+          element: arrowRef,
+          padding: arrowPadding,
+        }),
+      );
+    }
+
+    if (hideWhenReferenceHidden) {
+      middlewares.push(hideMiddleware());
+    }
+
+    return { middlewares, strictPlacement: isNotAutoPlacement ? placement : undefined };
+  }, [
+    offsetByCrossAxis,
+    arrowRef,
+    arrow,
+    arrowHeight,
+    arrowPadding,
+    offsetByMainAxis,
+    sameWidth,
+    customMiddlewares,
+    placement,
+    hideWhenReferenceHidden,
+  ]);
+};

--- a/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
+++ b/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
@@ -30,11 +30,11 @@ export interface UseFloatingMiddlewaresBootstrapOptions {
    */
   arrow?: boolean;
   /**
-   * Высота стрелки. Складывается с `mainAxis`, чтобы стрелка не залезала на якорный элемент..
+   * Высота стрелки. Складывается с `mainAxis`, чтобы стрелка не залезала на якорный элемент.
    */
   arrowHeight?: number;
   /**
-   * Безопасная зона вокруг стрелки, чтобы та не выходила за края контента..
+   * Безопасная зона вокруг стрелки, чтобы та не выходила за края контента.
    */
   arrowPadding?: number;
   /**
@@ -46,7 +46,7 @@ export interface UseFloatingMiddlewaresBootstrapOptions {
    */
   customMiddlewares?: UseFloatingMiddleware[];
   /**
-   * Принудительно скрывает компонет если целевой элемент исчез.
+   * Принудительно скрывает компонент если целевой элемент исчез.
    */
   hideWhenReferenceHidden?: boolean;
 }

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/__snapshots__/useFloatingWithInteractions.test.tsx.snap
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/__snapshots__/useFloatingWithInteractions.test.tsx.snap
@@ -35,12 +35,10 @@ exports[`useFloatingWithInteractions tests with snapshot should be hidden state 
 exports[`useFloatingWithInteractions tests with snapshot should be shown state 1`] = `
 {
   "floatingProps": {
-    "aria-modal": "true",
     "onAnimationEnd": [Function],
     "onAnimationStart": [Function],
     "onMouseLeave": [Function],
     "onMouseOver": [Function],
-    "role": "dialog",
     "style": {
       "bottom": "auto",
       "left": 0,
@@ -54,7 +52,6 @@ exports[`useFloatingWithInteractions tests with snapshot should be shown state 1
   "onRestoreFocus": [Function],
   "placement": "bottom",
   "referenceProps": {
-    "aria-labelledby": "some-floating-id",
     "onBlur": [Function],
     "onClick": [Function],
     "onFocus": [Function],
@@ -79,12 +76,10 @@ exports[`useFloatingWithInteractions tests with snapshot should be shown state 1
 exports[`useFloatingWithInteractions tests with snapshot should be shown state with disabled close on esc key and click outside events 1`] = `
 {
   "floatingProps": {
-    "aria-modal": "true",
     "onAnimationEnd": [Function],
     "onAnimationStart": [Function],
     "onMouseLeave": [Function],
     "onMouseOver": [Function],
-    "role": "dialog",
     "style": {
       "bottom": "auto",
       "left": 0,
@@ -98,7 +93,6 @@ exports[`useFloatingWithInteractions tests with snapshot should be shown state w
   "onRestoreFocus": [Function],
   "placement": "bottom",
   "referenceProps": {
-    "aria-labelledby": "some-floating-id",
     "onBlur": [Function],
     "onClick": [Function],
     "onFocus": [Function],
@@ -123,10 +117,8 @@ exports[`useFloatingWithInteractions tests with snapshot should be shown state w
 exports[`useFloatingWithInteractions tests with snapshot should be shown state with disabled interactive feature 1`] = `
 {
   "floatingProps": {
-    "aria-modal": "true",
     "onAnimationEnd": [Function],
     "onAnimationStart": [Function],
-    "role": "dialog",
     "style": {
       "bottom": "auto",
       "left": 0,
@@ -141,7 +133,6 @@ exports[`useFloatingWithInteractions tests with snapshot should be shown state w
   "onRestoreFocus": [Function],
   "placement": "bottom",
   "referenceProps": {
-    "aria-labelledby": "some-floating-id",
     "onBlur": [Function],
     "onClick": [Function],
     "onFocus": [Function],

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/__snapshots__/useFloatingWithInteractions.test.tsx.snap
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/__snapshots__/useFloatingWithInteractions.test.tsx.snap
@@ -1,0 +1,190 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useFloatingWithInteractions tests with snapshot should be hidden state 1`] = `
+{
+  "floatingProps": {
+    "onMouseLeave": [Function],
+    "onMouseOver": [Function],
+    "style": {},
+  },
+  "onEscapeKeyDown": undefined,
+  "onRestoreFocus": [Function],
+  "placement": "bottom",
+  "referenceProps": {
+    "onBlur": [Function],
+    "onClick": [Function],
+    "onFocus": [Function],
+    "onMouseLeave": [Function],
+    "onMouseOver": [Function],
+  },
+  "refs": {
+    "floating": {
+      "current": null,
+    },
+    "reference": {
+      "current": null,
+    },
+    "setFloating": [Function],
+    "setReference": [Function],
+  },
+  "shown": false,
+  "willBeHide": false,
+}
+`;
+
+exports[`useFloatingWithInteractions tests with snapshot should be shown state 1`] = `
+{
+  "floatingProps": {
+    "aria-modal": "true",
+    "onAnimationEnd": [Function],
+    "onAnimationStart": [Function],
+    "onMouseLeave": [Function],
+    "onMouseOver": [Function],
+    "role": "dialog",
+    "style": {
+      "bottom": "auto",
+      "left": 0,
+      "position": "fixed",
+      "right": "auto",
+      "top": 0,
+      "width": "max-content",
+    },
+  },
+  "onEscapeKeyDown": [Function],
+  "onRestoreFocus": [Function],
+  "placement": "bottom",
+  "referenceProps": {
+    "aria-labelledby": "some-floating-id",
+    "onBlur": [Function],
+    "onClick": [Function],
+    "onFocus": [Function],
+    "onMouseLeave": [Function],
+    "onMouseOver": [Function],
+  },
+  "refs": {
+    "floating": {
+      "current": null,
+    },
+    "reference": {
+      "current": null,
+    },
+    "setFloating": [Function],
+    "setReference": [Function],
+  },
+  "shown": true,
+  "willBeHide": false,
+}
+`;
+
+exports[`useFloatingWithInteractions tests with snapshot should be shown state with disabled close on esc key and click outside events 1`] = `
+{
+  "floatingProps": {
+    "aria-modal": "true",
+    "onAnimationEnd": [Function],
+    "onAnimationStart": [Function],
+    "onMouseLeave": [Function],
+    "onMouseOver": [Function],
+    "role": "dialog",
+    "style": {
+      "bottom": "auto",
+      "left": 0,
+      "position": "fixed",
+      "right": "auto",
+      "top": 0,
+      "width": "max-content",
+    },
+  },
+  "onEscapeKeyDown": undefined,
+  "onRestoreFocus": [Function],
+  "placement": "bottom",
+  "referenceProps": {
+    "aria-labelledby": "some-floating-id",
+    "onBlur": [Function],
+    "onClick": [Function],
+    "onFocus": [Function],
+    "onMouseLeave": [Function],
+    "onMouseOver": [Function],
+  },
+  "refs": {
+    "floating": {
+      "current": null,
+    },
+    "reference": {
+      "current": null,
+    },
+    "setFloating": [Function],
+    "setReference": [Function],
+  },
+  "shown": true,
+  "willBeHide": false,
+}
+`;
+
+exports[`useFloatingWithInteractions tests with snapshot should be shown state with disabled interactive feature 1`] = `
+{
+  "floatingProps": {
+    "aria-modal": "true",
+    "onAnimationEnd": [Function],
+    "onAnimationStart": [Function],
+    "role": "dialog",
+    "style": {
+      "bottom": "auto",
+      "left": 0,
+      "pointerEvents": "none",
+      "position": "fixed",
+      "right": "auto",
+      "top": 0,
+      "width": "max-content",
+    },
+  },
+  "onEscapeKeyDown": [Function],
+  "onRestoreFocus": [Function],
+  "placement": "bottom",
+  "referenceProps": {
+    "aria-labelledby": "some-floating-id",
+    "onBlur": [Function],
+    "onClick": [Function],
+    "onFocus": [Function],
+    "onMouseLeave": [Function],
+    "onMouseOver": [Function],
+  },
+  "refs": {
+    "floating": {
+      "current": null,
+    },
+    "reference": {
+      "current": null,
+    },
+    "setFloating": [Function],
+    "setReference": [Function],
+  },
+  "shown": true,
+  "willBeHide": false,
+}
+`;
+
+exports[`useFloatingWithInteractions tests with snapshot should return default values 1`] = `
+{
+  "floatingProps": {
+    "style": {},
+  },
+  "onEscapeKeyDown": undefined,
+  "onRestoreFocus": [Function],
+  "placement": "bottom",
+  "referenceProps": {
+    "onClick": [Function],
+  },
+  "refs": {
+    "floating": {
+      "current": null,
+    },
+    "reference": {
+      "current": null,
+    },
+    "setFloating": [Function],
+    "setReference": [Function],
+  },
+  "shown": false,
+  "willBeHide": false,
+}
+`;

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/constants.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TRIGGER = 'click';

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/index.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/index.ts
@@ -1,0 +1,5 @@
+export { useFloatingWithInteractions } from './useFloatingWithInteractions';
+
+export type { UseFloatingWithInteractionsProps } from './types';
+
+export { DEFAULT_TRIGGER } from './constants';

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
@@ -14,10 +14,6 @@ export interface UseFloatingWithInteractionsProps
     'placement' | 'offsetByMainAxis' | 'offsetByCrossAxis'
   > {
   /**
-   * Идентификатор всплывающего элемента для a11y.
-   */
-  id?: string;
-  /**
    * Механика вызова всплывающего окна.
    *
    * - `"click"` – показывается/скрывается только при нажатии.

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
@@ -1,0 +1,88 @@
+import type { UseFloatingMiddlewaresBootstrapOptions } from '../useFloatingMiddlewaresBootstrap';
+
+export type InteractiveTriggerType = 'click' | 'hover' | 'focus';
+
+export type ManualTriggerType = 'manual';
+
+export type TriggerType = ManualTriggerType | InteractiveTriggerType | InteractiveTriggerType[];
+
+export type ShownChangeReason = 'click-outside' | 'escape-key' | 'click' | 'hover' | 'focus';
+
+export interface UseFloatingWithInteractionsProps
+  extends Pick<
+    UseFloatingMiddlewaresBootstrapOptions,
+    'placement' | 'offsetByMainAxis' | 'offsetByCrossAxis'
+  > {
+  /**
+   * Идентификатор всплывающего элемента для a11y.
+   */
+  id?: string;
+  /**
+   * Механика вызова всплывающего окна.
+   *
+   * - `"click"` – показывается/скрывается только при нажатии.
+   * - `"hover"` – будет показываться/скрывается при наведении/отведении мыши.
+   * - `"focus"` – будет показываться/скрывается при фокусе/потере фокуса мыши.
+   * - `"manual"` – будет показываться/скрывается только через параметр `shown`. `onShownChange` будет
+   *    вызываться при нажатии за пределы целевого и всплывающего элемента, а также по кнопке ESC.
+
+   * > ⚠️`"hover"` на тач-устройствах будет работать как `"click"`, с одним лишь нюансом, что не будет закрываться
+   * > при повторном нажатии на целевой элемент. Для закрытия необходимо нажать на область вне целевого элемента
+   * > и выпадающего окна.
+   */
+  trigger?: TriggerType;
+  /**
+   * Количество миллисекунд, после которых произойдёт показ/скрытие всплывающего окна при наведении.
+   *
+   * > Чтобы задать разное время на показ и скрытие, передайте массив типа `[<показ>, <скрытие>]`.
+   *
+   * > Используется только для `trigger="hover"`.
+   */
+  hoverDelay?: number | [number, number];
+  /**
+   * Содержимое всплывающего окна.
+   */
+  content?: React.ReactNode;
+  /**
+   * Блокирует изменение состояния.
+   */
+  disabled?: boolean;
+  /**
+   * Отключает взаимодействие со всплывающим элементом.
+   */
+  disableInteractive?: boolean;
+  /**
+   * Отключает закрытие нажатием на область вне целевого и всплывающего элемента.
+   */
+  disableCloseOnClickOutside?: boolean;
+  /**
+   * Отключает закрытие нажатием на кнопку ESC.
+   */
+  disableCloseOnEscKey?: boolean;
+  /**
+   * Начальное состояние всплывающего окна.
+   */
+  defaultShown?: boolean;
+  /**
+   * Если передан, то всплывающее окно будет показано/скрыто в зависимости от значения свойства.
+   */
+  shown?: boolean;
+  /**
+   * Вызывается при каждом изменении видимости всплывающего окна.
+   */
+  onShownChange?(shown: boolean): void;
+}
+
+export type ReferenceProps<T = HTMLElement> = Omit<
+  React.HTMLAttributes<T>,
+  keyof React.DOMAttributes<T>
+> &
+  Pick<React.DOMAttributes<T>, 'onMouseOver' | 'onMouseLeave' | 'onClick' | 'onFocus' | 'onBlur'>;
+
+export type FloatingProps<T = HTMLElement> = Omit<
+  React.HTMLAttributes<T>,
+  keyof React.DOMAttributes<T> | 'style'
+> & { style: React.CSSProperties } & Pick<
+    React.DOMAttributes<T>,
+    'onMouseOver' | 'onMouseLeave' | 'onClick' | 'onAnimationStart' | 'onAnimationEnd'
+  >;

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -1,0 +1,297 @@
+import * as React from 'react';
+import { render, renderHook } from '@testing-library/react';
+import { AppRootContext } from '../../../components/AppRoot/AppRootContext';
+import { FocusTrap } from '../../../components/FocusTrap/FocusTrap';
+import { fireEventPatch, waitForFloatingPosition } from '../../../testing/utils';
+import { useFloatingWithInteractions } from './useFloatingWithInteractions';
+
+const TestComponent = ({
+  hookResultRef,
+  keyboardInput,
+}: {
+  hookResultRef: {
+    current: ReturnType<typeof useFloatingWithInteractions<HTMLButtonElement>>;
+  };
+  keyboardInput?: boolean;
+}) => {
+  const { shown, refs, referenceProps, floatingProps } = hookResultRef.current;
+
+  return (
+    <AppRootContext.Provider value={{ keyboardInput }}>
+      <button ref={refs.reference} {...referenceProps}>
+        Reference
+      </button>
+      {shown ? (
+        <span ref={refs.floating} {...floatingProps}>
+          <FocusTrap
+            autoFocus
+            restoreFocus={hookResultRef.current.onRestoreFocus}
+            onClose={hookResultRef.current.onEscapeKeyDown}
+          >
+            <input data-testid="focus-trap" type="text" defaultValue="Reference" />
+          </FocusTrap>
+        </span>
+      ) : null}
+    </AppRootContext.Provider>
+  );
+};
+
+describe(useFloatingWithInteractions, () => {
+  describe('test cases', () => {
+    it.each([
+      { trigger: 'focus' as const, openEventName: 'focus' as const, closeEventName: 'blur' as const }, // prettier-ignore
+      { trigger: 'click' as const, openEventName: 'click' as const, closeEventName: 'click' as const }, // prettier-ignore
+      { trigger: 'hover' as const, openEventName: 'mouseOver' as const, closeEventName: 'mouseLeave' as const }, // prettier-ignore
+      { trigger: 'focus' as const, openEventName: 'focus' as const, closeEventName: 'keyDown' as const }, // prettier-ignore
+      { trigger: 'click' as const, openEventName: 'click' as const, closeEventName: 'keyDown' as const }, // prettier-ignore
+      { trigger: 'hover' as const, openEventName: 'mouseOver' as const, closeEventName: 'keyDown' as const }, // prettier-ignore
+      { trigger: 'focus' as const, openEventName: 'focus' as const, closeEventName: 'clickOutside' as const }, // prettier-ignore
+      { trigger: 'click' as const, openEventName: 'click' as const, closeEventName: 'clickOutside' as const }, // prettier-ignore
+      { trigger: 'hover' as const, openEventName: 'mouseOver' as const, closeEventName: 'clickOutside' as const }, // prettier-ignore
+    ])(
+      'should shown by $openEventName event  and hidden by $closeEventName event (trigger: $trigger)',
+      async ({ trigger, openEventName, closeEventName }) => {
+        const onShownChange = jest.fn();
+        const { result } = renderHook(() =>
+          useFloatingWithInteractions<HTMLButtonElement>({
+            id: 'some-floating-id',
+            defaultShown: false,
+            trigger: trigger,
+            onShownChange,
+          }),
+        );
+        const { rerender } = render(<TestComponent hookResultRef={result} />);
+        expect(result.current.shown).toBeFalsy();
+        expect(onShownChange).toHaveBeenCalledTimes(0);
+        expect(onShownChange).not.toHaveBeenCalled();
+
+        await fireEventPatch(result.current.refs.reference.current, openEventName);
+        rerender(<TestComponent hookResultRef={result} />);
+        expect(result.current.shown).toBeTruthy();
+        expect(onShownChange).toHaveBeenCalledTimes(1);
+        expect(onShownChange).toHaveBeenLastCalledWith(true);
+
+        let shouldCloseAfter = false;
+        switch (closeEventName) {
+          case 'keyDown':
+            shouldCloseAfter = trigger === 'focus';
+            await fireEventPatch(document, closeEventName, {
+              key: 'Escape',
+              code: 'Escape',
+              charCode: 27,
+            });
+            break;
+          case 'clickOutside':
+            shouldCloseAfter = trigger === 'focus';
+            await fireEventPatch(document, 'click');
+            break;
+          default:
+            await fireEventPatch(result.current.refs.reference.current, closeEventName);
+            await waitForFloatingPosition();
+        }
+        rerender(<TestComponent hookResultRef={result} />);
+        expect(result.current.shown).toBeFalsy();
+        expect(onShownChange).toHaveBeenCalledTimes(2);
+        expect(onShownChange).toHaveBeenLastCalledWith(false);
+
+        if (shouldCloseAfter) {
+          // иначе фокус не сбрасывается
+          await fireEventPatch(result.current.refs.reference.current, 'blur');
+        }
+        await fireEventPatch(result.current.refs.reference.current, openEventName);
+        rerender(<TestComponent hookResultRef={result} />);
+        expect(result.current.shown).toBeTruthy();
+        expect(onShownChange).toHaveBeenCalledTimes(3);
+        expect(onShownChange).toHaveBeenLastCalledWith(true);
+      },
+    );
+
+    it('should stayed shown if hover to floating element', async () => {
+      const { result } = renderHook(() =>
+        useFloatingWithInteractions<HTMLButtonElement>({
+          id: 'some-floating-id',
+          defaultShown: false,
+          hoverDelay: 0,
+          trigger: 'hover',
+        }),
+      );
+      const { rerender } = render(<TestComponent hookResultRef={result} />);
+      expect(result.current.shown).toBeFalsy();
+
+      await fireEventPatch(result.current.refs.reference.current, 'mouseOver');
+      rerender(<TestComponent hookResultRef={result} />);
+      expect(result.current.shown).toBeTruthy();
+
+      await fireEventPatch(result.current.refs.floating.current, 'mouseOver');
+      expect(result.current.shown).toBeTruthy();
+
+      await fireEventPatch(result.current.refs.reference.current, 'mouseOver');
+      expect(result.current.shown).toBeTruthy();
+
+      await fireEventPatch(result.current.refs.floating.current, 'mouseOver');
+      expect(result.current.shown).toBeTruthy();
+
+      await fireEventPatch(result.current.refs.floating.current, 'mouseLeave');
+      rerender(<TestComponent hookResultRef={result} />);
+      expect(result.current.shown).toBeFalsy();
+    });
+
+    it('should restore focus', async () => {
+      const { result } = renderHook(() =>
+        useFloatingWithInteractions<HTMLButtonElement>({
+          id: 'some-floating-id',
+          defaultShown: false,
+          trigger: 'focus',
+        }),
+      );
+      const testComponentRender = render(<TestComponent hookResultRef={result} keyboardInput />);
+      expect(result.current.shown).toBeFalsy();
+
+      await fireEventPatch(result.current.refs.reference.current, 'focus');
+      testComponentRender.rerender(<TestComponent hookResultRef={result} keyboardInput />);
+      expect(result.current.shown).toBeTruthy();
+
+      await fireEventPatch(document, 'keyDown', {
+        key: 'Tab',
+        code: 'Tab',
+        charCode: 9,
+      });
+      expect(testComponentRender.getByTestId('focus-trap')).toHaveFocus();
+
+      await fireEventPatch(document, 'keyDown', {
+        key: 'Escape',
+        code: 'Escape',
+        charCode: 27,
+      });
+      testComponentRender.rerender(<TestComponent hookResultRef={result} keyboardInput />);
+      expect(result.current.shown).toBeFalsy();
+      expect(result.current.refs.reference.current).toHaveFocus();
+    });
+
+    it.each(['focus' as const, 'click' as const])(
+      'should prefer shown state by %s trigger',
+      async (eventName) => {
+        const { result } = renderHook(() =>
+          useFloatingWithInteractions<HTMLButtonElement>({
+            id: 'some-floating-id',
+            defaultShown: false,
+            trigger: ['focus', 'click', 'hover'],
+          }),
+        );
+        render(<TestComponent hookResultRef={result} />);
+        expect(result.current.shown).toBeFalsy();
+        await fireEventPatch(result.current.refs.reference.current, eventName);
+        await fireEventPatch(result.current.refs.reference.current, 'mouseLeave');
+        await fireEventPatch(result.current.refs.floating.current, 'mouseLeave');
+        expect(result.current.shown).toBeTruthy();
+      },
+    );
+
+    it('should use manual state', () => {
+      const { result, rerender } = renderHook(
+        (props) => useFloatingWithInteractions<HTMLButtonElement>(props),
+        {
+          initialProps: { id: 'some-floating-id', shown: false, trigger: 'manual' as const },
+        },
+      );
+      render(<TestComponent hookResultRef={result} />);
+      expect(result.current.shown).toBeFalsy();
+      rerender({
+        id: 'some-floating-id',
+        shown: true,
+        trigger: 'manual',
+      });
+      expect(result.current.shown).toBeTruthy();
+    });
+
+    it('should shown/hidden with animations', async () => {
+      const { result } = renderHook(() =>
+        useFloatingWithInteractions<HTMLButtonElement>({
+          id: 'some-floating-id',
+          defaultShown: false,
+          trigger: 'click',
+        }),
+      );
+      render(<TestComponent hookResultRef={result} />);
+      expect(result.current.shown).toBeFalsy();
+
+      // show
+      await fireEventPatch(result.current.refs.reference.current, 'click');
+      expect(result.current.willBeHide).toBeFalsy();
+      expect(result.current.shown).toBeTruthy();
+
+      const onAnimationStart = jest.spyOn(result.current.floatingProps, 'onAnimationStart');
+      render(<TestComponent hookResultRef={result} />);
+
+      await fireEventPatch(result.current.refs.floating.current, 'animationStart');
+      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+
+      // hide
+      await fireEventPatch(result.current.refs.reference.current, 'click');
+      expect(result.current.willBeHide).toBeTruthy();
+      expect(result.current.shown).toBeTruthy();
+
+      const onAnimationEnd = jest.spyOn(result.current.floatingProps, 'onAnimationEnd');
+      render(<TestComponent hookResultRef={result} />);
+
+      await fireEventPatch(result.current.refs.floating.current, 'animationEnd');
+      expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+      expect(result.current.willBeHide).toBeFalsy();
+      expect(result.current.shown).toBeFalsy();
+    });
+  });
+
+  describe('tests with snapshot', () => {
+    it('should return default values', () => {
+      const { result } = renderHook(() => useFloatingWithInteractions({}));
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('should be hidden state', () => {
+      const { result } = renderHook(() =>
+        useFloatingWithInteractions({
+          id: 'some-floating-id',
+          defaultShown: false,
+          trigger: ['focus', 'click', 'hover'],
+        }),
+      );
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('should be shown state', () => {
+      const { result } = renderHook(() =>
+        useFloatingWithInteractions({
+          id: 'some-floating-id',
+          defaultShown: true,
+          trigger: ['focus', 'click', 'hover'],
+        }),
+      );
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('should be shown state with disabled interactive feature', () => {
+      const { result } = renderHook(() =>
+        useFloatingWithInteractions({
+          id: 'some-floating-id',
+          defaultShown: true,
+          trigger: ['focus', 'click', 'hover'],
+          disableInteractive: true,
+        }),
+      );
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('should be shown state with disabled close on esc key and click outside events', () => {
+      const { result } = renderHook(() =>
+        useFloatingWithInteractions({
+          id: 'some-floating-id',
+          defaultShown: true,
+          trigger: ['focus', 'click', 'hover'],
+          disableCloseOnClickOutside: true,
+          disableCloseOnEscKey: true,
+        }),
+      );
+      expect(result.current).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -54,7 +54,6 @@ describe(useFloatingWithInteractions, () => {
         const onShownChange = jest.fn();
         const { result } = renderHook(() =>
           useFloatingWithInteractions<HTMLButtonElement>({
-            id: 'some-floating-id',
             defaultShown: false,
             trigger: trigger,
             onShownChange,
@@ -109,7 +108,6 @@ describe(useFloatingWithInteractions, () => {
     it('should stayed shown if hover to floating element', async () => {
       const { result } = renderHook(() =>
         useFloatingWithInteractions<HTMLButtonElement>({
-          id: 'some-floating-id',
           defaultShown: false,
           hoverDelay: 0,
           trigger: 'hover',
@@ -139,7 +137,6 @@ describe(useFloatingWithInteractions, () => {
     it('should restore focus', async () => {
       const { result } = renderHook(() =>
         useFloatingWithInteractions<HTMLButtonElement>({
-          id: 'some-floating-id',
           defaultShown: false,
           trigger: 'focus',
         }),
@@ -173,7 +170,6 @@ describe(useFloatingWithInteractions, () => {
       async (eventName) => {
         const { result } = renderHook(() =>
           useFloatingWithInteractions<HTMLButtonElement>({
-            id: 'some-floating-id',
             defaultShown: false,
             trigger: ['focus', 'click', 'hover'],
           }),
@@ -191,13 +187,12 @@ describe(useFloatingWithInteractions, () => {
       const { result, rerender } = renderHook(
         (props) => useFloatingWithInteractions<HTMLButtonElement>(props),
         {
-          initialProps: { id: 'some-floating-id', shown: false, trigger: 'manual' as const },
+          initialProps: { shown: false, trigger: 'manual' as const },
         },
       );
       render(<TestComponent hookResultRef={result} />);
       expect(result.current.shown).toBeFalsy();
       rerender({
-        id: 'some-floating-id',
         shown: true,
         trigger: 'manual',
       });
@@ -207,7 +202,6 @@ describe(useFloatingWithInteractions, () => {
     it('should shown/hidden with animations', async () => {
       const { result } = renderHook(() =>
         useFloatingWithInteractions<HTMLButtonElement>({
-          id: 'some-floating-id',
           defaultShown: false,
           trigger: 'click',
         }),
@@ -250,7 +244,6 @@ describe(useFloatingWithInteractions, () => {
     it('should be hidden state', () => {
       const { result } = renderHook(() =>
         useFloatingWithInteractions({
-          id: 'some-floating-id',
           defaultShown: false,
           trigger: ['focus', 'click', 'hover'],
         }),
@@ -261,7 +254,6 @@ describe(useFloatingWithInteractions, () => {
     it('should be shown state', () => {
       const { result } = renderHook(() =>
         useFloatingWithInteractions({
-          id: 'some-floating-id',
           defaultShown: true,
           trigger: ['focus', 'click', 'hover'],
         }),
@@ -272,7 +264,6 @@ describe(useFloatingWithInteractions, () => {
     it('should be shown state with disabled interactive feature', () => {
       const { result } = renderHook(() =>
         useFloatingWithInteractions({
-          id: 'some-floating-id',
           defaultShown: true,
           trigger: ['focus', 'click', 'hover'],
           disableInteractive: true,
@@ -284,7 +275,6 @@ describe(useFloatingWithInteractions, () => {
     it('should be shown state with disabled close on esc key and click outside events', () => {
       const { result } = renderHook(() =>
         useFloatingWithInteractions({
-          id: 'some-floating-id',
           defaultShown: true,
           trigger: ['focus', 'click', 'hover'],
           disableCloseOnClickOutside: true,

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -26,7 +26,6 @@ const whileElementsMounted: UseFloatingOptions['whileElementsMounted'] = (...arg
  * @private
  */
 export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>({
-  id,
   trigger = DEFAULT_TRIGGER,
 
   // UseFloatingMiddlewaresBootstrapProps
@@ -256,9 +255,6 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   const floatingPropsRef = React.useRef<FloatingProps>({ style: {} });
 
   if (shownFinalState) {
-    referencePropsRef.current['aria-labelledby'] = id;
-    floatingPropsRef.current['role'] = 'dialog';
-    floatingPropsRef.current['aria-modal'] = 'true';
     floatingPropsRef.current.style = convertFloatingDataToReactCSSProperties(strategy, x, y);
 
     if (disableInteractive) {

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -201,10 +201,10 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   useIsomorphicLayoutEffect(
     /**
      * Если пользователь покинул активное окно и:
-     * 1. целевой элемент был в состоянии сфокусирован;
+     * 1. целевой элемент был в состоянии фокуса;
      * 2. всплывающий элемент был закрытом состоянии;
      * то фокус должен быть заблокирован, когда пользователь вернётся обратно. Иначе покажется
-     * всплывающий.
+     * всплывающий элемент.
      */
     function setGlobalBlurForTriggerOnFocus() {
       if (!triggerOnFocus || !refs.reference.current) {

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -1,0 +1,317 @@
+import * as React from 'react';
+import { debounce, noop } from '@vkontakte/vkjs';
+import { getWindow, isHTMLElement } from '@vkontakte/vkui-floating-ui/utils/dom';
+import { useCustomEnsuredControl } from '../../../hooks/useEnsuredControl';
+import { useGlobalOnClickOutside } from '../../../hooks/useGlobalOnClickOutside';
+import { useStableCallback } from '../../../hooks/useStableCallback';
+import { contains, getActiveElementByAnotherElement } from '../../dom';
+import { useIsomorphicLayoutEffect } from '../../useIsomorphicLayoutEffect';
+import { autoUpdateFloatingElement, useFloating } from '../adapters';
+import { convertFloatingDataToReactCSSProperties } from '../functions';
+import { type UseFloatingOptions } from '../types';
+import { useFloatingMiddlewaresBootstrap } from '../useFloatingMiddlewaresBootstrap';
+import { DEFAULT_TRIGGER } from './constants';
+import type {
+  FloatingProps,
+  ReferenceProps,
+  ShownChangeReason,
+  UseFloatingWithInteractionsProps,
+} from './types';
+import { useResolveTriggerType } from './useResolveTriggerType';
+
+const whileElementsMounted: UseFloatingOptions['whileElementsMounted'] = (...args) =>
+  autoUpdateFloatingElement(...args, { elementResize: true });
+
+/**
+ * @private
+ */
+export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>({
+  id,
+  trigger = DEFAULT_TRIGGER,
+
+  // UseFloatingMiddlewaresBootstrapProps
+  placement: expectedPlacement = 'bottom',
+  offsetByMainAxis = 0,
+  offsetByCrossAxis = 0,
+  hoverDelay = 0,
+
+  // disables
+  disabled = false,
+  disableInteractive = false,
+  disableCloseOnClickOutside = false,
+  disableCloseOnEscKey = false,
+
+  // uncontrolled
+  defaultShown = false,
+
+  // controlled
+  shown: shownProp,
+  onShownChange = noop,
+}: UseFloatingWithInteractionsProps) => {
+  const [willBeHide, setWillBeHide] = React.useState(false);
+  const [shownLocalState, setShownLocalState] = useCustomEnsuredControl({
+    value: shownProp,
+    disabled,
+    defaultValue: defaultShown,
+    onChange: useStableCallback(onShownChange),
+  });
+  const [shownFinalState, setShownFinalState] = React.useState(shownLocalState);
+  const wasShowBy = React.useRef<ShownChangeReason | null>(null);
+
+  const hasCSSAnimation = React.useRef(false);
+
+  const blockFocusRef = React.useRef(false);
+  const blurTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
+
+  const handleCloseOnReferenceClickOutsideDisabled =
+    disabled || disableCloseOnClickOutside || willBeHide || !shownLocalState;
+  const handleCloseOnFloatingClickOutsideDisabled =
+    disableInteractive || handleCloseOnReferenceClickOutsideDisabled;
+
+  const { triggerOnFocus, triggerOnClick, triggerOnHover } = useResolveTriggerType(trigger);
+
+  // Библиотека `floating-ui`
+  const { middlewares, strictPlacement } = useFloatingMiddlewaresBootstrap({
+    placement: expectedPlacement,
+    offsetByMainAxis,
+    offsetByCrossAxis,
+  });
+  const { placement, x, y, strategy, refs } = useFloating<T>({
+    strategy: 'fixed',
+    placement: strictPlacement,
+    middleware: middlewares,
+    whileElementsMounted,
+  });
+
+  const commitShownLocalState = React.useCallback(
+    (nextShown: boolean, reason: ShownChangeReason) => {
+      setShownLocalState(nextShown);
+      wasShowBy.current = nextShown ? reason : null;
+    },
+    [setShownLocalState],
+  );
+
+  const [mouseEnterDelay, mouseLeaveDelay] =
+    typeof hoverDelay === 'number' ? [hoverDelay, hoverDelay] : hoverDelay;
+
+  const showWithDelay = React.useMemo(
+    () => debounce(() => commitShownLocalState(true, 'hover'), mouseEnterDelay),
+    [mouseEnterDelay, commitShownLocalState],
+  );
+
+  const hideWithDelay = React.useMemo(
+    () => debounce(() => commitShownLocalState(false, 'hover'), mouseLeaveDelay),
+    [mouseLeaveDelay, commitShownLocalState],
+  );
+
+  const handleFocusOnReference = useStableCallback(() => {
+    if (blockFocusRef.current) {
+      blockFocusRef.current = false;
+      return;
+    }
+
+    commitShownLocalState(true, 'focus');
+  });
+
+  const handleBlurOnReference = useStableCallback((event: React.FocusEvent) => {
+    blockFocusRef.current = false;
+
+    if (!shownLocalState) {
+      clearTimeout(blurTimeoutRef.current);
+      return;
+    }
+
+    const relatedTarget = event.relatedTarget;
+    blurTimeoutRef.current = setTimeout(function waitWindowBlurFire() {
+      const reference = refs.reference.current;
+      // Если пользователь покинул текущее окно в открытом состоянии, то
+      // не закрываем всплывающий элемент.
+      if (!relatedTarget && getActiveElementByAnotherElement(reference) === reference) {
+        return;
+      }
+
+      // Если пользователь нажал на всплывающий элемент, то не закрываем всплывающий элемент.
+      // Note: для этого элемент должен быть фокусируемый (например, за счёт `tabindex="-1"`).
+      if (contains(refs.floating.current, relatedTarget) || contains(reference, relatedTarget)) {
+        return;
+      }
+
+      commitShownLocalState(false, 'focus');
+    });
+  });
+
+  const handleClickOnReference = useStableCallback(() => {
+    commitShownLocalState(!shownLocalState, 'click');
+  });
+
+  const handleMouseEnterOnBoth = useStableCallback(() => {
+    showWithDelay.cancel();
+    hideWithDelay.cancel();
+
+    if (!shownLocalState) {
+      showWithDelay();
+    }
+  });
+
+  const handleMouseLeaveOnBothForHoverAndFocusStates = useStableCallback(() => {
+    blockFocusRef.current = false;
+
+    if (triggerOnHover) {
+      showWithDelay.cancel();
+      hideWithDelay.cancel();
+
+      if (wasShowBy.current !== 'focus' && wasShowBy.current !== 'click') {
+        hideWithDelay();
+      }
+    }
+  });
+
+  const handleFloatingAnimationStart = () => {
+    hasCSSAnimation.current = true;
+  };
+
+  const handleFloatingAnimationEnd = () => {
+    if (willBeHide) {
+      setShownFinalState(false);
+      setWillBeHide(false);
+    }
+  };
+
+  const handleRestoreFocus = React.useCallback(
+    () => (triggerOnFocus ? blockFocusRef.current : true),
+    [triggerOnFocus],
+  );
+
+  const handleEscapeKeyDown = React.useCallback(() => {
+    blockFocusRef.current = true;
+    commitShownLocalState(false, 'escape-key');
+  }, [commitShownLocalState]);
+
+  const handleClickOutside = React.useCallback(() => {
+    blockFocusRef.current = true;
+    commitShownLocalState(false, 'click-outside');
+  }, [commitShownLocalState]);
+
+  useGlobalOnClickOutside(
+    handleClickOutside,
+    handleCloseOnReferenceClickOutsideDisabled ? null : refs.reference,
+    handleCloseOnFloatingClickOutsideDisabled ? null : refs.floating,
+  );
+
+  useIsomorphicLayoutEffect(
+    /**
+     * Если пользователь покинул активное окно и:
+     * 1. целевой элемент был в состоянии сфокусирован;
+     * 2. всплывающий элемент был закрытом состоянии;
+     * то фокус должен быть заблокирован, когда пользователь вернётся обратно. Иначе покажется
+     * всплывающий.
+     */
+    function setGlobalBlurForTriggerOnFocus() {
+      if (!triggerOnFocus || !refs.reference.current) {
+        return;
+      }
+
+      const handleGlobalBlur = () => {
+        const reference = refs.reference.current;
+        if (
+          !shownLocalState &&
+          isHTMLElement(reference) &&
+          reference === getActiveElementByAnotherElement(reference)
+        ) {
+          blockFocusRef.current = true;
+        }
+      };
+
+      const win = getWindow(refs.reference.current);
+      win.addEventListener('blur', handleGlobalBlur);
+      return () => {
+        win.removeEventListener('blur', handleGlobalBlur);
+      };
+    },
+    [triggerOnFocus, refs.reference, shownLocalState],
+  );
+
+  useIsomorphicLayoutEffect(
+    function resolveShownStates() {
+      if (willBeHide || shownLocalState === shownFinalState) {
+        return;
+      }
+
+      if (shownLocalState) {
+        setShownFinalState(true);
+      } else if (hasCSSAnimation.current && !willBeHide) {
+        setWillBeHide(true);
+      } else {
+        setShownFinalState(false);
+      }
+
+      return () => {
+        clearTimeout(blurTimeoutRef.current);
+      };
+    },
+    [shownLocalState, shownFinalState, willBeHide],
+  );
+
+  const referencePropsRef = React.useRef<ReferenceProps>({});
+  const floatingPropsRef = React.useRef<FloatingProps>({ style: {} });
+
+  if (shownFinalState) {
+    referencePropsRef.current['aria-labelledby'] = id;
+    floatingPropsRef.current['role'] = 'dialog';
+    floatingPropsRef.current['aria-modal'] = 'true';
+    floatingPropsRef.current.style = convertFloatingDataToReactCSSProperties(strategy, x, y);
+
+    if (disableInteractive) {
+      floatingPropsRef.current.style.pointerEvents = 'none';
+    }
+  }
+
+  if (triggerOnFocus) {
+    referencePropsRef.current.onFocus = handleFocusOnReference;
+    referencePropsRef.current.onBlur = handleBlurOnReference;
+  }
+
+  if (triggerOnClick) {
+    referencePropsRef.current.onClick = handleClickOnReference;
+  }
+
+  if (triggerOnHover) {
+    referencePropsRef.current.onMouseOver = handleMouseEnterOnBoth;
+
+    if (!disableInteractive) {
+      floatingPropsRef.current.onMouseOver = handleMouseEnterOnBoth;
+    }
+  }
+
+  if (triggerOnHover || triggerOnFocus) {
+    referencePropsRef.current.onMouseLeave = handleMouseLeaveOnBothForHoverAndFocusStates;
+
+    if (!disableInteractive) {
+      floatingPropsRef.current.onMouseLeave = handleMouseLeaveOnBothForHoverAndFocusStates;
+    }
+  }
+
+  if (shownFinalState) {
+    floatingPropsRef.current.onAnimationStart = handleFloatingAnimationStart;
+    floatingPropsRef.current.onAnimationEnd = handleFloatingAnimationEnd;
+  }
+
+  return {
+    placement,
+    shown: shownFinalState,
+    willBeHide,
+    refs,
+    referenceProps: referencePropsRef.current,
+    floatingProps: floatingPropsRef.current,
+    // FocusTrap уже определяет нажатие на ESC, поэтому название события содержит конкретный код
+    // кнопки вместо просто onKeyDown.
+    onEscapeKeyDown: !shownFinalState || disableCloseOnEscKey ? undefined : handleEscapeKeyDown,
+    // [Обход баги с FocusTrap]
+    //
+    // Если сфокусироваться на целевой элемент через нажатие, а потом нажать в область за пределами
+    // целевого и всплывающего элемента, то появляется моргание из-за того, что FocusTrap
+    // восстанавливает фокус, из-за чего всплывающий элемент снова показывается за счёт
+    // `handleFocusOnReference`, а потом скрывается за счёт `handleBlurOnReference`.
+    onRestoreFocus: handleRestoreFocus,
+  };
+};

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useResolveTriggerType.test.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useResolveTriggerType.test.ts
@@ -1,0 +1,29 @@
+import { useResolveTriggerType } from './useResolveTriggerType';
+
+describe(useResolveTriggerType, () => {
+  const defaultResult = { triggerOnFocus: false, triggerOnClick: false, triggerOnHover: false };
+  const onlyFocusResult = { triggerOnFocus: true, triggerOnClick: false, triggerOnHover: false };
+  const onlyClickResult = { triggerOnFocus: false, triggerOnClick: true, triggerOnHover: false };
+  const onlyHoverResult = { triggerOnFocus: false, triggerOnClick: false, triggerOnHover: true };
+
+  it.each([
+    { type: 'focus', args: 'focus' as const, result: onlyFocusResult },
+    { type: 'focus', args: ['focus' as const], result: onlyFocusResult },
+    { type: 'click', args: ['click' as const], result: onlyClickResult },
+    { type: 'click', args: ['click' as const], result: onlyClickResult },
+    { type: 'hover', args: ['hover' as const], result: onlyHoverResult },
+    { type: 'hover', args: ['hover' as const], result: onlyHoverResult },
+    { type: 'manual', args: 'manual' as const, result: defaultResult },
+  ])(`should return only $type predicate for args are $args`, ({ args, result }) => {
+    expect(useResolveTriggerType(args)).toEqual(result);
+  });
+
+  it.each([
+    { args: ['focus' as const, 'click' as const, 'hover' as const], result: { triggerOnFocus: true, triggerOnClick: true, triggerOnHover: true } }, // prettier-ignore
+    { args: ['focus' as const, 'click' as const], result: { triggerOnFocus: true, triggerOnClick: true, triggerOnHover: false } }, // prettier-ignore
+    { args: ['focus' as const, 'hover' as const], result: { triggerOnFocus: true, triggerOnClick: false, triggerOnHover: true } }, // prettier-ignore
+    { args: ['click' as const, 'hover' as const], result: { triggerOnFocus: false, triggerOnClick: true, triggerOnHover: true } }, // prettier-ignore
+  ])(`should return combination predicates for args are $args`, ({ args, result }) => {
+    expect(useResolveTriggerType(args)).toEqual(result);
+  });
+});

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useResolveTriggerType.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useResolveTriggerType.ts
@@ -1,0 +1,25 @@
+import type { TriggerType } from './types';
+
+export const useResolveTriggerType = (triggerProp: TriggerType) =>
+  (typeof triggerProp === 'string' ? [triggerProp] : triggerProp).reduce(
+    (result, trigger) => {
+      switch (trigger) {
+        case 'click':
+          result.triggerOnClick = true;
+          return result;
+        case 'hover':
+          result.triggerOnHover = true;
+          return result;
+        case 'focus':
+          result.triggerOnFocus = true;
+          return result;
+        case 'manual':
+          return result;
+      }
+    },
+    {
+      triggerOnFocus: false,
+      triggerOnClick: false,
+      triggerOnHover: false,
+    },
+  );

--- a/packages/vkui/src/testing/utils.tsx
+++ b/packages/vkui/src/testing/utils.tsx
@@ -293,7 +293,7 @@ export const requestAnimationFrameMock = {
 };
 
 /**
- * Эта функция собирает бойлеплейт по работе с fireEvent.
+ * Эта функция собирает бойлерплейт по работе с fireEvent.
  */
 export const fireEventPatch = async (
   el: Document | Element | Window | Node | null,


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

- В `lib/floating` создал хук `useFloatingMiddlewaresBootstrap`, где вынес сборку миддлваров для `useFloating()` в единое место.
- В `lib/floating` создал хук `useFloatingWithInteractions()`, который реализует интерактивное поведение для всплывающих элементов. А именно открытие/скрытие на `focus`, `click` и `hover`. Можно комбинировать. Также добавил `manual`, который позволит полностью самому управлять показом/скрытием.
  Заложил логику для обработки CSS анимаций
  > **Note**
  > Учитываю, что у пользователя анимация может быть системна отключена. Проверяю через событие `onAnimationStart` была ли анимация при открытии.

Изменения нужны для issue:

- block #2523 

## Изменения

По ходу дела пошатал `FocusTrap`, получилось сделать его полегче, из изменений:
- Добавил параметр `autoFocus`.
- Параметр `restoreFocus` теперь мб функцией (в `useFloatingWithInteractions()`  у обработчика `onRestoreFocus` есть описание для чего).
- В эффекте `tryToRestoreFocusOnUnmount()` при анмаунте для тестов мы сразу вызываем фокус (написал комментарий в коде почему).
