### PR TITLE
Exclude monthNames prop from passed props to NativeDatePicker (#6386) (#6409)

### DIFF
--- a/packages/vkui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/vkui/src/components/DatePicker/DatePicker.tsx
@@ -147,10 +147,11 @@ const DatePickerCustom = ({
 const DatePickerNative = ({
   min = { day: 0, month: 0, year: 0 },
   max = { day: 31, month: 12, year: 2100 },
+  monthNames,
+  popupDirection,
   dayPlaceholder,
   monthPlaceholder,
   yearPlaceholder,
-  popupDirection,
   defaultValue,
   day,
   month,


### PR DESCRIPTION
## Внимание
базовая ветка v5.10-stable. В прошлом [PR](https://github.com/VKCOM/VKUI/pull/6409#issuecomment-1900109291) ошибся с тэгами и v5.10-stable не обновилась.


## Описание
Eсли смотреть компонент `DatePicker` с переданным `monthNames` на тач устройствах, то cвойство `monthNames` встает html-аттрибутом. В режиме локальной разработки есть реакт-варнинг.

Не передаем `monthNames` в компоненты ниже `NativeDatePicker`.