### PR TITLE
fix(DateInput): fix open calendar

### DIFF
--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -183,7 +183,6 @@ export const DateInput = ({
     calendarRef,
     open,
     openCalendar,
-    closeCalendar,
     internalValue,
     handleKeyDown,
     setFocusedElement,
@@ -295,7 +294,12 @@ export const DateInput = ({
         )}
       </Text>
       {open && !disableCalendar && (
-        <Popper targetRef={rootRef} offsetByMainAxis={8} placement={calendarPlacement}>
+        <Popper
+          targetRef={rootRef}
+          offsetByMainAxis={8}
+          placement={calendarPlacement}
+          autoUpdateOnTargetResize
+        >
           <Calendar
             value={value}
             onChange={onCalendarChange}
@@ -303,7 +307,7 @@ export const DateInput = ({
             disablePast={disablePast}
             disableFuture={disableFuture}
             shouldDisableDate={shouldDisableDate}
-            onClose={closeCalendar}
+            onClose={removeFocusFromField}
             getRootRef={calendarRef}
             doneButtonText={doneButtonText}
             disablePickers={disablePickers}


### PR DESCRIPTION
- close #6392

---

## Описание

По кнопке "Готово" вызывалось просто закрытие календаря без сброса фокуса. В итоге "невидимый" фокус был и не давал открыть календарь повторно.

## Изменения

Вызываем `removeFocusFromField`, чтобы сбрасывались все фокусы и закрывался календарь. 

Ещё добавила `autoUpdateOnTargetResize`, чтобы избавиться от такого:

https://github.com/VKCOM/VKUI/assets/7431217/0dfd2b06-f6e4-43cd-b9bf-2f4048b7bf63


