### PR TITLE
fix: npm pkg fix

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -2,10 +2,15 @@
   "name": "@vkontakte/vkui-codemods",
   "version": "0.0.2",
   "description": "Codemods for automatic VKUI major version upgrade",
-  "repository": "https://github.com/VKCOM/VKUI",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VKCOM/VKUI.git"
+  },
   "homepage": "https://vkcom.github.io/VKUI/",
   "license": "MIT",
-  "bin": "./dist/index.js",
+  "bin": {
+    "vkui-codemods": "dist/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/packages/token-translator/package.json
+++ b/packages/token-translator/package.json
@@ -2,10 +2,15 @@
   "name": "@vkontakte/vkui-token-translator",
   "version": "0.0.4",
   "description": "Tools for translate Appearance to vkui-tokens",
-  "repository": "https://github.com/VKCOM/VKUI",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VKCOM/VKUI.git"
+  },
   "homepage": "https://vkcom.github.io/VKUI/",
   "license": "MIT",
-  "bin": "./dist/index.js",
+  "bin": {
+    "vkui-token-translator": "dist/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vkui-floating-ui/package.json
+++ b/packages/vkui-floating-ui/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/VKCOM/VKUI",
   "repository": {
     "type": "git",
-    "url": "https://github.com/VKCOM/VKUI.git",
+    "url": "git+https://github.com/VKCOM/VKUI.git",
     "directory": "packages/vkui-floating-ui"
   },
   "files": [

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/VKCOM/VKUI.git",
+    "url": "git+https://github.com/VKCOM/VKUI.git",
     "directory": "packages/vkui"
   },
   "bugs": "https://github.com/VKCOM/VKUI/issues",


### PR DESCRIPTION
Исправляем ошибки в package.json:

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "bin" was converted to an object
npm WARN publish "bin[@vkontakte/vkui-codemods]" was renamed to "bin[vkui-codemods]"
npm WARN publish "bin[vkui-codemods]" script name was cleaned
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/VKCOM/VKUI.git"
```
