### PR TITLE
build(vkui-floating-ui): fix exports path

### DIFF
--- a/packages/vkui-floating-ui/package.json
+++ b/packages/vkui-floating-ui/package.json
@@ -51,12 +51,12 @@
     },
     "./utils/dom": {
       "import": {
-        "types": "./utils/dom/dist/floating-ui.utils.dom.d.ts",
-        "default": "./utils/dom/dist/floating-ui.utils.dom.esm.js"
+        "types": "./utils/dist/floating-ui.utils.dom.d.ts",
+        "default": "./utils/dist/floating-ui.utils.dom.esm.js"
       },
-      "types": "./utils/dom/dist/floating-ui.utils.dom.d.ts",
-      "module": "./utils/dom/dist/floating-ui.utils.dom.esm.js",
-      "default": "./utils/dom/dist/floating-ui.utils.dom.umd.js"
+      "types": "./utils/dist/floating-ui.utils.dom.d.ts",
+      "module": "./utils/dist/floating-ui.utils.dom.esm.js",
+      "default": "./utils/dist/floating-ui.utils.dom.umd.js"
     },
     "./react-dom": {
       "import": {
@@ -69,7 +69,7 @@
     }
   },
   "scripts": {
-    "build": "node index.mjs"
+    "build": "node --no-warnings=ExperimentalWarning --trace-warnings index.mjs"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
## Описание

Поправил в `package.json` пути в `"exports"`.

После [@floating-ui/utils@0.2.0](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Futils%400.2.0), изменилась структура папки `node_modules/@floating-ui/utils/`, из-за чего падает `swc.transformFile`, т.к. путь до нужного файла уже другой, а конкретно до `/node_modules/@floating-ui/utils/dom/dist/floating-ui.utils.dom.esm.js`. Теперь это `/node_modules/@floating-ui/utils/dom/floating-ui.utils.dom.esm.js`, либо `/node_modules/@floating-ui/utils/dist/floating-ui.utils.dom.esm.js` (в коде теперь использую именно этот).

```sh
node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^

[Error: failed to load file

Caused by:
    No such file or directory (os error 2)] {
  code: 'GenericFailure'
}

Node.js v20.10.0
```

- caused by #6480
