### PR TITLE
fix(Tooltip)[v5]: Merge getRootRef prop with floating ref and pass to BaseTooltip getRootRef

### DIFF
--- a/packages/vkui/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.test.tsx
@@ -47,6 +47,27 @@ describe('Tooltip', () => {
     expect(screen.getByText('text')).toBeTruthy();
   });
 
+  it('uses passed getRootRef prop', async () => {
+    let tooltipRef: React.MutableRefObject<HTMLDivElement | null> | undefined;
+    const TooltipComponent = () => {
+      tooltipRef = React.useRef<HTMLDivElement | null>(null);
+      return (
+        <Tooltip isShown text="text" getRootRef={tooltipRef} data-testid="tooltip">
+          <div />
+        </Tooltip>
+      );
+    };
+
+    await renderTooltip(<TooltipComponent />);
+
+    expect(screen.getByText('text')).toBeTruthy();
+    if (!tooltipRef || !tooltipRef.current) {
+      throw new Error('tootlipRef is not set');
+    }
+
+    expect(tooltipRef.current).toBeTruthy();
+  });
+
   it('does not create extra markup when isShown=false', () => {
     render(
       <TooltipContainer data-testid="container">

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -138,6 +138,7 @@ export const Tooltip = ({
   cornerAbsoluteOffset,
   arrow = true,
   arrowPadding = 14,
+  getRootRef,
   placement: placementProp,
   maxWidth = TOOLTIP_MAX_WIDTH,
   ...restProps
@@ -272,6 +273,7 @@ export const Tooltip = ({
       })
     : children;
 
+  const tooltipBaseRef = useExternRef<HTMLDivElement>(refs.setFloating, getRootRef);
   return (
     <React.Fragment>
       {child}
@@ -281,7 +283,7 @@ export const Tooltip = ({
           <>
             <TooltipBase
               {...restProps}
-              getRootRef={refs.setFloating}
+              getRootRef={tooltipBaseRef}
               floatingStyle={convertFloatingDataToReactCSSProperties(
                 floatingPositionStrategy,
                 floatingDataX,


### PR DESCRIPTION
- close #6216 

---

- [x] Unit-тесты

## Описание
Мы действительно не использовали переданный `getRootRef` в компоненте, перетирая его значеним, необходимым для позиционирования тултипа.
В v6 такой проблемы нет. Поэтому этот фикс только для v5. Раз уж мы готовим для v5 релиз.