### PR TITLE
fix(Switch): show focus in android talkback

### DIFF
--- a/packages/vkui/src/components/Switch/Switch.module.css
+++ b/packages/vkui/src/components/Switch/Switch.module.css
@@ -134,19 +134,6 @@
   }
 }
 
-.Switch__self {
-  position: absolute;
-  inset-inline-start: 0;
-  inset-block-start: 0;
-  inline-size: 100%;
-  block-size: 100%;
-  opacity: 0;
-  z-index: -1;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-}
-
 .Switch__self[disabled] + .Switch__pseudo {
   opacity: var(--vkui--opacity_disable);
 }

--- a/packages/vkui/src/components/Switch/Switch.module.css
+++ b/packages/vkui/src/components/Switch/Switch.module.css
@@ -134,6 +134,19 @@
   }
 }
 
+.Switch__self {
+  position: absolute;
+  inset-inline-start: 0;
+  inset-block-start: 0;
+  inline-size: 100%;
+  block-size: 100%;
+  opacity: 0;
+  z-index: -1;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
 .Switch__self[disabled] + .Switch__pseudo {
   opacity: var(--vkui--opacity_disable);
 }

--- a/packages/vkui/src/components/Switch/Switch.stories.tsx
+++ b/packages/vkui/src/components/Switch/Switch.stories.tsx
@@ -1,4 +1,6 @@
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
+import { SimpleCell } from '../../components/SimpleCell/SimpleCell';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { Switch, SwitchProps } from './Switch';
 
@@ -18,3 +20,13 @@ export default story;
 type Story = StoryObj<SwitchProps>;
 
 export const Playground: Story = {};
+
+export const WithSimpleCellLabel: Story = {
+  render: function Render(args) {
+    return (
+      <SimpleCell Component="label" after={<Switch {...args} />}>
+        Комментарии к записям
+      </SimpleCell>
+    );
+  },
+};

--- a/packages/vkui/src/components/Switch/Switch.test.tsx
+++ b/packages/vkui/src/components/Switch/Switch.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { Switch } from './Switch';
@@ -12,4 +13,69 @@ describe('Switch', () => {
       <Switch aria-labelledby="switch" {...props} />
     </>
   ));
+
+  it('(Uncontrolled) shows checked state', () => {
+    const { rerender } = render(<Switch data-testid="switch" />);
+
+    const component = screen.getByRole<HTMLInputElement>('switch');
+    if (!component) {
+      throw new Error('Can not find component');
+    }
+
+    expect(component.checked).toBeFalsy();
+    expect(component.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(component);
+
+    expect(component.checked).toBeTruthy();
+    expect(component.getAttribute('aria-checked')).toBe('true');
+
+    rerender(<Switch data-testid="switch" defaultChecked />);
+
+    const defaultCheckedComponent = screen.getByTestId<HTMLInputElement>('switch');
+    if (!defaultCheckedComponent) {
+      throw new Error('Can not find component');
+    }
+
+    expect(defaultCheckedComponent.checked).toBeTruthy();
+    expect(defaultCheckedComponent.getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(defaultCheckedComponent);
+
+    expect(defaultCheckedComponent.checked).toBeFalsy();
+    expect(defaultCheckedComponent.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('(Controlled) shows checked state', () => {
+    function ControlledSwitch() {
+      const [checked, setChecked] = React.useState(false);
+      return (
+        <React.Fragment>
+          <Switch data-testid="switch" checked={checked} onChange={jest.fn} />
+          <button onClick={() => setChecked((prevChecked) => !prevChecked)}>
+            change switch state
+          </button>
+        </React.Fragment>
+      );
+    }
+    render(<ControlledSwitch />);
+
+    const switchComponent = screen.getByRole<HTMLInputElement>('switch');
+    if (!switchComponent) {
+      throw new Error('Can not find component');
+    }
+
+    expect(switchComponent.checked).toBeFalsy();
+    expect(switchComponent.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(switchComponent);
+
+    expect(switchComponent.checked).toBeFalsy();
+    expect(switchComponent.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(switchComponent.checked).toBeTruthy();
+    expect(switchComponent.getAttribute('aria-checked')).toBe('true');
+  });
 });

--- a/packages/vkui/src/components/Switch/Switch.test.tsx
+++ b/packages/vkui/src/components/Switch/Switch.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, userEvent } from '../../testing/utils';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { Switch } from './Switch';
 
@@ -14,7 +14,7 @@ describe('Switch', () => {
     </>
   ));
 
-  it('(Uncontrolled) shows checked state', () => {
+  it('(Uncontrolled) shows checked state', async () => {
     const { rerender } = render(<Switch data-testid="switch" />);
 
     const component = screen.getByRole<HTMLInputElement>('switch');
@@ -44,6 +44,21 @@ describe('Switch', () => {
 
     expect(defaultCheckedComponent.checked).toBeFalsy();
     expect(defaultCheckedComponent.getAttribute('aria-checked')).toBe('false');
+
+    rerender(<Switch data-testid="switch" disabled />);
+
+    const disabledSwitch = screen.getByTestId<HTMLInputElement>('switch');
+    if (!disabledSwitch) {
+      throw new Error('Can not find component');
+    }
+    expect(disabledSwitch.checked).toBeFalsy();
+    expect(disabledSwitch.getAttribute('aria-checked')).toBe('false');
+
+    jest.useFakeTimers();
+    await userEvent.click(disabledSwitch);
+
+    expect(disabledSwitch.checked).toBeFalsy();
+    expect(disabledSwitch.getAttribute('aria-checked')).toBe('false');
   });
 
   it('(Controlled) shows checked state', () => {

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -6,6 +6,7 @@ import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
 import { usePlatform } from '../../hooks/usePlatform';
 import { callMultiple } from '../../lib/callMultiple';
 import { HasRef, HasRootRef } from '../../types';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './Switch.module.css';
 
 const sizeYClassNames = {
@@ -67,11 +68,12 @@ export const Switch = ({
       onBlur={callMultiple(onBlur, restProps.onBlur)}
       onFocus={callMultiple(onFocus, restProps.onFocus)}
     >
-      <input
+      <VisuallyHidden
         {...restProps}
         {...(isControlled && { checked: checkedProp })}
+        Component="input"
+        getRootRef={getRef}
         onClick={callMultiple(syncUncontrolledCheckedStateOnClick, restProps.onClick)}
-        ref={getRef}
         type="checkbox"
         role="switch"
         aria-checked={ariaCheckedState ? 'true' : 'false'}

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -6,7 +6,6 @@ import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
 import { usePlatform } from '../../hooks/usePlatform';
 import { callMultiple } from '../../lib/callMultiple';
 import { HasRef, HasRootRef } from '../../types';
-import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './Switch.module.css';
 
 const sizeYClassNames = {
@@ -22,12 +21,37 @@ export interface SwitchProps
 /**
  * @see https://vkcom.github.io/VKUI/#/Switch
  */
-export const Switch = ({ style, className, getRootRef, getRef, ...restProps }: SwitchProps) => {
+export const Switch = ({
+  style,
+  className,
+  getRootRef,
+  getRef,
+  checked: checkedProp,
+  ...restProps
+}: SwitchProps) => {
   const platform = usePlatform();
   const { sizeY = 'none' } = useAdaptivity();
   const { focusVisible, onBlur, onFocus } = useFocusVisible();
   const focusVisibleClassNames = useFocusVisibleClassName({ focusVisible, mode: 'outside' });
 
+  const [localUncontrolledChecked, setLocalUncontrolledChecked] = React.useState(
+    restProps.defaultChecked,
+  );
+  const isControlled = checkedProp !== undefined;
+
+  const syncUncontrolledCheckedStateOnClick = React.useCallback(
+    (e: React.MouseEvent<HTMLInputElement>) => {
+      if (isControlled) {
+        return;
+      }
+
+      const switchTarget = e.target as HTMLInputElement;
+      setLocalUncontrolledChecked(switchTarget.checked);
+    },
+    [isControlled],
+  );
+
+  const checkedState = isControlled ? checkedProp : localUncontrolledChecked;
   return (
     <label
       className={classNames(
@@ -43,11 +67,14 @@ export const Switch = ({ style, className, getRootRef, getRef, ...restProps }: S
       onBlur={callMultiple(onBlur, restProps.onBlur)}
       onFocus={callMultiple(onFocus, restProps.onFocus)}
     >
-      <VisuallyHidden
+      <input
         {...restProps}
-        Component="input"
-        getRootRef={getRef}
+        checked={checkedState}
+        onClick={callMultiple(syncUncontrolledCheckedStateOnClick, restProps.onClick)}
+        ref={getRef}
         type="checkbox"
+        role="switch"
+        aria-checked={checkedState ? 'true' : 'false'}
         className={styles['Switch__self']}
       />
       <span aria-hidden className={styles['Switch__pseudo']} />

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -35,7 +35,7 @@ export const Switch = ({
   const focusVisibleClassNames = useFocusVisibleClassName({ focusVisible, mode: 'outside' });
 
   const [localUncontrolledChecked, setLocalUncontrolledChecked] = React.useState(
-    restProps.defaultChecked,
+    Boolean(restProps.defaultChecked),
   );
   const isControlled = checkedProp !== undefined;
 
@@ -51,7 +51,7 @@ export const Switch = ({
     [isControlled],
   );
 
-  const checkedState = isControlled ? checkedProp : localUncontrolledChecked;
+  const ariaCheckedState = isControlled ? checkedProp : localUncontrolledChecked;
   return (
     <label
       className={classNames(
@@ -69,12 +69,12 @@ export const Switch = ({
     >
       <input
         {...restProps}
-        checked={checkedState}
+        {...(isControlled && { checked: checkedProp })}
         onClick={callMultiple(syncUncontrolledCheckedStateOnClick, restProps.onClick)}
         ref={getRef}
         type="checkbox"
         role="switch"
-        aria-checked={checkedState ? 'true' : 'false'}
+        aria-checked={ariaCheckedState ? 'true' : 'false'}
         className={styles['Switch__self']}
       />
       <span aria-hidden className={styles['Switch__pseudo']} />

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.module.css
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.module.css
@@ -12,4 +12,15 @@
   border: 0 !important;
   opacity: 0;
 }
+
+/* Чтобы input на который попадает фокус скринридера был виден.
+ * Особенно актуально для Android TalkBack */
+.VisuallyHidden--focusable-input {
+  inset-inline-start: 0;
+  inset-block-start: 0;
+  block-size: 100% !important;
+  inline-size: 100% !important;
+  clip: auto !important;
+  clip-path: none !important;
+}
 /* stylelint-enable declaration-no-important */

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.module.css
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.module.css
@@ -13,7 +13,7 @@
   opacity: 0;
 }
 
-/* Чтобы input на который попадает фокус скринридера был виден.
+/* Чтобы фокус скринридера, попавший на скрытый инпут был виден.
  * Особенно актуально для Android TalkBack */
 .VisuallyHidden--focusable-input {
   inset-inline-start: 0;
@@ -22,5 +22,6 @@
   inline-size: 100% !important;
   clip: auto !important;
   clip-path: none !important;
+  pointer-events: none;
 }
 /* stylelint-enable declaration-no-important */

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.test.tsx
@@ -1,6 +1,22 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { VisuallyHidden } from './VisuallyHidden';
+import styles from './VisuallyHidden.module.css';
 
 describe('VisuallyHidden', () => {
   baselineComponent(VisuallyHidden);
+
+  it('uses modifier to keep screen reader focus for input components', () => {
+    const { rerender } = render(<VisuallyHidden data-testid="visually-hidden" />);
+
+    const element = screen.getByTestId('visually-hidden');
+    expect(element).toHaveClass(styles['VisuallyHidden']);
+    expect(element).not.toHaveClass(styles['VisuallyHidden--focusable-input']);
+
+    rerender(<VisuallyHidden data-testid="visually-hidden" Component="input" />);
+    const inputElement = screen.getByTestId('visually-hidden');
+    expect(inputElement).toHaveClass(styles['VisuallyHidden']);
+    expect(inputElement).toHaveClass(styles['VisuallyHidden--focusable-input']);
+  });
 });

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { classNames } from '@vkontakte/vkjs';
 import { RootComponent, type RootComponentProps } from '../RootComponent/RootComponent';
 import styles from './VisuallyHidden.module.css';
 
@@ -15,5 +16,12 @@ export const VisuallyHidden = <T,>({
   Component = 'span',
   ...restProps
 }: VisuallyHiddenProps<T>) => (
-  <RootComponent Component={Component} {...restProps} baseClassName={styles['VisuallyHidden']} />
+  <RootComponent
+    Component={Component}
+    {...restProps}
+    baseClassName={classNames(
+      styles['VisuallyHidden'],
+      Component === 'input' && styles['VisuallyHidden--focusable-input'],
+    )}
+  />
 );


### PR DESCRIPTION
- close #3046 

---

- [x] Unit-тесты

## Описание
Действительно на Android в Talkback не видно фокуса при фокусировании на инпуте, потому что мы прячем этот инпут с помощью `VisuallyHidden` компонента.
Как вариант можно убрать использование VisuallyHidden и спрятать компонент позади визульной части.

## Изменения
- Добавил модификатор для VisuallyHidden, когда речь идет о `Component=input`. Явно задал размер равный размеру родительского элемента, чтобы выделение визуально было подобно размеру switch. Но изменение затронуло не только Switch, но и другие компоненты, в которых `<VisuallyHidden Component="input" \>`.
- добавил `role='switch'`
- добавил `aria-checked`. Так как значение этого аттрибута должно соответствовать значению инпута, то добавил переменную состояния.
- обновил пример в Storybook, добавив историю с испольованием SimpleCell чтобы как-то учесть пожелания из https://github.com/VKCOM/VKUI/issues/4931 

## Фото

<img width="400" src="https://github.com/VKCOM/VKUI/assets/5443359/4d5aeddc-6c44-4b5d-ba06-c5c3d914d883" />

