### PR TITLE
docs(Input): textInputRef.focus() when clear()

### DIFF
--- a/packages/vkui/src/components/Input/Readme.md
+++ b/packages/vkui/src/components/Input/Readme.md
@@ -55,8 +55,13 @@ const ExampleBase = ({ formItemStatus }) => {
 };
 
 const ExampleWithIcon = ({ formItemStatus }) => {
-  const textInput = React.createRef();
-  const clear = () => (textInput.current.value = '');
+  const textInput = React.useRef();
+  const clear = () => {
+    if (textInput.current) {
+      textInput.current.value = '';
+      textInput.current.focus();
+    }
+  };
 
   return (
     <FormLayoutGroup>


### PR DESCRIPTION
## Описание

В `ExampleWithIcon`, для полноты картины, не хватало `textInput.current.focus();`.
