### PR TITLE
docs: fix selection in chrome

### DIFF
--- a/styleguide/Components/Editor/Editor.css
+++ b/styleguide/Components/Editor/Editor.css
@@ -16,3 +16,7 @@
   z-index: 2;
   color: var(--vkui--color_icon_secondary);
 }
+
+.Editor textarea {
+  color: blue !important;
+}


### PR DESCRIPTION
- close #3791

---


## Описание

Исправляем такую работу подсветки в хроме:

https://user-images.githubusercontent.com/7431217/208252677-d69efc40-6d0b-4f16-8bb5-98d5b85dd06f.mov

## Изменения

Установка любого цвета, кроме `black` исправляет подсветку  ¯\ _(ツ)_/¯
