### PR TITLE
fix(PopoutRoot): use className by props in Popout and Modal sub-cmp

### DIFF
--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.test.tsx
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.test.tsx
@@ -1,6 +1,14 @@
 import { baselineComponent } from '../../testing/utils';
-import { PopoutRoot } from './PopoutRoot';
+import { PopoutRoot, PopoutRootModal, PopoutRootPopout } from './PopoutRoot';
 
-describe('PopoutRoot', () => {
+describe(PopoutRoot, () => {
   baselineComponent(PopoutRoot);
+});
+
+describe(PopoutRootModal, () => {
+  baselineComponent(PopoutRootModal);
+});
+
+describe(PopoutRootPopout, () => {
+  baselineComponent(PopoutRootPopout);
 });

--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.test.tsx
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.test.tsx
@@ -6,9 +6,9 @@ describe(PopoutRoot, () => {
 });
 
 describe(PopoutRootModal, () => {
-  baselineComponent(PopoutRootModal);
+  baselineComponent(PopoutRootModal, { getRootRef: false });
 });
 
 describe(PopoutRootPopout, () => {
-  baselineComponent(PopoutRootPopout);
+  baselineComponent(PopoutRootPopout, { getRootRef: false });
 });

--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
@@ -1,24 +1,23 @@
 import * as React from 'react';
+import { classNames } from '@vkontakte/vkjs';
 import { blurActiveElement, useDOM } from '../../lib/dom';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './PopoutRoot.module.css';
 
-interface PopoutRootPopoutProps {
-  children: React.ReactNode;
-}
-
-const PopoutRootPopout = (props: PopoutRootPopoutProps) => (
-  <div className={styles['PopoutRoot__popout']} {...props} />
+const PopoutRootPopout = ({
+  className,
+  ...restProps
+}: HTMLAttributesWithRootRef<HTMLDivElement>) => (
+  <div className={classNames(styles['PopoutRoot__popout'], className)} {...restProps} />
 );
 
-interface PopoutRootModalProps {
-  children: React.ReactNode;
-}
-
-const PopoutRootModal = (props: PopoutRootModalProps) => (
-  <div className={styles['PopoutRoot__modal']} {...props} />
+const PopoutRootModal = ({
+  className,
+  ...restProps
+}: HTMLAttributesWithRootRef<HTMLDivElement>) => (
+  <div className={classNames(styles['PopoutRoot__modal'], className)} {...restProps} />
 );
 
 export interface PopoutRootProps extends HTMLAttributesWithRootRef<HTMLDivElement> {

--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
@@ -11,14 +11,9 @@ import styles from './PopoutRoot.module.css';
  */
 export const PopoutRootPopout = ({
   className,
-  getRootRef,
   ...restProps
-}: HTMLAttributesWithRootRef<HTMLDivElement>) => (
-  <div
-    ref={getRootRef}
-    className={classNames(styles['PopoutRoot__popout'], className)}
-    {...restProps}
-  />
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={classNames(styles['PopoutRoot__popout'], className)} {...restProps} />
 );
 
 /**
@@ -26,14 +21,9 @@ export const PopoutRootPopout = ({
  */
 export const PopoutRootModal = ({
   className,
-  getRootRef,
   ...restProps
-}: HTMLAttributesWithRootRef<HTMLDivElement>) => (
-  <div
-    ref={getRootRef}
-    className={classNames(styles['PopoutRoot__modal'], className)}
-    {...restProps}
-  />
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={classNames(styles['PopoutRoot__modal'], className)} {...restProps} />
 );
 
 export interface PopoutRootProps extends HTMLAttributesWithRootRef<HTMLDivElement> {

--- a/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
+++ b/packages/vkui/src/components/PopoutRoot/PopoutRoot.tsx
@@ -6,18 +6,34 @@ import { AppRootPortal } from '../AppRoot/AppRootPortal';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './PopoutRoot.module.css';
 
-const PopoutRootPopout = ({
+/**
+ * @private
+ */
+export const PopoutRootPopout = ({
   className,
+  getRootRef,
   ...restProps
 }: HTMLAttributesWithRootRef<HTMLDivElement>) => (
-  <div className={classNames(styles['PopoutRoot__popout'], className)} {...restProps} />
+  <div
+    ref={getRootRef}
+    className={classNames(styles['PopoutRoot__popout'], className)}
+    {...restProps}
+  />
 );
 
-const PopoutRootModal = ({
+/**
+ * @private
+ */
+export const PopoutRootModal = ({
   className,
+  getRootRef,
   ...restProps
 }: HTMLAttributesWithRootRef<HTMLDivElement>) => (
-  <div className={classNames(styles['PopoutRoot__modal'], className)} {...restProps} />
+  <div
+    ref={getRootRef}
+    className={classNames(styles['PopoutRoot__modal'], className)}
+    {...restProps}
+  />
 );
 
 export interface PopoutRootProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
@@ -25,6 +41,9 @@ export interface PopoutRootProps extends HTMLAttributesWithRootRef<HTMLDivElemen
   modal?: React.ReactNode;
 }
 
+/**
+ * @private
+ */
 export const PopoutRoot = ({ popout, modal, children, ...restProps }: PopoutRootProps) => {
   const { document } = useDOM();
 


### PR DESCRIPTION
## Описание

Из-за того, что `PopoutRootPopout` и `PopoutRootModal` не резолвили `className`, `TokensClassProvider` затирал их `className`.

## Воспроизведение

Можно воспроизвести на странице https://vkcom.github.io/VKUI/6.0.0-beta.1/#/Group:

1. Прокручиваем до самого конца.
2. Нажимаем "Открыть Group в модальном окне".

### Фактический результат

<img width="480" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/686f538f-878d-42fc-aae8-18ccbccac094">

### Ожидаемый результат

<img width="480" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/6e98e9f5-fe2b-456f-98fd-b5784a4561aa">
