### PR TITLE
fix(a11y): `ChipsSelect` and `ChipsInput`

### DIFF
--- a/packages/vkui/src/components/ChipsInput/ChipsInput.stories.tsx
+++ b/packages/vkui/src/components/ChipsInput/ChipsInput.stories.tsx
@@ -1,6 +1,8 @@
+import * as React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import type { ChipOption } from '../ChipsInputBase/types';
+import { FormItem } from '../FormItem/FormItem';
 import { ChipsInput, ChipsInputProps } from './ChipsInput';
 
 const story: Meta<ChipsInputProps<ChipOption>> = {
@@ -13,4 +15,10 @@ export default story;
 
 type Story = StoryObj<ChipsInputProps<ChipOption>>;
 
-export const Playground: Story = {};
+export const Playground: Story = {
+  render: (args) => (
+    <FormItem top="Добавьте любимые теги" htmlFor="chips-input" style={{ width: 320 }}>
+      <ChipsInput {...args} id="chips-input" />
+    </FormItem>
+  ),
+};

--- a/packages/vkui/src/components/ChipsInput/useChipsInput.ts
+++ b/packages/vkui/src/components/ChipsInput/useChipsInput.ts
@@ -8,6 +8,7 @@ import {
   getOptionLabelDefault,
   getOptionValueDefault,
 } from '../ChipsInputBase/constants';
+import { isValueLikeChipOptionObject } from '../ChipsInputBase/helpers';
 import type {
   ChipOption,
   ChipOptionValue,
@@ -16,9 +17,6 @@ import type {
   GetOptionValue,
   UseChipsInputBaseProps,
 } from '../ChipsInputBase/types';
-
-const isValueLikeOption = <O extends ChipOption>(value: O | ChipOptionValue): value is O =>
-  typeof value === 'object' && 'value' in value;
 
 export const transformValue = <O extends ChipOption>(
   value: O[],
@@ -87,14 +85,16 @@ export const useChipsInput = <O extends ChipOption>({
   const toggleOption: ToggleOption<O> = React.useCallback(
     (nextValueProp: O | ChipOptionValue, isNewValue: boolean) => {
       setValue((prevValue) => {
-        const isLikeOption = isValueLikeOption(nextValueProp);
-        const resolvedOption = isLikeOption
+        const isLikeObjectOption = isValueLikeChipOptionObject(nextValueProp);
+        const resolvedOption = isLikeObjectOption
           ? getNewOptionData(nextValueProp.value, nextValueProp.label)
           : getNewOptionData(nextValueProp, typeof nextValueProp === 'string' ? nextValueProp : '');
         const nextValue = prevValue.filter((option: O) => resolvedOption.value !== option.value);
 
         if (isNewValue === true) {
-          nextValue.push(isLikeOption ? { ...nextValueProp, ...resolvedOption } : resolvedOption);
+          nextValue.push(
+            isLikeObjectOption ? { ...nextValueProp, ...resolvedOption } : resolvedOption,
+          );
         }
 
         return nextValue;

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
@@ -68,7 +68,6 @@ export const Chip = ({
         focusVisibleClassName,
         className,
       )}
-      tabIndex={-1} // [reason]: чтобы можно было выставлять состояние фокуса только программно через `*.focus()`
       aria-disabled={disabled}
       onFocus={disabled ? undefined : handleFocus}
       onBlur={disabled ? undefined : handleBlur}

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.module.css
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.module.css
@@ -19,19 +19,12 @@
   margin: 2px;
 }
 
-.ChipsInputBase__label {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  flex: 1;
-  margin-block: 2px 2px;
-  margin-inline: 10px 2px;
-}
-
 .ChipsInputBase__el {
+  flex: 1;
   position: relative;
   inline-size: 100%;
-  margin-block-end: 2px;
+  margin-block: 2px 4px;
+  margin-inline: 10px 2px;
   padding: 0;
   color: var(--vkui--color_text_primary);
   background: transparent;
@@ -66,13 +59,10 @@
   cursor: default;
 }
 
-.ChipsInputBase--hasPlaceholder .ChipsInputBase__label {
-  margin-inline: calc(12px - var(--vkui_internal--chips_input_base_container_gap)) 0;
-}
-
 .ChipsInputBase--hasPlaceholder .ChipsInputBase__el {
   white-space: nowrap;
   text-overflow: ellipsis;
+  margin-inline: calc(12px - var(--vkui_internal--chips_input_base_container_gap)) 0;
 }
 
 /**

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { baselineComponent, userEvent, withRexExp } from '../../testing/utils';
+import { baselineComponent, userEvent, withRegExp } from '../../testing/utils';
 import { ChipsInputBase } from './ChipsInputBase';
 import type { ChipOption, ChipsInputBasePrivateProps } from './types';
 
@@ -96,7 +96,7 @@ describe('ChipsInputBase', () => {
           onRemoveChipOption={onRemoveChipOption}
         />,
       );
-      const chipEl = result.getByRole('option', { name: withRexExp(TEST_OPTION.label) });
+      const chipEl = result.getByRole('option', { name: withRegExp(TEST_OPTION.label) });
       await userEvent.click(chipEl);
       await userEvent.type(chipEl, `{${type}}`);
       expect(onRemoveChipOption).not.toHaveBeenCalled();
@@ -123,7 +123,7 @@ describe('ChipsInputBase', () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    const chipEl = result.getByRole('option', { name: withRexExp(TEST_OPTION.label) });
+    const chipEl = result.getByRole('option', { name: withRegExp(TEST_OPTION.label) });
     await userEvent.click(chipEl);
     expect(chipEl).toHaveFocus();
   });

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
@@ -1,18 +1,32 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { baselineComponent, userEvent } from '../../testing/utils';
+import { baselineComponent, userEvent, withRexExp } from '../../testing/utils';
 import { ChipsInputBase } from './ChipsInputBase';
 import type { ChipOption, ChipsInputBasePrivateProps } from './types';
 
-const ChipsInputBaseTest = (props: ChipsInputBasePrivateProps) => (
-  <ChipsInputBase data-testid="chips-input" {...props} />
-);
+const ChipsInputBaseTest = ({
+  inputValue: inputValueProp,
+  ...restProps
+}: ChipsInputBasePrivateProps) => {
+  const [inputValue, setInputValue] = React.useState(inputValueProp);
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value);
+  };
+  return (
+    <ChipsInputBase
+      data-testid="chips-input"
+      {...restProps}
+      inputValue={inputValue}
+      onInputChange={handleInputChange}
+    />
+  );
+};
 
-const testOption = { value: 'red', label: 'Красный' };
-const chipsInputValue: ChipOption[] = [testOption];
+const TEST_OPTION = { value: 'red', label: 'Красный' };
+const chipsInputValue: ChipOption[] = [TEST_OPTION];
 
 describe('ChipsInputBase', () => {
-  baselineComponent(ChipsInputBase, {
+  baselineComponent(ChipsInputBaseTest, {
     // доступность должна быть реализована в обёртках над ChipsInputBase
     a11y: false,
   });
@@ -55,30 +69,39 @@ describe('ChipsInputBase', () => {
     expect(onAddChipOption).toHaveBeenCalledWith('Красный');
   });
 
-  it('removes chip on hitting backspace', async () => {
+  it('focuses to chip on hitting backspace', async () => {
     const result = render(
       <ChipsInputBaseTest
         value={chipsInputValue}
+        inputValue="0"
         onAddChipOption={onAddChipOption}
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await userEvent.type(result.getByTestId('chips-input'), '{backspace}');
-    expect(onRemoveChipOption).toHaveBeenCalledWith(testOption);
+    const chipsInputLocator = result.getByTestId('chips-input');
+    await userEvent.type(chipsInputLocator, '{backspace}');
+    expect(chipsInputLocator).toHaveFocus();
+    await userEvent.type(chipsInputLocator, '{backspace}');
+    expect(chipsInputLocator.previousSibling).toHaveFocus();
   });
 
-  it('does not delete chips on hitting backspace in readonly mode', async () => {
-    const result = render(
-      <ChipsInputBaseTest
-        readOnly
-        value={chipsInputValue}
-        onAddChipOption={onAddChipOption}
-        onRemoveChipOption={onRemoveChipOption}
-      />,
-    );
-    await userEvent.type(result.getByTestId('chips-input'), '{backspace}');
-    expect(onRemoveChipOption).not.toHaveBeenCalled();
-  });
+  it.each(['delete', 'backspace'])(
+    'does not delete chips on hitting "%s" key in readonly mode',
+    async (type) => {
+      const result = render(
+        <ChipsInputBaseTest
+          readOnly
+          value={chipsInputValue}
+          onAddChipOption={onAddChipOption}
+          onRemoveChipOption={onRemoveChipOption}
+        />,
+      );
+      const chipEl = result.getByRole('option', { name: withRexExp(TEST_OPTION.label) });
+      await userEvent.click(chipEl);
+      await userEvent.type(chipEl, `{${type}}`);
+      expect(onRemoveChipOption).not.toHaveBeenCalled();
+    },
+  );
 
   it('focuses ChipsInputBase on surrounding container click', async () => {
     const result = render(
@@ -92,7 +115,7 @@ describe('ChipsInputBase', () => {
     expect(result.getByTestId('chips-input')).toHaveFocus();
   });
 
-  it('focuses ChipsInputBase on chip click', async () => {
+  it('focuses on chip after click', async () => {
     const result = render(
       <ChipsInputBaseTest
         value={chipsInputValue}
@@ -100,9 +123,22 @@ describe('ChipsInputBase', () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await userEvent.click(result.queryByText('Красный')!);
-    expect(result.getByTestId('chips-input')).toHaveFocus();
+    const chipEl = result.getByRole('option', { name: withRexExp(TEST_OPTION.label) });
+    await userEvent.click(chipEl);
+    expect(chipEl).toHaveFocus();
   });
+
+  it.todo('focuses on input field after removing only one chip');
+
+  it.todo('focuses on nearest chip after removing one of chip');
+
+  it.todo('focuses on last focused chip after focus to component');
+
+  it.todo('focuses on last focused chip after enter to component with hitting "tab" key');
+
+  it.todo('focuses on last focused chip after hitting "shift + tab" key');
+
+  it.todo('navigates between chip with arrow buttons');
 
   it('add value on blur event if addOnBlur=true', async () => {
     const result = render(

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -12,10 +12,10 @@ import {
   getChipOptionIndexByHTMLElement,
   getChipOptionIndexByValueProp,
   getChipOptionValueByHTMLElement,
+  getNextChipOptionIndexByNavigateToProp,
   isInputValueEmpty,
-  resolveNextChipOptionIndex,
 } from './helpers';
-import type { ChipOption, ChipOptionValue, ChipsInputBasePrivateProps } from './types';
+import type { ChipOption, ChipOptionValue, ChipsInputBasePrivateProps, NavigateTo } from './types';
 import styles from './ChipsInputBase.module.css';
 
 const sizeYClassNames = {
@@ -68,10 +68,10 @@ export const ChipsInputBase = <O extends ChipOption>({
 
   const moveFocusToChipOption = (
     currentIndex: number,
-    nextIndex: 'first' | 'prev' | 'next' | 'last',
+    navigateTo: NavigateTo,
     listboxEl: HTMLElement,
   ) => {
-    const index = resolveNextChipOptionIndex(currentIndex, nextIndex, valueLength);
+    const index = getNextChipOptionIndexByNavigateToProp(currentIndex, navigateTo, valueLength);
     // eslint-disable-next-line no-restricted-properties
     const foundEl = listboxEl.querySelector<HTMLElement>(`[data-index="${index}"]`);
 

--- a/packages/vkui/src/components/ChipsInputBase/constants.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/constants.tsx
@@ -6,8 +6,6 @@ export const DEFAULT_VALUE = [];
 
 export const DEFAULT_INPUT_VALUE = '';
 
-export const DEFAULT_INPUT_LABEL = 'Введите ваше значение...';
-
 export function getOptionValueDefault<O extends ChipOption>(option: O) {
   return option.value;
 }

--- a/packages/vkui/src/components/ChipsInputBase/helpers.ts
+++ b/packages/vkui/src/components/ChipsInputBase/helpers.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_INPUT_VALUE } from './constants';
+import type { ChipOption, ChipOptionValue } from './types';
+
+/**
+ * @private
+ */
+export const isValueLikeChipOptionObject = <O extends ChipOption>(v: O | ChipOptionValue): v is O =>
+  typeof v === 'object' && 'value' in v;
+
+/**
+ * @private
+ */
+export const isInputValueEmpty = (value: string) => value === DEFAULT_INPUT_VALUE;
+
+/**
+ * @private
+ */
+export const getChipOptionIndexByValueProp = <O extends ChipOption>(
+  v: O | ChipOptionValue,
+  valueProp: O[],
+) => {
+  const value = isValueLikeChipOptionObject(v) ? v.value : v;
+  return valueProp.findIndex((o) => o.value === value);
+};
+
+/**
+ * @private
+ */
+export const getChipOptionIndexByHTMLElement = (el: HTMLElement | null) => {
+  const value = el && el.dataset.index;
+  return typeof value === 'string' ? Number(value) : -1;
+};
+
+/**
+ * @private
+ */
+export const getChipOptionValueByHTMLElement = (el: HTMLElement | null) => {
+  const value = el && el.dataset.value;
+  return typeof value === 'string' ? value : -1;
+};
+
+/**
+ * @private
+ */
+export const resolveNextChipOptionIndex = (
+  currentIndex: number,
+  nextIndex: 'first' | 'prev' | 'next' | 'last',
+  length: number,
+) => {
+  switch (nextIndex) {
+    case 'first':
+      return 0;
+    case 'prev':
+      return currentIndex - 1;
+    case 'next':
+      return currentIndex + 1;
+    case 'last':
+      return length - 1;
+    default:
+      return -1;
+  }
+};

--- a/packages/vkui/src/components/ChipsInputBase/helpers.ts
+++ b/packages/vkui/src/components/ChipsInputBase/helpers.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_INPUT_VALUE } from './constants';
-import type { ChipOption, ChipOptionValue } from './types';
+import type { ChipOption, ChipOptionValue, NavigateTo } from './types';
 
 /**
  * @private
@@ -16,11 +16,11 @@ export const isInputValueEmpty = (value: string) => value === DEFAULT_INPUT_VALU
  * @private
  */
 export const getChipOptionIndexByValueProp = <O extends ChipOption>(
-  v: O | ChipOptionValue,
+  optionProp: O | ChipOptionValue,
   valueProp: O[],
 ) => {
-  const value = isValueLikeChipOptionObject(v) ? v.value : v;
-  return valueProp.findIndex((o) => o.value === value);
+  const value = isValueLikeChipOptionObject(optionProp) ? optionProp.value : optionProp;
+  return valueProp.findIndex((option) => option.value === value);
 };
 
 /**
@@ -42,12 +42,12 @@ export const getChipOptionValueByHTMLElement = (el: HTMLElement | null) => {
 /**
  * @private
  */
-export const resolveNextChipOptionIndex = (
+export const getNextChipOptionIndexByNavigateToProp = (
   currentIndex: number,
-  nextIndex: 'first' | 'prev' | 'next' | 'last',
+  navigateTo: NavigateTo,
   length: number,
 ) => {
-  switch (nextIndex) {
+  switch (navigateTo) {
     case 'first':
       return 0;
     case 'prev':

--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -8,6 +8,8 @@ import type {
 } from '../../types';
 import { FormFieldProps } from '../FormField/FormField';
 
+export type NavigateTo = 'first' | 'prev' | 'next' | 'last';
+
 export type ChipOptionValue = string | number;
 
 export type ChipOptionLabel = React.ReactElement | string | number;

--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -88,8 +88,6 @@ export interface ChipsInputBaseProps<O extends ChipOption = ChipOption>
     HasRef<HTMLInputElement>,
     HasAlign {
   getRootRef?: React.Ref<HTMLDivElement>;
-
-  inputLabel?: string;
   /**
    * Добавляет значение в список на событие `onBlur`
    */

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.module.css
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.module.css
@@ -2,14 +2,6 @@
   position: relative;
 }
 
-.ChipsSelect__dropdown {
-  cursor: pointer;
-}
-
-.ChipsSelect__icon {
-  pointer-events: none;
-}
-
 .ChipsSelect__empty {
   padding-block: 12px;
   padding-inline: 0;

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.stories.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { Icon12Download } from '@vkontakte/icons';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import type { ChipOption } from '../ChipsInputBase/types';
+import { FormItem } from '../FormItem/FormItem';
 import { ChipsSelect, ChipsSelectProps } from './ChipsSelect';
 
 const story: Meta<ChipsSelectProps<ChipOption>> = {
@@ -31,6 +32,11 @@ const groups = [
 ];
 
 export const Playground: Story = {
+  render: (args) => (
+    <FormItem top="Выберите музыкальные группы" htmlFor="chips-select" style={{ width: 320 }}>
+      <ChipsSelect {...args} id="chips-select" />
+    </FormItem>
+  ),
   args: {
     options: groups,
   },

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -1,15 +1,22 @@
 import * as React from 'react';
 import { act, fireEvent, render, within } from '@testing-library/react';
 import { getTextFromChildren } from '../../lib/children';
-import { baselineComponent, userEvent, waitForFloatingPosition } from '../../testing/utils';
+import {
+  baselineComponent,
+  userEvent,
+  waitForFloatingPosition,
+  withRexExp,
+} from '../../testing/utils';
 import type { ChipOption } from '../ChipsInputBase/types';
 import { ChipsSelect } from './ChipsSelect';
 
-const colors: ChipOption[] = [
-  { value: 'red', label: 'Красный' },
-  { value: 'blue', label: 'Синий' },
-  { value: 'navarin', label: 'Наваринского пламени с дымом' },
-];
+const FIRST_OPTION = { value: 'red', label: 'Красный' };
+
+const SECOND_OPTION = { value: 'blue', label: 'Синий' };
+
+const THIRD_OPTION = { value: 'navarin', label: 'Наваринского пламени с дымом' };
+
+const colors: ChipOption[] = [FIRST_OPTION, SECOND_OPTION, THIRD_OPTION];
 
 const testValue = { value: 'testvalue', label: 'testvalue' };
 
@@ -83,7 +90,7 @@ describe('ChipsSelect', () => {
       await waitForFloatingPosition();
       await userEvent.click(
         within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(colors[0].label),
+          name: getTextFromChildren(FIRST_OPTION.label),
         }),
       );
       expect(() => result.getByTestId('dropdown')).toThrow();
@@ -103,7 +110,7 @@ describe('ChipsSelect', () => {
       await waitForFloatingPosition();
       await userEvent.click(
         within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(colors[0].label),
+          name: getTextFromChildren(FIRST_OPTION.label),
         }),
       );
       expect(() => result.getByTestId('dropdown')).toBeTruthy();
@@ -135,10 +142,10 @@ describe('ChipsSelect', () => {
       await waitForFloatingPosition();
       await userEvent.click(
         within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(colors[0].label),
+          name: getTextFromChildren(FIRST_OPTION.label),
         }),
       );
-      expect(onChange).toHaveBeenCalledWith([colors[0]]);
+      expect(onChange).toHaveBeenCalledWith([FIRST_OPTION]);
     });
 
     it('via keyboard', async () => {
@@ -169,7 +176,7 @@ describe('ChipsSelect', () => {
       const result = render(
         <ChipsSelect
           options={colors}
-          defaultValue={[colors[0]]}
+          defaultValue={[FIRST_OPTION]}
           selectedBehavior="highlight"
           dropdownTestId="dropdown"
         />,
@@ -178,7 +185,7 @@ describe('ChipsSelect', () => {
       await waitForFloatingPosition();
       expect(
         within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(colors[0].label),
+          name: getTextFromChildren(FIRST_OPTION.label),
         }),
       ).toBeTruthy();
     });
@@ -187,7 +194,7 @@ describe('ChipsSelect', () => {
       const result = render(
         <ChipsSelect
           options={colors}
-          defaultValue={[colors[0]]}
+          defaultValue={[FIRST_OPTION]}
           selectedBehavior="hide"
           dropdownTestId="dropdown"
         />,
@@ -196,22 +203,22 @@ describe('ChipsSelect', () => {
       await waitForFloatingPosition();
       expect(() =>
         within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(colors[0].label),
+          name: getTextFromChildren(FIRST_OPTION.label),
         }),
       ).toThrow();
     });
     it('deselects on chip click', async () => {
       const handleChange = jest.fn();
       const result = render(
-        <ChipsSelect options={colors} value={[colors[0]]} onChange={handleChange} />,
+        <ChipsSelect options={colors} value={[FIRST_OPTION]} onChange={handleChange} />,
       );
-      await userEvent.click(result.getByText(`Удалить ${colors[0].label}`).closest('button')!);
+      await userEvent.click(result.getByText(`Удалить ${FIRST_OPTION.label}`).closest('button')!);
       expect(handleChange).toHaveBeenCalledWith([]);
     });
   });
 
   it('does not focus ChipsSelect on chip click', async () => {
-    let selectedColors: ChipOption[] = [{ value: 'red', label: 'Красный' }];
+    let selectedColors: ChipOption[] = [FIRST_OPTION, SECOND_OPTION];
     const setSelectedColors = (updatedColors: ChipOption[]) => {
       selectedColors = [...updatedColors];
     };
@@ -226,7 +233,8 @@ describe('ChipsSelect', () => {
     };
 
     const result = render(<ChipsSelect data-testid="chips-select" {...colorsChipsProps} />);
-    await userEvent.click(result.getByText('Удалить Красный').closest('button')!);
+    const chipEl = result.getByRole('option', { name: withRexExp(FIRST_OPTION.label) });
+    await userEvent.click(within(chipEl).getByRole('button'));
     expect(result.getByTestId('chips-select')).not.toHaveFocus();
   });
 

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -5,7 +5,7 @@ import {
   baselineComponent,
   userEvent,
   waitForFloatingPosition,
-  withRexExp,
+  withRegExp,
 } from '../../testing/utils';
 import type { ChipOption } from '../ChipsInputBase/types';
 import { ChipsSelect } from './ChipsSelect';
@@ -233,7 +233,7 @@ describe('ChipsSelect', () => {
     };
 
     const result = render(<ChipsSelect data-testid="chips-select" {...colorsChipsProps} />);
-    const chipEl = result.getByRole('option', { name: withRexExp(FIRST_OPTION.label) });
+    const chipEl = result.getByRole('option', { name: withRegExp(FIRST_OPTION.label) });
     await userEvent.click(within(chipEl).getByRole('button'));
     expect(result.getByTestId('chips-select')).not.toHaveFocus();
   });

--- a/packages/vkui/src/components/ChipsSelect/constants.tsx
+++ b/packages/vkui/src/components/ChipsSelect/constants.tsx
@@ -19,8 +19,6 @@ export const FOCUS_ACTION_NEXT: FocusActionType = 'next';
 
 export const FOCUS_ACTION_PREV: FocusActionType = 'prev';
 
-export const getIconLabelDefault = (opened: boolean) => (opened ? 'Скрыть' : 'Развернуть');
-
 export const renderOptionDefault = (props: CustomSelectOptionProps) => (
   <CustomSelectOption {...props} />
 );

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -620,8 +620,8 @@ describe('CustomSelect', () => {
     );
 
     fireEvent.click(screen.getByTestId('inputTextId'));
-    fireEvent.mouseEnter(screen.getByTitle('Mike'));
-    fireEvent.click(screen.getByTitle('Mike'));
+    fireEvent.mouseEnter(screen.getByRole('option', { name: 'Mike' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Mike' }));
 
     expect(screen.queryByRole('button', { hidden: true })).toBeFalsy();
   });

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -70,7 +70,6 @@ export const CustomSelectOption = ({
   onClick,
   ...restProps
 }: CustomSelectOptionProps) => {
-  const title = typeof children === 'string' ? children : undefined;
   const { sizeY = 'none' } = useAdaptivity();
   const style = React.useMemo(
     () =>
@@ -89,7 +88,6 @@ export const CustomSelectOption = ({
       onClick={disabled ? undefined : onClick}
       Component="div"
       role="option"
-      title={title}
       aria-disabled={disabled}
       aria-selected={selected}
       className={classNames(

--- a/packages/vkui/src/lib/accessibility.ts
+++ b/packages/vkui/src/lib/accessibility.ts
@@ -23,6 +23,7 @@ export const Keys = {
   ESCAPE: 'Escape',
   HOME: 'Home',
   END: 'End',
+  DELETE: 'Delete',
   BACKSPACE: 'Backspace',
   ARROW_LEFT: 'ArrowLeft',
   ARROW_RIGHT: 'ArrowRight',
@@ -62,6 +63,8 @@ export const FOCUS_ALLOW_LIST_KEYS = new Set<string>([
   Keys.ARROW_RIGHT,
   Keys.ARROW_UP,
   Keys.ARROW_DOWN,
+  Keys.BACKSPACE,
+  Keys.DELETE,
 ]);
 
 export function isKeyboardFocusingStarted<T extends KeyboardEvent | React.KeyboardEvent>(event: T) {
@@ -150,9 +153,9 @@ export const getHorizontalFocusGoTo = (
   switch (keys) {
     case Keys.ARROW_UP:
     case Keys.ARROW_LEFT:
-      return 'left';
+      return 'prev';
     case Keys.ARROW_DOWN:
     case Keys.ARROW_RIGHT:
-      return 'right';
+      return 'next';
   }
 };

--- a/packages/vkui/src/lib/dom.tsx
+++ b/packages/vkui/src/lib/dom.tsx
@@ -155,24 +155,3 @@ export const getActiveElementByAnotherElement = (el: Element | null) =>
 export const contains = (parent?: Element | null, child?: Element | null) => {
   return parent && child ? parent.contains(child) : false;
 };
-
-export const getHTMLElementByChildren = (children: HTMLCollection, index: number) => {
-  const foundEl = children[index];
-  return isHTMLElement(foundEl) ? foundEl : null;
-};
-
-export const getHTMLElementSiblingByDirection = <T extends Element>(
-  el: T,
-  direction: 'left' | 'right',
-) => {
-  let siblingEl: Element | null = null;
-  switch (direction) {
-    case 'left':
-      siblingEl = el.previousElementSibling;
-      break;
-    case 'right':
-      siblingEl = el.nextElementSibling;
-      break;
-  }
-  return isHTMLElement(siblingEl) ? siblingEl : null;
-};

--- a/packages/vkui/src/testing/utils.tsx
+++ b/packages/vkui/src/testing/utils.tsx
@@ -329,3 +329,5 @@ export const fireEventPatch = async (
     }
   });
 };
+
+export const withRexExp = (v: string) => new RegExp(v);

--- a/packages/vkui/src/testing/utils.tsx
+++ b/packages/vkui/src/testing/utils.tsx
@@ -330,4 +330,4 @@ export const fireEventPatch = async (
   });
 };
 
-export const withRexExp = (v: string) => new RegExp(v);
+export const withRegExp = (v: string) => new RegExp(v);


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #4143

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~ – снова отдельным PR, оставил `it.todo`.
- ~[ ] Гайд миграции~ – отдельным PR:
  - добавить про удаление `inputLabel` (нужно использовать `FormItem`)
  - добавить про удаление `getIconLabel`

## Описание

> [!NOTE]
> см. https://github.com/VKCOM/VKUI/issues/4143#issuecomment-1884598384
>
> Добавил логику работы `ChipsInput`/`ChipsSelect` в описание задачи https://github.com/VKCOM/VKUI/issues/4143#user-content-logic.

Проверил `ChipsSelect` и `ChipsInput` в **NVDA** и нашёл причину почему он не видит компоненты – причиной был скрытый текст для визуальной доступности, который располагался прямо перед полем ввода. Оно осталось со старой реализации, думал так и надо. Я удалил этот скрытый текст, т.к. его содержание должно быть в атрибуте `placeholder`, который есть у текстовых полей. Удалили параметр `inputLabel`.

По ходу дела изменил некоторое поведение (ориентировался на пример из https://material.angular.io/components/chips/overview#chips-autocomplete):

- Смена фокуса при удалении чипа.
  - Если чип один, то удаление этого чип перенесет фокус на текстовое поле.
  - Если чипов несколько, то после удаление одного из них фокус перенесется на ближайший чип. Если удалили с конца, то на последний чип, если удалили в начале, то на следующий чип.
- Нажатии на **Backpace** будучи в пустом текстовом поле – перенесёт фокус на последний чип.
- Иконка с шевроном верх/вниз теперь чисто декоративная. Удалил параметр `getIconLabel`.

## Изменения

- В `src/testing/utils` добавил функцию `withRexExp` – если передать в параметр `name` в селектора типа `getByRole('option', { name: '<string>' });`, то DOM-элемент не находится. Исправляет оборачивание в регулярку `getByRole('option', { name: new RegExp('<string>') });`
