### PR TITLE
fix(DateInput): Clear DateInput focus when click Done button

### DIFF
--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -183,7 +183,6 @@ export const DateInput = ({
     calendarRef,
     open,
     openCalendar,
-    closeCalendar,
     internalValue,
     handleKeyDown,
     setFocusedElement,
@@ -303,7 +302,7 @@ export const DateInput = ({
             disablePast={disablePast}
             disableFuture={disableFuture}
             shouldDisableDate={shouldDisableDate}
-            onClose={closeCalendar}
+            onClose={removeFocusFromField}
             getRootRef={calendarRef}
             doneButtonText={doneButtonText}
             disablePickers={disablePickers}

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -183,6 +183,7 @@ export const DateInput = ({
     calendarRef,
     open,
     openCalendar,
+    closeCalendar,
     internalValue,
     handleKeyDown,
     setFocusedElement,
@@ -302,7 +303,7 @@ export const DateInput = ({
             disablePast={disablePast}
             disableFuture={disableFuture}
             shouldDisableDate={shouldDisableDate}
-            onClose={removeFocusFromField}
+            onClose={closeCalendar}
             getRootRef={calendarRef}
             doneButtonText={doneButtonText}
             disablePickers={disablePickers}

--- a/packages/vkui/src/hooks/useDateInput.ts
+++ b/packages/vkui/src/hooks/useDateInput.ts
@@ -77,28 +77,25 @@ export function useDateInput<T extends HTMLElement, D>({
     }
   }, [autoFocus, selectFirst]);
 
-  React.useEffect(
-    function focusActiveElement() {
-      if (disabled || focusedElement === null) {
-        return;
-      }
+  React.useEffect(() => {
+    if (disabled || focusedElement === null) {
+      return;
+    }
 
-      const range = window!.document.createRange();
+    const range = window!.document.createRange();
 
-      let element = refs[focusedElement].current;
+    let element = refs[focusedElement].current;
 
-      if (element) {
-        element.focus();
-        openCalendar();
-        range.selectNodeContents(element as Node);
+    if (element) {
+      element.focus();
+      openCalendar();
+      range.selectNodeContents(element as Node);
 
-        const selection = window!.getSelection();
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      }
-    },
-    [disabled, focusedElement, openCalendar, refs, window],
-  );
+      const selection = window!.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+  }, [disabled, focusedElement, openCalendar, refs, window]);
 
   const clear = React.useCallback(() => {
     onChange?.(undefined);

--- a/packages/vkui/src/hooks/useDateInput.ts
+++ b/packages/vkui/src/hooks/useDateInput.ts
@@ -39,7 +39,7 @@ export function useDateInput<T extends HTMLElement, D>({
   const { window } = useDOM();
 
   const removeFocusFromField = React.useCallback(() => {
-    if (focusedElement) {
+    if (focusedElement !== null) {
       setFocusedElement(null);
       closeCalendar();
       window!.getSelection()?.removeAllRanges();

--- a/packages/vkui/src/hooks/useDateInput.ts
+++ b/packages/vkui/src/hooks/useDateInput.ts
@@ -39,13 +39,13 @@ export function useDateInput<T extends HTMLElement, D>({
   const { window } = useDOM();
 
   const removeFocusFromField = React.useCallback(() => {
-    if (open) {
+    if (focusedElement) {
       setFocusedElement(null);
       closeCalendar();
       window!.getSelection()?.removeAllRanges();
       setInternalValue(getInternalValue(value));
     }
-  }, [closeCalendar, getInternalValue, open, value, window]);
+  }, [focusedElement, closeCalendar, getInternalValue, value, window]);
 
   const handleClickOutside = React.useCallback(
     (e: MouseEvent) => {
@@ -77,25 +77,28 @@ export function useDateInput<T extends HTMLElement, D>({
     }
   }, [autoFocus, selectFirst]);
 
-  React.useEffect(() => {
-    if (disabled || focusedElement === null) {
-      return;
-    }
+  React.useEffect(
+    function focusActiveElement() {
+      if (disabled || focusedElement === null) {
+        return;
+      }
 
-    const range = window!.document.createRange();
+      const range = window!.document.createRange();
 
-    let element = refs[focusedElement].current;
+      let element = refs[focusedElement].current;
 
-    if (element) {
-      element.focus();
-      openCalendar();
-      range.selectNodeContents(element as Node);
+      if (element) {
+        element.focus();
+        openCalendar();
+        range.selectNodeContents(element as Node);
 
-      const selection = window!.getSelection();
-      selection?.removeAllRanges();
-      selection?.addRange(range);
-    }
-  }, [disabled, focusedElement, openCalendar, refs, window]);
+        const selection = window!.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+    },
+    [disabled, focusedElement, openCalendar, refs, window],
+  );
 
   const clear = React.useCallback(() => {
     onChange?.(undefined);


### PR DESCRIPTION
- close #6244

---


- [ ] Unit-тесты - тяжеловато проверить, тесты получаются не очень стабильные.

## Описание
Немного поменял логику сброса программного фокуса. 
Функция для сброса вызывается при клике снаружи или при выборе даты, если используется свойство `closeOnChange`.
Но функция сброса внутри проверяет состояние календаря`open` и только если оно true, то фокус сбрасывается.
В #6244 как раз ситуация, когда по клику на кнопку "Готово", мы закрываем попап календаря, но фокус не убираем. Потом кликаем по другой кнопке, это как раз "click outside", но фокус не сбрасывается, потому что `open` ужe `false`.

Переделал проверку с `open` на `focusedElement`.
Работать будет аналогично, но и фокус сбрасываться будет более предсказуемо и всегда при вызове `resetFocusFormField` если фокус установлен.