### PR TITLE
fix(useAutoDetectAppearance): rm window from useState

### DIFF
--- a/packages/vkui/src/hooks/useAutoDetectAppearance.test.ts
+++ b/packages/vkui/src/hooks/useAutoDetectAppearance.test.ts
@@ -1,10 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
+import { Appearance } from '../lib/appearance';
 import * as LibDOM from '../lib/dom';
 import { useAutoDetectAppearance } from './useAutoDetectAppearance';
-
-const LIGHT = 'light' as const;
-const DARK = 'dark' as const;
 
 jest.mock('../lib/dom', () => {
   return {
@@ -15,20 +13,35 @@ jest.mock('../lib/dom', () => {
 
 describe(useAutoDetectAppearance, () => {
   describe('client', () => {
-    it.each([LIGHT, DARK])('should return appearance by property (%s)', (appearanceProp) => {
-      const { result } = renderHook(() => useAutoDetectAppearance(appearanceProp));
-      expect(result.current).toBe(appearanceProp);
-    });
+    it.each([Appearance.LIGHT, Appearance.DARK])(
+      'should return appearance by property (%s)',
+      (appearanceProp) => {
+        const { result } = renderHook(() => useAutoDetectAppearance(appearanceProp));
+        expect(result.current).toBe(appearanceProp);
+      },
+    );
 
     it.each([
       {
         initialMatches: false,
         listenerMatches: false,
-        appearance: { before: LIGHT, after: LIGHT },
+        appearance: { before: Appearance.LIGHT, after: Appearance.LIGHT },
       },
-      { initialMatches: true, listenerMatches: true, appearance: { before: DARK, after: DARK } },
-      { initialMatches: false, listenerMatches: true, appearance: { before: LIGHT, after: DARK } },
-      { initialMatches: true, listenerMatches: false, appearance: { before: DARK, after: LIGHT } },
+      {
+        initialMatches: true,
+        listenerMatches: true,
+        appearance: { before: Appearance.DARK, after: Appearance.DARK },
+      },
+      {
+        initialMatches: false,
+        listenerMatches: true,
+        appearance: { before: Appearance.LIGHT, after: Appearance.DARK },
+      },
+      {
+        initialMatches: true,
+        listenerMatches: false,
+        appearance: { before: Appearance.DARK, after: Appearance.LIGHT },
+      },
     ])(
       'should auto detect appearance (initialMatches is $initialMatches, listenerMatches is $listenerMatches, appearance is $appearance)',
       ({ initialMatches, listenerMatches, appearance }) => {
@@ -70,7 +83,7 @@ describe(useAutoDetectAppearance, () => {
         };
       });
       const { result } = renderHook(() => useAutoDetectAppearance());
-      expect(result.current).toBeUndefined();
+      expect(result.current).toBe(Appearance.LIGHT);
     });
   });
 });

--- a/packages/vkui/src/hooks/useAutoDetectAppearance.test.ts
+++ b/packages/vkui/src/hooks/useAutoDetectAppearance.test.ts
@@ -1,0 +1,76 @@
+import { act, renderHook } from '@testing-library/react';
+import { noop } from '@vkontakte/vkjs';
+import * as LibDOM from '../lib/dom';
+import { useAutoDetectAppearance } from './useAutoDetectAppearance';
+
+const LIGHT = 'light' as const;
+const DARK = 'dark' as const;
+
+jest.mock('../lib/dom', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('../lib/dom'),
+  };
+});
+
+describe(useAutoDetectAppearance, () => {
+  describe('client', () => {
+    it.each([LIGHT, DARK])('should return appearance by property (%s)', (appearanceProp) => {
+      const { result } = renderHook(() => useAutoDetectAppearance(appearanceProp));
+      expect(result.current).toBe(appearanceProp);
+    });
+
+    it.each([
+      {
+        initialMatches: false,
+        listenerMatches: false,
+        appearance: { before: LIGHT, after: LIGHT },
+      },
+      { initialMatches: true, listenerMatches: true, appearance: { before: DARK, after: DARK } },
+      { initialMatches: false, listenerMatches: true, appearance: { before: LIGHT, after: DARK } },
+      { initialMatches: true, listenerMatches: false, appearance: { before: DARK, after: LIGHT } },
+    ])(
+      'should auto detect appearance (initialMatches is $initialMatches, listenerMatches is $listenerMatches, appearance is $appearance)',
+      ({ initialMatches, listenerMatches, appearance }) => {
+        let addEventListenerHandler = noop;
+        const addEventListener = jest.fn().mockImplementation((_, handlerByHook) => {
+          addEventListenerHandler = () => {
+            handlerByHook({ matches: listenerMatches });
+          };
+        });
+
+        // Объявление скопировано из документации https://jestjs.io/docs/manual-mocks
+        Object.defineProperty(window, 'matchMedia', {
+          writable: true,
+          value: jest.fn().mockImplementation((query) => ({
+            matches: initialMatches,
+            media: query,
+            onchange: null,
+            addListener: addEventListener, // устарело
+            removeListener: jest.fn(), // устарело
+            addEventListener: addEventListener,
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+          })),
+        });
+        const { result } = renderHook(() => useAutoDetectAppearance());
+        expect(result.current).toBe(appearance.before);
+        act(addEventListenerHandler);
+        expect(result.current).toBe(appearance.after);
+      },
+    );
+  });
+
+  describe('server', () => {
+    it('should auto detect appearance ($appearance)', () => {
+      jest.spyOn<any, any>(LibDOM, 'useDOM').mockReturnValue(() => {
+        return {
+          document: undefined,
+          window: undefined,
+        };
+      });
+      const { result } = renderHook(() => useAutoDetectAppearance());
+      expect(result.current).toBeUndefined();
+    });
+  });
+});

--- a/packages/vkui/src/hooks/useAutoDetectAppearance.ts
+++ b/packages/vkui/src/hooks/useAutoDetectAppearance.ts
@@ -11,13 +11,12 @@ import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
 export const useAutoDetectAppearance = (appearanceProp?: AppearanceType): AppearanceType => {
   const { window } = useDOM();
 
-  const [appearance, setAppearance] = React.useState<AppearanceType>(() => {
-    if (appearanceProp) {
+  const [appearance, setAppearance] = React.useState<AppearanceType>(
+    // @ts-expect-error: TS2345 Из-за SSR мы не можем определять значение по умолчанию, чтобы не было ошибки при гидрации.
+    () => {
       return appearanceProp;
-    }
-    // eslint-disable-next-line no-restricted-properties
-    return window!.matchMedia('(prefers-color-scheme: dark)')?.matches ? 'dark' : 'light';
-  });
+    },
+  );
 
   useIsomorphicLayoutEffect(() => {
     if (appearanceProp) {
@@ -25,7 +24,7 @@ export const useAutoDetectAppearance = (appearanceProp?: AppearanceType): Appear
       return noop;
     }
 
-    const mediaQuery = window!.matchMedia('(prefers-color-scheme: dark)');
+    const mediaQuery = window ? window.matchMedia('(prefers-color-scheme: dark)') : undefined;
 
     if (!mediaQuery) {
       return noop;

--- a/packages/vkui/src/hooks/useAutoDetectAppearance.ts
+++ b/packages/vkui/src/hooks/useAutoDetectAppearance.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { noop } from '@vkontakte/vkjs';
-import type { AppearanceType } from '../lib/appearance';
+import { Appearance, type AppearanceType } from '../lib/appearance';
 import { useDOM } from '../lib/dom';
 import { matchMediaListAddListener, matchMediaListRemoveListener } from '../lib/matchMedia';
 import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
@@ -12,10 +12,7 @@ export const useAutoDetectAppearance = (appearanceProp?: AppearanceType): Appear
   const { window } = useDOM();
 
   const [appearance, setAppearance] = React.useState<AppearanceType>(
-    // @ts-expect-error: TS2345 Из-за SSR мы не можем определять значение по умолчанию, чтобы не было ошибки при гидрации.
-    () => {
-      return appearanceProp;
-    },
+    appearanceProp || Appearance.LIGHT,
   );
 
   useIsomorphicLayoutEffect(() => {
@@ -32,7 +29,7 @@ export const useAutoDetectAppearance = (appearanceProp?: AppearanceType): Appear
 
     const check = (event: MediaQueryList | MediaQueryListEvent) => {
       // eslint-disable-next-line no-restricted-properties
-      setAppearance(event.matches ? 'dark' : 'light');
+      setAppearance(event.matches ? Appearance.DARK : Appearance.LIGHT);
     };
     check(mediaQuery);
     matchMediaListAddListener(mediaQuery, check);


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6240

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Документация фичи

## Описание

Не учёл, что `useState()` вызывается и на сервере. Первое, что может придти в голову – это проверять в `useState` существует ли `window`, но так сделать не можем, т.к. на клиенте, если пользователь не передал `appearance`, то условие отработает удовлетворительно и в первый мы получим автоматическое определение `appearance`, тем самым у нас уже будет разница между клиентом и сервером.

В `useState` теперь возвращаем либо пользовательский `appearance`, либо `'light'` по умолчанию.

В самом эффекте добавил условие для `window`, чтобы убрать неочевидный **Non-null Assertion Operator** (`!`).

---

- caused by #5868 