### PR TITLE
fix: rest of TODO (FormLayout & SubnavigationButton)

### DIFF
--- a/packages/vkui/src/components/FormLayout/FormLayout.tsx
+++ b/packages/vkui/src/components/FormLayout/FormLayout.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { useExternRef } from '../../hooks/useExternRef';
 import { HasComponent, HasRef, HasRootRef } from '../../types';
 import styles from './FormLayout.module.css';
 
@@ -17,20 +16,17 @@ export type FormLayoutProps = React.AllHTMLAttributes<HTMLElement> &
 export const FormLayout = ({
   children,
   Component = 'form',
-  getRef, // TOOD [>=6]: remove
   getRootRef,
   onSubmit = preventDefault,
   className,
   ...restProps
 }: FormLayoutProps) => {
-  const formLayoutRef = useExternRef(getRef, getRootRef);
-
   return (
     <Component
       {...restProps}
       className={classNames(styles['FormLayout'], className)}
       onSubmit={onSubmit}
-      ref={formLayoutRef}
+      ref={getRootRef}
     >
       {children}
       {Component === 'form' && (

--- a/packages/vkui/src/components/RootComponent/RootComponent.tsx
+++ b/packages/vkui/src/components/RootComponent/RootComponent.tsx
@@ -6,7 +6,7 @@ export interface RootComponentProps<T>
   extends React.AllHTMLAttributes<T>,
     HasRootRef<T>,
     HasComponent {
-  baseClassName?: string;
+  baseClassName?: string | false;
 }
 
 /**

--- a/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.module.css
+++ b/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.module.css
@@ -26,12 +26,7 @@
   margin-inline-start: var(--vkui--size_subnavigation_bar_gap--regular);
 }
 
-/**
- * CMP:
- * SubnavigationBar
- */
-
-:global(.vkuiInternalSubnavigationBar--mode-fixed) .SubnavigationBar__item {
+.SubnavigationBar--mode-fixed .SubnavigationBar__item {
   flex: 1;
   min-inline-size: 0;
 }

--- a/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
+++ b/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
@@ -50,12 +50,7 @@ export const SubnavigationBar = ({
 
   return (
     <RootComponent
-      // TODO: [>=6]
-      // Заменить у SubnavigationButton `display: inline-block` на `width: 100%`
-      // и удалить применение селектора в `SubnavigationButton.module.css`.
-      // 2. Заменить глобальный селектор на CSS Modules `styles['SubnavigationBar--mode-fixed']`
-      // mode !== 'fixed' && classNames('vkuiInternalSubnavigationBar--mode-fixed')
-      baseClassName={mode === 'fixed' ? 'vkuiInternalSubnavigationBar--mode-fixed' : undefined}
+      baseClassName={mode === 'fixed' && styles['SubnavigationBar--mode-fixed']}
       {...restProps}
     >
       <ScrollWrapper className={styles['SubnavigationBar__in']} {...scrollWrapperProps}>

--- a/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.module.css
+++ b/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.module.css
@@ -1,5 +1,5 @@
 .SubnavigationButton {
-  display: inline-block;
+  inline-size: 100%;
   user-select: none;
   border-radius: var(--vkui--size_border_radius--regular);
 }
@@ -166,9 +166,4 @@
 .SubnavigationButton--selected.SubnavigationButton--appearance-neutral {
   --vkui_internal--counter_inherit_background: var(--vkui--color_background_content);
   --vkui_internal--counter_inherit_color: var(--vkui--color_text_primary);
-}
-
-:global(.vkuiInternalSubnavigationBar--mode-fixed) .SubnavigationButton {
-  flex: 1;
-  min-inline-size: 0;
 }

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -26,6 +26,7 @@
   - <a href="{{anchor}}">`FixedLayout`</a>
   - <a href="{{anchor}}">`Footer`</a>
   - <a href="{{anchor}}">`FormItem`</a>
+  - <a href="{{anchor}}">`FormLayout`</a>
   - <a href="{{anchor}}">`Gradient`</a>
   - <a href="{{anchor}}">`Header`</a>
   - <a href="{{anchor}}">`ModalCard` и `ModaCardBase`</a>
@@ -523,6 +524,15 @@ npx @vkontakte/vkui-codemods --help
 
 ```jsx static
 <FormItem top="Имя" topComponent="h5" />
+```
+
+<br/>
+
+### [`FormLayout`](#/FormLayout)
+
+```diff
+- <FormLayout getRef={ref}>...</FormLayout>
++ <FormLayout getRootRef={ref}>...</FormLayout>
 ```
 
 <br/>


### PR DESCRIPTION
## Описание

- related #6160 

Не зацепили ещё пару TODOшек

## Изменения

`FormLayout` - просто удалили `getRef`

`SubnavigationBar` - немного изменили верстку, избавились от глобального класса

`RootComponent` - позволяю в `baseClassName` прокидывать `false` булик, чтобы не форсить прокидывание `undefined` при навешивании класса по условию (?)


_Кодмод под изменения завезу в следующем PRе_