### PR TITLE
fix(AppRoot): bring back setting color-scheme

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
@@ -180,7 +180,7 @@ describe('AppRoot', () => {
 
     it.each(['embedded', 'full'] as const)('should add adaptivity classes in %s mode', (mode) => {
       const { unmount, rerender, container } = render(<AppRoot mode={mode} />);
-      const parentElement = mode === 'embedded' ? container : document.body;
+      const parentElement = mode === 'embedded' ? container : document.documentElement;
       expect(parentElement).not.toHaveClass('vkui--sizeX-regular');
       rerender(
         <AdaptivityProvider sizeX="regular">
@@ -200,7 +200,7 @@ describe('AppRoot', () => {
       const { unmount, rerender, container } = render(
         <AppRoot mode={mode} safeAreaInsets={{ top: 0 }} />,
       );
-      const parentElement = mode === 'embedded' ? container : document.body;
+      const parentElement = mode === 'embedded' ? container : document.documentElement;
       expect(parentElement).toHaveStyle(CUSTOM_PROPERTY_INSET_TOP);
 
       rerender(<AppRoot mode={mode} safeAreaInsets={{ top: 0, bottom: 0 }} />);
@@ -220,7 +220,7 @@ describe('AppRoot', () => {
       { mode: 'partial', layout: 'plain' },
     ] as const)('should resolve "$layout" layout prop (mode="$mode")', ({ mode, layout }) => {
       const { unmount, container, rerender } = render(<AppRoot mode={mode} />);
-      const conditionalContainer = mode === 'full' ? document.body : container;
+      const conditionalContainer = mode === 'full' ? document.documentElement : container;
       const className = layout === 'card' ? 'vkui--layout-card' : 'vkui--layout-plain';
 
       expect(conditionalContainer).not.toHaveClass(className);
@@ -238,7 +238,7 @@ describe('AppRoot', () => {
       expect(conditionalContainer).not.toHaveClass(className);
     });
 
-    it('should add VKUITokenClassName to document.body on mount and removes on unmount', async () => {
+    it('should add VKUITokenClassName to html tag on mount and removes on unmount', async () => {
       const config = { appearance: 'light', platform: 'vkcom' } as const;
       const vkuiTokenClassName = generateVKUITokensClassName(config.platform, config.appearance);
       const { unmount } = render(
@@ -246,9 +246,9 @@ describe('AppRoot', () => {
           <AppRoot />
         </ConfigProvider>,
       );
-      expect(document.body).toHaveClass(vkuiTokenClassName);
+      expect(document.documentElement).toHaveClass(vkuiTokenClassName);
       unmount();
-      expect(document.body).not.toHaveClass(vkuiTokenClassName);
+      expect(document.documentElement).not.toHaveClass(vkuiTokenClassName);
     });
 
     it('should add VKUITokenClassName to embedded element of AppRoot inner full AppRoot and removes on unmount', async () => {
@@ -286,19 +286,19 @@ describe('AppRoot', () => {
 
       const result = render(<TestComponent />);
 
-      expect(document.body).toHaveClass(vkuiTokenModeClassNameForFullMode);
+      expect(document.documentElement).toHaveClass(vkuiTokenModeClassNameForFullMode);
       expect(result.getByTestId('app-root-embedded')).toHaveClass(
         vkuiTokenModeClassNameForEmbeddedMode,
       );
 
       fireEvent.click(screen.getByRole('button'));
 
-      expect(document.body).toHaveClass(vkuiTokenModeClassNameForFullMode);
+      expect(document.documentElement).toHaveClass(vkuiTokenModeClassNameForFullMode);
       expect(result.queryByTestId('app-root-embedded')).toBeNull();
 
       result.unmount();
 
-      expect(document.body).not.toHaveClass(vkuiTokenModeClassNameForFullMode);
+      expect(document.documentElement).not.toHaveClass(vkuiTokenModeClassNameForFullMode);
     });
   });
 

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -128,7 +128,7 @@ export const AppRoot = ({
           }
 
           documentElement.classList.add(...stylesClassNames, 'vkui');
-          const unsetSafeAreaInsets = setSafeAreaInsets(safeAreaInsets, documentBody);
+          const unsetSafeAreaInsets = setSafeAreaInsets(safeAreaInsets, documentElement);
 
           return function cleanup() {
             if (parentElement) {

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -129,6 +129,7 @@ export const AppRoot = ({
           documentBody.classList.add(...stylesClassNames);
           const unsetSafeAreaInsets = setSafeAreaInsets(safeAreaInsets, documentBody);
           documentElement.classList.add('vkui');
+          documentElement.style.setProperty('color-scheme', appearance);
           return function cleanup() {
             if (parentElement) {
               parentElement.classList.remove(...baseClassNames);
@@ -136,6 +137,7 @@ export const AppRoot = ({
             documentBody.classList.remove(...stylesClassNames);
             unsetSafeAreaInsets();
             documentElement.classList.remove('vkui');
+            documentElement.style.removeProperty('color-scheme');
           };
         }
         case 'embedded': {

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -126,18 +126,17 @@ export const AppRoot = ({
           if (parentElement) {
             parentElement.classList.add(...baseClassNames);
           }
-          documentBody.classList.add(...stylesClassNames);
+
+          documentElement.classList.add(...stylesClassNames, 'vkui');
           const unsetSafeAreaInsets = setSafeAreaInsets(safeAreaInsets, documentBody);
-          documentElement.classList.add('vkui');
-          documentElement.style.setProperty('color-scheme', appearance);
+
           return function cleanup() {
             if (parentElement) {
               parentElement.classList.remove(...baseClassNames);
             }
-            documentBody.classList.remove(...stylesClassNames);
+
+            documentElement.classList.remove(...stylesClassNames, 'vkui');
             unsetSafeAreaInsets();
-            documentElement.classList.remove('vkui');
-            documentElement.style.removeProperty('color-scheme');
           };
         }
         case 'embedded': {

--- a/packages/vkui/src/components/Slider/__image_snapshots__/slider-with-tooltip-slider-with-tooltip-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Slider/__image_snapshots__/slider-with-tooltip-slider-with-tooltip-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b20831f5b54fe7e0dc0fcf6310a59a32d24d1e234f03cc19a68ef68745678d5
-size 3474
+oid sha256:e549fcf1f1933d56c175dc812d30259c775dfddabf3537882a401973ffa50d96
+size 3457

--- a/packages/vkui/src/components/Slider/__image_snapshots__/slider-with-tooltip-slider-with-tooltip-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/Slider/__image_snapshots__/slider-with-tooltip-slider-with-tooltip-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25f0275504bec920c97b2bbd009ddb14eb09240456567ddcaec657df53bd6b91
-size 6419
+oid sha256:68fba4eeed714a85e7212cb996e59758362af91562cd5010ae00226b83d2a317
+size 5503

--- a/packages/vkui/src/components/Slider/__image_snapshots__/slider-with-tooltip-slider-with-tooltip-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/Slider/__image_snapshots__/slider-with-tooltip-slider-with-tooltip-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b067eb3f1f6fd365aeba58afcb90f3a42cf744e3f2a70f8e0180c863974ecf3
-size 2801
+oid sha256:b7e1e379e6a9aad288181cf8570d08f32d0f22d7b80966dbf3b972db98d12ca8
+size 2820

--- a/packages/vkui/src/components/Tappable/Tappable.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+import '../Clickable/Clickable.module.css'; // eslint-disable-line import/order
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
@@ -6,7 +8,6 @@ import { mergeCalls } from '../../lib/mergeCalls';
 import { checkClickable, Clickable, ClickableProps } from '../Clickable/Clickable';
 import { Ripple, useMaybeNeedRipple, useRipple } from './Ripple';
 import { activeClass, DEFAULT_STATE_MODE, hoverClass, StateProps } from './state';
-import '../Clickable/Clickable.module.css'; // Reorder css
 import styles from './Tappable.module.css';
 
 const sizeXClassNames = {

--- a/packages/vkui/src/components/Tappable/Tappable.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.tsx
@@ -6,6 +6,7 @@ import { mergeCalls } from '../../lib/mergeCalls';
 import { checkClickable, Clickable, ClickableProps } from '../Clickable/Clickable';
 import { Ripple, useMaybeNeedRipple, useRipple } from './Ripple';
 import { activeClass, DEFAULT_STATE_MODE, hoverClass, StateProps } from './state';
+import '../Clickable/Clickable.module.css'; // Reorder css
 import styles from './Tappable.module.css';
 
 const sizeXClassNames = {

--- a/styleguide/setup.js
+++ b/styleguide/setup.js
@@ -1,3 +1,4 @@
+import '../packages/vkui/src/styles/constants.css';
 import '../packages/vkui/src/styles/themes.css';
 import '../packages/vkui/src/styles/common.css';
 


### PR DESCRIPTION
## Описание


https://github.com/VKCOM/VKUI/assets/7431217/e462c3cc-4612-40c3-9b8d-88f7459649e3

---

- caused by #6263

---

## Секция WTF

- Почему изменились скриншоты:
Для тогглика задаем обводку `outline: var(--vkui_internal--outline);`, но `--vkui_internal--outline` определена в `:root` у [constants.css](https://github.com/VKCOM/VKUI/blob/6b1683cf63c259598db487eb93c69e72803c45a8/packages/vkui/src/styles/constants.css), поэтому токен раньше скатывался в дефолтовый андроидовский, сейчас починился

- Почему добавили `import '../Clickable/Clickable.module.css'; // Reorder css`:
На `codesandbox`'e словила, что стили `Clickable` перебивали `Tappable`, не работал ховер, например
