### PR TITLE
fix(RichCell, ImageBaseOverlay): add noop default + remove disabled prop

### DIFF
--- a/packages/vkui/src/components/Image/Readme.md
+++ b/packages/vkui/src/components/Image/Readme.md
@@ -47,7 +47,7 @@ const OthersFeatures = () => {
               </Image.Badge>
             )}
             {overlay && (
-              <Image.Overlay {...overlay} onClick={() => null}>
+              <Image.Overlay {...overlay}>
                 <IconExampleForOverlayBasedOnImageBaseSize />
               </Image.Overlay>
             )}

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNames } from '@vkontakte/vkjs';
+import { classNames, noop } from '@vkontakte/vkjs';
 import { useAdaptivityHasPointer } from '../../../hooks/useAdaptivityHasPointer';
 import { useAppearance } from '../../../hooks/useAppearance';
 import { focusVisiblePresetModeClassNames } from '../../../hooks/useFocusVisibleClassName';
@@ -50,7 +50,7 @@ export const ImageBaseOverlay = ({
   theme: themeProp,
   visibility: visibilityProp,
   children,
-  onClick,
+  onClick = noop,
   ...restProps
 }: ImageBaseOverlayProps) => {
   const appearance = useAppearance();

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
@@ -50,7 +50,7 @@ export const ImageBaseOverlay = ({
   theme: themeProp,
   visibility: visibilityProp,
   children,
-  onClick = noop,
+  onClick: onClickProp,
   ...restProps
 }: ImageBaseOverlayProps) => {
   const appearance = useAppearance();
@@ -65,6 +65,8 @@ export const ImageBaseOverlay = ({
       validateOverlayIcon(size, { name: 'children', value: children });
     }
   }
+
+  const onClick = onClickProp ?? visibility === 'on-hover' ? noop : undefined;
 
   return (
     <Tappable

--- a/packages/vkui/src/components/RichCell/Readme.md
+++ b/packages/vkui/src/components/RichCell/Readme.md
@@ -27,7 +27,6 @@
             </Button>
           </ButtonGroup>
         }
-        disabled
       >
         Children
       </RichCell>
@@ -57,7 +56,6 @@
             </Button>
           </ButtonGroup>
         }
-        disabled
       >
         Илья Гришин
       </RichCell>
@@ -89,7 +87,6 @@
             </Button>
           </ButtonGroup>
         }
-        disabled
       >
         Ром Захаров
       </RichCell>
@@ -112,7 +109,6 @@
           </ButtonGroup>
         }
         multiline
-        disabled
       >
         Тарас Иванов{' '}
         <Icon16Verified


### PR DESCRIPTION
- close #6284 

## Описание

- caused by https://github.com/VKCOM/VKUI/pull/6132

## Изменения

Убираем из примеров `RichCell` проп `disabled`, потому что без `onClick` компонент и так неактивный
В `ImageBaseOverlay` устанавливаем по умолчанию `onClick=noop` в режиме `on-hover`, потому что хотим, чтобы он реагировал на наведение.
