### PR TITLE
feat(Badge/Counter): pass `aria-label` via children

### DIFF
--- a/packages/vkui/src/components/Badge/Badge.stories.tsx
+++ b/packages/vkui/src/components/Badge/Badge.stories.tsx
@@ -19,11 +19,13 @@ export const Playground: Story = {};
 export const NewMode: Story = {
   args: {
     mode: 'new',
+    children: 'Есть обновления',
   },
 };
 
 export const ProminentMode: Story = {
   args: {
     mode: 'prominent',
+    children: 'Новый раздел',
   },
 };

--- a/packages/vkui/src/components/Badge/Badge.tsx
+++ b/packages/vkui/src/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { HTMLAttributesWithRootRef } from '../../types';
-import { RootComponent } from '../RootComponent/RootComponent';
+import { RootComponent, RootComponentProps } from '../RootComponent/RootComponent';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './Badge.module.css';
 
 const stylesMode = {
@@ -9,17 +9,19 @@ const stylesMode = {
   prominent: styles['Badge--mode-prominent'],
 };
 
-export interface BadgeProps extends HTMLAttributesWithRootRef<HTMLSpanElement> {
+export interface BadgeProps extends RootComponentProps<HTMLSpanElement> {
   mode: 'new' | 'prominent';
 }
 
 /**
  * @see https://vkcom.github.io/VKUI/#/Badge
  */
-export const Badge = ({ mode = 'new', ...restProps }: BadgeProps) => (
+export const Badge = ({ mode = 'new', children, ...restProps }: BadgeProps) => (
   <RootComponent
     Component="span"
     baseClassName={classNames(styles['Badge'], stylesMode[mode])}
     {...restProps}
-  />
+  >
+    {children && <VisuallyHidden>{children}</VisuallyHidden>}
+  </RootComponent>
 );

--- a/packages/vkui/src/components/Badge/Readme.md
+++ b/packages/vkui/src/components/Badge/Readme.md
@@ -1,24 +1,24 @@
 Индикатор, с помощью которого можно привлечь внимание пользователя к определенному разделу.
 
+## Цифровая доступность (a11y)
+
+Чтобы `Badge` был доступным для ассистивных технологий, у него должен быть текст, который сможет прочитать скринридер. Этот текст можно передать в `children`.
+
 ```jsx
 <View activePanel="badge">
   <Panel id="badge">
     <PanelHeader>Бейдж</PanelHeader>
 
     <Group header={<Header mode="secondary">В пунктах меню</Header>}>
-      <Cell
-        expandable="auto"
-        before={<Icon28Notifications />}
-        badgeAfterTitle={<Badge aria-label="Есть новые" />}
-      >
+      <Cell expandable before={<Icon28Notifications />} badgeAfterTitle={<Badge>Есть новые</Badge>}>
         Уведомления
       </Cell>
     </Group>
 
     <Group header={<Header mode="secondary">В переключателях</Header>}>
       <Tabs>
-        <TabsItem after={<Badge mode="prominent" aria-label="Есть новые" />}>Диалоги</TabsItem>
-        <TabsItem selected after={<Badge mode="prominent" aria-label="Есть новые" />}>
+        <TabsItem after={<Badge mode="prominent">Есть новые</Badge>}>Диалоги</TabsItem>
+        <TabsItem selected after={<Badge mode="prominent">Есть новые</Badge>}>
           Сообщения
         </TabsItem>
       </Tabs>
@@ -38,7 +38,7 @@
       >
         <Icon28MessageOutline />
       </TabbarItem>
-      <TabbarItem indicator={<Badge mode="prominent" aria-label="Новый раздел" />} text="Клипы">
+      <TabbarItem indicator={<Badge mode="prominent">Новый раздел</Badge>} text="Клипы">
         <Icon28ClipOutline />
       </TabbarItem>
     </Tabbar>

--- a/packages/vkui/src/components/Counter/Counter.stories.tsx
+++ b/packages/vkui/src/components/Counter/Counter.stories.tsx
@@ -1,6 +1,8 @@
+import * as React from 'react';
 import { withCartesian } from '@project-tools/storybook-addon-cartesian';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout } from '../../storybook/constants';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { Counter, CounterProps } from './Counter';
 
 const story: Meta<CounterProps> = {
@@ -16,6 +18,10 @@ type Story = StoryObj<CounterProps>;
 
 export const Playground: Story = {
   args: {
-    children: '5',
+    children: (
+      <>
+        <VisuallyHidden>Обновлений:</VisuallyHidden> 5
+      </>
+    ),
   },
 };

--- a/packages/vkui/src/components/Counter/Readme.md
+++ b/packages/vkui/src/components/Counter/Readme.md
@@ -1,6 +1,10 @@
 Компонент для отрисовки счетчика в ячейках и кнопках.
 Принимает в качестве `children` число или строку с отформатированным числом по разрядам.
 
+## Цифровая доступность (a11y)
+
+Если для того, чтобы `Counter` был доступным для ассистивных технологий, нужен поясняющий текст, который сможет прочитать скринридер, вы можете передать его в `children` вместе с числом, предварительно обернув текст в компонент [VisuallyHidden](#/VisuallyHidden).
+
 ```jsx
 <View activePanel="counter-demo">
   <Panel id="counter-demo">
@@ -13,7 +17,14 @@
         <Cell before={<Icon28UsersOutline />} indicator={<Counter mode="primary">2</Counter>}>
           Группы
         </Cell>
-        <Cell before={<Icon28MessageOutline />} indicator={<Counter>224</Counter>}>
+        <Cell
+          before={<Icon28MessageOutline />}
+          indicator={
+            <Counter>
+              <VisuallyHidden>Новых:</VisuallyHidden> 224
+            </Counter>
+          }
+        >
           Сообщения
         </Cell>
         <Cell before={<Icon28FavoriteOutline />} indicator={<Counter mode="primary">1</Counter>}>
@@ -53,7 +64,7 @@
         <Header
           indicator={
             <Counter size="s" mode="prominent">
-              5
+              5 <VisuallyHidden>новых</VisuallyHidden>
             </Counter>
           }
           aside={<Link>Посмотреть все</Link>}

--- a/packages/vkui/src/components/Epic/Epic.stories.tsx
+++ b/packages/vkui/src/components/Epic/Epic.stories.tsx
@@ -157,7 +157,7 @@ export const Example: Story = {
                     onClick={onStoryChange}
                     selected={activeStory === 'profile'}
                     data-story="profile"
-                    indicator={<Badge mode="prominent" />}
+                    indicator={<Badge mode="prominent">Есть обновления</Badge>}
                     text="Профиль"
                   >
                     <Icon28UserCircleOutline />

--- a/packages/vkui/src/components/Epic/Readme.md
+++ b/packages/vkui/src/components/Epic/Readme.md
@@ -134,7 +134,7 @@ const Example = () => {
                   onClick={onStoryChange}
                   selected={activeStory === 'profile'}
                   data-story="profile"
-                  indicator={<Badge mode="prominent" />}
+                  indicator={<Badge mode="prominent">Есть обновления</Badge>}
                   text="Профиль"
                 >
                   <Icon28UserCircleOutline />

--- a/packages/vkui/src/components/PanelHeader/Readme.md
+++ b/packages/vkui/src/components/PanelHeader/Readme.md
@@ -48,7 +48,8 @@ const Example = () => {
               <PanelHeaderButton
                 aria-label="Изображения"
                 label={
-                  <Counter size="s" mode="prominent" aria-label="Обновлений: ">
+                  <Counter size="s" mode="prominent">
+                    <VisuallyHidden>Обновлений: </VisuallyHidden>
                     21
                   </Counter>
                 }
@@ -74,8 +75,8 @@ const Example = () => {
                 <PanelHeaderButton
                   aria-label="Настройки"
                   label={
-                    <Counter size="s" mode="prominent" aria-label="Новые настройки: ">
-                      3
+                    <Counter size="s" mode="prominent">
+                      <VisuallyHidden>Новых: </VisuallyHidden>3
                     </Counter>
                   }
                 >
@@ -87,7 +88,7 @@ const Example = () => {
                 <PanelHeaderButton
                   aria-label="Уведомления"
                   label={
-                    <Counter size="s" mode="prominent" aria-label="Уведомлений: ">
+                    <Counter size="s" mode="prominent">
                       2
                     </Counter>
                   }

--- a/packages/vkui/src/components/SubnavigationBar/Readme.md
+++ b/packages/vkui/src/components/SubnavigationBar/Readme.md
@@ -145,7 +145,14 @@ const SubnavigationBarExample = () => {
                   before={<Icon24Filter />}
                   selected={filtersCount > 0}
                   expandable
-                  after={filtersCount > 0 && <Counter size="s">{filtersCount}</Counter>}
+                  after={
+                    filtersCount > 0 && (
+                      <Counter size="s">
+                        <VisuallyHidden>Применено: </VisuallyHidden>
+                        {filtersCount}
+                      </Counter>
+                    )
+                  }
                   onClick={openModal}
                 >
                   Фильтры

--- a/packages/vkui/src/components/Tabbar/Tabbar.stories.tsx
+++ b/packages/vkui/src/components/Tabbar/Tabbar.stories.tsx
@@ -74,7 +74,7 @@ export const Playground: Story = {
           onClick={onStoryChange}
           selected={activeStory === 'profile'}
           data-story="profile"
-          indicator={<Badge mode="prominent" />}
+          indicator={<Badge mode="prominent">Есть обновления</Badge>}
           text="Профиль"
         >
           <Icon28UserCircleOutline />

--- a/packages/vkui/src/components/TabbarItem/Readme.md
+++ b/packages/vkui/src/components/TabbarItem/Readme.md
@@ -62,7 +62,7 @@ const [indicator, setIndicator] = useState('one');
       <TabbarItem
         selected={indicator === 'one'}
         onClick={() => setIndicator('one')}
-        indicator={<Badge mode="prominent" />}
+        indicator={<Badge mode="prominent">Есть обновления</Badge>}
         text="Новости"
       >
         <Icon28NewsfeedOutline />

--- a/packages/vkui/src/components/TabbarItem/TabbarItem.stories.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.stories.tsx
@@ -18,7 +18,7 @@ const story: Meta<TabbarItemProps> = {
       options: ['None', 'Badge', 'Counter'],
       mapping: {
         None: null,
-        Badge: <Badge mode="prominent" />,
+        Badge: <Badge mode="prominent">Есть обновления</Badge>,
         Counter: (
           <Counter size="s" mode="prominent">
             3

--- a/packages/vkui/src/components/Tabs/Readme.md
+++ b/packages/vkui/src/components/Tabs/Readme.md
@@ -162,7 +162,7 @@ const Scrollable = () => {
           </TabsItem>
           <TabsItem
             before={mode === 'default' ? <Icon24ThumbsUpOutline /> : <Icon20ThumbsUpOutline />}
-            status={<Badge mode="prominent" />}
+            status={<Badge mode="prominent">Есть новые</Badge>}
             after={<Icon16Dropdown />}
             selected={selected === 'recommendations'}
             disabled={disabled}

--- a/packages/vkui/src/components/Tabs/Tabs.e2e-playground.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.e2e-playground.tsx
@@ -46,7 +46,7 @@ const Scrollable = ({ disabled }: { disabled?: boolean }) => {
         </TabsItem>
         <TabsItem
           before={beforeIconByMode}
-          status={<Badge mode="prominent" />}
+          status={<Badge mode="prominent">Есть новые</Badge>}
           after={<Icon16Dropdown />}
           disabled={disabled}
         >
@@ -89,8 +89,8 @@ export const TabsPlayground = (props: ComponentPlaygroundProps) => {
             <Unscrollable key="tabs">
               <TabsItem>Лента</TabsItem>
             </Unscrollable>,
-            <Unscrollable key="tabs" status={<Badge mode="prominent" />} />,
-            <Unscrollable key="tabs" status={<Badge mode="prominent" />}>
+            <Unscrollable key="tabs" status={<Badge mode="prominent">Есть обновления</Badge>} />,
+            <Unscrollable key="tabs" status={<Badge mode="prominent">Есть обновления</Badge>}>
               <TabsItem>Лента</TabsItem>
             </Unscrollable>,
             <Unscrollable

--- a/packages/vkui/src/components/TabsItem/TabsItem.stories.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.stories.tsx
@@ -50,7 +50,7 @@ export const WithBadge: Story = {
     children: 'Рекомендации',
     before: <Icon20ThumbsUpOutline />,
     after: <Icon16Dropdown />,
-    status: <Badge mode="prominent" />,
+    status: <Badge mode="prominent">Есть обновления</Badge>,
   },
 };
 


### PR DESCRIPTION
- relates to https://github.com/VKCOM/VKUI/issues/2673
- closes https://github.com/VKCOM/VKUI/issues/5012

---

- [x] Документация фичи

## Описание

Растаскиваю на части #6139, чтобы было попроще ревьюить.

(Badge и Counter я воспринимаю как один компонент, который было бы классно однажды смерджить назад в один, поэтому решила вытащить их вдвоем вместе.)

## Изменения

- [x] `Badge`: добавила возможность прокинуть `children` с нужным текстом, примеры, обновила пример в сторибуке
- [x] `Counter`: добавила примеры того, как добавить поясняющий текст через `children`, обновила пример в сторибуке