### PR TITLE
fix(NonClickable): props not for dom

### DIFF
--- a/packages/vkui/src/components/Clickable/Clickable.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.tsx
@@ -30,6 +30,10 @@ const NonClickable = <T,>({
   onClickCapture,
   activeClassName,
   hoverClassName,
+  hasActive,
+  hasHover,
+  hovered,
+  activated,
   activeEffectDelay,
   ...restProps
 }: ClickableProps<T>) => <RootComponent {...restProps} />;


### PR DESCRIPTION
Убираем свойства, которые не требуются для DOM