### PR TITLE
feat(ChipsInputBase): add cycle navigates between chips

### DIFF
--- a/packages/vkui/src/components/ChipsInput/Readme.md
+++ b/packages/vkui/src/components/ChipsInput/Readme.md
@@ -63,7 +63,7 @@ const Example = () => {
           <FormItem htmlFor="color" top="Цвет (контролируемый компонент)">
             <ChipsInput
               id="color"
-              inputLabel="Введите цвета"
+              placeholder="Введите цвета"
               after={
                 <IconButton hoverMode="opacity" label="Очистить поле" onClick={onClick}>
                   <Icon16Clear />

--- a/packages/vkui/src/components/ChipsInput/useChipsInput.ts
+++ b/packages/vkui/src/components/ChipsInput/useChipsInput.ts
@@ -104,6 +104,7 @@ export const useChipsInput = <O extends ChipOption>({
   );
 
   const clearInput = React.useCallback(() => {
+    /* istanbul ignore if */
     if (!inputRef.current) {
       return;
     }

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.test.tsx
@@ -12,6 +12,15 @@ describe('Chip', () => {
     a11y: false,
   });
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
   it('removes chip on onRemove click', async () => {
     const onRemove = jest.fn();
 
@@ -24,5 +33,18 @@ describe('Chip', () => {
     await userEvent.click(screen.getByRole('button'));
 
     expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('hides remove button if readOnly', async () => {
+    const result = render(<Chip value="white">Белый</Chip>);
+
+    expect(screen.getByRole('button')).toBeTruthy();
+
+    result.rerender(
+      <Chip value="white" readOnly>
+        Белый
+      </Chip>,
+    );
+    expect(() => screen.getByRole('button')).toThrow();
   });
 });

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
-import { baselineComponent, userEvent } from '../../../testing/utils';
+import { act, render, screen } from '@testing-library/react';
+import { baselineComponent, fakeTimers, userEvent } from '../../../testing/utils';
 import { Chip } from './Chip';
 
-describe('Chip', () => {
+describe(Chip, () => {
   baselineComponent(Chip, {
     // TODO [a11y]: "Certain ARIA roles must be contained by particular parents (aria-required-parent)"
     //              https://dequeuniversity.com/rules/axe/4.5/aria-required-parent?application=axeAPI
@@ -12,14 +12,7 @@ describe('Chip', () => {
     a11y: false,
   });
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
-  });
+  fakeTimers();
 
   it('removes chip on onRemove click', async () => {
     const onRemove = jest.fn();
@@ -30,7 +23,7 @@ describe('Chip', () => {
       </Chip>,
     );
 
-    await userEvent.click(screen.getByRole('button'));
+    await act(() => userEvent.click(screen.getByRole('button')));
 
     expect(onRemove).toHaveBeenCalled();
   });
@@ -47,4 +40,28 @@ describe('Chip', () => {
     );
     expect(() => screen.getByRole('button')).toThrow();
   });
+
+  it.each([{ readOnly: false }, { readOnly: true }])(
+    'calls user events (`readOnly` prop is `$readOnly`)',
+    async ({ readOnly }) => {
+      const onFocus = jest.fn();
+      const onBlur = jest.fn();
+      render(
+        <Chip
+          value="white"
+          readOnly={readOnly}
+          data-testid="input"
+          tabIndex={0}
+          onFocus={onFocus}
+          onBlur={onBlur}
+        />,
+      );
+
+      await act(() => userEvent.tab());
+      await act(() => userEvent.tab({ shift: true }));
+
+      expect(onFocus).toHaveBeenCalled();
+      expect(onBlur).toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
@@ -88,7 +88,7 @@ export const Chip = ({
             onClick={disabled ? undefined : onRemoveWrapper}
           >
             <VisuallyHidden>
-              {removeLabel} {children}
+              &nbsp; {removeLabel} {children}
             </VisuallyHidden>
             <Icon16Cancel />
           </button>

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
@@ -40,7 +40,6 @@ export const Chip = ({
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     if (onFocusProp) {
-      /* istanbul ignore next */
       onFocusProp(event);
     }
     onFocus(event);
@@ -48,7 +47,6 @@ export const Chip = ({
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     if (onBlurProp) {
-      /* istanbul ignore next */
       onBlurProp(event);
     }
     onBlur(event);

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
@@ -38,17 +38,19 @@ export const Chip = ({
   const focusVisibleClassName = useFocusVisibleClassName({ focusVisible });
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    onFocus(event);
     if (onFocusProp) {
+      /* istanbul ignore next */
       onFocusProp(event);
     }
+    onFocus(event);
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    onBlur(event);
     if (onBlurProp) {
+      /* istanbul ignore next */
       onBlurProp(event);
     }
+    onBlur(event);
   };
 
   const onRemoveWrapper = React.useCallback(

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
@@ -27,6 +27,7 @@ export const Chip = ({
   before,
   after,
   disabled,
+  readOnly,
   children,
   className,
   onFocus: onFocusProp,
@@ -70,6 +71,7 @@ export const Chip = ({
         focusVisibleClassName,
         className,
       )}
+      aria-readonly={readOnly}
       aria-disabled={disabled}
       onFocus={disabled ? undefined : handleFocus}
       onBlur={disabled ? undefined : handleBlur}
@@ -79,7 +81,7 @@ export const Chip = ({
         <Footnote className={styles['Chip__content']}>{children}</Footnote>
         {hasReactNode(after) && <div className={styles['Chip__after']}>{after}</div>}
       </div>
-      {removable && (
+      {!readOnly && removable && (
         <div className={styles['Chip__removable']}>
           <button
             tabIndex={-1} // [reason]: чтобы можно было выставлять состояние фокуса только программно через `*.focus()`

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.module.css
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.module.css
@@ -33,7 +33,7 @@
   appearance: none;
 }
 
-.ChipsInputBase__el:focus {
+.ChipsInputBase__el:not(:read-only):focus {
   min-inline-size: 64px;
 }
 

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, within } from '@testing-library/react';
+import { act, render, within } from '@testing-library/react';
 import { baselineComponent, userEvent, withRegExp } from '../../testing/utils';
 import { ChipsInputBase } from './ChipsInputBase';
 import type { ChipsInputBasePrivateProps } from './types';
@@ -68,7 +68,7 @@ describe(ChipsInputBase, () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await userEvent.type(result.getByTestId('chips-input'), 'Красный{enter}');
+    await act(() => userEvent.type(result.getByTestId('chips-input'), 'Красный{enter}'));
     expect(onAddChipOption).toHaveBeenCalledWith('Красный');
   });
 
@@ -81,8 +81,8 @@ describe(ChipsInputBase, () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await userEvent.type(result.getByTestId('chips-input'), 'Красный');
-    await userEvent.click(document.body);
+    await act(() => userEvent.type(result.getByTestId('chips-input'), 'Красный'));
+    await act(() => userEvent.click(document.body));
     expect(onAddChipOption).toHaveBeenCalledWith('Красный');
   });
 
@@ -96,7 +96,7 @@ describe(ChipsInputBase, () => {
     );
     const chipRedLocator = result.getByRole('option', { name: withRegExp(RED_OPTION.label) });
     const removeButton = within(chipRedLocator).getByRole('button');
-    await userEvent.click(removeButton);
+    await act(() => userEvent.click(removeButton));
     expect(onRemoveChipOption).toHaveBeenCalledWith(RED_OPTION.value);
   });
 
@@ -108,10 +108,12 @@ describe(ChipsInputBase, () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await userEvent.tab();
-    await userEvent.type(
-      result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
-      `{${type}}`,
+    await act(() => userEvent.tab());
+    await act(() =>
+      userEvent.type(
+        result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
+        `{${type}}`,
+      ),
     );
     expect(onRemoveChipOption).toHaveBeenCalledWith(RED_OPTION.value);
   });
@@ -127,10 +129,12 @@ describe(ChipsInputBase, () => {
           onRemoveChipOption={onRemoveChipOption}
         />,
       );
-      await userEvent.tab();
-      await userEvent.type(
-        result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
-        `{${type}}`,
+      await act(() => userEvent.tab());
+      await act(() =>
+        userEvent.type(
+          result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
+          `{${type}}`,
+        ),
       );
       expect(onRemoveChipOption).not.toHaveBeenCalled();
     },
@@ -146,7 +150,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const containerEl = result.getByRole('listbox').closest('div')!;
-      await userEvent.click(containerEl);
+      await act(() => userEvent.click(containerEl));
       expect(result.getByTestId('chips-input')).toHaveFocus();
     });
 
@@ -159,7 +163,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const containerEl = result.getByRole('listbox').closest('div')!;
-      await userEvent.click(containerEl);
+      await act(() => userEvent.click(containerEl));
       expect(result.getByRole('option', { name: withRegExp(RED_OPTION.label) })).toHaveFocus();
     });
 
@@ -171,7 +175,7 @@ describe(ChipsInputBase, () => {
           onRemoveChipOption={onRemoveChipOption}
         />,
       );
-      await userEvent.click(result.getByTestId('chips-input'));
+      await act(() => userEvent.click(result.getByTestId('chips-input')));
       expect(result.getByTestId('chips-input')).toHaveFocus();
     });
 
@@ -184,7 +188,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const chipLocator = result.getByRole('option', { name: withRegExp(RED_OPTION.label) });
-      await userEvent.click(chipLocator);
+      await act(() => userEvent.click(chipLocator));
       expect(chipLocator).toHaveFocus();
     });
 
@@ -199,10 +203,10 @@ describe(ChipsInputBase, () => {
       );
       const chipsInputLocator = result.getByTestId('chips-input');
 
-      await userEvent.type(chipsInputLocator, '{Backspace}');
+      await act(() => userEvent.type(chipsInputLocator, '{Backspace}'));
       expect(chipsInputLocator).toHaveFocus();
 
-      await userEvent.type(chipsInputLocator, '{Backspace}');
+      await act(() => userEvent.type(chipsInputLocator, '{Backspace}'));
       expect(chipsInputLocator.previousSibling).toHaveFocus();
     });
 
@@ -219,22 +223,22 @@ describe(ChipsInputBase, () => {
         result.getByRole('option', { name: withRegExp(label) }),
       );
 
-      await userEvent.type(chipRedLocator, '{ArrowRight}');
+      await act(() => userEvent.type(chipRedLocator, '{ArrowRight}'));
       expect(chipBlueLocator).toHaveFocus();
 
-      await userEvent.type(chipBlueLocator, '{ArrowRight}');
+      await act(() => userEvent.type(chipBlueLocator, '{ArrowRight}'));
       expect(chipYellowLocator).toHaveFocus();
 
-      await userEvent.type(chipYellowLocator, '{ArrowRight}');
+      await act(() => userEvent.type(chipYellowLocator, '{ArrowRight}'));
       expect(chipRedLocator).toHaveFocus();
 
-      await userEvent.type(chipRedLocator, '{ArrowLeft}');
+      await act(() => userEvent.type(chipRedLocator, '{ArrowLeft}'));
       expect(chipYellowLocator).toHaveFocus();
 
-      await userEvent.type(chipYellowLocator, '{ArrowLeft}');
+      await act(() => userEvent.type(chipYellowLocator, '{ArrowLeft}'));
       expect(chipBlueLocator).toHaveFocus();
 
-      await userEvent.type(chipBlueLocator, '{ArrowRight}');
+      await act(() => userEvent.type(chipBlueLocator, '{ArrowRight}'));
       expect(chipYellowLocator).toHaveFocus();
     });
 
@@ -252,28 +256,28 @@ describe(ChipsInputBase, () => {
         result.getByRole('option', { name: withRegExp(label) }),
       );
 
-      await userEvent.tab();
+      await act(() => userEvent.tab());
       expect(chipRedLocator).toHaveFocus();
 
-      await userEvent.tab();
+      await act(() => userEvent.tab());
       expect(chipsInputLocator).toHaveFocus();
 
-      await userEvent.tab({ shift: true });
+      await act(() => userEvent.tab({ shift: true }));
       expect(chipRedLocator).toHaveFocus();
 
-      await userEvent.type(chipRedLocator, '{ArrowRight}');
+      await act(() => userEvent.type(chipRedLocator, '{ArrowRight}'));
       expect(chipBlueLocator).toHaveFocus();
 
-      await userEvent.tab();
+      await act(() => userEvent.tab());
       expect(chipsInputLocator).toHaveFocus();
 
-      await userEvent.tab({ shift: true });
+      await act(() => userEvent.tab({ shift: true }));
       expect(chipBlueLocator).toHaveFocus();
 
-      await userEvent.tab({ shift: true });
+      await act(() => userEvent.tab({ shift: true }));
       expect(document.body).toHaveFocus();
 
-      await userEvent.tab();
+      await act(() => userEvent.tab());
       expect(chipBlueLocator).toHaveFocus();
     });
 
@@ -291,7 +295,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const chipRedLocator = result.getByRole('option', { name: withRegExp(RED_OPTION.label) });
-      await userEvent.type(chipRedLocator, '{Delete}');
+      await act(() => userEvent.type(chipRedLocator, '{Delete}'));
       const nextLocatorWithFocus =
         value.length <= 1
           ? result.getByTestId('chips-input')
@@ -299,4 +303,25 @@ describe(ChipsInputBase, () => {
       expect(nextLocatorWithFocus).toHaveFocus();
     });
   });
+
+  it.each([{ readOnly: false }, { readOnly: true }])(
+    'calls user events (`readOnly` prop is `$readOnly`)',
+    async ({ readOnly }) => {
+      const onBlur = jest.fn();
+      render(
+        <ChipsInputBaseTest
+          readOnly={readOnly}
+          value={[]}
+          onAddChipOption={onAddChipOption}
+          onRemoveChipOption={onRemoveChipOption}
+          onBlur={onBlur}
+        />,
+      );
+
+      await act(() => userEvent.tab());
+      await act(() => userEvent.tab({ shift: true }));
+
+      expect(onBlur).toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
@@ -137,7 +137,33 @@ describe(ChipsInputBase, () => {
   );
 
   describe('focus', () => {
-    it('focuses input field on clicking on them', async () => {
+    it('focuses on input field after clicking to container', async () => {
+      const result = render(
+        <ChipsInputBaseTest
+          value={[]}
+          onAddChipOption={onAddChipOption}
+          onRemoveChipOption={onRemoveChipOption}
+        />,
+      );
+      const containerEl = result.getByRole('listbox').closest('div')!;
+      await userEvent.click(containerEl);
+      expect(result.getByTestId('chips-input')).toHaveFocus();
+    });
+
+    it('focuses to first chip after clicking to container', async () => {
+      const result = render(
+        <ChipsInputBaseTest
+          value={[RED_OPTION]}
+          onAddChipOption={onAddChipOption}
+          onRemoveChipOption={onRemoveChipOption}
+        />,
+      );
+      const containerEl = result.getByRole('listbox').closest('div')!;
+      await userEvent.click(containerEl);
+      expect(result.getByRole('option', { name: withRegExp(RED_OPTION.label) })).toHaveFocus();
+    });
+
+    it('focuses on input field on clicking on them', async () => {
       const result = render(
         <ChipsInputBaseTest
           value={[RED_OPTION]}

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -85,7 +85,7 @@ export const ChipsInputBase = <O extends ChipOption>({
   };
 
   const removeChipOption = (o: O | ChipOptionValue, index: number) => {
-    /* istanbul ignore if */
+    /* istanbul ignore if: невозможный кейс (в SSR вызова этой функции не будет) */
     if (!inputRef.current || !listboxRef.current) {
       return;
     }
@@ -105,7 +105,7 @@ export const ChipsInputBase = <O extends ChipOption>({
 
   const handleListboxKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const targetEl = event.target;
-    /* istanbul ignore if */
+    /* istanbul ignore if: невозможный кейс (в SSR вызова этой функции не будет) */
     if (event.defaultPrevented || !listboxRef.current || !isHTMLElement(targetEl)) {
       return;
     }
@@ -162,7 +162,6 @@ export const ChipsInputBase = <O extends ChipOption>({
 
   const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     if (onBlur) {
-      /* istanbul ignore next */
       onBlur(event);
     }
 

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -224,8 +224,9 @@ export const ChipsInputBase = <O extends ChipOption>({
                 'value': option.value,
                 'label': option.label,
                 'disabled': disabled,
+                'readOnly': readOnly,
                 'className': styles['ChipsInputBase__chip'],
-                'onRemove': disabled || readOnly ? undefined : handleChipRemove,
+                'onRemove': handleChipRemove,
                 // чтобы можно было легче найти этот чип в DOM
                 'data-index': index,
                 'data-value': option.value,

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -59,10 +59,10 @@ export const ChipsInputBase = <O extends ChipOption>({
   const valueLength = value.length;
   const withPlaceholder = valueLength === 0;
   const isDisabled = disabled || readOnly;
-  const [chipFocusedIndex, setChipFocusedIndex] = React.useState(0);
+  const [lastFocusedChipOptionIndex, setLastFocusedChipOptionIndex] = React.useState(0);
 
   const resetChipOptionFocusToInputEl = (inputEl: HTMLInputElement) => {
-    setChipFocusedIndex(0);
+    setLastFocusedChipOptionIndex(0);
     inputEl.focus();
   };
 
@@ -76,14 +76,13 @@ export const ChipsInputBase = <O extends ChipOption>({
     const foundEl = listboxEl.querySelector<HTMLElement>(`[data-index="${index}"]`);
 
     if (foundEl) {
-      setChipFocusedIndex(index);
+      setLastFocusedChipOptionIndex(index);
       foundEl.focus();
-    } else {
-      setChipFocusedIndex(0);
     }
   };
 
   const removeChipOption = (o: O | ChipOptionValue, index: number) => {
+    /* istanbul ignore if */
     if (!inputRef.current || !listboxRef.current) {
       return;
     }
@@ -103,6 +102,7 @@ export const ChipsInputBase = <O extends ChipOption>({
 
   const handleListboxKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const targetEl = event.target;
+    /* istanbul ignore if */
     if (
       event.defaultPrevented ||
       !inputRef.current ||
@@ -162,6 +162,7 @@ export const ChipsInputBase = <O extends ChipOption>({
 
   const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     if (onBlur) {
+      /* istanbul ignore next */
       onBlur(event);
     }
 
@@ -216,7 +217,7 @@ export const ChipsInputBase = <O extends ChipOption>({
                 'data-index': index,
                 'data-value': option.value,
                 // для a11y
-                'tabIndex': chipFocusedIndex === index ? 0 : -1,
+                'tabIndex': lastFocusedChipOptionIndex === index ? 0 : -1,
                 'role': 'option',
                 'aria-selected': true,
                 'aria-posinset': index + 1,

--- a/packages/vkui/src/components/ChipsInputBase/helpers.ts
+++ b/packages/vkui/src/components/ChipsInputBase/helpers.ts
@@ -10,7 +10,8 @@ export const isValueLikeChipOptionObject = <O extends ChipOption>(v: O | ChipOpt
 /**
  * @private
  */
-export const isInputValueEmpty = (value: string) => value === DEFAULT_INPUT_VALUE;
+export const isInputValueEmpty = (input: HTMLInputElement | null) =>
+  input ? input.value === DEFAULT_INPUT_VALUE : true;
 
 /**
  * @private
@@ -47,8 +48,11 @@ export const getNextChipOptionIndexByNavigateToProp = (
   navigateTo: NavigateTo,
   length: number,
 ) => {
+  const FIRST_INDEX = 0;
   const LAST_INDEX = length - 1;
   switch (navigateTo) {
+    case 'first':
+      return FIRST_INDEX;
     case 'prev':
       const prevIndex = currentIndex - 1;
       return prevIndex < 0 ? LAST_INDEX : prevIndex;

--- a/packages/vkui/src/components/ChipsInputBase/helpers.ts
+++ b/packages/vkui/src/components/ChipsInputBase/helpers.ts
@@ -47,16 +47,18 @@ export const getNextChipOptionIndexByNavigateToProp = (
   navigateTo: NavigateTo,
   length: number,
 ) => {
+  const LAST_INDEX = length - 1;
   switch (navigateTo) {
-    case 'first':
-      return 0;
     case 'prev':
-      return currentIndex - 1;
+      const prevIndex = currentIndex - 1;
+      return prevIndex < 0 ? LAST_INDEX : prevIndex;
     case 'next':
-      return currentIndex + 1;
+      const nextIndex = currentIndex + 1;
+      return nextIndex > LAST_INDEX ? 0 : nextIndex;
     case 'last':
-      return length - 1;
+      return LAST_INDEX;
     default:
+      /* istanbul ignore next */
       return -1;
   }
 };

--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../types';
 import { FormFieldProps } from '../FormField/FormField';
 
-export type NavigateTo = 'first' | 'prev' | 'next' | 'last';
+export type NavigateTo = 'prev' | 'next' | 'last';
 
 export type ChipOptionValue = string | number;
 

--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../types';
 import { FormFieldProps } from '../FormField/FormField';
 
-export type NavigateTo = 'prev' | 'next' | 'last';
+export type NavigateTo = 'first' | 'prev' | 'next' | 'last';
 
 export type ChipOptionValue = string | number;
 

--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -27,6 +27,7 @@ export interface ChipProps
   value?: ChipOptionValue;
   removable?: boolean;
   disabled?: boolean;
+  readOnly?: boolean;
   removeLabel?: string;
   before?: React.ReactNode;
   after?: React.ReactNode;

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { act, fireEvent, render, within } from '@testing-library/react';
-import { getTextFromChildren } from '../../lib/children';
+import { act, render, within } from '@testing-library/react';
 import {
   baselineComponent,
   userEvent,
@@ -18,8 +17,6 @@ const THIRD_OPTION = { value: 'navarin', label: 'Наваринского пла
 
 const colors: ChipOption[] = [FIRST_OPTION, SECOND_OPTION, THIRD_OPTION];
 
-const testValue = { value: 'testvalue', label: 'testvalue' };
-
 describe('ChipsSelect', () => {
   baselineComponent(ChipsSelect, { a11y: false });
 
@@ -35,236 +32,346 @@ describe('ChipsSelect', () => {
   });
 
   it('renders empty text', async () => {
-    const result = render(<ChipsSelect options={[]} defaultValue={[]} emptyText="__empty__" />);
+    const result = render(
+      <ChipsSelect
+        options={[]}
+        defaultValue={[]}
+        dropdownTestId="dropdown"
+        emptyText="__empty__"
+      />,
+    );
     await userEvent.click(result.getByRole('combobox'));
     await waitForFloatingPosition();
-    expect(result.queryByText('__empty__')).toBeTruthy();
+    const dropdownLocator = result.getByTestId('dropdown');
+    expect(within(dropdownLocator).queryByText('__empty__')).toBeTruthy();
   });
 
   it('filters options', async () => {
     const result = render(
       <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
     );
-    const inputEl = result.getByRole('combobox');
-    await userEvent.type(inputEl, 'Син');
+    await userEvent.type(result.getByRole('combobox'), 'Син');
     await waitForFloatingPosition();
-    await userEvent.click(inputEl);
-    expect(within(result.getByTestId('dropdown')).getAllByRole('option')).toHaveLength(1);
-    expect(result.getByRole('option', { name: 'Синий' })).toBeTruthy();
+    const dropdownLocator = result.getByTestId('dropdown');
+    expect(within(dropdownLocator).getAllByRole('option')).toHaveLength(1);
+    expect(within(dropdownLocator).getByRole('option', { name: 'Синий' })).toBeTruthy();
   });
 
   it('shows spinner if fetching', async () => {
-    const result = render(<ChipsSelect fetching defaultValue={[]} />);
+    const result = render(<ChipsSelect fetching defaultValue={[]} dropdownTestId="dropdown" />);
     await userEvent.click(result.getByRole('combobox'));
     await waitForFloatingPosition();
-    expect(result.queryByRole('status')).toBeTruthy();
+    const dropdownLocator = result.getByTestId('dropdown');
+    expect(within(dropdownLocator).getByRole('status')).toBeTruthy();
   });
 
-  describe('controls dropdown', () => {
-    it.each(['click', 'focus'])('opens options on %s', async (eventType) => {
-      const result = render(<ChipsSelect options={colors} defaultValue={[]} />);
-      if (eventType === 'focus') {
-        fireEvent.focus(result.getByRole('combobox'));
-      }
-      await userEvent.click(result.getByRole('combobox'));
-      await waitForFloatingPosition();
-      expect(result.getAllByRole('option')[0]).toBeTruthy();
-    });
-
-    it('closes options on click outside', async () => {
-      const result = render(
-        <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
-      );
-      await userEvent.click(result.getByRole('combobox'));
-      await waitForFloatingPosition();
-      expect(result.getByTestId('dropdown')).not.toBeNull();
-      await userEvent.click(document.body);
-      expect(() => result.getByTestId('dropdown')).toThrow();
-    });
-
-    it('closes options after select', async () => {
-      const result = render(
-        <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
-      );
-      await userEvent.click(result.getByRole('combobox'));
-      await waitForFloatingPosition();
-      await userEvent.click(
-        within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(FIRST_OPTION.label),
-        }),
-      );
-      expect(() => result.getByTestId('dropdown')).toThrow();
-    });
-
-    it('does not close options after select with selectedBehavior and closeAfterSelect={false}', async () => {
-      const result = render(
-        <ChipsSelect
-          options={colors}
-          defaultValue={[]}
-          selectedBehavior="highlight"
-          closeAfterSelect={false}
-          dropdownTestId="dropdown"
-        />,
-      );
-      await userEvent.click(result.getByRole('combobox'));
-      await waitForFloatingPosition();
-      await userEvent.click(
-        within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(FIRST_OPTION.label),
-        }),
-      );
-      expect(() => result.getByTestId('dropdown')).toBeTruthy();
-    });
-
-    it('closes options on esc', async () => {
-      const result = render(
-        <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
-      );
-      await userEvent.click(result.getByRole('combobox'));
-      await waitForFloatingPosition();
-      await userEvent.type(result.getByRole('combobox'), '{Escape}');
-      expect(() => result.getByTestId('dropdown')).toThrow();
-    });
+  it.each(['click', 'focus'])('opens dropdown when %s on input field', async (eventType) => {
+    const result = render(
+      <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
+    );
+    const inputLocator = result.getByRole('combobox');
+    if (eventType === 'focus') {
+      await userEvent.tab();
+    } else {
+      await userEvent.click(inputLocator);
+    }
+    await waitForFloatingPosition();
+    const dropdownLocator = result.getByTestId('dropdown');
+    expect(within(dropdownLocator).getAllByRole('option')).toHaveLength(colors.length);
   });
 
-  describe('selects', () => {
-    it('on click', async () => {
-      const onChange = jest.fn();
+  it('closes options on click outside', async () => {
+    const result = render(
+      <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
+    );
+    await userEvent.click(result.getByRole('combobox'));
+    await waitForFloatingPosition();
+    expect(result.getByTestId('dropdown')).toBeTruthy();
+    await userEvent.click(document.body);
+    expect(() => result.getByTestId('dropdown')).toThrow();
+  });
+
+  it.each(['{ArrowDown}', 'typing text'])(
+    'closes dropdown on {Escape} and open when %s',
+    async (type) => {
       const result = render(
-        <ChipsSelect
-          options={colors}
-          onChange={onChange}
-          defaultValue={[]}
-          dropdownTestId="dropdown"
-        />,
+        <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
       );
-      await userEvent.click(result.getByRole('combobox'));
+      const inputLocator = result.getByRole('combobox');
+      await userEvent.click(inputLocator);
+
       await waitForFloatingPosition();
-      await userEvent.click(
-        within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(FIRST_OPTION.label),
-        }),
-      );
-      expect(onChange).toHaveBeenCalledWith([FIRST_OPTION]);
-    });
+      await userEvent.type(inputLocator, '{Escape}');
+      await userEvent.type(inputLocator, '{Enter}'); // если dropdown'а пока нет, то выбор из списка на {Enter} должно игнорироваться (см. в коде `case Keys.ENTER`)
+      expect(() => result.getByTestId('dropdown')).toThrow();
 
-    it('via keyboard', async () => {
-      const onChange = jest.fn();
-      const options = new Array(20).fill(0).map((_, i) => ({ value: i, label: `Option #${i}` }));
-      const result = render(
-        <ChipsSelect value={[]} options={options} onChange={onChange} dropdownTestId="dropdown" />,
-      );
-
-      await userEvent.click(result.getByRole('combobox'));
+      await userEvent.type(inputLocator, type);
       await waitForFloatingPosition();
-      const dropdown = result.getByTestId('dropdown');
+      expect(result.getByTestId('dropdown')).toBeTruthy();
+    },
+  );
 
-      // Focus on first element
-      await userEvent.keyboard('{arrowdown}');
+  it.each([
+    { closeAfterSelect: true, description: 'closes' },
+    { closeAfterSelect: false, description: 'does not close' },
+  ])('$description dropdown after select', async ({ closeAfterSelect }) => {
+    const result = render(
+      <ChipsSelect
+        options={colors}
+        defaultValue={[]}
+        dropdownTestId="dropdown"
+        closeAfterSelect={closeAfterSelect}
+      />,
+    );
+    await userEvent.click(result.getByRole('combobox'));
+    await waitForFloatingPosition();
+    await userEvent.click(
+      within(result.getByTestId('dropdown')).getByRole('option', {
+        name: withRegExp(FIRST_OPTION.label),
+      }),
+    );
+    if (closeAfterSelect) {
+      expect(() => result.getByTestId('dropdown')).toThrow();
+    } else {
+      expect(result.getByTestId('dropdown')).toBeTruthy();
+    }
+  });
 
-      const idx = 7;
-      for (let i = 0; i < idx; i++) {
-        await userEvent.keyboard('{arrowdown}');
-      }
-      await userEvent.keyboard('{enter}');
-
-      expect(within(dropdown).getByRole('option', { name: options[idx].label })).toBeTruthy();
-      expect(onChange).toHaveBeenCalledWith([options[idx]]);
-    });
-
-    it('does not hide selected option from list', async () => {
+  it.each([
+    { selectedBehavior: 'highlight' as const, description: 'hides' },
+    { selectedBehavior: 'hide' as const, description: 'does not hide' },
+  ])(
+    '$description selected option if `selectedBehavior` is `"$selectedBehavior"`',
+    async ({ selectedBehavior }) => {
       const result = render(
         <ChipsSelect
           options={colors}
           defaultValue={[FIRST_OPTION]}
-          selectedBehavior="highlight"
+          selectedBehavior={selectedBehavior}
           dropdownTestId="dropdown"
         />,
       );
-      await userEvent.click(result.getByRole('combobox'));
-      await waitForFloatingPosition();
-      expect(
-        within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(FIRST_OPTION.label),
-        }),
-      ).toBeTruthy();
-    });
 
-    it('hides selected option from list', async () => {
-      const result = render(
-        <ChipsSelect
-          options={colors}
-          defaultValue={[FIRST_OPTION]}
-          selectedBehavior="hide"
-          dropdownTestId="dropdown"
-        />,
-      );
       await userEvent.click(result.getByRole('combobox'));
       await waitForFloatingPosition();
-      expect(() =>
+
+      const getFirstOption = () => {
         within(result.getByTestId('dropdown')).getByRole('option', {
-          name: getTextFromChildren(FIRST_OPTION.label),
-        }),
-      ).toThrow();
-    });
-    it('deselects on chip click', async () => {
-      const handleChange = jest.fn();
-      const result = render(
-        <ChipsSelect options={colors} value={[FIRST_OPTION]} onChange={handleChange} />,
-      );
-      await userEvent.click(result.getByText(`Удалить ${FIRST_OPTION.label}`).closest('button')!);
-      expect(handleChange).toHaveBeenCalledWith([]);
-    });
+          name: withRegExp(FIRST_OPTION.label),
+        });
+      };
+
+      if (selectedBehavior === 'highlight') {
+        expect(getFirstOption).toBeTruthy();
+      } else {
+        expect(getFirstOption).toThrow();
+      }
+    },
+  );
+
+  it('should cycle navigates with {ArrowUp} and {ArrowDown}', async () => {
+    const result = render(
+      <ChipsSelect
+        options={[FIRST_OPTION, SECOND_OPTION, THIRD_OPTION]}
+        dropdownTestId="dropdown"
+      />,
+    );
+
+    const inputLocator = result.getByRole('combobox');
+    await userEvent.click(inputLocator);
+    await waitForFloatingPosition();
+
+    const boundDropdownLocator = within(result.getByTestId('dropdown'));
+    const [firstOptionLocator, , thirdOptionLocator] = [
+      boundDropdownLocator.getByRole('option', {
+        name: withRegExp(FIRST_OPTION.label),
+      }),
+      boundDropdownLocator.getByRole('option', {
+        name: withRegExp(SECOND_OPTION.label),
+      }),
+      boundDropdownLocator.getByRole('option', {
+        name: withRegExp(THIRD_OPTION.label),
+      }),
+    ];
+
+    await userEvent.type(inputLocator, '{ArrowDown}');
+    expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
+
+    await userEvent.type(inputLocator, '{ArrowUp}');
+    expect(thirdOptionLocator).toHaveAttribute('data-hovered', 'true');
+
+    await userEvent.type(inputLocator, '{ArrowDown}');
+    expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
   });
 
-  it('does not focus ChipsSelect on chip click', async () => {
-    let selectedColors: ChipOption[] = [FIRST_OPTION, SECOND_OPTION];
-    const setSelectedColors = (updatedColors: ChipOption[]) => {
-      selectedColors = [...updatedColors];
-    };
+  it('adds chip from dropdown with click to option', async () => {
+    const onChangeStart = jest.fn();
+    const onChange = jest.fn();
+    const result = render(
+      <ChipsSelect
+        value={[]}
+        options={colors}
+        onChangeStart={onChangeStart}
+        onChange={onChange}
+        dropdownTestId="dropdown"
+      />,
+    );
 
-    const colorsChipsProps = {
-      value: selectedColors,
-      onChange: setSelectedColors,
-      options: colors,
-      top: 'Выберите или добавьте цвета',
-      placeholder: 'Не выбраны',
-      creatable: true,
-    };
+    const inputLocator = result.getByRole('combobox');
+    await userEvent.click(inputLocator);
+    await waitForFloatingPosition();
 
-    const result = render(<ChipsSelect data-testid="chips-select" {...colorsChipsProps} />);
+    const dropdownOption = within(result.getByTestId('dropdown')).getByRole('option', {
+      name: withRegExp(FIRST_OPTION.label),
+    });
+    await userEvent.hover(dropdownOption); // для вызова onDropdownMouseLeave
+    await userEvent.hover(inputLocator);
+    await userEvent.click(dropdownOption);
+
+    result.rerender(
+      <ChipsSelect
+        value={[FIRST_OPTION]}
+        options={colors}
+        onChangeStart={onChangeStart}
+        onChange={onChange}
+        dropdownTestId="dropdown"
+      />,
+    );
+    expect(
+      result.getByRole('option', {
+        name: withRegExp(FIRST_OPTION.label),
+      }),
+    ).toBeTruthy();
+    expect(onChangeStart).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith([FIRST_OPTION]);
+  });
+
+  it('adds chip from dropdown with {Enter} to option', async () => {
+    const onChangeStart = jest.fn();
+    const onChange = jest.fn();
+    const options = new Array(20).fill(0).map((_, i) => ({ value: i, label: `Option #${i}` }));
+    const result = render(
+      <ChipsSelect
+        value={[]}
+        options={options}
+        onChangeStart={onChangeStart}
+        onChange={onChange}
+      />,
+    );
+
+    const inputLocator = result.getByRole('combobox');
+    await userEvent.click(inputLocator);
+    await waitForFloatingPosition();
+
+    const targetOptionIndex = 7;
+    await userEvent.type(inputLocator, '{ArrowDown}');
+    for (let i = 0; i < targetOptionIndex; i += 1) {
+      await userEvent.type(inputLocator, '{ArrowDown}');
+    }
+    await userEvent.type(inputLocator, '{Enter}');
+
+    const selectedOption = options[targetOptionIndex];
+    result.rerender(
+      <ChipsSelect
+        value={[options[targetOptionIndex]]}
+        options={options}
+        onChangeStart={onChangeStart}
+        onChange={onChange}
+      />,
+    );
+    expect(
+      result.getByRole('option', {
+        name: withRegExp(selectedOption.label),
+      }),
+    ).toBeTruthy();
+    expect(onChangeStart).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith([selectedOption]);
+  });
+
+  it('does not focus input field on chip click', async () => {
+    const result = render(
+      <ChipsSelect defaultValue={[FIRST_OPTION, SECOND_OPTION]} options={colors} />,
+    );
     const chipEl = result.getByRole('option', { name: withRegExp(FIRST_OPTION.label) });
-    await userEvent.click(within(chipEl).getByRole('button'));
-    expect(result.getByTestId('chips-select')).not.toHaveFocus();
+    await userEvent.click(chipEl);
+    expect(result.getByRole('combobox')).not.toHaveFocus();
   });
 
-  describe('addOnBlur prop', () => {
-    it('add value on blur event if creatable=true', async () => {
-      let value;
-      const result = render(
-        <ChipsSelect
-          options={colors}
-          value={[]}
-          onChange={(e) => (value = e)}
-          creatable
-          addOnBlur
-        />,
-      );
-      await userEvent.type(result.getByRole('combobox'), testValue.label);
-      await waitForFloatingPosition();
-      await userEvent.click(document.body);
-      expect(value).toEqual([testValue]);
-    });
+  describe('creatable', () => {
+    const customChip = { value: 'testvalue', label: 'testvalue' };
 
-    it('does not add value on blur event if creatable=false', async () => {
+    it.each([
+      { creatable: true, description: 'adds custom chip' },
+      { creatable: false, description: 'does not add custom chip' },
+    ])('$description by pressing {Enter}', async ({ creatable }) => {
       const onChange = jest.fn();
       const result = render(
-        <ChipsSelect options={colors} value={[]} onChange={onChange} creatable={false} addOnBlur />,
+        <ChipsSelect
+          creatable={creatable}
+          options={colors}
+          defaultValue={[]}
+          onChange={onChange}
+        />,
       );
-      await userEvent.type(result.getByRole('combobox'), testValue.label);
-      await waitForFloatingPosition();
-      await userEvent.click(document.body);
-      expect(onChange).not.toHaveBeenCalled();
+      const inputLocator = result.getByRole('combobox');
+      await userEvent.type(inputLocator, customChip.label);
+      await userEvent.type(inputLocator, '{Enter}');
+      if (creatable) {
+        expect(onChange).toHaveBeenCalledWith([customChip]);
+      } else {
+        expect(onChange).not.toHaveBeenCalled();
+      }
     });
+
+    it('adds custom chip by add button in dropdown', async () => {
+      const onChange = jest.fn();
+      const result = render(
+        <ChipsSelect
+          creatable="Добавить новую опцию"
+          options={colors}
+          defaultValue={[]}
+          onChange={onChange}
+          dropdownTestId="dropdown"
+        />,
+      );
+      const inputLocator = result.getByRole('combobox');
+      await userEvent.type(inputLocator, customChip.label);
+      await waitForFloatingPosition();
+      await userEvent.click(
+        within(result.getByTestId('dropdown')).getByRole('option', {
+          name: withRegExp('Добавить новую опцию'),
+        }),
+      );
+      expect(onChange).toHaveBeenCalledWith([customChip]);
+    });
+
+    it.each([
+      { creatable: true, description: 'adds custom chip' },
+      { creatable: false, description: 'does not add custom chip' },
+    ])(
+      '$description when `addOnBlur` provided and `creatable` is $creatable',
+      async ({ creatable }) => {
+        const onChange = jest.fn();
+        const result = render(
+          <ChipsSelect
+            creatable={creatable}
+            addOnBlur
+            options={colors}
+            defaultValue={[]}
+            onChange={onChange}
+          />,
+        );
+
+        await userEvent.type(result.getByRole('combobox'), customChip.label);
+        await waitForFloatingPosition();
+        await userEvent.click(document.body);
+
+        if (creatable) {
+          expect(onChange).toHaveBeenCalledWith([customChip]);
+        } else {
+          expect(onChange).not.toHaveBeenCalledWith([]);
+        }
+      },
+    );
   });
 });

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { act, render, within } from '@testing-library/react';
 import {
   baselineComponent,
+  fakeTimers,
   userEvent,
   waitForFloatingPosition,
   withRegExp,
@@ -20,16 +21,7 @@ const colors: ChipOption[] = [FIRST_OPTION, SECOND_OPTION, THIRD_OPTION];
 describe('ChipsSelect', () => {
   baselineComponent(ChipsSelect, { a11y: false });
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    act(() => {
-      jest.runOnlyPendingTimers();
-      jest.useRealTimers();
-    });
-  });
+  fakeTimers();
 
   it('renders empty text', async () => {
     const result = render(
@@ -40,7 +32,7 @@ describe('ChipsSelect', () => {
         emptyText="__empty__"
       />,
     );
-    await userEvent.click(result.getByRole('combobox'));
+    await act(() => userEvent.click(result.getByRole('combobox')));
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
     expect(within(dropdownLocator).queryByText('__empty__')).toBeTruthy();
@@ -50,7 +42,7 @@ describe('ChipsSelect', () => {
     const result = render(
       <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
     );
-    await userEvent.type(result.getByRole('combobox'), 'Син');
+    await act(() => userEvent.type(result.getByRole('combobox'), 'Син'));
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
     expect(within(dropdownLocator).getAllByRole('option')).toHaveLength(1);
@@ -59,7 +51,7 @@ describe('ChipsSelect', () => {
 
   it('shows spinner if fetching', async () => {
     const result = render(<ChipsSelect fetching defaultValue={[]} dropdownTestId="dropdown" />);
-    await userEvent.click(result.getByRole('combobox'));
+    await act(() => userEvent.click(result.getByRole('combobox')));
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
     expect(within(dropdownLocator).getByRole('status')).toBeTruthy();
@@ -71,9 +63,9 @@ describe('ChipsSelect', () => {
     );
     const inputLocator = result.getByRole('combobox');
     if (eventType === 'focus') {
-      await userEvent.tab();
+      await act(() => userEvent.tab());
     } else {
-      await userEvent.click(inputLocator);
+      await act(() => userEvent.click(inputLocator));
     }
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
@@ -84,10 +76,10 @@ describe('ChipsSelect', () => {
     const result = render(
       <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
     );
-    await userEvent.click(result.getByRole('combobox'));
+    await act(() => userEvent.click(result.getByRole('combobox')));
     await waitForFloatingPosition();
     expect(result.getByTestId('dropdown')).toBeTruthy();
-    await userEvent.click(document.body);
+    await act(() => userEvent.click(document.body));
     expect(() => result.getByTestId('dropdown')).toThrow();
   });
 
@@ -98,14 +90,14 @@ describe('ChipsSelect', () => {
         <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
       );
       const inputLocator = result.getByRole('combobox');
-      await userEvent.click(inputLocator);
+      await act(() => userEvent.click(inputLocator));
 
       await waitForFloatingPosition();
-      await userEvent.type(inputLocator, '{Escape}');
-      await userEvent.type(inputLocator, '{Enter}'); // если dropdown'а пока нет, то выбор из списка на {Enter} должно игнорироваться (см. в коде `case Keys.ENTER`)
+      await act(() => userEvent.type(inputLocator, '{Escape}'));
+      await act(() => userEvent.type(inputLocator, '{Enter}')); // если dropdown'а пока нет, то выбор из списка на {Enter} должно игнорироваться (см. в коде `case Keys.ENTER`
       expect(() => result.getByTestId('dropdown')).toThrow();
 
-      await userEvent.type(inputLocator, type);
+      await act(() => userEvent.type(inputLocator, type));
       await waitForFloatingPosition();
       expect(result.getByTestId('dropdown')).toBeTruthy();
     },
@@ -123,12 +115,14 @@ describe('ChipsSelect', () => {
         closeAfterSelect={closeAfterSelect}
       />,
     );
-    await userEvent.click(result.getByRole('combobox'));
+    await act(() => userEvent.click(result.getByRole('combobox')));
     await waitForFloatingPosition();
-    await userEvent.click(
-      within(result.getByTestId('dropdown')).getByRole('option', {
-        name: withRegExp(FIRST_OPTION.label),
-      }),
+    await act(() =>
+      userEvent.click(
+        within(result.getByTestId('dropdown')).getByRole('option', {
+          name: withRegExp(FIRST_OPTION.label),
+        }),
+      ),
     );
     if (closeAfterSelect) {
       expect(() => result.getByTestId('dropdown')).toThrow();
@@ -152,7 +146,7 @@ describe('ChipsSelect', () => {
         />,
       );
 
-      await userEvent.click(result.getByRole('combobox'));
+      await act(() => userEvent.click(result.getByRole('combobox')));
       await waitForFloatingPosition();
 
       const getFirstOption = () => {
@@ -178,7 +172,7 @@ describe('ChipsSelect', () => {
     );
 
     const inputLocator = result.getByRole('combobox');
-    await userEvent.click(inputLocator);
+    await act(() => userEvent.click(inputLocator));
     await waitForFloatingPosition();
 
     const boundDropdownLocator = within(result.getByTestId('dropdown'));
@@ -194,13 +188,13 @@ describe('ChipsSelect', () => {
       }),
     ];
 
-    await userEvent.type(inputLocator, '{ArrowDown}');
+    await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
     expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
 
-    await userEvent.type(inputLocator, '{ArrowUp}');
+    await act(() => userEvent.type(inputLocator, '{ArrowUp}'));
     expect(thirdOptionLocator).toHaveAttribute('data-hovered', 'true');
 
-    await userEvent.type(inputLocator, '{ArrowDown}');
+    await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
     expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
   });
 
@@ -218,15 +212,15 @@ describe('ChipsSelect', () => {
     );
 
     const inputLocator = result.getByRole('combobox');
-    await userEvent.click(inputLocator);
+    await act(() => userEvent.click(inputLocator));
     await waitForFloatingPosition();
 
     const dropdownOption = within(result.getByTestId('dropdown')).getByRole('option', {
       name: withRegExp(FIRST_OPTION.label),
     });
-    await userEvent.hover(dropdownOption); // для вызова onDropdownMouseLeave
-    await userEvent.hover(inputLocator);
-    await userEvent.click(dropdownOption);
+    await act(() => userEvent.hover(dropdownOption)); // для вызова onDropdownMouseLeav
+    await act(() => userEvent.hover(inputLocator));
+    await act(() => userEvent.click(dropdownOption));
 
     result.rerender(
       <ChipsSelect
@@ -260,15 +254,15 @@ describe('ChipsSelect', () => {
     );
 
     const inputLocator = result.getByRole('combobox');
-    await userEvent.click(inputLocator);
+    await act(() => userEvent.click(inputLocator));
     await waitForFloatingPosition();
 
     const targetOptionIndex = 7;
-    await userEvent.type(inputLocator, '{ArrowDown}');
+    await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
     for (let i = 0; i < targetOptionIndex; i += 1) {
-      await userEvent.type(inputLocator, '{ArrowDown}');
+      await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
     }
-    await userEvent.type(inputLocator, '{Enter}');
+    await act(() => userEvent.type(inputLocator, '{Enter}'));
 
     const selectedOption = options[targetOptionIndex];
     result.rerender(
@@ -293,7 +287,7 @@ describe('ChipsSelect', () => {
       <ChipsSelect defaultValue={[FIRST_OPTION, SECOND_OPTION]} options={colors} />,
     );
     const chipEl = result.getByRole('option', { name: withRegExp(FIRST_OPTION.label) });
-    await userEvent.click(chipEl);
+    await act(() => userEvent.click(chipEl));
     expect(result.getByRole('combobox')).not.toHaveFocus();
   });
 
@@ -314,8 +308,8 @@ describe('ChipsSelect', () => {
         />,
       );
       const inputLocator = result.getByRole('combobox');
-      await userEvent.type(inputLocator, customChip.label);
-      await userEvent.type(inputLocator, '{Enter}');
+      await act(() => userEvent.type(inputLocator, customChip.label));
+      await act(() => userEvent.type(inputLocator, '{Enter}'));
       if (creatable) {
         expect(onChange).toHaveBeenCalledWith([customChip]);
       } else {
@@ -335,12 +329,14 @@ describe('ChipsSelect', () => {
         />,
       );
       const inputLocator = result.getByRole('combobox');
-      await userEvent.type(inputLocator, customChip.label);
+      await act(() => userEvent.type(inputLocator, customChip.label));
       await waitForFloatingPosition();
-      await userEvent.click(
-        within(result.getByTestId('dropdown')).getByRole('option', {
-          name: withRegExp('Добавить новую опцию'),
-        }),
+      await act(() =>
+        userEvent.click(
+          within(result.getByTestId('dropdown')).getByRole('option', {
+            name: withRegExp('Добавить новую опцию'),
+          }),
+        ),
       );
       expect(onChange).toHaveBeenCalledWith([customChip]);
     });
@@ -362,9 +358,9 @@ describe('ChipsSelect', () => {
           />,
         );
 
-        await userEvent.type(result.getByRole('combobox'), customChip.label);
+        await act(() => userEvent.type(result.getByRole('combobox'), customChip.label));
         await waitForFloatingPosition();
-        await userEvent.click(document.body);
+        await act(() => userEvent.click(document.body));
 
         if (creatable) {
           expect(onChange).toHaveBeenCalledWith([customChip]);
@@ -374,4 +370,34 @@ describe('ChipsSelect', () => {
       },
     );
   });
+
+  it.each([{ readOnly: false }, { readOnly: true }])(
+    'calls user events (`readOnly` prop is `$readOnly`)',
+    async ({ readOnly }) => {
+      const onFocus = jest.fn();
+      const onBlur = jest.fn();
+      const onKeyDown = jest.fn();
+      const result = render(
+        <ChipsSelect
+          readOnly={readOnly}
+          data-testid="input"
+          options={colors}
+          defaultValue={[]}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onKeyDown={onKeyDown}
+        />,
+      );
+
+      const inputLocator = result.getByTestId('input');
+
+      await act(() => userEvent.tab());
+      await act(() => userEvent.type(inputLocator, '{ArrowUp}'));
+      await act(() => userEvent.tab({ shift: true }));
+
+      expect(onFocus).toHaveBeenCalled();
+      expect(onBlur).toHaveBeenCalled();
+      expect(onKeyDown).toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -125,10 +125,10 @@ export const ChipsSelect = <Option extends ChipOption>({
   renderChip = renderChipDefault,
   renderOption = renderOptionDefault,
   onChange,
-  onFocus,
+  onFocus: onFocusProp,
   onInputChange: onInputChangeProp,
-  onBlur,
-  onKeyDown,
+  onBlur: onBlurProp,
+  onKeyDown: onKeyDownProp,
   ...restProps
 }: ChipsSelectProps<Option>) => {
   const {
@@ -191,9 +191,8 @@ export const ChipsSelect = <Option extends ChipOption>({
   const dropdownScrollBoxRef = React.useRef<HTMLDivElement>(null);
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (onFocus) {
-      /* istanbul ignore next */
-      onFocus(event);
+    if (onFocusProp) {
+      onFocusProp(event);
     }
 
     if (!readOnly) {
@@ -203,9 +202,8 @@ export const ChipsSelect = <Option extends ChipOption>({
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (onBlur) {
-      /* istanbul ignore next */
-      onBlur(event);
+    if (onBlurProp) {
+      onBlurProp(event);
     }
 
     // Не добавляем значение, если его нужно выбрать строго из списка
@@ -220,7 +218,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     const dropdown = dropdownScrollBoxRef.current;
     const item = chipsSelectOptions[index];
 
-    /* istanbul ignore if */
+    /* istanbul ignore if: невозможный кейс (в SSR вызова этой функции не будет) */
     if (!item || !dropdown) {
       return;
     }
@@ -230,7 +228,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     const itemTop = item.offsetTop;
     const itemHeight = item.offsetHeight;
 
-    /* istanbul ignore next */
+    /* istanbul ignore next: нет представления как воспроизвести */
     if (center) {
       dropdown.scrollTop = itemTop - dropdownHeight / 2 + itemHeight / 2;
     } else if (itemTop + itemHeight > dropdownHeight + scrollTop) {
@@ -250,7 +248,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     }
 
     if (index === oldIndex) {
-      /* istanbul ignore next */
+      /* istanbul ignore next: нет представления как воспроизвести */
       return;
     }
 
@@ -271,13 +269,11 @@ export const ChipsSelect = <Option extends ChipOption>({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (onKeyDown) {
-      /* istanbul ignore next */
-      onKeyDown(event);
+    if (onKeyDownProp) {
+      onKeyDownProp(event);
     }
 
-    if (event.defaultPrevented && readOnly) {
-      /* istanbul ignore next */
+    if (event.defaultPrevented || readOnly) {
       return;
     }
 
@@ -346,7 +342,7 @@ export const ChipsSelect = <Option extends ChipOption>({
   }, [options, focusedOptionIndex, setFocusedOption]);
 
   const onDropdownPlacementChange = React.useCallback((placement: Placement) => {
-    /* istanbul ignore next */
+    /* istanbul ignore next:  */
     if (placement.startsWith('top')) {
       setDropdownVerticalPlacement('top');
     } else if (placement.startsWith('bottom')) {

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -118,6 +118,7 @@ export const ChipsSelect = <Option extends ChipOption>({
   inputValue: inputValueProp,
   defaultInputValue,
   disabled,
+  readOnly,
   getOptionValue = getOptionValueDefault,
   getOptionLabel = getOptionLabelDefault,
   getNewOptionData = getNewOptionDataDefault,
@@ -195,8 +196,10 @@ export const ChipsSelect = <Option extends ChipOption>({
       onFocus(event);
     }
 
-    setOpened(true);
-    setFocusedOptionIndex(null);
+    if (!readOnly) {
+      setOpened(true);
+      setFocusedOptionIndex(null);
+    }
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -206,7 +209,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     }
 
     // Не добавляем значение, если его нужно выбрать строго из списка
-    if (!event.defaultPrevented && !creatable) {
+    if (!readOnly && !event.defaultPrevented && !creatable) {
       event.preventDefault();
     }
   };
@@ -273,7 +276,7 @@ export const ChipsSelect = <Option extends ChipOption>({
       onKeyDown(event);
     }
 
-    if (event.defaultPrevented) {
+    if (event.defaultPrevented && readOnly) {
       /* istanbul ignore next */
       return;
     }
@@ -370,6 +373,7 @@ export const ChipsSelect = <Option extends ChipOption>({
       <ChipsInputBase
         {...restProps}
         disabled={disabled}
+        readOnly={readOnly}
         // FormFieldProps
         id={labelledbyId}
         getRootRef={rootRef}

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -191,6 +191,7 @@ export const ChipsSelect = <Option extends ChipOption>({
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     if (onFocus) {
+      /* istanbul ignore next */
       onFocus(event);
     }
 
@@ -200,6 +201,7 @@ export const ChipsSelect = <Option extends ChipOption>({
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     if (onBlur) {
+      /* istanbul ignore next */
       onBlur(event);
     }
 
@@ -215,6 +217,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     const dropdown = dropdownScrollBoxRef.current;
     const item = chipsSelectOptions[index];
 
+    /* istanbul ignore if */
     if (!item || !dropdown) {
       return;
     }
@@ -224,6 +227,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     const itemTop = item.offsetTop;
     const itemHeight = item.offsetHeight;
 
+    /* istanbul ignore next */
     if (center) {
       dropdown.scrollTop = itemTop - dropdownHeight / 2 + itemHeight / 2;
     } else if (itemTop + itemHeight > dropdownHeight + scrollTop) {
@@ -243,6 +247,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     }
 
     if (index === oldIndex) {
+      /* istanbul ignore next */
       return;
     }
 
@@ -264,10 +269,12 @@ export const ChipsSelect = <Option extends ChipOption>({
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (onKeyDown) {
+      /* istanbul ignore next */
       onKeyDown(event);
     }
 
     if (event.defaultPrevented) {
+      /* istanbul ignore next */
       return;
     }
 
@@ -336,7 +343,7 @@ export const ChipsSelect = <Option extends ChipOption>({
   }, [options, focusedOptionIndex, setFocusedOption]);
 
   const onDropdownPlacementChange = React.useCallback((placement: Placement) => {
-    // console.log(placement);
+    /* istanbul ignore next */
     if (placement.startsWith('top')) {
       setDropdownVerticalPlacement('top');
     } else if (placement.startsWith('bottom')) {

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -59,7 +59,7 @@ export interface CustomSelectOptionProps extends HTMLAttributesWithRootRef<HTMLD
 export const CustomSelectOption = ({
   children,
   hierarchy = 0,
-  hovered,
+  hovered: hoveredProp,
   selected,
   before,
   after,
@@ -81,6 +81,7 @@ export const CustomSelectOption = ({
         : styleProp,
     [hierarchy, styleProp],
   );
+  const hovered = hoveredProp && !disabled ? true : false;
 
   return (
     <Paragraph
@@ -90,10 +91,11 @@ export const CustomSelectOption = ({
       role="option"
       aria-disabled={disabled}
       aria-selected={selected}
+      data-hovered={hovered}
       className={classNames(
         styles['CustomSelectOption'],
         sizeY !== 'compact' && sizeYClassNames[sizeY],
-        hovered && !disabled && styles['CustomSelectOption--hover'],
+        hovered && styles['CustomSelectOption--hover'],
         disabled && styles['CustomSelectOption--disabled'],
         hierarchy > 0 && styles['CustomSelectOption--hierarchy'],
         className,


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

- Добавил цикличную навигацию стрелками между чипами.

    https://github.com/VKCOM/VKUI/assets/5850354/a849e56c-9912-4cd3-802a-97f224d9f03b

- Покрыл тестами `ChipsSelect`, `ChipsInputBase`, `Chip`.
- `Chip`
  - теперь принимает `readOnly`. При его передаче, скрывается кнопка удаления чипа;
  - для корректного произношения скринридером, добавил `&nbsp;` перед скрытым текстом `"Удалить <children>"`.

---

- related to #6367
