### PR TITLE
refactor: useKeyboardInputTracker()

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -99,7 +99,7 @@ export const AppRoot = ({
   layout,
   ...props
 }: AppRootProps) => {
-  const isKeyboardInputActive = useKeyboardInputTracker();
+  const isKeyboardInputActiveRef = useKeyboardInputTracker();
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   const [portalRoot, setPortalRoot] = React.useState<HTMLElement | null>(null);
   const { document } = useDOM();
@@ -238,10 +238,12 @@ export const AppRoot = ({
         appRoot: rootRef,
         portalRoot,
         embedded: mode === 'embedded',
-        keyboardInput: isKeyboardInputActive,
         mode,
         disablePortal,
         layout,
+        get keyboardInput() {
+          return isKeyboardInputActiveRef.current;
+        },
       }}
     >
       <ScrollController elRef={rootRef}>{children}</ScrollController>

--- a/packages/vkui/src/hooks/useKeyboardInputTracker.test.ts
+++ b/packages/vkui/src/hooks/useKeyboardInputTracker.test.ts
@@ -1,0 +1,79 @@
+import { act, fireEvent, renderHook } from '@testing-library/react';
+import { FOCUS_ALLOW_LIST_KEYS, Keys } from '../lib/accessibility';
+import {
+  DISABLE_KEYBOARD_INPUT_EVENT_NAME,
+  ENABLE_KEYBOARD_INPUT_EVENT_NAME,
+  useKeyboardInputTracker,
+} from './useKeyboardInputTracker';
+
+describe(useKeyboardInputTracker, () => {
+  const KEYBOARD_EXPECTED_EVENT = { key: Keys.TAB, code: Keys.TAB };
+  const ALL_KEYBOARD_EXPECTED_EVENTS = Array.from(FOCUS_ALLOW_LIST_KEYS).map((key) => ({
+    key,
+    code: key,
+  }));
+  it.each(ALL_KEYBOARD_EXPECTED_EVENTS)(
+    'should returns true when user calls keyDown event with code $key',
+    (event) => {
+      const result = renderHook(() => useKeyboardInputTracker());
+      expect(result.result.current.current).toBeFalsy();
+
+      fireEvent.keyDown(document, event);
+      expect(result.result.current.current).toBeTruthy();
+
+      act(() => {
+        document.dispatchEvent(new Event(DISABLE_KEYBOARD_INPUT_EVENT_NAME, { bubbles: true }));
+      });
+      expect(result.result.current.current).toBeFalsy();
+    },
+  );
+
+  it('should returns true/false when user calls custom event', () => {
+    const result = renderHook(() => useKeyboardInputTracker());
+
+    act(() => {
+      document.dispatchEvent(new Event(ENABLE_KEYBOARD_INPUT_EVENT_NAME, { bubbles: true }));
+    });
+    expect(result.result.current.current).toBeTruthy();
+
+    act(() => {
+      document.dispatchEvent(new Event(DISABLE_KEYBOARD_INPUT_EVENT_NAME, { bubbles: true }));
+    });
+    expect(result.result.current.current).toBeFalsy();
+  });
+
+  it('should returns false when user calls mouseDown event', () => {
+    const result = renderHook(() => useKeyboardInputTracker());
+
+    fireEvent.keyDown(document, KEYBOARD_EXPECTED_EVENT);
+    expect(result.result.current.current).toBeTruthy();
+
+    fireEvent.mouseDown(document);
+    expect(result.result.current.current).toBeFalsy();
+  });
+
+  it('should returns false when user calls touchStart event', () => {
+    const result = renderHook(() => useKeyboardInputTracker());
+
+    fireEvent.keyDown(document, KEYBOARD_EXPECTED_EVENT);
+    expect(result.result.current.current).toBeTruthy();
+
+    fireEvent.touchStart(document);
+    expect(result.result.current.current).toBeFalsy();
+  });
+
+  it('should cleanups events after unmount', () => {
+    const result = renderHook(() => useKeyboardInputTracker());
+
+    fireEvent.keyDown(document, KEYBOARD_EXPECTED_EVENT);
+    expect(result.result.current.current).toBeTruthy();
+
+    fireEvent.touchStart(document);
+    expect(result.result.current.current).toBeFalsy();
+
+    result.unmount();
+
+    fireEvent.keyDown(document, KEYBOARD_EXPECTED_EVENT);
+    expect(result.result.current.current).toBeFalsy();
+  });
+});

--- a/packages/vkui/src/lib/accessibility.ts
+++ b/packages/vkui/src/lib/accessibility.ts
@@ -32,80 +32,38 @@ export const Keys = {
 
 export type KeysValues = ValuesOfObject<typeof Keys>;
 
-interface AccessibleKey {
-  code: KeysValues;
-  key: string[];
-  keyCode: number;
+const EVENT_KEY_TO_COMMON_KEY_MAP = new Map([
+  ['Enter', Keys.ENTER],
+  ['Space', Keys.SPACE],
+  ['Spacebar', Keys.SPACE],
+  [' ', Keys.SPACE],
+  ['Tab', Keys.TAB],
+  ['Escape', Keys.ESCAPE],
+  ['Home', Keys.HOME],
+  ['End', Keys.END],
+  ['ArrowLeft', Keys.ARROW_LEFT],
+  ['ArrowRight', Keys.ARROW_RIGHT],
+  ['ArrowUp', Keys.ARROW_UP],
+  ['ArrowDown', Keys.ARROW_DOWN],
+  ['PageUp', Keys.PAGE_UP],
+  ['PageDown', Keys.PAGE_DOWN],
+]);
+
+export function pressedKey<T extends KeyboardEvent | React.KeyboardEvent>(event: T) {
+  const foundKey = EVENT_KEY_TO_COMMON_KEY_MAP.get(event.key);
+  return foundKey ? foundKey : null;
 }
 
-const ACCESSIBLE_KEYS: AccessibleKey[] = [
-  {
-    code: Keys.ENTER,
-    key: ['Enter'],
-    keyCode: 13,
-  },
-  {
-    code: Keys.SPACE,
-    key: ['Space', 'Spacebar', ' '],
-    keyCode: 32,
-  },
-  {
-    code: Keys.TAB,
-    key: ['Tab'],
-    keyCode: 9,
-  },
-  {
-    code: Keys.ESCAPE,
-    key: ['Escape'],
-    keyCode: 27,
-  },
-  {
-    code: Keys.HOME,
-    key: ['Home'],
-    keyCode: 36,
-  },
-  {
-    code: Keys.END,
-    key: ['End'],
-    keyCode: 35,
-  },
-  {
-    code: Keys.ARROW_LEFT,
-    key: ['ArrowLeft'],
-    keyCode: 37,
-  },
-  {
-    code: Keys.ARROW_RIGHT,
-    key: ['ArrowRight'],
-    keyCode: 39,
-  },
-  {
-    code: Keys.ARROW_UP,
-    key: ['ArrowUp'],
-    keyCode: 40,
-  },
-  {
-    code: Keys.ARROW_DOWN,
-    key: ['ArrowDown'],
-    keyCode: 40,
-  },
-  {
-    code: Keys.PAGE_UP,
-    key: ['PageUp'],
-    keyCode: 40,
-  },
-  {
-    code: Keys.PAGE_DOWN,
-    key: ['PageDown'],
-    keyCode: 40,
-  },
-];
+export const FOCUS_ALLOW_LIST_KEYS = new Set<string>([
+  Keys.TAB,
+  Keys.ARROW_LEFT,
+  Keys.ARROW_RIGHT,
+  Keys.ARROW_UP,
+  Keys.ARROW_DOWN,
+]);
 
-export function pressedKey(e: KeyboardEvent | React.KeyboardEvent<HTMLElement>) {
-  return (
-    ACCESSIBLE_KEYS.find(({ key, keyCode }) => key.includes(e.key) || keyCode === e.keyCode)
-      ?.code || null
-  );
+export function isKeyboardFocusingStarted<T extends KeyboardEvent | React.KeyboardEvent>(event: T) {
+  return FOCUS_ALLOW_LIST_KEYS.has(event.key);
 }
 
 export function shouldTriggerClickOnEnterOrSpace(


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

- Заменил `useState` на `useRef`, чтобы оптимизировать рендер. В `AppRoot` использую getter, чтобы по коду не пришлось менять на `keyboardInput.current`.
- Оптимизируем подписку на события: вместо нескольких `useGlobalEventListener`, которые порождают по два эффекта внутри, используем один и разом подписываем/отписываемся. Обработчики переносим в этот эффект.

## Изменения

- Рефактор `lib/accessibility`: массив с ожидаемыми кодами кнопок переделал на `Map`, тем самым упростилась `pressedKey()`. Создал `isKeyboardFocusingStarted()`, которую использую в `useKeyboardInputTracker()`.

---

- block #2518
