### PR TITLE
codemode(chips-input): mv inputAriaLabel to placeholder

### DIFF
--- a/packages/codemods/src/transforms/__tests__/__snapshots__/chips-input.ts.snap
+++ b/packages/codemods/src/transforms/__tests__/__snapshots__/chips-input.ts.snap
@@ -7,7 +7,7 @@ import React from 'react';
 const App = () => {
   return (
     <React.Fragment>
-      <ChipsInput id="color" value={colors} inputLabel="Введите название цвета">
+      <ChipsInput id="color" value={colors} placeholder="Введите название цвета">
         Чип
       </ChipsInput>
     </React.Fragment>

--- a/packages/codemods/src/transforms/chips-input.ts
+++ b/packages/codemods/src/transforms/chips-input.ts
@@ -5,7 +5,7 @@ import { JSCodeShiftOptions } from '../types';
 export const parser = 'tsx';
 
 const RENAME_MAP = {
-  inputAriaLabel: 'inputLabel',
+  inputAriaLabel: 'placeholder',
 };
 
 export default function transformer(file: FileInfo, api: API, options: JSCodeShiftOptions) {


### PR DESCRIPTION
## Описание

После #6367 `inputLabel` (a.k.a `inputAriaLabel`) был удалён. Вместо него нужно использовать либо `placeholder`, либо оборачивать в `FormItem`.

- caused by #6367
