### PR TITLE
fix(CustomScrollView): use default scrollbar if hasPointer=false

### DIFF
--- a/packages/vkui/src/components/CustomScrollView/CustomScrollView.module.css
+++ b/packages/vkui/src/components/CustomScrollView/CustomScrollView.module.css
@@ -13,16 +13,6 @@
   overflow-x: hidden;
   padding-inline-end: 100px;
   position: relative;
-
-  /**
-   * Для удаление скролла в Firefox.
-   * В версии ниже 64 будет виден скролл, но это не ломает функциональность.
-   */
-  scrollbar-width: none;
-}
-
-.CustomScrollView__box::-webkit-scrollbar {
-  display: none;
 }
 
 .CustomScrollView__barY:active + .CustomScrollView__box {
@@ -82,4 +72,43 @@
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
 :global(.vkuiInternalCustomSelectDropdown--wide) .CustomScrollView__box {
   padding-inline-end: 0;
+}
+
+.CustomScrollView--hasPointer-true .CustomScrollView__box {
+  /**
+   * Для удаление скролла в Firefox.
+   * В версии ниже 64 будет виден скролл, но это не ломает функциональность.
+   */
+  scrollbar-width: none;
+}
+
+.CustomScrollView--hasPointer-true .CustomScrollView__box::-webkit-scrollbar {
+  display: none;
+}
+
+@media (--pointer-has) {
+  .CustomScrollView--hasPointer-none .CustomScrollView__box {
+    /**
+     * Для удаление скролла в Firefox.
+     * В версии ниже 64 будет виден скролл, но это не ломает функциональность.
+     */
+    scrollbar-width: none;
+  }
+
+  .CustomScrollView--hasPointer-none .CustomScrollView__box::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+/**
+ * Не отрисовываем полосу прокрутки, если у устройства отсутствует мышь
+ */
+.CustomScrollView--hasPointer-false .CustomScrollView__barY {
+  display: none;
+}
+
+@media (--pointer-has-not) {
+  .CustomScrollView--hasPointer-none .CustomScrollView__barY {
+    display: none;
+  }
 }

--- a/packages/vkui/src/components/CustomScrollView/CustomScrollView.tsx
+++ b/packages/vkui/src/components/CustomScrollView/CustomScrollView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
+import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useEventListener } from '../../hooks/useEventListener';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useDOM } from '../../lib/dom';
@@ -8,6 +9,17 @@ import { stopPropagation } from '../../lib/utils';
 import type { HasRootRef } from '../../types';
 import { TrackerOptionsProps, useTrackerVisibility } from './useTrackerVisibility';
 import styles from './CustomScrollView.module.css';
+
+function hasPointerClassName(hasPointer: boolean | undefined) {
+  switch (hasPointer) {
+    case undefined:
+      return styles['CustomScrollView--hasPointer-none'];
+    case false:
+      return styles['CustomScrollView--hasPointer-false'];
+  }
+
+  return styles['CustomScrollView--hasPointer-true'];
+}
 
 export interface CustomScrollViewProps
   extends React.AllHTMLAttributes<HTMLDivElement>,
@@ -32,6 +44,7 @@ export const CustomScrollView = ({
   ...restProps
 }: CustomScrollViewProps) => {
   const { document, window } = useDOM();
+  const { hasPointer } = useAdaptivity();
 
   const ratio = React.useRef(NaN);
   const lastTrackerTop = React.useRef(0);
@@ -181,7 +194,7 @@ export const CustomScrollView = ({
 
   return (
     <div
-      className={classNames(styles['CustomScrollView'], className)}
+      className={classNames(className, styles['CustomScrollView'], hasPointerClassName(hasPointer))}
       ref={getRootRef}
       {...restProps}
     >


### PR DESCRIPTION
- fixed #4756


---

- [ ] ~Unit-тесты~
- [ ] ~e2e-тесты~
- [ ] ~Дизайн-ревью~
- [ ] ~Документация фичи~

## Описание

На смартфонах не требуется скроллбар

## Изменения

Если главное устройство ввода не мышь, отключаем кастомый скроллбар 