### PR TITLE
fix(SubnavigationBar): ignore falsy children

### DIFF
--- a/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.test.tsx
+++ b/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.test.tsx
@@ -1,6 +1,25 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
+import { SubnavigationButton } from '../SubnavigationButton/SubnavigationButton';
 import { SubnavigationBar } from './SubnavigationBar';
 
 describe('SubnavigationBar', () => {
   baselineComponent(SubnavigationBar);
+
+  it('Does not render falsy children', () => {
+    const falseCondition = false;
+    const trueCondition = true;
+    render(
+      <SubnavigationBar mode="fixed">
+        <SubnavigationButton>Сканировать</SubnavigationButton>
+        {null}
+        {trueCondition && <SubnavigationButton>Добавить</SubnavigationButton>}
+        {false}
+        {falseCondition && <SubnavigationButton>Удалить</SubnavigationButton>}
+      </SubnavigationBar>,
+    );
+
+    expect(screen.getAllByRole('listitem').length).toEqual(2);
+  });
 });

--- a/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
+++ b/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { hasReactNode } from '@vkontakte/vkjs';
 import { HTMLAttributesWithRootRef } from '../../types';
 import {
   HorizontalScroll,
@@ -48,8 +49,6 @@ export const SubnavigationBar = ({
     };
   }
 
-  const actualChildren = React.useMemo(() => React.Children.toArray(children), [children]);
-
   return (
     <RootComponent
       baseClassName={mode === 'fixed' && styles['SubnavigationBar--mode-fixed']}
@@ -57,11 +56,13 @@ export const SubnavigationBar = ({
     >
       <ScrollWrapper className={styles['SubnavigationBar__in']} {...scrollWrapperProps}>
         <ul className={styles['SubnavigationBar__scrollIn']}>
-          {actualChildren.map((child, idx) => (
-            <li key={idx} className={styles['SubnavigationBar__item']}>
-              {child}
-            </li>
-          ))}
+          {React.Children.map(children, (child, idx) =>
+            hasReactNode(child) ? (
+              <li key={idx} className={styles['SubnavigationBar__item']}>
+                {child}
+              </li>
+            ) : null,
+          )}
         </ul>
       </ScrollWrapper>
     </RootComponent>

--- a/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
+++ b/packages/vkui/src/components/SubnavigationBar/SubnavigationBar.tsx
@@ -48,6 +48,8 @@ export const SubnavigationBar = ({
     };
   }
 
+  const actualChildren = React.useMemo(() => React.Children.toArray(children), [children]);
+
   return (
     <RootComponent
       baseClassName={mode === 'fixed' && styles['SubnavigationBar--mode-fixed']}
@@ -55,7 +57,7 @@ export const SubnavigationBar = ({
     >
       <ScrollWrapper className={styles['SubnavigationBar__in']} {...scrollWrapperProps}>
         <ul className={styles['SubnavigationBar__scrollIn']}>
-          {React.Children.map(children, (child, idx) => (
+          {actualChildren.map((child, idx) => (
             <li key={idx} className={styles['SubnavigationBar__item']}>
               {child}
             </li>


### PR DESCRIPTION
- close #6111

---

- [x] Unit-тесты

## Изменения

Используем `hasReactNode(child)`, чтобы отфильтровать все пустые ноды 
