### PR TITLE
tech(jest): resolve warnings in packages/vkui

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@swc/cli": "^0.1.64",
     "@swc/core": "1.3.105",
     "@swc/jest": "^0.2.31",
-    "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.1",

--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { ViewWidth } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';
-import { baselineComponent, fakeTimers, runAllTimers, userEvent } from '../../testing/utils';
+import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { Alert, type AlertProps } from './Alert';
@@ -14,6 +14,7 @@ describe('Alert', () => {
     // TODO [a11y]: "ARIA dialog and alertdialog nodes should have an accessible name (aria-dialog-name)"
     a11y: false,
   });
+
   describe('closes', () => {
     it.each(['overlay', 'close'])('with %s click', async (trigger) => {
       const onClose = jest.fn();
@@ -27,57 +28,59 @@ describe('Alert', () => {
 
       await userEvent.click(document.querySelector(target) as Element);
       expect(onClose).not.toHaveBeenCalled();
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
-  describe('calls actions', () => {
-    describe.each([Platform.ANDROID, Platform.IOS])('on %s', (platform) => {
-      it('calls action and do not calls onClose with autoCloseDisabled=true', async () => {
-        const action = jest.fn();
-        const onClose = jest.fn();
-        render(
-          <ConfigProvider platform={platform}>
-            <Alert
-              onClose={onClose}
-              actions={[{ action, title: '__action__', autoCloseDisabled: true, mode: 'default' }]}
-            />
-          </ConfigProvider>,
-        );
-        await userEvent.click(screen.getByText('__action__'));
-        expect(action).toHaveBeenCalledTimes(1);
-        expect(onClose).not.toHaveBeenCalled();
-        runAllTimers();
-        expect(onClose).not.toHaveBeenCalled();
-      });
-      it('calls action after close by default', async () => {
-        const action = jest.fn();
-        const onClose = jest.fn();
-        render(
-          <ConfigProvider platform={platform}>
-            <Alert
-              onClose={onClose}
-              actions={[
-                {
-                  action,
-                  title: '__action__',
-                  mode: 'default',
-                },
-              ]}
-            />
-          </ConfigProvider>,
-        );
-        await userEvent.click(screen.getByText('__action__'));
-        expect(action).not.toHaveBeenCalled();
-        expect(onClose).not.toHaveBeenCalled();
-        runAllTimers();
-        expect(action).toHaveBeenCalledTimes(1);
-        expect(onClose).toHaveBeenCalledTimes(1);
-      });
+
+  describe('calls action and do not calls onClose with autoCloseDisabled=true', () => {
+    it.each([Platform.ANDROID, Platform.IOS])('%s', async (platform) => {
+      const action = jest.fn();
+      const onClose = jest.fn();
+      render(
+        <ConfigProvider platform={platform}>
+          <Alert
+            onClose={onClose}
+            actions={[{ action, title: '__action__', autoCloseDisabled: true, mode: 'default' }]}
+          />
+        </ConfigProvider>,
+      );
+      await userEvent.click(screen.getByText('__action__'));
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(onClose).not.toHaveBeenCalled();
+      act(jest.runAllTimers);
+      expect(onClose).not.toHaveBeenCalled();
     });
   });
 
-  it('passes data-testid to actions', () => {
+  describe('calls action after close by default', () => {
+    it.each([Platform.ANDROID, Platform.IOS])('%s', async (platform) => {
+      const action = jest.fn();
+      const onClose = jest.fn();
+      render(
+        <ConfigProvider platform={platform}>
+          <Alert
+            onClose={onClose}
+            actions={[
+              {
+                action,
+                title: '__action__',
+                mode: 'default',
+              },
+            ]}
+          />
+        </ConfigProvider>,
+      );
+      await userEvent.click(screen.getByText('__action__'));
+      expect(action).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+      act(jest.runAllTimers);
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('passes data-testid to actions', async () => {
     render(
       <Alert
         onClose={jest.fn()}
@@ -87,14 +90,14 @@ describe('Alert', () => {
         ]}
       />,
     );
-
+    act(jest.runAllTimers);
     expect(screen.getByTestId('allow-test-id')).toHaveTextContent('Allow');
     expect(screen.getByTestId('deny-test-id')).toHaveTextContent('Deny');
   });
 
   it.each<AlertProps['dismissButtonMode']>(['outside', 'inside'])(
     'passes data-testid to dismiss button in %s dismissButtonMode',
-    (dismissButtonMode) => {
+    async (dismissButtonMode) => {
       render(
         <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET}>
           <Alert
@@ -105,7 +108,7 @@ describe('Alert', () => {
           />
         </AdaptivityProvider>,
       );
-
+      act(jest.runAllTimers);
       expect(screen.getByTestId('dismiss-button-test-id')).toHaveTextContent(
         'Закрыть предупреждение',
       );

--- a/packages/vkui/src/components/Avatar/Avatar.test.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import {
   IconExampleForBadgeBasedOnImageBaseSize,
   IconExampleForFallbackBasedOnImageBaseSize,
 } from '../../testing/icons';
-import { baselineComponent, tryToGetByTestId } from '../../testing/utils';
+import { baselineComponent } from '../../testing/utils';
 import { Avatar, AvatarProps } from './Avatar';
 import avatarBadgeStyles from './AvatarBadge/AvatarBadge.module.css';
 
@@ -33,22 +33,19 @@ describe(Avatar, () => {
     );
 
     const elAvatar = getAvatarRootEl();
-    const fallbackIcon = tryToGetByTestId(
-      IconExampleForFallbackBasedOnImageBaseSize.DATA_TEST_ID,
-      elAvatar,
-    );
 
     expect(elAvatar).toHaveTextContent(INITIALS);
-    expect(elAvatar).not.toContainElement(fallbackIcon);
+    expect(() =>
+      within(elAvatar).getByTestId(IconExampleForFallbackBasedOnImageBaseSize.DATA_TEST_ID),
+    ).toThrow();
   });
 
   it('should use `fallbackIcon` if `initials` is not provided', () => {
     render(<AvatarTest fallbackIcon={<IconExampleForFallbackBasedOnImageBaseSize />} />);
 
     const elAvatar = getAvatarRootEl();
-    const fallbackIcon = tryToGetByTestId(
+    const fallbackIcon = within(elAvatar).getByTestId(
       IconExampleForFallbackBasedOnImageBaseSize.DATA_TEST_ID,
-      elAvatar,
     );
 
     expect(elAvatar).toContainElement(fallbackIcon);

--- a/packages/vkui/src/components/Calendar/Calendar.test.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.test.tsx
@@ -31,9 +31,9 @@ describe('Calendar', () => {
       />,
     );
     await userEvent.click(screen.getByText(`${firstDayDate.getDate()}`));
-    expect(onChange).not.toBeCalled();
+    expect(onChange).not.toHaveBeenCalled();
     await userEvent.click(screen.getByText(`${maxDate.getDate() + 1}`));
-    expect(onChange).not.toBeCalled();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('onChange respects minDateTime', async () => {

--- a/packages/vkui/src/components/ChipsInput/ChipsInput.test.tsx
+++ b/packages/vkui/src/components/ChipsInput/ChipsInput.test.tsx
@@ -1,6 +1,6 @@
 import { baselineComponent } from '../../testing/utils';
 import { ChipsInput } from './ChipsInput';
 
-describe('ChipsInput', () => {
+describe(ChipsInput, () => {
   baselineComponent(ChipsInput, { a11y: false });
 });

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent, fakeTimers, userEvent } from '../../../testing/utils';
 import { Chip } from './Chip';
 
@@ -23,7 +23,7 @@ describe(Chip, () => {
       </Chip>,
     );
 
-    await act(() => userEvent.click(screen.getByRole('button')));
+    await userEvent.click(screen.getByRole('button'));
 
     expect(onRemove).toHaveBeenCalled();
   });
@@ -57,8 +57,8 @@ describe(Chip, () => {
         />,
       );
 
-      await act(() => userEvent.tab());
-      await act(() => userEvent.tab({ shift: true }));
+      await userEvent.tab();
+      await userEvent.tab({ shift: true });
 
       expect(onFocus).toHaveBeenCalled();
       expect(onBlur).toHaveBeenCalled();

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, render, within } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import { baselineComponent, userEvent, withRegExp } from '../../testing/utils';
 import { ChipsInputBase } from './ChipsInputBase';
 import type { ChipsInputBasePrivateProps } from './types';
@@ -68,7 +68,7 @@ describe(ChipsInputBase, () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await act(() => userEvent.type(result.getByTestId('chips-input'), 'Красный{enter}'));
+    await userEvent.type(result.getByTestId('chips-input'), 'Красный{enter}');
     expect(onAddChipOption).toHaveBeenCalledWith('Красный');
   });
 
@@ -81,8 +81,8 @@ describe(ChipsInputBase, () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await act(() => userEvent.type(result.getByTestId('chips-input'), 'Красный'));
-    await act(() => userEvent.click(document.body));
+    await userEvent.type(result.getByTestId('chips-input'), 'Красный');
+    await userEvent.click(document.body);
     expect(onAddChipOption).toHaveBeenCalledWith('Красный');
   });
 
@@ -96,7 +96,7 @@ describe(ChipsInputBase, () => {
     );
     const chipRedLocator = result.getByRole('option', { name: withRegExp(RED_OPTION.label) });
     const removeButton = within(chipRedLocator).getByRole('button');
-    await act(() => userEvent.click(removeButton));
+    await userEvent.click(removeButton);
     expect(onRemoveChipOption).toHaveBeenCalledWith(RED_OPTION.value);
   });
 
@@ -108,12 +108,10 @@ describe(ChipsInputBase, () => {
         onRemoveChipOption={onRemoveChipOption}
       />,
     );
-    await act(() => userEvent.tab());
-    await act(() =>
-      userEvent.type(
-        result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
-        `{${type}}`,
-      ),
+    await userEvent.tab();
+    await userEvent.type(
+      result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
+      `{${type}}`,
     );
     expect(onRemoveChipOption).toHaveBeenCalledWith(RED_OPTION.value);
   });
@@ -129,12 +127,10 @@ describe(ChipsInputBase, () => {
           onRemoveChipOption={onRemoveChipOption}
         />,
       );
-      await act(() => userEvent.tab());
-      await act(() =>
-        userEvent.type(
-          result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
-          `{${type}}`,
-        ),
+      await userEvent.tab();
+      await userEvent.type(
+        result.getByRole('option', { name: withRegExp(RED_OPTION.label) }),
+        `{${type}}`,
       );
       expect(onRemoveChipOption).not.toHaveBeenCalled();
     },
@@ -150,7 +146,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const containerEl = result.getByRole('listbox').closest('div')!;
-      await act(() => userEvent.click(containerEl));
+      await userEvent.click(containerEl);
       expect(result.getByTestId('chips-input')).toHaveFocus();
     });
 
@@ -163,7 +159,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const containerEl = result.getByRole('listbox').closest('div')!;
-      await act(() => userEvent.click(containerEl));
+      await userEvent.click(containerEl);
       expect(result.getByRole('option', { name: withRegExp(RED_OPTION.label) })).toHaveFocus();
     });
 
@@ -175,7 +171,7 @@ describe(ChipsInputBase, () => {
           onRemoveChipOption={onRemoveChipOption}
         />,
       );
-      await act(() => userEvent.click(result.getByTestId('chips-input')));
+      await userEvent.click(result.getByTestId('chips-input'));
       expect(result.getByTestId('chips-input')).toHaveFocus();
     });
 
@@ -188,7 +184,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const chipLocator = result.getByRole('option', { name: withRegExp(RED_OPTION.label) });
-      await act(() => userEvent.click(chipLocator));
+      await userEvent.click(chipLocator);
       expect(chipLocator).toHaveFocus();
     });
 
@@ -203,10 +199,10 @@ describe(ChipsInputBase, () => {
       );
       const chipsInputLocator = result.getByTestId('chips-input');
 
-      await act(() => userEvent.type(chipsInputLocator, '{Backspace}'));
+      await userEvent.type(chipsInputLocator, '{Backspace}');
       expect(chipsInputLocator).toHaveFocus();
 
-      await act(() => userEvent.type(chipsInputLocator, '{Backspace}'));
+      await userEvent.type(chipsInputLocator, '{Backspace}');
       expect(chipsInputLocator.previousSibling).toHaveFocus();
     });
 
@@ -223,22 +219,22 @@ describe(ChipsInputBase, () => {
         result.getByRole('option', { name: withRegExp(label) }),
       );
 
-      await act(() => userEvent.type(chipRedLocator, '{ArrowRight}'));
+      await userEvent.type(chipRedLocator, '{ArrowRight}');
       expect(chipBlueLocator).toHaveFocus();
 
-      await act(() => userEvent.type(chipBlueLocator, '{ArrowRight}'));
+      await userEvent.type(chipBlueLocator, '{ArrowRight}');
       expect(chipYellowLocator).toHaveFocus();
 
-      await act(() => userEvent.type(chipYellowLocator, '{ArrowRight}'));
+      await userEvent.type(chipYellowLocator, '{ArrowRight}');
       expect(chipRedLocator).toHaveFocus();
 
-      await act(() => userEvent.type(chipRedLocator, '{ArrowLeft}'));
+      await userEvent.type(chipRedLocator, '{ArrowLeft}');
       expect(chipYellowLocator).toHaveFocus();
 
-      await act(() => userEvent.type(chipYellowLocator, '{ArrowLeft}'));
+      await userEvent.type(chipYellowLocator, '{ArrowLeft}');
       expect(chipBlueLocator).toHaveFocus();
 
-      await act(() => userEvent.type(chipBlueLocator, '{ArrowRight}'));
+      await userEvent.type(chipBlueLocator, '{ArrowRight}');
       expect(chipYellowLocator).toHaveFocus();
     });
 
@@ -256,28 +252,28 @@ describe(ChipsInputBase, () => {
         result.getByRole('option', { name: withRegExp(label) }),
       );
 
-      await act(() => userEvent.tab());
+      await userEvent.tab();
       expect(chipRedLocator).toHaveFocus();
 
-      await act(() => userEvent.tab());
+      await userEvent.tab();
       expect(chipsInputLocator).toHaveFocus();
 
-      await act(() => userEvent.tab({ shift: true }));
+      await userEvent.tab({ shift: true });
       expect(chipRedLocator).toHaveFocus();
 
-      await act(() => userEvent.type(chipRedLocator, '{ArrowRight}'));
+      await userEvent.type(chipRedLocator, '{ArrowRight}');
       expect(chipBlueLocator).toHaveFocus();
 
-      await act(() => userEvent.tab());
+      await userEvent.tab();
       expect(chipsInputLocator).toHaveFocus();
 
-      await act(() => userEvent.tab({ shift: true }));
+      await userEvent.tab({ shift: true });
       expect(chipBlueLocator).toHaveFocus();
 
-      await act(() => userEvent.tab({ shift: true }));
+      await userEvent.tab({ shift: true });
       expect(document.body).toHaveFocus();
 
-      await act(() => userEvent.tab());
+      await userEvent.tab();
       expect(chipBlueLocator).toHaveFocus();
     });
 
@@ -295,7 +291,7 @@ describe(ChipsInputBase, () => {
         />,
       );
       const chipRedLocator = result.getByRole('option', { name: withRegExp(RED_OPTION.label) });
-      await act(() => userEvent.type(chipRedLocator, '{Delete}'));
+      await userEvent.type(chipRedLocator, '{Delete}');
       const nextLocatorWithFocus =
         value.length <= 1
           ? result.getByTestId('chips-input')
@@ -318,8 +314,8 @@ describe(ChipsInputBase, () => {
         />,
       );
 
-      await act(() => userEvent.tab());
-      await act(() => userEvent.tab({ shift: true }));
+      await userEvent.tab();
+      await userEvent.tab({ shift: true });
 
       expect(onBlur).toHaveBeenCalled();
     },

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, render, within } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import {
   baselineComponent,
   fakeTimers,
@@ -32,7 +32,7 @@ describe('ChipsSelect', () => {
         emptyText="__empty__"
       />,
     );
-    await act(() => userEvent.click(result.getByRole('combobox')));
+    await userEvent.click(result.getByRole('combobox'));
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
     expect(within(dropdownLocator).queryByText('__empty__')).toBeTruthy();
@@ -42,7 +42,7 @@ describe('ChipsSelect', () => {
     const result = render(
       <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
     );
-    await act(() => userEvent.type(result.getByRole('combobox'), 'Син'));
+    await userEvent.type(result.getByRole('combobox'), 'Син');
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
     expect(within(dropdownLocator).getAllByRole('option')).toHaveLength(1);
@@ -51,7 +51,7 @@ describe('ChipsSelect', () => {
 
   it('shows spinner if fetching', async () => {
     const result = render(<ChipsSelect fetching defaultValue={[]} dropdownTestId="dropdown" />);
-    await act(() => userEvent.click(result.getByRole('combobox')));
+    await userEvent.click(result.getByRole('combobox'));
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
     expect(within(dropdownLocator).getByRole('status')).toBeTruthy();
@@ -63,9 +63,9 @@ describe('ChipsSelect', () => {
     );
     const inputLocator = result.getByRole('combobox');
     if (eventType === 'focus') {
-      await act(() => userEvent.tab());
+      await userEvent.tab();
     } else {
-      await act(() => userEvent.click(inputLocator));
+      await userEvent.click(inputLocator);
     }
     await waitForFloatingPosition();
     const dropdownLocator = result.getByTestId('dropdown');
@@ -76,10 +76,10 @@ describe('ChipsSelect', () => {
     const result = render(
       <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
     );
-    await act(() => userEvent.click(result.getByRole('combobox')));
+    await userEvent.click(result.getByRole('combobox'));
     await waitForFloatingPosition();
     expect(result.getByTestId('dropdown')).toBeTruthy();
-    await act(() => userEvent.click(document.body));
+    await userEvent.click(document.body);
     expect(() => result.getByTestId('dropdown')).toThrow();
   });
 
@@ -90,14 +90,14 @@ describe('ChipsSelect', () => {
         <ChipsSelect options={colors} defaultValue={[]} dropdownTestId="dropdown" />,
       );
       const inputLocator = result.getByRole('combobox');
-      await act(() => userEvent.click(inputLocator));
+      await userEvent.click(inputLocator);
 
       await waitForFloatingPosition();
-      await act(() => userEvent.type(inputLocator, '{Escape}'));
-      await act(() => userEvent.type(inputLocator, '{Enter}')); // если dropdown'а пока нет, то выбор из списка на {Enter} должно игнорироваться (см. в коде `case Keys.ENTER`
+      await userEvent.type(inputLocator, '{Escape}');
+      await userEvent.type(inputLocator, '{Enter}'); // если dropdown'а пока нет, то выбор из списка на {Enter} должно игнорироваться (см. в коде `case Keys.ENTER`)
       expect(() => result.getByTestId('dropdown')).toThrow();
 
-      await act(() => userEvent.type(inputLocator, type));
+      await userEvent.type(inputLocator, type);
       await waitForFloatingPosition();
       expect(result.getByTestId('dropdown')).toBeTruthy();
     },
@@ -115,14 +115,12 @@ describe('ChipsSelect', () => {
         closeAfterSelect={closeAfterSelect}
       />,
     );
-    await act(() => userEvent.click(result.getByRole('combobox')));
+    await userEvent.click(result.getByRole('combobox'));
     await waitForFloatingPosition();
-    await act(() =>
-      userEvent.click(
-        within(result.getByTestId('dropdown')).getByRole('option', {
-          name: withRegExp(FIRST_OPTION.label),
-        }),
-      ),
+    await userEvent.click(
+      within(result.getByTestId('dropdown')).getByRole('option', {
+        name: withRegExp(FIRST_OPTION.label),
+      }),
     );
     if (closeAfterSelect) {
       expect(() => result.getByTestId('dropdown')).toThrow();
@@ -146,7 +144,7 @@ describe('ChipsSelect', () => {
         />,
       );
 
-      await act(() => userEvent.click(result.getByRole('combobox')));
+      await userEvent.click(result.getByRole('combobox'));
       await waitForFloatingPosition();
 
       const getFirstOption = () => {
@@ -172,7 +170,7 @@ describe('ChipsSelect', () => {
     );
 
     const inputLocator = result.getByRole('combobox');
-    await act(() => userEvent.click(inputLocator));
+    await userEvent.click(inputLocator);
     await waitForFloatingPosition();
 
     const boundDropdownLocator = within(result.getByTestId('dropdown'));
@@ -188,13 +186,13 @@ describe('ChipsSelect', () => {
       }),
     ];
 
-    await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
+    await userEvent.type(inputLocator, '{ArrowDown}');
     expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
 
-    await act(() => userEvent.type(inputLocator, '{ArrowUp}'));
+    await userEvent.type(inputLocator, '{ArrowUp}');
     expect(thirdOptionLocator).toHaveAttribute('data-hovered', 'true');
 
-    await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
+    await userEvent.type(inputLocator, '{ArrowDown}');
     expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
   });
 
@@ -212,15 +210,15 @@ describe('ChipsSelect', () => {
     );
 
     const inputLocator = result.getByRole('combobox');
-    await act(() => userEvent.click(inputLocator));
+    await userEvent.click(inputLocator);
     await waitForFloatingPosition();
 
     const dropdownOption = within(result.getByTestId('dropdown')).getByRole('option', {
       name: withRegExp(FIRST_OPTION.label),
     });
-    await act(() => userEvent.hover(dropdownOption)); // для вызова onDropdownMouseLeav
-    await act(() => userEvent.hover(inputLocator));
-    await act(() => userEvent.click(dropdownOption));
+    await userEvent.hover(dropdownOption); // для вызова onDropdownMouseLeave
+    await userEvent.hover(inputLocator);
+    await userEvent.click(dropdownOption);
 
     result.rerender(
       <ChipsSelect
@@ -254,15 +252,15 @@ describe('ChipsSelect', () => {
     );
 
     const inputLocator = result.getByRole('combobox');
-    await act(() => userEvent.click(inputLocator));
+    await userEvent.click(inputLocator);
     await waitForFloatingPosition();
 
     const targetOptionIndex = 7;
-    await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
+    await userEvent.type(inputLocator, '{ArrowDown}');
     for (let i = 0; i < targetOptionIndex; i += 1) {
-      await act(() => userEvent.type(inputLocator, '{ArrowDown}'));
+      await userEvent.type(inputLocator, '{ArrowDown}');
     }
-    await act(() => userEvent.type(inputLocator, '{Enter}'));
+    await userEvent.type(inputLocator, '{Enter}');
 
     const selectedOption = options[targetOptionIndex];
     result.rerender(
@@ -287,7 +285,7 @@ describe('ChipsSelect', () => {
       <ChipsSelect defaultValue={[FIRST_OPTION, SECOND_OPTION]} options={colors} />,
     );
     const chipEl = result.getByRole('option', { name: withRegExp(FIRST_OPTION.label) });
-    await act(() => userEvent.click(chipEl));
+    await userEvent.click(chipEl);
     expect(result.getByRole('combobox')).not.toHaveFocus();
   });
 
@@ -308,8 +306,8 @@ describe('ChipsSelect', () => {
         />,
       );
       const inputLocator = result.getByRole('combobox');
-      await act(() => userEvent.type(inputLocator, customChip.label));
-      await act(() => userEvent.type(inputLocator, '{Enter}'));
+      await userEvent.type(inputLocator, customChip.label);
+      await userEvent.type(inputLocator, '{Enter}');
       if (creatable) {
         expect(onChange).toHaveBeenCalledWith([customChip]);
       } else {
@@ -329,14 +327,12 @@ describe('ChipsSelect', () => {
         />,
       );
       const inputLocator = result.getByRole('combobox');
-      await act(() => userEvent.type(inputLocator, customChip.label));
+      await userEvent.type(inputLocator, customChip.label);
       await waitForFloatingPosition();
-      await act(() =>
-        userEvent.click(
-          within(result.getByTestId('dropdown')).getByRole('option', {
-            name: withRegExp('Добавить новую опцию'),
-          }),
-        ),
+      await userEvent.click(
+        within(result.getByTestId('dropdown')).getByRole('option', {
+          name: withRegExp('Добавить новую опцию'),
+        }),
       );
       expect(onChange).toHaveBeenCalledWith([customChip]);
     });
@@ -358,9 +354,9 @@ describe('ChipsSelect', () => {
           />,
         );
 
-        await act(() => userEvent.type(result.getByRole('combobox'), customChip.label));
+        await userEvent.type(result.getByRole('combobox'), customChip.label);
         await waitForFloatingPosition();
-        await act(() => userEvent.click(document.body));
+        await userEvent.click(document.body);
 
         if (creatable) {
           expect(onChange).toHaveBeenCalledWith([customChip]);
@@ -391,9 +387,10 @@ describe('ChipsSelect', () => {
 
       const inputLocator = result.getByTestId('input');
 
-      await act(() => userEvent.tab());
-      await act(() => userEvent.type(inputLocator, '{ArrowUp}'));
-      await act(() => userEvent.tab({ shift: true }));
+      await userEvent.tab();
+      await waitForFloatingPosition();
+      await userEvent.type(inputLocator, '{ArrowUp}');
+      await userEvent.tab({ shift: true });
 
       expect(onFocus).toHaveBeenCalled();
       expect(onBlur).toHaveBeenCalled();

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -31,6 +31,12 @@ describe('CustomSelect', () => {
   ));
 
   it('Does not explode on NaN value', () => {
+    jest.spyOn(global.console, 'error').mockImplementationOnce((message) => {
+      if (message.includes('Received NaN')) {
+        return;
+      }
+      global.console.error(message);
+    });
     const h = render(<CustomSelect value={NaN} options={[]} />);
     expect(() => h.rerender(<CustomSelect value={NaN} options={[]} />)).not.toThrow();
   });

--- a/packages/vkui/src/components/Gallery/Gallery.test.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.test.tsx
@@ -42,7 +42,7 @@ describe('Gallery', () => {
     it('keeps slideIndex when 0 slides', () => {
       const setIndex = jest.fn();
       render(<Gallery onChange={setIndex} slideIndex={10} />);
-      expect(setIndex).not.toBeCalled();
+      expect(setIndex).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
@@ -23,7 +23,7 @@ describe('HorizontalScroll', () => {
       deltaY: 10,
     });
 
-    expect(scrollBy).toBeCalledTimes(1);
+    expect(scrollBy).toHaveBeenCalledTimes(1);
   });
 
   it('calculates and shows arrow on hover', async () => {

--- a/packages/vkui/src/components/LocaleProvider/LocaleProvider.test.tsx
+++ b/packages/vkui/src/components/LocaleProvider/LocaleProvider.test.tsx
@@ -8,10 +8,10 @@ import {
 } from '../ConfigProvider/ConfigProviderContext';
 import { LocaleProvider } from './LocaleProvider';
 
-describe('LocaleProvider', () => {
+describe(LocaleProvider, () => {
   baselineComponent<any>(LocaleProvider, { forward: false, a11y: false, getRootRef: false });
 
-  describe('override config context', () => {
+  it('override config context', () => {
     let config: ConfigProviderContextInterface | undefined;
     const ReadConfig = () => {
       config = useConfigProvider();

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
-import { baselineComponent, mountTest, runAllTimers, userEvent } from '../../testing/utils';
+import { act, render, screen } from '@testing-library/react';
+import { baselineComponent, mountTest, userEvent } from '../../testing/utils';
 import { ModalCard } from '../ModalCard/ModalCard';
 import { ModalPage } from '../ModalPage/ModalPage';
 import { ModalRootTouch } from './ModalRoot';
@@ -54,25 +54,25 @@ describe.each([
     });
     it('shows via prop update', () => {
       const h = render(<ModalRoot activeModal={null}>{modals}</ModalRoot>);
-      runAllTimers();
+      act(jest.runAllTimers);
       h.rerender(<ModalRoot activeModal="m">{modals}</ModalRoot>);
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(document.getElementById('m')).not.toBeNull();
       expect(document.getElementById('other')).toBeNull();
     });
     it('hides via prop update', () => {
       const h = render(<ModalRoot activeModal="m">{modals}</ModalRoot>);
-      runAllTimers();
+      act(jest.runAllTimers);
       h.rerender(<ModalRoot activeModal={null}>{modals}</ModalRoot>);
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(document.getElementById('m')).toBeNull();
       expect(document.getElementById('other')).toBeNull();
     });
     it('changes via prop update', () => {
       const h = render(<ModalRoot activeModal="m">{modals}</ModalRoot>);
-      runAllTimers();
+      act(jest.runAllTimers);
       h.rerender(<ModalRoot activeModal="other">{modals}</ModalRoot>);
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(document.getElementById('m')).toBeNull();
       expect(document.getElementById('other')).not.toBeNull();
     });
@@ -89,10 +89,10 @@ describe.each([
           </ModalRoot>,
         );
         // wait for animations
-        runAllTimers();
+        act(jest.runAllTimers);
         await clickFade();
-        expect(onClose).toBeCalledTimes(1);
-        expect(onCloseRoot).not.toBeCalled();
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(onCloseRoot).not.toHaveBeenCalled();
       });
       it('calls root onClose if modal has no onClose', async () => {
         const onCloseRoot = jest.fn();
@@ -102,9 +102,9 @@ describe.each([
           </ModalRoot>,
         );
         // wait for animations
-        runAllTimers();
+        act(jest.runAllTimers);
         await clickFade();
-        expect(onCloseRoot).toBeCalledTimes(1);
+        expect(onCloseRoot).toHaveBeenCalledTimes(1);
       });
     });
     if (name === 'ModalRootDesktop') {
@@ -116,9 +116,9 @@ describe.each([
           </ModalRoot>,
         );
         // wait for animations
-        runAllTimers();
+        act(jest.runAllTimers);
         await userEvent.keyboard('{Escape}');
-        expect(onCloseRoot).toBeCalledTimes(1);
+        expect(onCloseRoot).toHaveBeenCalledTimes(1);
       });
     }
   });
@@ -131,10 +131,10 @@ describe.each([
     ];
 
     const h = render(<ModalRoot activeModal="m">{modals}</ModalRoot>);
-    runAllTimers();
+    act(jest.runAllTimers);
     h.rerender(<ModalRoot activeModal={null}>{modals}</ModalRoot>);
     h.rerender(<ModalRoot activeModal="other">{modals}</ModalRoot>);
-    runAllTimers();
+    act(jest.runAllTimers);
 
     // check if mask is present
     expect(document.querySelector<HTMLElement>(`.${styles.ModalRoot__mask}`)?.style.opacity).toBe(
@@ -143,7 +143,7 @@ describe.each([
 
     // onClose is working
     await clickFade();
-    expect(onClose).toBeCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('disables native pull-to-refresh when modal is open', () => {
@@ -152,12 +152,12 @@ describe.each([
     const component = render(<ModalRoot activeModal={null}>{modals}</ModalRoot>, {
       baseElement: document.documentElement,
     });
-    runAllTimers();
+    act(jest.runAllTimers);
 
     expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
 
     component.rerender(<ModalRoot activeModal="m">{modals}</ModalRoot>);
-    runAllTimers();
+    act(jest.runAllTimers);
 
     if (name === 'ModalRootTouch') {
       expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeTruthy();
@@ -166,7 +166,7 @@ describe.each([
     }
 
     component.rerender(<ModalRoot activeModal={null}>{modals}</ModalRoot>);
-    runAllTimers();
+    act(jest.runAllTimers);
 
     expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
   });
@@ -206,12 +206,12 @@ describe.each([
       const component = render(<ModalRoot activeModal="modal-page">{modals}</ModalRoot>, {
         baseElement: document.documentElement,
       });
-      runAllTimers();
+      act(jest.runAllTimers);
 
       expect(modalPageRef.current).toHaveFocus();
 
       component.rerender(<ModalRoot activeModal="modal-card">{modals}</ModalRoot>);
-      runAllTimers();
+      act(jest.runAllTimers);
 
       expect(modalCardRef.current).toHaveFocus();
     });
@@ -220,7 +220,7 @@ describe.each([
       render(<ModalRoot activeModal="modal-page-with-input">{modals}</ModalRoot>, {
         baseElement: document.documentElement,
       });
-      runAllTimers();
+      act(jest.runAllTimers);
 
       expect(modalPageWithInputRef.current).not.toHaveFocus();
       expect(inputInnerModalPageRef.current).toHaveFocus();
@@ -235,7 +235,7 @@ describe.each([
           baseElement: document.documentElement,
         },
       );
-      runAllTimers();
+      act(jest.runAllTimers);
 
       expect(modalPageRef.current).not.toHaveFocus();
 
@@ -244,7 +244,7 @@ describe.each([
           {modals}
         </ModalRoot>,
       );
-      runAllTimers();
+      act(jest.runAllTimers);
 
       expect(modalPageWithInputRef.current).not.toHaveFocus();
       expect(inputInnerModalPageRef.current).toHaveFocus();

--- a/packages/vkui/src/components/ModalRoot/useModalManager.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/useModalManager.test.tsx
@@ -195,14 +195,14 @@ describe(useModalManager, () => {
         useModalManager('m1', <MockModal id="m1" onOpen={onOpenOfComponent} />, onOpenOfArgument),
       );
       handle.result.current.onEnter();
-      expect(onOpenOfComponent).toBeCalledTimes(1);
-      expect(onOpenOfArgument).toBeCalledTimes(0);
+      expect(onOpenOfComponent).toHaveBeenCalledTimes(1);
+      expect(onOpenOfArgument).toHaveBeenCalledTimes(0);
     });
     it('calls own onOpen if missing in modal props', () => {
       const onOpen = jest.fn();
       const handle = renderHook(() => useModalManager('m1', <MockModal id="m1" />, onOpen));
       handle.result.current.onEnter();
-      expect(onOpen).toBeCalledTimes(1);
+      expect(onOpen).toHaveBeenCalledTimes(1);
     });
     it('calls active modal onOpened', () => {
       const onOpenedOfComponent = jest.fn();
@@ -218,8 +218,8 @@ describe(useModalManager, () => {
       act(() => {
         handle.result.current.onEntered('m1');
       });
-      expect(onOpenedOfComponent).toBeCalledTimes(1);
-      expect(onOpenedOfArgument).toBeCalledTimes(0);
+      expect(onOpenedOfComponent).toHaveBeenCalledTimes(1);
+      expect(onOpenedOfArgument).toHaveBeenCalledTimes(0);
     });
     it('calls own onOpened if missing in modal props', () => {
       const onOpened = jest.fn();
@@ -227,7 +227,7 @@ describe(useModalManager, () => {
       act(() => {
         handle.result.current.onEntered('m1');
       });
-      expect(onOpened).toBeCalledTimes(1);
+      expect(onOpened).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -245,8 +245,8 @@ describe(useModalManager, () => {
         ),
       );
       handle.result.current.onExit();
-      expect(onCloseOfComponent).toBeCalledTimes(1);
-      expect(onCloseOfArgument).toBeCalledTimes(0);
+      expect(onCloseOfComponent).toHaveBeenCalledTimes(1);
+      expect(onCloseOfArgument).toHaveBeenCalledTimes(0);
     });
     it('calls own onClose if missing in modal props', () => {
       const onClose = jest.fn();
@@ -254,7 +254,7 @@ describe(useModalManager, () => {
         useModalManager('m1', <MockModal id="m1" />, noop, noop, onClose),
       );
       handle.result.current.onExit();
-      expect(onClose).toBeCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
     it('calls active modal onClosed', () => {
       const onClosedOfComponent = jest.fn();
@@ -272,8 +272,8 @@ describe(useModalManager, () => {
       act(() => {
         handle.result.current.onExited('m1');
       });
-      expect(onClosedOfComponent).toBeCalledTimes(1);
-      expect(onClosedOfArgument).toBeCalledTimes(0);
+      expect(onClosedOfComponent).toHaveBeenCalledTimes(1);
+      expect(onClosedOfArgument).toHaveBeenCalledTimes(0);
     });
     it('calls own onClosed if missing in modal props', () => {
       const onClosed = jest.fn();
@@ -283,7 +283,7 @@ describe(useModalManager, () => {
       act(() => {
         handle.result.current.onExited('m1');
       });
-      expect(onClosed).toBeCalledTimes(1);
+      expect(onClosed).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.test.tsx
+++ b/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
-import { fakeTimers, runAllTimers } from '../../testing/utils';
+import { act, render, screen } from '@testing-library/react';
+import { fakeTimers } from '../../testing/utils';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { Panel } from '../Panel/Panel';
 import { Root } from '../Root/Root';
@@ -62,45 +62,53 @@ describe('useNavTransition', () => {
     const { TestComponent } = setup({ withAnimationsMode });
     // transition between views
     const component = render(<TestComponent activeView="v1" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: undefined')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v3" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: forwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v2" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: backwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v1" />);
-    runAllTimers();
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: backwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v2" />);
-    runAllTimers();
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: forwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v3" />);
-    runAllTimers();
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: forwards')).toBeTruthy();
 
     // transition between panels
     component.rerender(<TestComponent activeView="v2" activePanel="v2.1" />);
-    runAllTimers();
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: backwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v2" activePanel="v2.2" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: forwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v2" activePanel="v2.1" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: backwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v2" activePanel="v2.3" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: forwards')).toBeTruthy();
 
     component.rerender(<TestComponent activeView="v2" activePanel="v2.2" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: backwards')).toBeTruthy();
 
     // transition to another view
     component.rerender(<TestComponent activeView="v3" />);
+    act(jest.runAllTimers);
     expect(screen.queryByText('Direction: forwards')).toBeTruthy();
   });
 });

--- a/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
+++ b/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { ViewWidth } from '../../lib/adaptivity';
-import { baselineComponent, fakeTimers, runAllTimers, userEvent } from '../../testing/utils';
+import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
 import { PanelHeaderContext } from './PanelHeaderContext';
 
@@ -28,14 +28,14 @@ describe('PanelHeaderContext', () => {
         </AdaptivityProvider>,
       );
       await userEvent.click(document.body);
-      expect(onClose).toBeCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it('on mobile fade click', async () => {
       const onClose = jest.fn();
       render(<PanelHeaderContext opened onClose={onClose} />);
       await userEvent.click(document.querySelector('.vkuiPanelHeaderContext__fade') as Element);
-      expect(onClose).toBeCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it('does not close on content click', async () => {
@@ -46,7 +46,7 @@ describe('PanelHeaderContext', () => {
         </PanelHeaderContext>,
       );
       await userEvent.click(screen.getByTestId('xxx'));
-      expect(onClose).not.toBeCalled();
+      expect(onClose).not.toHaveBeenCalled();
     });
 
     it('Removes content after opened=false', () => {
@@ -60,7 +60,7 @@ describe('PanelHeaderContext', () => {
           <div data-testid="xxx" />
         </PanelHeaderContext>,
       );
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(screen.queryByTestId('xxx')).toBeNull();
     });
   });

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
-import { baselineComponent, fakeTimers, runAllTimers } from '../../testing/utils';
+import { act, render } from '@testing-library/react';
+import { baselineComponent, fakeTimers } from '../../testing/utils';
 import { PopoutWrapper } from './PopoutWrapper';
 import styles from './PopoutWrapper.module.css';
 
@@ -19,7 +19,7 @@ describe(PopoutWrapper, () => {
       const result = render(<PopoutWrapper data-testid="popout-wrapper" />);
       const locator = result.getByTestId('popout-wrapper');
       expect(locator).not.toHaveClass(styles['PopoutWrapper--opened']);
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(locator).toHaveClass(styles['PopoutWrapper--opened']);
     });
   });

--- a/packages/vkui/src/components/Root/Root.test.tsx
+++ b/packages/vkui/src/components/Root/Root.test.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
-import {
-  baselineComponent,
-  fakeTimers,
-  mockScrollContext,
-  mountTest,
-  runAllTimers,
-} from '../../testing/utils';
+import { act, render } from '@testing-library/react';
+import { baselineComponent, fakeTimers, mockScrollContext, mountTest } from '../../testing/utils';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { View } from '../View/View';
 import { Root } from './Root';
@@ -23,10 +17,10 @@ const views = [
   </View>,
 ];
 
-describe('Root', () => {
-  fakeTimers();
-
+describe(Root, () => {
   baselineComponent(Root);
+
+  fakeTimers();
 
   describe('With View', () =>
     mountTest(() => (
@@ -45,7 +39,7 @@ describe('Root', () => {
     });
     it('after prop update', () => {
       render(<Root activeView="v1">{views}</Root>).rerender(<Root activeView="v2">{views}</Root>);
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(document.getElementById('v1')).toBeNull();
       expect(document.getElementById('v2')).not.toBeNull();
     });
@@ -70,9 +64,9 @@ describe('Root', () => {
           </Root>
         </ConfigProvider>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledTimes(1);
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledTimes(1);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'v1',
         to: 'v2',
         isBack: false,
@@ -89,8 +83,8 @@ describe('Root', () => {
           {views}
         </Root>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'v2',
         to: 'v1',
         isBack: true,
@@ -113,9 +107,9 @@ describe('Root', () => {
           {views}
         </Root>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledTimes(1);
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledTimes(1);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'v1',
         to: 'v3',
         isBack: false,
@@ -138,9 +132,9 @@ describe('Root', () => {
           {views}
         </Root>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledTimes(1);
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledTimes(1);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'v2',
         to: 'v1',
         isBack: true,
@@ -163,6 +157,7 @@ describe('Root', () => {
       render(<Root activeView="focus">{views}</Root>).rerender(
         <Root activeView="other">{views}</Root>,
       );
+      act(jest.runAllTimers);
       expect(document.activeElement === document.body).toBe(true);
     });
   });
@@ -187,8 +182,8 @@ describe('Root', () => {
           <Root activeView="v1">{views}</Root>
         </MockScroll>,
       );
-      runAllTimers();
-      expect(scrollTo).toBeCalledWith(0, y);
+      act(jest.runAllTimers);
+      expect(scrollTo).toHaveBeenCalledWith(0, y);
     });
     it('resets on forward navigation', () => {
       let y = 101;
@@ -209,7 +204,7 @@ describe('Root', () => {
           <Root activeView="v2">{views}</Root>
         </MockScroll>,
       );
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(scrollTo.mock.calls[scrollTo.mock.calls.length - 1]).toEqual([0, 0]);
     });
   });

--- a/packages/vkui/src/components/Search/Search.test.tsx
+++ b/packages/vkui/src/components/Search/Search.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';
 import { Search } from './Search';
 import styles from './Search.module.css';
@@ -8,9 +8,10 @@ const getInput = () => screen.getByRole('searchbox');
 const getClearIcon = () => document.querySelector(`.${styles.Search__icon}`)!;
 const getFindButton = () => document.querySelector(`.${styles.Search__findButton}`)!;
 
-describe('Search', () => {
-  fakeTimers();
+describe(Search, () => {
   baselineComponent(Search);
+
+  fakeTimers();
 
   describe('works uncontrolled', () => {
     it('uses defaultValue', () => {
@@ -98,6 +99,7 @@ describe('Search', () => {
     const cb = jest.fn();
     render(<Search value="test" onFindButtonClick={cb} />);
     await userEvent.click(getFindButton());
+    act(jest.runAllTimers);
     expect(cb).toHaveBeenCalled();
   });
 });

--- a/packages/vkui/src/components/Slider/Slider.test.tsx
+++ b/packages/vkui/src/components/Slider/Slider.test.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { setRef } from '../../lib/utils';
-import { baselineComponent, mockRect, userEvent } from '../../testing/utils';
+import {
+  baselineComponent,
+  fakeTimers,
+  mockRect,
+  userEvent,
+  waitForFloatingPosition,
+} from '../../testing/utils';
 import type { TouchEvent } from '../Touch/Touch';
 import { Slider as SliderBase, type SliderMultipleProps, type SliderProps } from './Slider';
 
@@ -18,7 +24,7 @@ const Slider = ({
   return <SliderBase data-testid="root" getRootRef={getRootRef} {...restProps} />;
 };
 
-describe('Slider', () => {
+describe(Slider, () => {
   baselineComponent((props) => <Slider getAriaLabel={() => 'Slider'} {...props} />);
 
   describe('uncontrolled', () => {
@@ -211,6 +217,8 @@ describe('Slider', () => {
   });
 
   describe('with tooltip', () => {
+    fakeTimers();
+
     it('shows tooltip on hover/focus', async () => {
       render(<Slider defaultValue={30} withTooltip />);
       const slider = screen.getByRole('slider');
@@ -219,18 +227,20 @@ describe('Slider', () => {
 
       // shows tooltip on hover
       await userEvent.hover(slider);
+      await waitForFloatingPosition();
       expect(screen.queryByText('30')).toBeInTheDocument();
 
       // hides on unhover
       await userEvent.unhover(slider);
+      await waitForFloatingPosition();
       expect(screen.queryByText('30')).not.toBeInTheDocument();
 
       // shows tooltip on focus
-      slider.focus();
+      act(() => slider.focus());
       await waitFor(() => expect(screen.queryByText('30')).toBeInTheDocument());
 
       // hides on blur
-      slider.blur();
+      act(() => slider.blur());
       await waitFor(() => expect(screen.queryByText('30')).not.toBeInTheDocument());
     });
   });

--- a/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { noop } from '@vkontakte/vkjs';
 import { baselineComponent } from '../../testing/utils';
 import { Snackbar } from './Snackbar';
 
 describe('Snackbar', () => {
-  baselineComponent(Snackbar);
+  baselineComponent((props) => <Snackbar onClose={jest.fn()} {...props} />);
 
   it('custom offsetY', () => {
-    render(<Snackbar data-testid="snackbar" onClose={noop} offsetY={200} />);
+    render(<Snackbar data-testid="snackbar" onClose={jest.fn()} offsetY={200} />);
 
     expect(screen.getByTestId('snackbar').style.bottom).toBe('200px');
   });

--- a/packages/vkui/src/components/TabbarItem/TabbarItem.test.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.test.tsx
@@ -34,10 +34,10 @@ describe('TabbarItem', () => {
 
     const { rerender } = render(<TabbarItem onClick={cb} data-testid="test" />);
     await userEvent.click(screen.getByTestId('test'));
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toHaveBeenCalledTimes(1);
 
     rerender(<TabbarItem onClick={cb} data-testid="test" disabled />);
     await userEvent.click(screen.getByTestId('test'));
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/vkui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ComponentProps, useState } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { Group } from '../Group/Group';
 import { TabsItem } from '../TabsItem/TabsItem';
@@ -81,8 +81,10 @@ function isTabFocused(el: HTMLElement) {
 
 function renderTestTabs(props: ComponentProps<typeof TestTabs> = {}) {
   render(<TestTabs {...props} />);
-  screen.getByTestId('first').focus();
-  screen.getByTestId('first').click();
+  act(() => {
+    screen.getByTestId('first').focus();
+    screen.getByTestId('first').click();
+  });
 }
 
 function pressKey(key: string) {
@@ -95,7 +97,7 @@ function pressKey(key: string) {
   });
 }
 
-describe('Tabs', () => {
+describe(Tabs, () => {
   baselineComponent(Tabs);
 
   describe('Mouse handlers', () => {
@@ -118,43 +120,43 @@ describe('Tabs', () => {
   describe('Keyboard handlers', () => {
     it("doesn't focus previous element when first focused", () => {
       renderTestTabs();
-      screen.getByTestId('first').focus();
+      act(() => screen.getByTestId('first').focus());
       pressKey('ArrowLeft');
       expect(isTabFocused(screen.getByTestId('first'))).toBeTruthy();
     });
     it("doesn't focus next element when last focused", () => {
       renderTestTabs();
-      screen.getByTestId('third').focus();
+      act(() => screen.getByTestId('third').focus());
       pressKey('ArrowRight');
       expect(isTabFocused(screen.getByTestId('third'))).toBeTruthy();
     });
     it('focus next element with ArrowRight key', () => {
       renderTestTabs();
-      screen.getByTestId('second').focus();
+      act(() => screen.getByTestId('second').focus());
       pressKey('ArrowRight');
       expect(isTabFocused(screen.getByTestId('third'))).toBeTruthy();
     });
     it('focus previuos element with ArrowLeft key', () => {
       renderTestTabs();
-      screen.getByTestId('second').focus();
+      act(() => screen.getByTestId('second').focus());
       pressKey('ArrowLeft');
       expect(isTabFocused(screen.getByTestId('first'))).toBeTruthy();
     });
     it('focus first element with Home key', () => {
       renderTestTabs();
-      screen.getByTestId('third').focus();
+      act(() => screen.getByTestId('third').focus());
       pressKey('Home');
       expect(isTabFocused(screen.getByTestId('first'))).toBeTruthy();
     });
     it('focus last element with End key', () => {
       renderTestTabs();
-      screen.getByTestId('first').focus();
+      act(() => screen.getByTestId('first').focus());
       pressKey('End');
       expect(isTabFocused(screen.getByTestId('third'))).toBeTruthy();
     });
     it('select element with Space key', () => {
       renderTestTabs();
-      screen.getByTestId('first').focus();
+      act(() => screen.getByTestId('first').focus());
       pressKey('ArrowRight');
       pressKey('Space');
       expect(isTabFocused(screen.getByTestId('second'))).toBeTruthy();
@@ -162,7 +164,7 @@ describe('Tabs', () => {
     });
     it('select element with Enter key', () => {
       renderTestTabs();
-      screen.getByTestId('first').focus();
+      act(() => screen.getByTestId('first').focus());
       pressKey('ArrowRight');
       pressKey('Enter');
       expect(isTabFocused(screen.getByTestId('second'))).toBeTruthy();
@@ -170,7 +172,7 @@ describe('Tabs', () => {
     });
     it('skip disabled elements', () => {
       renderTestTabs({ disabledKeys: ['second'] });
-      screen.getByTestId('first').focus();
+      act(() => screen.getByTestId('first').focus());
       pressKey('ArrowRight');
       pressKey('Enter');
       expect(isTabFocused(screen.getByTestId('third'))).toBeTruthy();
@@ -179,7 +181,7 @@ describe('Tabs', () => {
     });
     it('focus content with Down key', () => {
       renderTestTabs();
-      screen.getByTestId('second').focus();
+      act(() => screen.getByTestId('second').focus());
       pressKey('Enter');
       pressKey('ArrowDown');
       expect(isTabSelected(screen.getByTestId('second'))).toBeTruthy();

--- a/packages/vkui/src/components/Textarea/Textarea.test.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { baselineComponent, userEvent } from '../../testing/utils';
+import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { Textarea } from './Textarea';
 
 const getInput = () => screen.getByRole('textbox');
 
-describe('Textarea', () => {
+describe(Textarea, () => {
   baselineComponent((props) => (
     <>
       <VisuallyHidden Component="label" id="textarea">
@@ -17,6 +17,8 @@ describe('Textarea', () => {
   ));
 
   describe('works uncontrolled', () => {
+    fakeTimers();
+
     it('uses defaultValue', () => {
       render(<Textarea defaultValue="def" />);
       expect(getInput()).toHaveValue('def');
@@ -36,6 +38,8 @@ describe('Textarea', () => {
   });
 
   describe('works controlled', () => {
+    fakeTimers();
+
     it('respects outer value', () => {
       const { rerender } = render(<Textarea value="init" />);
       expect(getInput()).toHaveValue('init');
@@ -60,6 +64,8 @@ describe('Textarea', () => {
   });
 
   describe('calls onResize', () => {
+    fakeTimers();
+
     it('when editing', async () => {
       const onResize = jest.fn();
       render(<Textarea value="" onResize={onResize} />);

--- a/packages/vkui/src/components/Touch/Touch.test.tsx
+++ b/packages/vkui/src/components/Touch/Touch.test.tsx
@@ -95,16 +95,16 @@ describe('Touch', () => {
       const onLeave = jest.fn();
       render(<Touch data-testid="__t__" onEnter={onEnter} onLeave={onLeave} />);
       fireEvent.mouseEnter(screen.getByTestId('__t__'));
-      expect(onEnter).toBeCalledTimes(1);
+      expect(onEnter).toHaveBeenCalledTimes(1);
       fireEvent.mouseLeave(screen.getByTestId('__t__'));
-      expect(onLeave).toBeCalledTimes(1);
+      expect(onLeave).toHaveBeenCalledTimes(1);
     });
     it('simulates onLeave with touch', () => {
       window['ontouchstart'] = null;
       const onLeave = jest.fn();
       render(<Touch data-testid="__t__" onLeave={onLeave} />);
       fireTouchSwipe(screen.getByTestId('__t__'), [[0, 0]]);
-      expect(onLeave).toBeCalledTimes(1);
+      expect(onLeave).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -151,15 +151,15 @@ describe('Touch', () => {
           const handlers = makeHandlers();
           render(<Touch {...handlers} data-testid="__t__" />);
           fireGesture(screen.getByTestId('__t__'), [[20, 20]]);
-          expect(handlers.onStart).toBeCalledTimes(1);
-          expect(handlers.onStart).toBeCalledWith(emptyGesture(20, 20));
+          expect(handlers.onStart).toHaveBeenCalledTimes(1);
+          expect(handlers.onStart).toHaveBeenCalledWith(emptyGesture(20, 20));
         });
         it('has all params end gesture on clean tap', () => {
           const handlers = makeHandlers();
           render(<Touch {...handlers} data-testid="__t__" />);
           fireGesture(screen.getByTestId('__t__'), [[20, 20]]);
-          expect(handlers.onEnd).toBeCalledTimes(1);
-          expect(handlers.onEnd).toBeCalledWith(emptyGesture(20, 20));
+          expect(handlers.onEnd).toHaveBeenCalledTimes(1);
+          expect(handlers.onEnd).toHaveBeenCalledWith(emptyGesture(20, 20));
         });
       });
 
@@ -175,12 +175,12 @@ describe('Touch', () => {
           screen.getByTestId('__t__'),
           [0, 1, 2, 3].map((t) => [20 + vx * t, 20 + vy * t]),
         );
-        expect(handlers.onStartX).toBeCalledTimes(1);
-        expect(handlers.onStartY).toBeCalledTimes(1);
-        expect(handlers.onMoveX).toBeCalledTimes(vx ? 2 : 0);
-        expect(handlers.onMoveY).toBeCalledTimes(vy ? 2 : 0);
-        expect(handlers.onEndX).toBeCalledTimes(vx ? 1 : 0);
-        expect(handlers.onEndY).toBeCalledTimes(vy ? 1 : 0);
+        expect(handlers.onStartX).toHaveBeenCalledTimes(1);
+        expect(handlers.onStartY).toHaveBeenCalledTimes(1);
+        expect(handlers.onMoveX).toHaveBeenCalledTimes(vx ? 2 : 0);
+        expect(handlers.onMoveY).toHaveBeenCalledTimes(vy ? 2 : 0);
+        expect(handlers.onEndX).toHaveBeenCalledTimes(vx ? 1 : 0);
+        expect(handlers.onEndY).toHaveBeenCalledTimes(vy ? 1 : 0);
       });
 
       it('does not detect slide on small movement', () => {
@@ -192,9 +192,9 @@ describe('Touch', () => {
           [23, 20],
           [20, 17],
         ]);
-        expect(handlers.onStartY).toBeCalledTimes(1);
-        expect(handlers.onMoveY).not.toBeCalled();
-        expect(handlers.onEndY).not.toBeCalled();
+        expect(handlers.onStartY).toHaveBeenCalledTimes(1);
+        expect(handlers.onMoveY).not.toHaveBeenCalled();
+        expect(handlers.onEndY).not.toHaveBeenCalled();
       });
 
       it('does not detect slide if onMove[X|Y] not passed', () => {
@@ -204,8 +204,8 @@ describe('Touch', () => {
           [20, 20],
           [20, 30],
         ]);
-        expect(handlers.onEnd).toBeCalledTimes(1);
-        expect(handlers.onEnd).toBeCalledWith(
+        expect(handlers.onEnd).toHaveBeenCalledTimes(1);
+        expect(handlers.onEnd).toHaveBeenCalledWith(
           expect.objectContaining({
             isSlideX: false,
             isSlideY: false,
@@ -222,9 +222,9 @@ describe('Touch', () => {
           [20, 20],
           [30, 20],
         ]);
-        expect(handlers.onMoveX).not.toBeCalled();
-        expect(handlers.onEndX).not.toBeCalled();
-        expect(handlers.onEnd).toBeCalledWith(
+        expect(handlers.onMoveX).not.toHaveBeenCalled();
+        expect(handlers.onEndX).not.toHaveBeenCalled();
+        expect(handlers.onEnd).toHaveBeenCalledWith(
           expect.objectContaining({
             isSlide: true,
             isSlideY: true,
@@ -249,8 +249,10 @@ describe('Touch', () => {
               [25, 30],
             ],
           ]);
-          expect(handlers.onMove).toBeCalledTimes(1);
-          expect(handlers.onEnd).toBeCalledWith(expect.objectContaining({ shiftX: 0, shiftY: 6 }));
+          expect(handlers.onMove).toHaveBeenCalledTimes(1);
+          expect(handlers.onEnd).toHaveBeenCalledWith(
+            expect.objectContaining({ shiftX: 0, shiftY: 6 }),
+          );
         });
       }
 
@@ -267,10 +269,10 @@ describe('Touch', () => {
             ],
             { startEl: screen.getByTestId('__t__') },
           );
-          expect(handlers.onStart).toBeCalledTimes(1);
-          expect(handlers.onMoveY).toBeCalledTimes(2);
-          expect(handlers.onEnd).toBeCalledTimes(1);
-          expect(handlers.onEnd).toBeCalledWith(
+          expect(handlers.onStart).toHaveBeenCalledTimes(1);
+          expect(handlers.onMoveY).toHaveBeenCalledTimes(2);
+          expect(handlers.onEnd).toHaveBeenCalledTimes(1);
+          expect(handlers.onEnd).toHaveBeenCalledWith(
             expect.objectContaining({ isSlideY: true, shiftY: 10 }),
           );
         });
@@ -294,7 +296,7 @@ describe('Touch', () => {
           );
           h.rerender(<Touch {...handlers} data-testid="__t__" />);
           fireEnd();
-          expect(handlers.onEnd).toBeCalledTimes(1);
+          expect(handlers.onEnd).toHaveBeenCalledTimes(1);
         });
       }
     });
@@ -360,10 +362,10 @@ describe('Touch', () => {
       const cb = jest.fn(() => null);
       render(<Touch onClickCapture={cb} onMove={noop} data-testid="touch" />);
       await userEvent.click(screen.getByTestId('touch'));
-      expect(cb).toBeCalledTimes(1);
+      expect(cb).toHaveBeenCalledTimes(1);
       cb.mockReset();
       slideRight(screen.getByTestId('touch'));
-      expect(cb).toBeCalledTimes(1);
+      expect(cb).toHaveBeenCalledTimes(1);
     });
     it('does not fire click after slide if noSlideClick=true', () => {
       const clicked = new Set();
@@ -387,7 +389,7 @@ describe('Touch', () => {
       render(<Touch onClickCapture={cb} data-testid="touch" />);
       slideRight(screen.getByTestId('touch'));
       await userEvent.click(screen.getByTestId('touch'));
-      expect(cb).toBeCalled();
+      expect(cb).toHaveBeenCalled();
     });
     it('does not prevent click of a button after slide of a parent on mobile', () => {
       window['ontouchstart'] = null;

--- a/packages/vkui/src/components/View/View.test.tsx
+++ b/packages/vkui/src/components/View/View.test.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 import { type ComponentType, Fragment, type ReactNode } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { getRandomUsers } from '../../testing/mock';
-import {
-  baselineComponent,
-  fakeTimers,
-  mockScrollContext,
-  mountTest,
-  runAllTimers,
-} from '../../testing/utils';
+import { baselineComponent, fakeTimers, mockScrollContext, mountTest } from '../../testing/utils';
 import { HasChildren } from '../../types';
 import { Avatar } from '../Avatar/Avatar';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
@@ -22,9 +16,10 @@ import { SWIPE_BACK_SHIFT_THRESHOLD } from './utils';
 
 // Basically the same as Root.test.tsx
 
-describe('View', () => {
-  fakeTimers();
+describe(View, () => {
   baselineComponent(View);
+
+  fakeTimers();
 
   describe('With Panel', () =>
     mountTest(() => (
@@ -44,7 +39,7 @@ describe('View', () => {
       render(<View activePanel="p1">{panels}</View>).rerender(
         <View activePanel="p2">{panels}</View>,
       );
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(document.getElementById('p1')).toBeNull();
       expect(document.getElementById('p2')).not.toBeNull();
     });
@@ -59,9 +54,9 @@ describe('View', () => {
           {panels}
         </View>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledTimes(1);
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledTimes(1);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'p1',
         to: 'p2',
         isBack: false,
@@ -78,8 +73,8 @@ describe('View', () => {
           {panels}
         </View>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'p2',
         to: 'p1',
         isBack: true,
@@ -88,13 +83,15 @@ describe('View', () => {
   });
 
   describe('blurs active element', () => {
+    const panels = [<Panel id="focus" key="1" />, <Panel id="other" key="2" />];
     const renderFocused = () => render(<input autoFocus data-testid="__autofocus__" />);
-    it('on activePanel change', () => {
+
+    it('on activePanel change', async () => {
       renderFocused();
-      const panels = [<Panel id="focus" key="1" />, <Panel id="other" key="2" />];
       render(<View activePanel="focus">{panels}</View>).rerender(
         <View activePanel="other">{panels}</View>,
       );
+      act(jest.runAllTimers);
       expect(document.activeElement === document.body).toBe(true);
     });
   });
@@ -107,11 +104,11 @@ describe('View', () => {
       const { view, ...events } = setupSwipeBack();
       fireEvent.mouseDown(view, { clientX: 0, clientY: 100 });
       fireEvent.mouseMove(view, { clientX: SWIPE_BACK_SHIFT_THRESHOLD, clientY: 100 });
-      expect(events.onSwipeBackStart).toBeCalledTimes(1);
+      expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
       fireEvent.mouseUp(view, { clientX: 0, clientY: 100 });
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).toBeCalledTimes(1);
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).toHaveBeenCalledTimes(1);
     });
     it('does swipeBack immediately on overscroll', () => {
       const { view, ...events } = setupSwipeBack();
@@ -119,9 +116,9 @@ describe('View', () => {
       fireEvent.mouseMove(view, { clientX: SWIPE_BACK_SHIFT_THRESHOLD, clientY: 100 });
       fireEvent.mouseMove(view, { clientX: window.innerWidth + 1, clientY: 100 });
       fireEvent.mouseUp(view);
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).toBeCalledTimes(1);
-      expect(events.onSwipeBackCancel).not.toBeCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
     });
     it('detects transition direction on swipeBack with useNavDirection() hook', async () => {
       const PanelContent = () => {
@@ -172,8 +169,8 @@ describe('View', () => {
         });
         fireEvent.mouseMove(elPreventSwipeBack, { clientX: window.innerWidth + 1, clientY: 100 });
         fireEvent.mouseUp(elPreventSwipeBack);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).not.toBeCalled();
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).not.toHaveBeenCalled();
       });
 
       it('should prevent swipe back if swiped to opposite', () => {
@@ -184,8 +181,8 @@ describe('View', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(view);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).not.toBeCalled();
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).not.toHaveBeenCalled();
       });
     });
     it('does swipeBack after animation', () => {
@@ -196,10 +193,10 @@ describe('View', () => {
       // speed to 0
       nowMock.mockImplementation(() => Infinity);
       fireEvent.mouseUp(view);
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).not.toBeCalled();
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).toBeCalledTimes(1);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
     });
     it('should swipe back by start touch anywhere', () => {
       const { view, ...events } = setupSwipeBack();
@@ -213,11 +210,11 @@ describe('View', () => {
 
       const shiftXWithOffset = fromQuarterScreenX * 2; // event.shiftX начинается с 0, для правильного высчитывания swipeBackShift, смещаем это значение
       fireEvent.mouseMove(view, { clientX: fromQuarterScreenX + shiftXWithOffset, clientY: 100 });
-      expect(events.onSwipeBackStart).toBeCalledTimes(1);
+      expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
       fireEvent.mouseUp(view);
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).toBeCalledTimes(1);
-      expect(events.onSwipeBackCancel).not.toBeCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
     });
     it('fails weak swipeBack', () => {
       const { view, ...events } = setupSwipeBack();
@@ -229,9 +226,9 @@ describe('View', () => {
       // speed to 0
       nowMock.mockImplementation(() => Infinity);
       fireEvent.mouseUp(view);
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).toBeCalledTimes(1);
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).toHaveBeenCalledTimes(1);
     });
     it('recovers after swipeBack', () => {
       const { view, rerender, SwipeBack, ...events } = setupSwipeBack();
@@ -245,7 +242,7 @@ describe('View', () => {
       expect(document.getElementById('p1')).toBeTruthy();
       expect(document.getElementById('p2')).toBeTruthy();
       rerender(<SwipeBack activePanel="p1" history={['p1']} />);
-      expect(events.onTransition).toBeCalledTimes(1);
+      expect(events.onTransition).toHaveBeenCalledTimes(1);
       expect(document.getElementById('p1')).toBeTruthy();
       expect(document.getElementById('p2')).toBeNull();
     });
@@ -319,10 +316,10 @@ describe('View', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).toBeCalledTimes(1);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).toBeCalledTimes(1);
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
 
         elWithScroll.scrollLeft = 0;
 
@@ -336,10 +333,10 @@ describe('View', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).toBeCalledTimes(1);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).toBeCalledTimes(1);
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
       });
 
       it('should prevent swipe back only if scroll left is not on start', () => {
@@ -363,10 +360,10 @@ describe('View', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).not.toBeCalled();
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).not.toBeCalled();
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).not.toHaveBeenCalled();
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).not.toHaveBeenCalled();
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
 
         elWithScroll.scrollLeft = 0;
 
@@ -380,10 +377,10 @@ describe('View', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).toBeCalledTimes(1);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).toBeCalledTimes(1);
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
       });
     });
 
@@ -407,10 +404,10 @@ describe('View', () => {
       fireEvent.mouseMove(elSlide1, { clientX: SWIPE_BACK_SHIFT_THRESHOLD, clientY: 100 });
       fireEvent.mouseMove(elSlide1, { clientX: window.innerWidth / 2, clientY: 100 });
       fireEvent.mouseUp(elSlide1);
-      expect(events.onSwipeBackStart).not.toBeCalled();
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).not.toBeCalled();
+      expect(events.onSwipeBackStart).not.toHaveBeenCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
     });
   });
 
@@ -435,8 +432,8 @@ describe('View', () => {
           <View activePanel="p1">{panels}</View>
         </MockScroll>,
       );
-      runAllTimers();
-      expect(scrollTo).toBeCalledWith(0, y);
+      act(jest.runAllTimers);
+      expect(scrollTo).toHaveBeenCalledWith(0, y);
     });
     it('resets scroll on forward navigation', () => {
       let y = 101;
@@ -452,15 +449,15 @@ describe('View', () => {
           <View activePanel="p1">{panels}</View>
         </MockScroll>,
       );
-      runAllTimers();
+      act(jest.runAllTimers);
       scrollTo.mockReset();
       h.rerender(
         <MockScroll>
           <View activePanel="p2">{panels}</View>
         </MockScroll>,
       );
-      runAllTimers();
-      expect(scrollTo).toBeCalledWith(0, 0);
+      act(jest.runAllTimers);
+      expect(scrollTo).toHaveBeenCalledWith(0, 0);
     });
   });
 });
@@ -501,6 +498,6 @@ function setupSwipeBack({
     </Wrapper>
   );
   const component = render(<SwipeBack />);
-  act(() => jest.runAllTimers());
+  act(jest.runAllTimers);
   return { view: component.getByTestId('view'), ...events, ...component, SwipeBack };
 }

--- a/packages/vkui/src/components/View/ViewInfinite.test.tsx
+++ b/packages/vkui/src/components/View/ViewInfinite.test.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 import { type ComponentType, Fragment, type ReactNode } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { getRandomUsers } from '../../testing/mock';
-import {
-  baselineComponent,
-  fakeTimers,
-  mockScrollContext,
-  mountTest,
-  runAllTimers,
-} from '../../testing/utils';
+import { baselineComponent, fakeTimers, mockScrollContext, mountTest } from '../../testing/utils';
 import { HasChildren } from '../../types';
 import { Avatar } from '../Avatar/Avatar';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
@@ -44,7 +38,7 @@ describe('ViewInfinite', () => {
       render(<ViewInfinite activePanel="p1">{panels}</ViewInfinite>).rerender(
         <ViewInfinite activePanel="p2">{panels}</ViewInfinite>,
       );
-      runAllTimers();
+      act(jest.runAllTimers);
       expect(document.getElementById('p1')).toBeNull();
       expect(document.getElementById('p2')).not.toBeNull();
     });
@@ -59,9 +53,9 @@ describe('ViewInfinite', () => {
           {panels}
         </ViewInfinite>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledTimes(1);
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledTimes(1);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'p1',
         to: 'p2',
         isBack: false,
@@ -78,8 +72,8 @@ describe('ViewInfinite', () => {
           {panels}
         </ViewInfinite>,
       );
-      runAllTimers();
-      expect(onTransition).toBeCalledWith({
+      act(jest.runAllTimers);
+      expect(onTransition).toHaveBeenCalledWith({
         from: 'p2',
         to: 'p1',
         isBack: true,
@@ -88,13 +82,14 @@ describe('ViewInfinite', () => {
   });
 
   describe('blurs active element', () => {
+    const panels = [<Panel id="focus" key="1" />, <Panel id="other" key="2" />];
     const renderFocused = () => render(<input autoFocus data-testid="__autofocus__" />);
     it('on activePanel change', () => {
       renderFocused();
-      const panels = [<Panel id="focus" key="1" />, <Panel id="other" key="2" />];
       render(<ViewInfinite activePanel="focus">{panels}</ViewInfinite>).rerender(
         <ViewInfinite activePanel="other">{panels}</ViewInfinite>,
       );
+      act(jest.runAllTimers);
       expect(document.activeElement === document.body).toBe(true);
     });
   });
@@ -107,11 +102,11 @@ describe('ViewInfinite', () => {
       const { view, ...events } = setupSwipeBack();
       fireEvent.mouseDown(view, { clientX: 0, clientY: 100 });
       fireEvent.mouseMove(view, { clientX: SWIPE_BACK_SHIFT_THRESHOLD, clientY: 100 });
-      expect(events.onSwipeBackStart).toBeCalledTimes(1);
+      expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
       fireEvent.mouseUp(view, { clientX: 0, clientY: 100 });
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).toBeCalledTimes(1);
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).toHaveBeenCalledTimes(1);
     });
     it('does swipeBack immediately on overscroll', () => {
       const { view, ...events } = setupSwipeBack();
@@ -119,9 +114,9 @@ describe('ViewInfinite', () => {
       fireEvent.mouseMove(view, { clientX: SWIPE_BACK_SHIFT_THRESHOLD, clientY: 100 });
       fireEvent.mouseMove(view, { clientX: window.innerWidth + 1, clientY: 100 });
       fireEvent.mouseUp(view);
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).toBeCalledTimes(1);
-      expect(events.onSwipeBackCancel).not.toBeCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
     });
     it('detects transition direction on swipeBack with useNavDirection() hook', async () => {
       const PanelContent = () => {
@@ -172,8 +167,8 @@ describe('ViewInfinite', () => {
         });
         fireEvent.mouseMove(elPreventSwipeBack, { clientX: window.innerWidth + 1, clientY: 100 });
         fireEvent.mouseUp(elPreventSwipeBack);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).not.toBeCalled();
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).not.toHaveBeenCalled();
       });
 
       it('should prevent swipe back if swiped to opposite', () => {
@@ -184,8 +179,8 @@ describe('ViewInfinite', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(view);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).not.toBeCalled();
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).not.toHaveBeenCalled();
       });
     });
     it('does swipeBack after animation', () => {
@@ -196,10 +191,10 @@ describe('ViewInfinite', () => {
       // speed to 0
       nowMock.mockImplementation(() => Infinity);
       fireEvent.mouseUp(view);
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).not.toBeCalled();
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).toBeCalledTimes(1);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
     });
     it('should swipe back by start touch anywhere', () => {
       const { view, ...events } = setupSwipeBack();
@@ -213,11 +208,11 @@ describe('ViewInfinite', () => {
 
       const shiftXWithOffset = fromQuarterScreenX * 2; // event.shiftX начинается с 0, для правильного высчитывания swipeBackShift, смещаем это значение
       fireEvent.mouseMove(view, { clientX: fromQuarterScreenX + shiftXWithOffset, clientY: 100 });
-      expect(events.onSwipeBackStart).toBeCalledTimes(1);
+      expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
       fireEvent.mouseUp(view);
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).toBeCalledTimes(1);
-      expect(events.onSwipeBackCancel).not.toBeCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
     });
     it('fails weak swipeBack', () => {
       const { view, ...events } = setupSwipeBack();
@@ -229,9 +224,9 @@ describe('ViewInfinite', () => {
       // speed to 0
       nowMock.mockImplementation(() => Infinity);
       fireEvent.mouseUp(view);
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).toBeCalledTimes(1);
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).toHaveBeenCalledTimes(1);
     });
     it('recovers after swipeBack', () => {
       const { view, rerender, SwipeBack, ...events } = setupSwipeBack();
@@ -245,7 +240,7 @@ describe('ViewInfinite', () => {
       expect(document.getElementById('p1')).toBeTruthy();
       expect(document.getElementById('p2')).toBeTruthy();
       rerender(<SwipeBack activePanel="p1" history={['p1']} />);
-      expect(events.onTransition).toBeCalledTimes(1);
+      expect(events.onTransition).toHaveBeenCalledTimes(1);
       expect(document.getElementById('p1')).toBeTruthy();
       expect(document.getElementById('p2')).toBeNull();
     });
@@ -262,7 +257,7 @@ describe('ViewInfinite', () => {
       });
       fireEvent.mouseUp(view);
       rerender(<SwipeBack activePanel="p1" history={['p1']} />);
-      expect(scrollTo).toBeCalledWith(0, 22);
+      expect(scrollTo).toHaveBeenCalledWith(0, 22);
     });
 
     describe('horizontal scrollable elements', () => {
@@ -304,10 +299,10 @@ describe('ViewInfinite', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).toBeCalledTimes(1);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).toBeCalledTimes(1);
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
 
         elWithScroll.scrollLeft = 0;
 
@@ -321,10 +316,10 @@ describe('ViewInfinite', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).toBeCalledTimes(1);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).toBeCalledTimes(1);
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
       });
 
       it('should prevent swipe back only if scroll left is not on start', () => {
@@ -348,10 +343,10 @@ describe('ViewInfinite', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).not.toBeCalled();
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).not.toBeCalled();
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).not.toHaveBeenCalled();
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).not.toHaveBeenCalled();
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
 
         elWithScroll.scrollLeft = 0;
 
@@ -365,10 +360,10 @@ describe('ViewInfinite', () => {
           clientY: 100,
         });
         fireEvent.mouseUp(elMiddleHorizontalCell);
-        expect(events.onSwipeBackStart).toBeCalledTimes(1);
-        act(() => jest.runAllTimers());
-        expect(events.onSwipeBack).toBeCalledTimes(1);
-        expect(events.onSwipeBackCancel).not.toBeCalled();
+        expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
+        act(jest.runAllTimers);
+        expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
+        expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
       });
     });
 
@@ -392,10 +387,10 @@ describe('ViewInfinite', () => {
       fireEvent.mouseMove(elSlide1, { clientX: SWIPE_BACK_SHIFT_THRESHOLD, clientY: 100 });
       fireEvent.mouseMove(elSlide1, { clientX: window.innerWidth / 2, clientY: 100 });
       fireEvent.mouseUp(elSlide1);
-      expect(events.onSwipeBackStart).not.toBeCalled();
-      act(() => jest.runAllTimers());
-      expect(events.onSwipeBack).not.toBeCalled();
-      expect(events.onSwipeBackCancel).not.toBeCalled();
+      expect(events.onSwipeBackStart).not.toHaveBeenCalled();
+      act(jest.runAllTimers);
+      expect(events.onSwipeBack).not.toHaveBeenCalled();
+      expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
     });
   });
 
@@ -420,8 +415,8 @@ describe('ViewInfinite', () => {
           <ViewInfinite activePanel="p1">{panels}</ViewInfinite>
         </MockScroll>,
       );
-      runAllTimers();
-      expect(scrollTo).toBeCalledWith(0, y);
+      act(jest.runAllTimers);
+      expect(scrollTo).toHaveBeenCalledWith(0, y);
     });
     it('resets scroll on forward navigation', () => {
       let y = 101;
@@ -437,15 +432,15 @@ describe('ViewInfinite', () => {
           <ViewInfinite activePanel="p1">{panels}</ViewInfinite>
         </MockScroll>,
       );
-      runAllTimers();
+      act(jest.runAllTimers);
       scrollTo.mockReset();
       h.rerender(
         <MockScroll>
           <ViewInfinite activePanel="p2">{panels}</ViewInfinite>
         </MockScroll>,
       );
-      runAllTimers();
-      expect(scrollTo).toBeCalledWith(0, 0);
+      act(jest.runAllTimers);
+      expect(scrollTo).toHaveBeenCalledWith(0, 0);
     });
   });
 });
@@ -486,6 +481,6 @@ function setupSwipeBack({
     </Wrapper>
   );
   const component = render(<SwipeBack />);
-  runAllTimers();
+  act(jest.runAllTimers);
   return { view: component.getByTestId('view'), ...events, ...component, SwipeBack };
 }

--- a/packages/vkui/src/hooks/useAutoFocus.test.tsx
+++ b/packages/vkui/src/hooks/useAutoFocus.test.tsx
@@ -14,7 +14,7 @@ describe(useAutoFocus, () => {
     const onFocus = jest.fn();
     render(<Playground onFocus={onFocus} />);
 
-    expect(onFocus).not.toBeCalled();
+    expect(onFocus).not.toHaveBeenCalled();
 
     const el = screen.getByTestId('div');
     expect(document.activeElement).not.toBe(el);
@@ -24,7 +24,7 @@ describe(useAutoFocus, () => {
     const onFocus = jest.fn();
     render(<Playground onFocus={onFocus} autoFocus />);
 
-    expect(onFocus).toBeCalled();
+    expect(onFocus).toHaveBeenCalled();
 
     const el = screen.getByTestId('div');
     expect(document.activeElement).toBe(el);

--- a/packages/vkui/src/hooks/usePatchChildren.test.tsx
+++ b/packages/vkui/src/hooks/usePatchChildren.test.tsx
@@ -74,6 +74,12 @@ describe(usePatchChildren, () => {
   ])(
     'should inject $event event to $type (hasOwnEvent: $hasOwnEvent)',
     ({ type, event, hasOwnEvent }) => {
+      jest.spyOn(global.console, 'error').mockImplementationOnce((message) => {
+        if (message.includes('React does not recognize the')) {
+          return;
+        }
+        global.console.error(message);
+      });
       const reactElementRef = React.createRef<HTMLDivElement>();
       const ownEvent = {
         someIntValue: 1,

--- a/packages/vkui/src/hooks/useTimeout.test.ts
+++ b/packages/vkui/src/hooks/useTimeout.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
-import { fakeTimers, runAllTimers } from '../testing/utils';
+import { fakeTimers } from '../testing/utils';
 import { useTimeout } from './useTimeout';
 
 describe(useTimeout, () => {
@@ -11,13 +11,13 @@ describe(useTimeout, () => {
     act(() => {
       result.current.set();
     });
-    runAllTimers();
-    expect(cb).toBeCalledTimes(1);
+    act(jest.runAllTimers);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
   it('clears timeout on unmount', () => {
     const { result, unmount } = renderHook(() => useTimeout(noop, 100));
     // run useEffect
-    runAllTimers();
+    act(jest.runAllTimers);
     act(() => {
       result.current.set();
     });
@@ -31,8 +31,8 @@ describe(useTimeout, () => {
     });
     const cb = jest.fn();
     rerender(cb);
-    runAllTimers();
-    expect(cb).toBeCalledTimes(1);
+    act(jest.runAllTimers);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
   it('set() replaces old timeout', () => {
     const cb = jest.fn();
@@ -43,7 +43,7 @@ describe(useTimeout, () => {
     act(() => {
       result.current.set();
     });
-    runAllTimers();
-    expect(cb).toBeCalledTimes(1);
+    act(jest.runAllTimers);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/vkui/src/lib/getNavId.test.ts
+++ b/packages/vkui/src/lib/getNavId.test.ts
@@ -12,12 +12,12 @@ describe(getNavId, () => {
       getNavId({ nav: 'ok' }, warn);
       getNavId({ id: 'ok' }, warn);
       getNavId({ nav: 'ok', id: 'dont' }, warn);
-      expect(warn).not.toBeCalled();
+      expect(warn).not.toHaveBeenCalled();
     });
     it('errors if nav id missing', () => {
       const warn = jest.fn();
       getNavId({}, warn);
-      expect(warn).toBeCalled();
+      expect(warn).toHaveBeenCalled();
     });
   });
 });

--- a/packages/vkui/src/lib/warnOnce.test.ts
+++ b/packages/vkui/src/lib/warnOnce.test.ts
@@ -1,15 +1,15 @@
 import { warnOnce } from './warnOnce';
 
-describe('warnOnce', () => {
+describe(warnOnce, () => {
   afterAll(() => {
     // eslint-disable-next-line no-console
     console.clear();
     jest.clearAllMocks();
   });
 
-  const warnSpy = jest.spyOn(console, 'warn');
-  const errorSpy = jest.spyOn(console, 'error');
-  const logSpy = jest.spyOn(console, 'log');
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => void 0);
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => void 0);
 
   const warn = warnOnce('zone');
   const warnMsg = 'warn message';
@@ -38,7 +38,7 @@ describe('warnOnce', () => {
     warn('log message', 'log');
 
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toBeCalledWith(
+    expect(logSpy).toHaveBeenCalledWith(
       '%c[VKUI/zone] log message',
       'color: steelblue; font-style: italic',
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4510,22 +4510,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^9.3.4":
-  version: 9.3.4
-  resolution: "@testing-library/dom@npm:9.3.4"
-  dependencies:
-    "@babel/code-frame": ^7.10.4
-    "@babel/runtime": ^7.12.5
-    "@types/aria-query": ^5.0.1
-    aria-query: 5.1.3
-    chalk: ^4.1.0
-    dom-accessibility-api: ^0.5.9
-    lz-string: ^1.5.0
-    pretty-format: ^27.0.2
-  checksum: dfd6fb0d6c7b4dd716ba3c47309bc9541b4a55772cb61758b4f396b3785efe2dbc75dc63423545c039078c7ffcc5e4b8c67c2db1b6af4799580466036f70026f
-  languageName: node
-  linkType: hard
-
 "@testing-library/jest-dom@npm:^6.3.0":
   version: 6.3.0
   resolution: "@testing-library/jest-dom@npm:6.3.0"
@@ -5654,7 +5638,6 @@ __metadata:
     "@swc/cli": ^0.1.64
     "@swc/core": 1.3.105
     "@swc/jest": ^0.2.31
-    "@testing-library/dom": ^9.3.4
     "@testing-library/jest-dom": ^6.3.0
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.5.1


### PR DESCRIPTION
## Описание

Исправляет консольные предупреждения во время запуска юнит-тестов в папке `packages/vkui`.

## Изменения

- Удалил зависимость `@testing-library/dom`, т.к. это транзитивная зависимость `@testing-library/react` (см. доку [Testing Library / User Interactions / Installation](https://testing-library.com/docs/user-event/install/)). Благодаря этому, `userEvent` теперь не надо оборачивать в `await act(() => ...)`
- `packages/vkui/src/testing/utils.tsx`
  - удалил `runAllTimers()` и заменил его использование на `act(jest.runAllTimers)`, т.к. `runAllTimers()` лишняя абстракция;
  - заинлайнил `tryToGetByTestId()` и удалил;
  - отрефакторил логкику `mountTest()`, чтобы поправить `console.warn` – теперь будет проверяться, что `expect` был вызван 3 раза, что означает _mount_/_rerender_/_unmount_;
  - в `a11yTest()` добавляем `jest.useFakeTimers();` после выполнения команды `axe` (см. доку Usage with [GitHub / jest-axe / jest.useFakeTimers() or mocking setTimeout](https://github.com/nickcolley/jest-axe?tab=readme-ov-file#usage-with-jestusefaketimers-or-mocking-settimeout));
  - `baselineComponent()` – используем `jest.useFakeTimers();` в рамках своего контекста.
- Заменил депрекейтнутые API:
  - `toBeCalled`
  - `toBeCalledTimes`
  - `toBeCalledWith`
