### PR TITLE
Make sure we show focus when user navigates using Talkback

### DIFF
--- a/packages/vkui/src/components/SegmentedControl/SegmentedControlOption/SegmentedControlOption.module.css
+++ b/packages/vkui/src/components/SegmentedControl/SegmentedControlOption/SegmentedControlOption.module.css
@@ -23,3 +23,16 @@
 .SegmentedControlOption__before {
   margin-inline-end: 6px;
 }
+
+.SegmentedControlOption__input {
+  position: absolute;
+  inset-inline-start: 0;
+  inset-block-start: 0;
+  inline-size: 100%;
+  block-size: 100%;
+  opacity: 0;
+  z-index: -1;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}

--- a/packages/vkui/src/components/SegmentedControl/SegmentedControlOption/SegmentedControlOption.tsx
+++ b/packages/vkui/src/components/SegmentedControl/SegmentedControlOption/SegmentedControlOption.tsx
@@ -5,7 +5,6 @@ import { useFocusVisibleClassName } from '../../../hooks/useFocusVisibleClassNam
 import { callMultiple } from '../../../lib/callMultiple';
 import { HasRef, HasRootRef } from '../../../types';
 import { Headline } from '../../Typography/Headline/Headline';
-import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import styles from './SegmentedControlOption.module.css';
 
 export interface SegmentedControlOptionProps
@@ -41,10 +40,10 @@ export const SegmentedControlOption = ({
       ref={getRootRef}
       style={style}
     >
-      <VisuallyHidden
+      <input
         {...restProps}
-        Component="input"
-        getRootRef={getRef}
+        className={styles['SegmentedControlOption__input']}
+        ref={getRef}
         type="radio"
         onBlur={callMultiple(onBlur, restProps.onBlur)}
         onFocus={callMultiple(onFocus, restProps.onFocus)}


### PR DESCRIPTION
- close #3392

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [ ] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [ ] Гайд миграции

## Описание
Элементы с фокусом не видны через Android TalkBack если они спрятаны с помощью VisuallyHidden.


## Изменения
Меняем `VisuallyHidden` на несколько другой подход, чтобы область фокуса была видна.