### PR TITLE
[CustomSelect]: Pass required prop to native select instead of search input (#6373) (#6408)

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -1061,7 +1061,6 @@ describe('CustomSelect', () => {
   });
 
   it('native select is reachable via nativeSelectTestId', () => {
-    // Это позволяет скринридеру зачитывать placeholder, если опция не выбрана.
     render(
       <CustomSelect
         nativeSelectTestId="nativeSelectTestId"
@@ -1077,5 +1076,28 @@ describe('CustomSelect', () => {
 
     const nativeSelect = screen.getByTestId<HTMLSelectElement>('nativeSelectTestId');
     expect(nativeSelect.value).toBe('1');
+  });
+
+  it('passes required prop to native select, not input', () => {
+    render(
+      <CustomSelect
+        nativeSelectTestId="nativeSelectTestId"
+        data-testid="inputTestId"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        placeholder="Не выбрано"
+        allowClearButton
+        defaultValue={1}
+        required
+      />,
+    );
+
+    const nativeSelect = screen.getByTestId<HTMLSelectElement>('nativeSelectTestId');
+    expect(nativeSelect.required).toBeTruthy();
+
+    const input = screen.getByTestId<HTMLInputElement>('inputTestId');
+    expect(input.required).toBeFalsy();
   });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -253,6 +253,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     clearButtonTestId,
     nativeSelectTestId,
     defaultValue,
+    required,
     ...restProps
   } = props;
 
@@ -890,6 +891,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         aria-hidden
         className={styles['CustomSelect__control']}
         data-testid={nativeSelectTestId}
+        required={required}
       >
         {allowClearButton && <option key="" value="" />}
         {optionsProp.map((item) => (


### PR DESCRIPTION
## Внимание
базовая ветка v5.10-stable. В прошлом [PR](https://github.com/VKCOM/VKUI/pull/6408#issuecomment-1900109015) ошибся с тэгами и v5.10-stable не обновилась.

## Описание
В старой реализации CustomSelect (v5.9.3) мы передавали required на div, тем самым он вообще не был задействован в обработке формы. В v5.10.0 мы поломали это поведение и `required` стал передаваться на input, используемый для поиска. 

Исправляем это передавая `required` на спрятанный нативный селект.