### PR TITLE
ci: Add permissions to dependabot

### DIFF
--- a/.github/workflows/pull_request_dependabot.yml
+++ b/.github/workflows/pull_request_dependabot.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   pull-requests: write
   repository-projects: write
+  contents: write
 
 concurrency:
   group: pr-dependabot-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Описание

Упал [экшон](https://github.com/VKCOM/VKUI/actions/runs/7606839113/job/20713235256), потому что не смог запушить изменения

## Изменения

Добавляем `contents: write` как указано [здесь](https://github.com/ad-m/github-push-action?tab=readme-ov-file#requirements-and-prerequisites)