### PR TITLE
fix: Add popper changes for v6

### DIFF
--- a/packages/codemods/src/transforms/__testfixtures__/tooltip-container/basic.input.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/tooltip-container/basic.input.tsx
@@ -1,0 +1,10 @@
+import { TooltipContainer } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <React.Fragment>
+      <TooltipContainer>Tooltip</TooltipContainer>
+    </React.Fragment>
+  );
+};

--- a/packages/codemods/src/transforms/__testfixtures__/tooltip/basic.input.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/tooltip/basic.input.tsx
@@ -21,6 +21,10 @@ const App = () => {
       <Tooltip alignX="right" alignY="top">target</Tooltip>
 
       <Tooltip alignX="right" alignY="top" placement="auto">target</Tooltip>
+
+      <Tooltip arrow></Tooltip>
+
+      <Tooltip arrow={false}>target</Tooltip>
     </React.Fragment>
   );
 };

--- a/packages/codemods/src/transforms/__tests__/__snapshots__/tooltip-container.ts.snap
+++ b/packages/codemods/src/transforms/__tests__/__snapshots__/tooltip-container.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tooltip-container transforms correctly 1`] = `
+"import { OnboardingTooltipContainer } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <React.Fragment>
+      <OnboardingTooltipContainer>Tooltip</OnboardingTooltipContainer>
+    </React.Fragment>
+  );
+};"
+`;

--- a/packages/codemods/src/transforms/__tests__/__snapshots__/tooltip.ts.snap
+++ b/packages/codemods/src/transforms/__tests__/__snapshots__/tooltip.ts.snap
@@ -24,6 +24,10 @@ const App = () => {
       <OnboardingTooltip placement="top-end">target</OnboardingTooltip>
 
       <OnboardingTooltip placement="auto">target</OnboardingTooltip>
+
+      <OnboardingTooltip></OnboardingTooltip>
+
+      <OnboardingTooltip disableArrow>target</OnboardingTooltip>
     </React.Fragment>
   );
 };"

--- a/packages/codemods/src/transforms/__tests__/tooltip-container.ts
+++ b/packages/codemods/src/transforms/__tests__/tooltip-container.ts
@@ -1,0 +1,12 @@
+jest.autoMockOff();
+
+import { defineSnapshotTestFromFixture } from '../../testHelpers/testHelper';
+
+const name = 'tooltip-container';
+const fixtures = ['basic'] as const;
+
+describe(name, () => {
+  fixtures.forEach((test) =>
+    defineSnapshotTestFromFixture(__dirname, name, global.TRANSFORM_OPTIONS, `${name}/${test}`),
+  );
+});

--- a/packages/codemods/src/transforms/tooltip-container.ts
+++ b/packages/codemods/src/transforms/tooltip-container.ts
@@ -1,0 +1,51 @@
+import type { API, FileInfo } from 'jscodeshift';
+import { getImportInfo } from '../codemod-helpers';
+import type { JSCodeShiftOptions } from '../types';
+
+export const parser = 'tsx';
+
+const componentName = 'TooltipContainer';
+const componentNameTo = 'OnboardingTooltipContainer';
+
+export default function transformer(file: FileInfo, api: API, options: JSCodeShiftOptions) {
+  const { alias } = options;
+  const j = api.jscodeshift;
+  const source = j(file.source);
+  const { localName } = getImportInfo(j, file, componentName, alias);
+  let needRename = true;
+
+  // подменяем импорт
+  source
+    .find(j.ImportDeclaration)
+    .filter((path) => path.node.source.value === alias)
+    .find(j.ImportSpecifier, { imported: { name: componentName } })
+    .forEach((path) => {
+      j(path).replaceWith((path) => {
+        if (path.node.local && path.node.local.name !== path.node.imported.name) {
+          needRename = false;
+        }
+        return j.importSpecifier(
+          j.jsxIdentifier(componentNameTo),
+          needRename ? null : path.node.local,
+        );
+      });
+    });
+
+  source.findJSXElements(localName).forEach((element) => {
+    // меняем название компонента в JSX на переименованный в импорте (если нужно)
+    j(element).replaceWith((path) => {
+      const renamedLocalName = needRename ? componentNameTo : localName;
+      return j.jsxElement(
+        j.jsxOpeningElement(
+          j.jsxIdentifier(renamedLocalName),
+          path.node.openingElement.attributes,
+          path.node.closingElement ? false : true,
+        ),
+        path.node.closingElement ? j.jsxClosingElement(j.jsxIdentifier(renamedLocalName)) : null,
+        path.node.children,
+      );
+    });
+  });
+
+  return source.toSource();
+}

--- a/packages/codemods/src/transforms/tooltip.ts
+++ b/packages/codemods/src/transforms/tooltip.ts
@@ -3,6 +3,7 @@ import {
   type AttributeManipulator,
   createAttributeManipulator,
   getImportInfo,
+  swapBooleanValue,
 } from '../codemod-helpers';
 import type { JSCodeShiftOptions } from '../types';
 
@@ -65,6 +66,8 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName } = getImportInfo(j, file, componentName, alias);
   const attributeReplacer = createAttributeManipulator(ATTRIBUTE_REPLACER, api);
   let needRename = true;
+
+  swapBooleanValue(api, source, localName, 'arrow', 'disableArrow');
 
   // подменяем импорт
   source

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.test.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.test.tsx
@@ -3,7 +3,7 @@ import { Fragment, HtmlHTMLAttributes, ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
 import { baselineComponent, waitForFloatingPosition } from '../../testing/utils';
 import { HasRootRef } from '../../types';
-import { OnboardingTooltip } from './OnboardingTooltip';
+import { OnboardingTooltip, OnboardingTooltipProps } from './OnboardingTooltip';
 import { OnboardingTooltipContainer } from './OnboardingTooltipContainer';
 
 const renderTooltip = async (jsx: ReactElement) => {
@@ -102,5 +102,27 @@ describe(OnboardingTooltip, () => {
       );
       expect(ref).toHaveBeenCalledWith(screen.getByTestId('xxx'));
     });
+  });
+
+  it('should call onPlacementChange', async () => {
+    const onPlacementChange = jest.fn();
+
+    const Fixture = (props: OnboardingTooltipProps) => (
+      <OnboardingTooltipContainer data-testid="container">
+        <OnboardingTooltip shown text="text" {...props}>
+          <div data-testid="xxx" />
+        </OnboardingTooltip>
+      </OnboardingTooltipContainer>
+    );
+
+    const result = render(<Fixture placement="bottom" onPlacementChange={onPlacementChange} />);
+    await waitForFloatingPosition();
+
+    expect(onPlacementChange).not.toHaveBeenCalled();
+
+    result.rerender(<Fixture placement="auto" onPlacementChange={onPlacementChange} />);
+    await waitForFloatingPosition();
+
+    expect(onPlacementChange).toHaveBeenCalledWith('top');
   });
 });

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -9,6 +9,7 @@ import {
   type FloatingComponentProps,
   useFloating,
   useFloatingMiddlewaresBootstrap,
+  usePlacementChangeCallback,
 } from '../../lib/floating';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { warnOnce } from '../../lib/warnOnce';
@@ -31,6 +32,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'offsetByCrossAxis'
   | 'shown'
   | 'children'
+  | 'onPlacementChange'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -50,6 +52,10 @@ export interface OnboardingTooltipProps
   extends AllowedFloatingComponentProps,
     AllowedTooltipBaseProps,
     AllowedFloatingArrowProps {
+  /**
+   * Скрывает стрелку, указывающую на якорный элемент.
+   */
+  disableArrow?: boolean;
   /**
    * Callback, который вызывается при клике по любому месту в пределах экрана.
    */
@@ -74,6 +80,8 @@ export const OnboardingTooltip = ({
   maxWidth = TOOLTIP_MAX_WIDTH,
   style: styleProp,
   getRootRef,
+  disableArrow = false,
+  onPlacementChange,
   ...restProps
 }: OnboardingTooltipProps) => {
   const generatedId = React.useId();
@@ -90,7 +98,7 @@ export const OnboardingTooltip = ({
     offsetByMainAxis,
     offsetByCrossAxis,
     arrowRef,
-    arrow: true,
+    arrow: !disableArrow,
     arrowHeight,
     arrowPadding,
   });
@@ -110,6 +118,8 @@ export const OnboardingTooltip = ({
   const [childRef, child] = usePatchChildren(children, {
     'aria-describedby': shown ? tooltipId : undefined,
   });
+
+  usePlacementChangeCallback(resolvedPlacement, onPlacementChange);
 
   let tooltip: React.ReactPortal | null = null;
   if (shown) {
@@ -131,13 +141,17 @@ export const OnboardingTooltip = ({
           getRootRef={tooltipRef}
           style={floatingStyle}
           maxWidth={maxWidth}
-          arrowProps={{
-            offset: arrowOffset,
-            isStaticOffset: isStaticArrowOffset,
-            coords: arrowCoords,
-            placement: resolvedPlacement,
-            getRootRef: setArrowRef,
-          }}
+          arrowProps={
+            disableArrow
+              ? undefined
+              : {
+                  offset: arrowOffset,
+                  isStaticOffset: isStaticArrowOffset,
+                  coords: arrowCoords,
+                  placement: resolvedPlacement,
+                  getRootRef: setArrowRef,
+                }
+          }
         />
         <div className={styles['OnboardingTooltip__overlay']} onClickCapture={onClose} />
       </>,

--- a/packages/vkui/src/components/Popover/Popover.test.tsx
+++ b/packages/vkui/src/components/Popover/Popover.test.tsx
@@ -48,4 +48,24 @@ describe(Popover, () => {
     await waitForFloatingPosition();
     expect(result.getByTestId('target')).toHaveAttribute('aria-expanded', 'false');
   });
+
+  it('should call onPlacementChange', async () => {
+    const onPlacementChange = jest.fn();
+
+    const Fixture = (props: PopoverProps) => (
+      <Popover defaultShown {...props}>
+        <div>Target</div>
+      </Popover>
+    );
+
+    const result = render(<Fixture placement="bottom" onPlacementChange={onPlacementChange} />);
+    await waitForFloatingPosition();
+
+    expect(onPlacementChange).not.toHaveBeenCalled();
+
+    result.rerender(<Fixture placement="auto" onPlacementChange={onPlacementChange} />);
+    await waitForFloatingPosition();
+
+    expect(onPlacementChange).toHaveBeenCalledWith('top');
+  });
 });

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -9,6 +9,7 @@ import {
   type OnShownChange,
   useFloatingMiddlewaresBootstrap,
   useFloatingWithInteractions,
+  usePlacementChangeCallback,
 } from '../../lib/floating';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
@@ -30,6 +31,7 @@ export type PopoverContentRenderProp = FloatingContentRenderProp;
 type AllowedFloatingComponentProps = Pick<
   FloatingComponentProps,
   | 'placement'
+  | 'onPlacementChange'
   | 'trigger'
   | 'content'
   | 'hoverDelay'
@@ -75,6 +77,7 @@ export interface PopoverProps
 export const Popover = ({
   // UsePopoverProps
   placement: expectedPlacement = 'bottom-start',
+  onPlacementChange,
   trigger = 'click',
   content,
   hoverDelay = 150,
@@ -138,6 +141,8 @@ export const Popover = ({
     shown: shownProp,
     onShownChange,
   });
+
+  usePlacementChangeCallback(placement, onPlacementChange);
 
   const [, child] = usePatchChildren<HTMLDivElement>(
     children,

--- a/packages/vkui/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { baselineComponent } from '../../testing/utils';
-import { Tooltip } from './Tooltip';
+import { render } from '@testing-library/react';
+import { baselineComponent, waitForFloatingPosition } from '../../testing/utils';
+import { Tooltip, TooltipProps } from './Tooltip';
 
 describe(Tooltip, () => {
   baselineComponent((props) => (
@@ -8,4 +9,24 @@ describe(Tooltip, () => {
       <div>Target</div>
     </Tooltip>
   ));
+
+  it('should call onPlacementChange', async () => {
+    const onPlacementChange = jest.fn();
+
+    const Fixture = (props: TooltipProps) => (
+      <Tooltip defaultShown {...props}>
+        <div>Target</div>
+      </Tooltip>
+    );
+
+    const result = render(<Fixture placement="bottom" onPlacementChange={onPlacementChange} />);
+    await waitForFloatingPosition();
+
+    expect(onPlacementChange).not.toHaveBeenCalled();
+
+    result.rerender(<Fixture placement="auto" onPlacementChange={onPlacementChange} />);
+    await waitForFloatingPosition();
+
+    expect(onPlacementChange).toHaveBeenCalledWith('top');
+  });
 });

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -10,6 +10,7 @@ import {
   getArrowCoordsByMiddlewareData,
   useFloatingMiddlewaresBootstrap,
   useFloatingWithInteractions,
+  usePlacementChangeCallback,
 } from '../../lib/floating';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
@@ -30,6 +31,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'children'
   | 'zIndex'
   | 'usePortal'
+  | 'onPlacementChange'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -94,6 +96,7 @@ export const Tooltip = ({
   style: styleProp,
   className,
   zIndex = 'var(--vkui--z_index_popout)',
+  onPlacementChange,
   ...popperProps
 }: TooltipProps) => {
   const generatedId = React.useId();
@@ -134,6 +137,8 @@ export const Tooltip = ({
     middlewares,
   });
   const tooltipRef = useExternRef<HTMLDivElement>(getRootRef, refs.setFloating);
+
+  usePlacementChangeCallback(placement, onPlacementChange);
 
   let tooltip: React.ReactNode = null;
   if (shown) {

--- a/packages/vkui/src/lib/floating/index.ts
+++ b/packages/vkui/src/lib/floating/index.ts
@@ -5,6 +5,7 @@ export type {
   PlacementWithAuto,
   AutoPlacementType,
   UseFloatingMiddleware,
+  OnPlacementChange,
 } from './types/common';
 
 export type { FloatingComponentProps, FloatingContentRenderProp } from './types/component';
@@ -35,3 +36,5 @@ export {
 } from './useFloatingMiddlewaresBootstrap';
 
 export * from './useFloatingWithInteractions';
+
+export { usePlacementChangeCallback } from './usePlacementChangeCallback';

--- a/packages/vkui/src/lib/floating/types/common.ts
+++ b/packages/vkui/src/lib/floating/types/common.ts
@@ -22,3 +22,5 @@ export type {
 
 export type UseFloatingRefs<RT extends ReferenceType = ReferenceType> =
   UseFloatingReturn<RT>['refs'];
+
+export type OnPlacementChange = (nextPlacement: Placement) => void;

--- a/packages/vkui/src/lib/floating/types/component.ts
+++ b/packages/vkui/src/lib/floating/types/component.ts
@@ -4,6 +4,7 @@ import type {
   UseFloatingWithInteractionsProps,
   UseFloatingWithInteractionsReturn,
 } from '../useFloatingWithInteractions';
+import { OnPlacementChange } from './common';
 
 /**
  * @private используйте алиасы, если для какого-то компонента нужно экспортировать тип
@@ -52,4 +53,9 @@ export interface FloatingComponentProps
    * По умолчанию используется document.body.
    */
   usePortal?: boolean | HTMLElement | React.RefObject<HTMLElement>;
+  /**
+   * В зависимости от области видимости, позиция может смениться на более оптимальную,
+   * чтобы всплывающий элемент вместился в эту область видимости.
+   */
+  onPlacementChange?: OnPlacementChange;
 }

--- a/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
+++ b/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
@@ -1,0 +1,19 @@
+import { usePrevious } from '../../hooks/usePrevious';
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
+import { OnPlacementChange, Placement } from './types/common';
+
+export function usePlacementChangeCallback(
+  placement: Placement,
+  onPlacementChange: OnPlacementChange | undefined,
+): void {
+  const prevPlacement = usePrevious(placement);
+
+  useIsomorphicLayoutEffect(() => {
+    if (prevPlacement === undefined || !onPlacementChange) {
+      return;
+    }
+    if (prevPlacement !== placement) {
+      onPlacementChange(placement);
+    }
+  }, [prevPlacement, placement, onPlacementChange]);
+}

--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -54,6 +54,7 @@
   - <a href="{{anchor}}">`Tabbar`</a>
   - <a href="{{anchor}}">`Tappable`</a>
   - <a href="{{anchor}}">~~`Tooltip`~~ -> `OnboardingTooltip`</a>
+  - <a href="{{anchor}}">~~`TooltipContainer`~~ -> `OnboardingTooltipContainer`</a>
   - <a href="{{anchor}}">`Typography/Title`</a>
   - <a href="{{anchor}}">`Typography/Headline`</a>
   - <a href="{{anchor}}">`Typography/Subhead`</a>
@@ -1018,6 +1019,9 @@ npx @vkontakte/vkui-codemods --help
 - alignY="left"
 + placement="bottom-start"
 
+- arrow={false}
++ disableArrow
+
 - offsetX={0}
 + offsetByCrossAxis={0}
 
@@ -1034,6 +1038,17 @@ npx @vkontakte/vkui-codemods --help
   <div>Target</div>
 - </Tooltip>
 + </OnboardingTooltip>
+```
+
+<br/>
+
+### ~~`TooltipContainer`~~ -> [`OnboardingTooltipContainer`](#/OnboardingTooltip)
+
+- Компонент переименован.
+
+```diff
+- <TooltipContainer />
++ <OnboardingTooltipContainer />
 ```
 
 <br/>


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

Принесли фидбэк по гайду миграции и codemod:

- У компонента Tooltip был проп arrow, в 6 версии у OnboardingTooltip его убрали. В гайде по миграции об этом не сказано, codemods тоже никак об этом не сообщает
- У Popover был проп onPlacementChange, в 6 версии его убрали. В гайде по миграции об этом не сказано, codemods тоже никак об этом не сообщает
- codemods не переименовывает TooltipContainer. В гайде не упоминается о переименовании TooltipContainer в OnboardingTooltipContainer

## Изменения

- Добавлен проп `disableArrow` у `OnboardingTooltip`, взамен `arrow` 
- у всех всплывающих элементов добавлен `onPlacementChange`, какой был в `v5`
- Добавлен `codemod` для переименовывания `TooltipContainer` в `OnboardingTooltipContainer` и замена пропа `arrow` на `disableArrow` в `Tooltip`