### PR TITLE
fix(DateInput): Clear DateInput focus when click Done button (#6312)

### DIFF
--- a/packages/vkui/src/hooks/useDateInput.ts
+++ b/packages/vkui/src/hooks/useDateInput.ts
@@ -39,13 +39,13 @@ export function useDateInput<T extends HTMLElement, D>({
   const { window } = useDOM();
 
   const removeFocusFromField = React.useCallback(() => {
-    if (open) {
+    if (focusedElement !== null) {
       setFocusedElement(null);
       closeCalendar();
       window!.getSelection()?.removeAllRanges();
       setInternalValue(getInternalValue(value));
     }
-  }, [closeCalendar, getInternalValue, open, value, window]);
+  }, [focusedElement, closeCalendar, getInternalValue, value, window]);
 
   const handleClickOutside = React.useCallback(
     (e: MouseEvent) => {


### PR DESCRIPTION
## Важно
Это cherry-pick из #6312, из v6 в v5.

## Описание

Немного поменял логику сброса программного фокуса.  Функция для сброса вызывается при клике снаружи или при выборе даты, если используется свойство `closeOnChange`. Но функция сброса внутри проверяет состояние календаря`open` и только если оно true, то фокус сбрасывается. В #6244 как раз ситуация, когда по клику на кнопку "Готово", мы закрываем попап календаря, но фокус не убираем. Потом кликаем по другой кнопке, это как раз "click outside", но фокус не сбрасывается, потому что `open` ужe `false`.

Переделал проверку с `open` на `focusedElement`.
Работать будет аналогично, но и фокус сбрасываться будет более предсказуемо и всегда при вызове `resetFocusFormField` если фокус установлен.