### PR TITLE
fix(ModalRoot): clean up stale state

### DIFF
--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -265,6 +265,7 @@ class ModalRootTouchComponent extends React.Component<
       this.setMaskOpacity(prevModalState, 0);
       this.setState({ modalOpenedLog: [] });
       prevModalState.translateY = undefined;
+      prevModalState.expandable = undefined;
     } else if (nextModalState.id && !this.state.modalOpenedLog.includes(nextModalState.id)) {
       nextModalState.translateY = undefined;
       this.setState((prevState) => ({


### PR DESCRIPTION
- close #6268

---

## Изменения

Зануляем предыдущий стейт, чтобы модалка не разворачивалась в некоторых случаях на всю высоту