### PR TITLE
docs(styleguide): use gzipped https://registry.npmjs.org/@vkontakte/vkui req

### DIFF
--- a/styleguide/Components/Modals/Versions.js
+++ b/styleguide/Components/Modals/Versions.js
@@ -8,7 +8,12 @@ const MINIMUM_VERSION = '3.12.4';
 const filterPrereleaseVersion = (version) => !version.includes('-');
 
 export function Versions({ id }) {
-  const { data: dataRaw, error } = useFetch('https://registry.npmjs.org/@vkontakte/vkui');
+  const { data: dataRaw, error } = useFetch('https://registry.npmjs.org/@vkontakte/vkui', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/vnd.npm.install-v1+json',
+    },
+  });
   const data = React.useMemo(() => {
     if (!dataRaw) {
       return null;


### PR DESCRIPTION
## Описание

В запросе в NPM для получения информации о пакете, починили сжатие для запроса с заголовком `application/vnd.npm.install-v1+json`. По этому заголовку возвращается более урезанная информация по пакету.

По размеру на **~100 kb** запрос стал легче:

```diff
- 441 kb
+ 339 kb
```

- related to #5500
- https://github.com/npm/feedback/discussions/749
