### PR TITLE
feat(FormItem): Allow to change default tag for top prop

### DIFF
--- a/packages/vkui/src/components/FormItem/FormItem.test.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.test.tsx
@@ -1,6 +1,26 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { FormItem } from './FormItem';
 
 describe('FormItem', () => {
   baselineComponent(FormItem);
+
+  it('controls top prop text wrapper', () => {
+    const { rerender } = render(<FormItem top="Имя" />);
+
+    // по умолчанию span
+    expect(screen.getByText('Имя').tagName.toLowerCase()).toMatch('span');
+
+    rerender(<FormItem top="Имя" topComponent="p" />);
+    expect(screen.getByText('Имя').tagName.toLowerCase()).toMatch('p');
+
+    rerender(
+      <FormItem top="Имя" htmlFor="name">
+        <input id="name" />
+      </FormItem>,
+    );
+    // c htmlFor и без topComponent используется "label"
+    expect(screen.getByText('Имя').tagName.toLowerCase()).toMatch('label');
+  });
 });

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -25,6 +25,12 @@ export interface FormItemProps
     HasComponent,
     RemovableProps {
   top?: React.ReactNode;
+  /**
+   * Позволяет поменять тег используемый для top
+   * Если оставить пустым, то тег top будет span.
+   * Если оставить пустым и использовать htmlFor, то тег top будет label.
+   */
+  topComponent?: React.ElementType;
   bottom?: React.ReactNode;
   /**
    * Передаётся при использовании `bottom`.
@@ -52,6 +58,7 @@ export interface FormItemProps
 export const FormItem = ({
   children,
   top,
+  topComponent: topComponentProp,
   bottom,
   status = 'default',
   removable,
@@ -66,14 +73,11 @@ export const FormItem = ({
   const rootEl = useExternRef(getRootRef);
   const { sizeY = 'none' } = useAdaptivity();
 
+  const topComponent = topComponentProp || (htmlFor && 'label') || 'span';
   const wrappedChildren = (
     <React.Fragment>
       {hasReactNode(top) && (
-        <Subhead
-          className={styles['FormItem__top']}
-          Component={htmlFor ? 'label' : 'h5'}
-          htmlFor={htmlFor}
-        >
+        <Subhead className={styles['FormItem__top']} Component={topComponent} htmlFor={htmlFor}>
           {top}
         </Subhead>
       )}

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -230,6 +230,18 @@ interface HasInsets {
 
 <br/><br/>
 
+## FormItem
+
+Изменён тeг (с `h5` на `span`), в котором значение `top` рендерится по умолчанию, если не указано свойство `htmlFor`.
+Если свойство `htmlFor` указано, но тег будет `label`.
+Переопределить тeг по умолчанию можно с помощью свойства `topComponent`.
+
+```jsx static
+<FormItem top="Имя topComponent="h5" />
+```
+
+<br/><br/>
+
 ## Header
 
 Теперь для подзаголовка `subtitle` можно задать тип тэга с помощью свойства `subtitleComponent`.


### PR DESCRIPTION
- related #4696 

---

- [x] Unit-тесты
- [x] Документация фичи
- [x] Гайд миграции

## Описание
Так как использование `h5` как тега по умолчанию может повредить доступности мы меняем значение тега по умолчанию для свойства `top`. Теперь это `span`, если не задан `htmlFor` или `topComponent`. 
Добавили новое свойство `topComponent`, чтобы дать возможность менять `тэг` `top`.