### PR TITLE
feat(Header): Allow to change subtitle component

### DIFF
--- a/packages/vkui/src/components/Header/Header.stories.tsx
+++ b/packages/vkui/src/components/Header/Header.stories.tsx
@@ -28,6 +28,7 @@ export const WithSubtitle: Story = {
   args: {
     ...Playground.args,
     subtitle: 'SOHN — Conrad',
+    subtitleComponent: 'h3',
   },
 };
 

--- a/packages/vkui/src/components/Header/Header.test.tsx
+++ b/packages/vkui/src/components/Header/Header.test.tsx
@@ -85,7 +85,7 @@ describe('Header', () => {
     expect(screen.getByText('中國人').parentElement?.tagName.toLowerCase()).toMatch('h2');
   });
 
-  it('[typography] HeaderSubtitle is span regardless of mode', () => {
+  it('[typography] HeaderSubtitle is span by default regardless of mode', () => {
     render(
       <Fragment>
         <Header mode="primary" subtitle="Русский" />
@@ -96,6 +96,19 @@ describe('Header', () => {
     expect(getTypographyTagNameByText('Русский')).toMatch('span');
     expect(getTypographyTagNameByText('English')).toMatch('span');
     expect(getTypographyTagNameByText('Espanõl')).toMatch('span');
+  });
+
+  it('[typography] HeaderSubtitle is h3 with subtitleComponent prop regardless of mode', () => {
+    render(
+      <Fragment>
+        <Header mode="primary" subtitle="Русский" subtitleComponent="h3" />
+        <Header mode="secondary" subtitle="English" subtitleComponent="h3" />
+        <Header mode="tertiary" subtitle="Espanõl" subtitleComponent="h3" />
+      </Fragment>,
+    );
+    expect(getTypographyTagNameByText('Русский')).toMatch('h3');
+    expect(getTypographyTagNameByText('English')).toMatch('h3');
+    expect(getTypographyTagNameByText('Espanõl')).toMatch('h3');
   });
 
   it('[typography] HeaderAside is span regardless of platform', () => {

--- a/packages/vkui/src/components/Header/Header.tsx
+++ b/packages/vkui/src/components/Header/Header.tsx
@@ -14,6 +14,8 @@ export interface HeaderProps extends HTMLAttributesWithRootRef<HTMLElement>, Has
   mode?: 'primary' | 'secondary' | 'tertiary';
   size?: 'regular' | 'large';
   subtitle?: React.ReactNode;
+  /* Позволяет задать тип элемента в который будет обёрнут subtitle */
+  subtitleComponent?: React.ElementType;
   /**
    * Допускаются иконки, текст, Link
    */
@@ -77,6 +79,7 @@ export const Header = ({
   Component = 'h2',
   children,
   subtitle,
+  subtitleComponent = 'span',
   indicator,
   aside,
   multiline,
@@ -121,7 +124,7 @@ export const Header = ({
               styles['Header__subtitle'],
               multiline && styles['Header__content--multiline'],
             )}
-            Component="span"
+            Component={subtitleComponent}
           >
             {subtitle}
           </Subhead>

--- a/packages/vkui/src/components/Header/Readme.md
+++ b/packages/vkui/src/components/Header/Readme.md
@@ -27,6 +27,7 @@ const Example = () => {
               </Link>
             }
             subtitle="SOHN — Conrad"
+            subtitleComponent="h3"
           >
             Плейлисты
           </Header>

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -214,3 +214,15 @@
 ```
 
 <br/><br/>
+
+## Header
+
+Теперь для подзаголовка `subtitle` можно задать тип тэга с помощью свойства `subtitleComponent`.
+
+```jsx static
+<Header subtitle="SOHN — Conrad" subtitleComponent="h3">
+  Плейлисты
+</Header>
+```
+
+<br/><br/>


### PR DESCRIPTION
- related #4696

---

- [x] Unit-тесты
- [x] Документация фичи
- [x] Гайд миграции

## Описание
Компонент `Header` позволяет задать текст `subtitle`, но не позволяет поменять тип элемента в котором этот текст будет отрендерен.

Добавляем новый проп `subtitleComponent`.

## Вопрос

Надо ли менять значение по умолчанию свойства `Component` у `Header` с `h2` на `span`? 
~Этот компонент не используется внутри других компонентов у нас. Может быть и лишнее.~

Ответ: 
Лучше не трогать значение по умолчанию.