### PR TITLE
fix(HorizontalCell): use max-width for size="m"

### DIFF
--- a/packages/vkui/src/components/HorizontalCell/HorizontalCell.module.css
+++ b/packages/vkui/src/components/HorizontalCell/HorizontalCell.module.css
@@ -65,7 +65,7 @@
 .HorizontalCell--size-m {
   --vkui_internal--side_cell_width: calc(100px + var(--vkui_internal--side_cell_gap));
 
-  inline-size: 100px;
+  max-inline-size: 100px;
 }
 
 .HorizontalCell--size-l {
@@ -85,5 +85,5 @@
 
 .HorizontalCell--size-m:first-child,
 .HorizontalCell--size-m:last-child {
-  inline-size: var(--vkui_internal--side_cell_width);
+  max-inline-size: var(--vkui_internal--side_cell_width);
 }


### PR DESCRIPTION
## Описание

При `<HorizontalCell size="m" />` зашивалась ширина, в отличии от `<HorizontalCell size="s" />`.


- related to #1316 – в этом PR добавили `max-width` только для `size="s"`