### PR TITLE
fix(AdaptivityProvider): calculate size y when viewWidth is provided

### DIFF
--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.test.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-// import {hasMouse}from "@vkontakte/vkjs";
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { ViewHeight, ViewWidth } from '../../lib/adaptivity';
 import { baselineComponent } from '../../testing/utils';
@@ -17,21 +16,15 @@ jest.mock('@vkontakte/vkjs', () => ({
   },
   detectIOS: () => false,
 }));
-const mediaQueryListSub = {
-  addEventListener: () => jest.fn(),
-  addListener: () => jest.fn(),
-  removeEventListener: () => jest.fn(),
-  removeListener: () => jest.fn(),
-};
 jest.mock('../../hooks/useMediaQueries', () => ({
   useMediaQueries: () => ({
-    desktopPlus: () => mediaQueryListSub,
-    smallTabletPlus: () => mediaQueryListSub,
-    tablet: () => mediaQueryListSub,
-    smallTablet: () => mediaQueryListSub,
-    mobile: () => mediaQueryListSub,
-    mediumHeight: () => mediaQueryListSub,
-    mobileLandscapeHeight: () => mediaQueryListSub,
+    desktopPlus: () => jest.fn(),
+    smallTabletPlus: () => jest.fn(),
+    tablet: () => jest.fn(),
+    smallTablet: () => jest.fn(),
+    mobile: () => jest.fn(),
+    mediumHeight: () => jest.fn(),
+    mobileLandscapeHeight: () => jest.fn(),
   }),
 }));
 jest.mock('../../lib/matchMedia', () => ({
@@ -57,6 +50,7 @@ interface AdaptivityResultsRef {
 const CatchAdaptivityProviderContext = React.forwardRef<AdaptivityResultsRef>((_, ref) => {
   const adaptivityProviderResults = React.useContext(AdaptivityContext);
   const adaptivityWithJsMediaQueriesHookResults = useAdaptivityWithJSMediaQueries();
+
   React.useImperativeHandle(
     ref,
     () => ({
@@ -68,287 +62,303 @@ const CatchAdaptivityProviderContext = React.forwardRef<AdaptivityResultsRef>((_
   return null;
 });
 
-const TestAdaptiveProvider = React.forwardRef<
-  {
-    adaptivityProviderResults: AdaptivityProps;
-    adaptivityWithJsMediaQueriesHookResults: AdaptivityProps;
-  },
-  AdaptivityProviderProps
->((props, ref) => (
-  <AdaptivityProvider {...props}>
-    <CatchAdaptivityProviderContext ref={ref} />
-  </AdaptivityProvider>
-));
+const TestAdaptiveProvider = React.forwardRef<AdaptivityResultsRef, AdaptivityProviderProps>(
+  (props, ref) => (
+    <AdaptivityProvider {...props}>
+      <CatchAdaptivityProviderContext ref={ref} />
+    </AdaptivityProvider>
+  ),
+);
 
-describe('AdaptivityProvider + useAdaptivityWithJSMediaQueries should return identical results for identical input', () => {
+interface TestSuite {
+  inProps: AdaptivityProviderProps & { hasMouseLibDetection?: boolean; runOnlyThisSuite?: boolean };
+  outProps: AdaptivityProps;
+}
+
+const testSuites: TestSuite[] = [
+  {
+    inProps: {
+      viewWidth: ViewWidth.DESKTOP,
+      viewHeight: ViewHeight.MEDIUM,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+      viewWidth: ViewWidth.DESKTOP,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.DESKTOP,
+      viewHeight: ViewHeight.MEDIUM,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'compact',
+      viewWidth: ViewWidth.DESKTOP,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: { viewWidth: ViewWidth.MOBILE, viewHeight: ViewHeight.EXTRA_SMALL },
+    outProps: {
+      sizeX: 'compact',
+      sizeY: 'compact',
+      viewWidth: ViewWidth.MOBILE,
+      viewHeight: ViewHeight.EXTRA_SMALL,
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'compact',
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: {
+      sizeX: 'compact' as const,
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'compact',
+      sizeY: 'regular',
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: {
+      sizeX: 'compact' as const,
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'compact',
+      sizeY: 'compact',
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: {
+      sizeY: 'regular' as const,
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: {
+      sizeX: 'regular' as const,
+      sizeY: 'regular' as const,
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+      viewWidth: ViewWidth.SMALL_TABLET,
+      viewHeight: ViewHeight.MEDIUM,
+    },
+  },
+  {
+    inProps: {
+      sizeX: 'regular' as const,
+      sizeY: 'regular' as const,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.SMALL_MOBILE,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'compact',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.SMALL_MOBILE,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'compact',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.MOBILE,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'compact',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.MOBILE,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'compact',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.SMALL_TABLET,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.SMALL_TABLET,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'compact',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.TABLET,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.TABLET,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'compact',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.DESKTOP,
+      hasMouseLibDetection: false,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'regular',
+    },
+  },
+  {
+    inProps: {
+      viewWidth: ViewWidth.DESKTOP,
+      hasMouseLibDetection: true,
+    },
+    outProps: {
+      sizeX: 'regular',
+      sizeY: 'compact',
+    },
+  },
+];
+
+describe('AdaptivityProvider', () => {
   baselineComponent(AdaptivityProvider, { forward: false, a11y: false, getRootRef: false });
 
   it('should return undefined adaptivity props', () => {
     const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
     render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} />);
-    expect(adaptivityProviderResultsRef.current?.adaptivityProviderResults).toEqual({
+    expect(adaptivityProviderResultsRef.current?.adaptivityProviderResults).toMatchObject({
       sizeX: undefined,
       sizeY: undefined,
       viewWidth: undefined,
       viewHeight: undefined,
     });
   });
+});
 
-  [
-    {
-      inProps: {
-        viewWidth: ViewWidth.DESKTOP,
-        viewHeight: ViewHeight.MEDIUM,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-        viewWidth: ViewWidth.DESKTOP,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.DESKTOP,
-        viewHeight: ViewHeight.MEDIUM,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'compact',
-        viewWidth: ViewWidth.DESKTOP,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: { viewWidth: ViewWidth.MOBILE, viewHeight: ViewHeight.EXTRA_SMALL },
-      outProps: {
-        sizeX: 'compact',
-        sizeY: 'compact',
-        viewWidth: ViewWidth.MOBILE,
-        viewHeight: ViewHeight.EXTRA_SMALL,
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'compact',
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: {
-        sizeX: 'compact' as const,
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'compact',
-        sizeY: 'regular',
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: {
-        sizeX: 'compact' as const,
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'compact',
-        sizeY: 'compact',
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: {
-        sizeY: 'regular' as const,
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: {
-        sizeX: 'regular' as const,
-        sizeY: 'regular' as const,
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-        viewWidth: ViewWidth.SMALL_TABLET,
-        viewHeight: ViewHeight.MEDIUM,
-      },
-    },
-    {
-      inProps: {
-        sizeX: 'regular' as const,
-        sizeY: 'regular' as const,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.SMALL_MOBILE,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'compact',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.SMALL_MOBILE,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'compact',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.MOBILE,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'compact',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.MOBILE,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'compact',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.SMALL_TABLET,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.SMALL_TABLET,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'compact',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.TABLET,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.TABLET,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'compact',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.DESKTOP,
-        hasMouseLibDetection: false,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'regular',
-      },
-    },
-    {
-      inProps: {
-        viewWidth: ViewWidth.DESKTOP,
-        hasMouseLibDetection: true,
-      },
-      outProps: {
-        sizeX: 'regular',
-        sizeY: 'compact',
-      },
-    },
-  ].map((testOptions) => {
+describe('AdaptiveProvider and useAdaptivityWithJSMediaQueries should return similar results', () => {
+  testSuites.map((testOptions) => {
     const { inProps, outProps } = testOptions;
 
-    const test = inProps.only ? it.only : it;
-
-    test(`should define sizeX and sizeY adaptivity props for input: \n${JSON.stringify(
+    describe(`should define sizeX and sizeY adaptivity props for input: \n${JSON.stringify(
       inProps,
       null,
       '\t',
     )}\n`, () => {
       const { hasMouseLibDetection, ...props } = inProps;
 
-      hasMouseLibDetectionStub.mockReturnValue(hasMouseLibDetection ?? false);
-      getViewWidthByMediaQueriesStub.mockReturnValue(() => inProps.viewWidth);
-      getViewHeightByMediaQueriesStub.mockReturnValue(() => inProps.viewHeight);
+      beforeEach(() => {
+        hasMouseLibDetectionStub.mockReturnValue(hasMouseLibDetection ?? false);
+        getViewWidthByMediaQueriesStub.mockReturnValue(() => inProps.viewWidth);
+        getViewHeightByMediaQueriesStub.mockReturnValue(() => inProps.viewHeight);
+      });
 
-      const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
+      const test = inProps.runOnlyThisSuite ? it.only : it;
 
-      render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...props} />);
+      test('AdaptiveProvider', () => {
+        const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
 
-      // AdaptivityProvider results
-      expect(adaptivityProviderResultsRef.current?.adaptivityProviderResults).toMatchObject(
-        outProps,
-      );
-      // useAdaptivityWithJSMediaQueries results
-      expect(
-        adaptivityProviderResultsRef.current?.adaptivityWithJsMediaQueriesHookResults,
-      ).toMatchObject(outProps);
+        render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...props} />);
+
+        // AdaptivityProvider results
+        expect(adaptivityProviderResultsRef.current?.adaptivityProviderResults).toMatchObject(
+          outProps,
+        );
+      });
+
+      test('useAdaptivityWithJSMediaQueries', () => {
+        const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
+
+        render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...props} />);
+
+        // useAdaptivityWithJSMediaQueries results
+        expect(
+          adaptivityProviderResultsRef.current?.adaptivityWithJsMediaQueriesHookResults,
+        ).toMatchObject(outProps);
+      });
     });
   });
 });

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.test.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.test.tsx
@@ -1,31 +1,92 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
+// import {hasMouse}from "@vkontakte/vkjs";
+import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { ViewHeight, ViewWidth } from '../../lib/adaptivity';
 import { baselineComponent } from '../../testing/utils';
 import { AdaptivityContext, type AdaptivityProps } from './AdaptivityContext';
 import { AdaptivityProvider, type AdaptivityProviderProps } from './AdaptivityProvider';
 
-const CatchAdaptivityProviderContext = React.forwardRef<AdaptivityProps>((_, ref) => {
-  const adaptivityProps = React.useContext(AdaptivityContext);
-  React.useImperativeHandle(ref, () => adaptivityProps, [adaptivityProps]);
+const hasMouseLibDetectionStub = jest.fn(() => false);
+jest.mock('@vkontakte/vkjs', () => ({
+  get hasMouse() {
+    return hasMouseLibDetectionStub();
+  },
+  get canUseDOM() {
+    return true;
+  },
+  detectIOS: () => false,
+}));
+const mediaQueryListSub = {
+  addEventListener: () => jest.fn(),
+  addListener: () => jest.fn(),
+  removeEventListener: () => jest.fn(),
+  removeListener: () => jest.fn(),
+};
+jest.mock('../../hooks/useMediaQueries', () => ({
+  useMediaQueries: () => ({
+    desktopPlus: () => mediaQueryListSub,
+    smallTabletPlus: () => mediaQueryListSub,
+    tablet: () => mediaQueryListSub,
+    smallTablet: () => mediaQueryListSub,
+    mobile: () => mediaQueryListSub,
+    mediumHeight: () => mediaQueryListSub,
+    mobileLandscapeHeight: () => mediaQueryListSub,
+  }),
+}));
+jest.mock('../../lib/matchMedia', () => ({
+  matchMediaListAddListener: () => jest.fn(),
+  matchMediaListRemoveListener: () => jest.fn(),
+}));
+
+const getViewWidthByMediaQueriesStub = jest.fn().mockReturnValue(ViewWidth.SMALL_MOBILE);
+const getViewHeightByMediaQueriesStub = jest.fn().mockReturnValue(ViewHeight.SMALL);
+jest.mock('../../lib/adaptivity', () => {
+  return {
+    ...jest.requireActual('../../lib/adaptivity'),
+    getViewWidthByMediaQueries: () => getViewWidthByMediaQueriesStub(),
+    getViewHeightByMediaQueries: () => getViewHeightByMediaQueriesStub(),
+  };
+});
+
+interface AdaptivityResultsRef {
+  adaptivityProviderResults: AdaptivityProps;
+  adaptivityWithJsMediaQueriesHookResults: AdaptivityProps;
+}
+
+const CatchAdaptivityProviderContext = React.forwardRef<AdaptivityResultsRef>((_, ref) => {
+  const adaptivityProviderResults = React.useContext(AdaptivityContext);
+  const adaptivityWithJsMediaQueriesHookResults = useAdaptivityWithJSMediaQueries();
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      adaptivityProviderResults,
+      adaptivityWithJsMediaQueriesHookResults,
+    }),
+    [adaptivityProviderResults, adaptivityWithJsMediaQueriesHookResults],
+  );
   return null;
 });
 
-const TestAdaptiveProvider = React.forwardRef<AdaptivityProps, AdaptivityProviderProps>(
-  (props, ref) => (
-    <AdaptivityProvider {...props}>
-      <CatchAdaptivityProviderContext ref={ref} />
-    </AdaptivityProvider>
-  ),
-);
+const TestAdaptiveProvider = React.forwardRef<
+  {
+    adaptivityProviderResults: AdaptivityProps;
+    adaptivityWithJsMediaQueriesHookResults: AdaptivityProps;
+  },
+  AdaptivityProviderProps
+>((props, ref) => (
+  <AdaptivityProvider {...props}>
+    <CatchAdaptivityProviderContext ref={ref} />
+  </AdaptivityProvider>
+));
 
-describe('AdaptivityProvider', () => {
+describe('AdaptivityProvider + useAdaptivityWithJSMediaQueries should return identical results for identical input', () => {
   baselineComponent(AdaptivityProvider, { forward: false, a11y: false, getRootRef: false });
 
   it('should return undefined adaptivity props', () => {
-    const adaptivityPropsRef = React.createRef<AdaptivityProps>();
-    render(<TestAdaptiveProvider ref={adaptivityPropsRef} />);
-    expect(adaptivityPropsRef.current).toEqual({
+    const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
+    render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} />);
+    expect(adaptivityProviderResultsRef.current?.adaptivityProviderResults).toEqual({
       sizeX: undefined,
       sizeY: undefined,
       viewWidth: undefined,
@@ -33,9 +94,26 @@ describe('AdaptivityProvider', () => {
     });
   });
 
-  it.each([
+  [
     {
-      inProps: { viewWidth: ViewWidth.DESKTOP, viewHeight: ViewHeight.MEDIUM },
+      inProps: {
+        viewWidth: ViewWidth.DESKTOP,
+        viewHeight: ViewHeight.MEDIUM,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'regular',
+        viewWidth: ViewWidth.DESKTOP,
+        viewHeight: ViewHeight.MEDIUM,
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.DESKTOP,
+        viewHeight: ViewHeight.MEDIUM,
+        hasMouseLibDetection: true,
+      },
       outProps: {
         sizeX: 'regular',
         sizeY: 'compact',
@@ -53,7 +131,24 @@ describe('AdaptivityProvider', () => {
       },
     },
     {
-      inProps: { viewWidth: ViewWidth.SMALL_TABLET, viewHeight: ViewHeight.MEDIUM },
+      inProps: {
+        viewWidth: ViewWidth.SMALL_TABLET,
+        viewHeight: ViewHeight.MEDIUM,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'regular',
+        viewWidth: ViewWidth.SMALL_TABLET,
+        viewHeight: ViewHeight.MEDIUM,
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.SMALL_TABLET,
+        viewHeight: ViewHeight.MEDIUM,
+        hasMouseLibDetection: true,
+      },
       outProps: {
         sizeX: 'regular',
         sizeY: 'compact',
@@ -66,6 +161,21 @@ describe('AdaptivityProvider', () => {
         sizeX: 'compact' as const,
         viewWidth: ViewWidth.SMALL_TABLET,
         viewHeight: ViewHeight.MEDIUM,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'compact',
+        sizeY: 'regular',
+        viewWidth: ViewWidth.SMALL_TABLET,
+        viewHeight: ViewHeight.MEDIUM,
+      },
+    },
+    {
+      inProps: {
+        sizeX: 'compact' as const,
+        viewWidth: ViewWidth.SMALL_TABLET,
+        viewHeight: ViewHeight.MEDIUM,
+        hasMouseLibDetection: true,
       },
       outProps: {
         sizeX: 'compact',
@@ -111,9 +221,134 @@ describe('AdaptivityProvider', () => {
         sizeY: 'regular',
       },
     },
-  ])('should define sizeX and sizeY adaptivity props', ({ inProps, outProps }) => {
-    const adaptivityPropsRef = React.createRef<AdaptivityProps>();
-    render(<TestAdaptiveProvider ref={adaptivityPropsRef} {...inProps} />);
-    expect(adaptivityPropsRef.current).toEqual(outProps);
+    {
+      inProps: {
+        viewWidth: ViewWidth.SMALL_MOBILE,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'compact',
+        sizeY: 'regular',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.SMALL_MOBILE,
+        hasMouseLibDetection: true,
+      },
+      outProps: {
+        sizeX: 'compact',
+        sizeY: 'regular',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.MOBILE,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'compact',
+        sizeY: 'regular',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.MOBILE,
+        hasMouseLibDetection: true,
+      },
+      outProps: {
+        sizeX: 'compact',
+        sizeY: 'regular',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.SMALL_TABLET,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'regular',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.SMALL_TABLET,
+        hasMouseLibDetection: true,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'compact',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.TABLET,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'regular',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.TABLET,
+        hasMouseLibDetection: true,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'compact',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.DESKTOP,
+        hasMouseLibDetection: false,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'regular',
+      },
+    },
+    {
+      inProps: {
+        viewWidth: ViewWidth.DESKTOP,
+        hasMouseLibDetection: true,
+      },
+      outProps: {
+        sizeX: 'regular',
+        sizeY: 'compact',
+      },
+    },
+  ].map((testOptions) => {
+    const { inProps, outProps } = testOptions;
+
+    const test = inProps.only ? it.only : it;
+
+    test(`should define sizeX and sizeY adaptivity props for input: \n${JSON.stringify(
+      inProps,
+      null,
+      '\t',
+    )}\n`, () => {
+      const { hasMouseLibDetection, ...props } = inProps;
+
+      hasMouseLibDetectionStub.mockReturnValue(hasMouseLibDetection ?? false);
+      getViewWidthByMediaQueriesStub.mockReturnValue(() => inProps.viewWidth);
+      getViewHeightByMediaQueriesStub.mockReturnValue(() => inProps.viewHeight);
+
+      const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
+
+      render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...props} />);
+
+      // AdaptivityProvider results
+      expect(adaptivityProviderResultsRef.current?.adaptivityProviderResults).toMatchObject(
+        outProps,
+      );
+      // useAdaptivityWithJSMediaQueries results
+      expect(
+        adaptivityProviderResultsRef.current?.adaptivityWithJsMediaQueriesHookResults,
+      ).toMatchObject(outProps);
+    });
   });
 });

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.test.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.test.tsx
@@ -6,11 +6,7 @@ import { baselineComponent } from '../../testing/utils';
 import { AdaptivityContext, type AdaptivityProps } from './AdaptivityContext';
 import { AdaptivityProvider, type AdaptivityProviderProps } from './AdaptivityProvider';
 
-const hasMouseLibDetectionStub = jest.fn(() => false);
 jest.mock('@vkontakte/vkjs', () => ({
-  get hasMouse() {
-    return hasMouseLibDetectionStub();
-  },
   get canUseDOM() {
     return true;
   },
@@ -71,7 +67,9 @@ const TestAdaptiveProvider = React.forwardRef<AdaptivityResultsRef, AdaptivityPr
 );
 
 interface TestSuite {
-  inProps: AdaptivityProviderProps & { hasMouseLibDetection?: boolean; runOnlyThisSuite?: boolean };
+  inProps: AdaptivityProviderProps & {
+    runOnlyThisSuite?: boolean;
+  };
   outProps: AdaptivityProps;
 }
 
@@ -80,7 +78,7 @@ const testSuites: TestSuite[] = [
     inProps: {
       viewWidth: ViewWidth.DESKTOP,
       viewHeight: ViewHeight.MEDIUM,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'regular',
@@ -93,7 +91,7 @@ const testSuites: TestSuite[] = [
     inProps: {
       viewWidth: ViewWidth.DESKTOP,
       viewHeight: ViewHeight.MEDIUM,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'regular',
@@ -115,7 +113,7 @@ const testSuites: TestSuite[] = [
     inProps: {
       viewWidth: ViewWidth.SMALL_TABLET,
       viewHeight: ViewHeight.MEDIUM,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'regular',
@@ -128,7 +126,7 @@ const testSuites: TestSuite[] = [
     inProps: {
       viewWidth: ViewWidth.SMALL_TABLET,
       viewHeight: ViewHeight.MEDIUM,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'regular',
@@ -142,7 +140,7 @@ const testSuites: TestSuite[] = [
       sizeX: 'compact' as const,
       viewWidth: ViewWidth.SMALL_TABLET,
       viewHeight: ViewHeight.MEDIUM,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'compact',
@@ -156,7 +154,7 @@ const testSuites: TestSuite[] = [
       sizeX: 'compact' as const,
       viewWidth: ViewWidth.SMALL_TABLET,
       viewHeight: ViewHeight.MEDIUM,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'compact',
@@ -205,7 +203,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.SMALL_MOBILE,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'compact',
@@ -215,7 +213,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.SMALL_MOBILE,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'compact',
@@ -225,7 +223,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.MOBILE,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'compact',
@@ -235,7 +233,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.MOBILE,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'compact',
@@ -245,7 +243,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.SMALL_TABLET,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'regular',
@@ -255,7 +253,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.SMALL_TABLET,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'regular',
@@ -265,7 +263,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.TABLET,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'regular',
@@ -275,7 +273,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.TABLET,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'regular',
@@ -285,7 +283,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.DESKTOP,
-      hasMouseLibDetection: false,
+      hasPointer: false,
     },
     outProps: {
       sizeX: 'regular',
@@ -295,7 +293,7 @@ const testSuites: TestSuite[] = [
   {
     inProps: {
       viewWidth: ViewWidth.DESKTOP,
-      hasMouseLibDetection: true,
+      hasPointer: true,
     },
     outProps: {
       sizeX: 'regular',
@@ -328,20 +326,16 @@ describe('AdaptiveProvider and useAdaptivityWithJSMediaQueries should return sim
       null,
       '\t',
     )}\n`, () => {
-      const { hasMouseLibDetection, ...props } = inProps;
-
       beforeEach(() => {
-        hasMouseLibDetectionStub.mockReturnValue(hasMouseLibDetection ?? false);
         getViewWidthByMediaQueriesStub.mockReturnValue(() => inProps.viewWidth);
         getViewHeightByMediaQueriesStub.mockReturnValue(() => inProps.viewHeight);
       });
 
       const test = inProps.runOnlyThisSuite ? it.only : it;
-
       test('AdaptiveProvider', () => {
         const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
 
-        render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...props} />);
+        render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...inProps} />);
 
         // AdaptivityProvider results
         expect(adaptivityProviderResultsRef.current?.adaptivityProviderResults).toMatchObject(
@@ -352,7 +346,7 @@ describe('AdaptiveProvider and useAdaptivityWithJSMediaQueries should return sim
       test('useAdaptivityWithJSMediaQueries', () => {
         const adaptivityProviderResultsRef = React.createRef<AdaptivityResultsRef>();
 
-        render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...props} />);
+        render(<TestAdaptiveProvider ref={adaptivityProviderResultsRef} {...inProps} />);
 
         // useAdaptivityWithJSMediaQueries results
         expect(

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { hasMouse as _hasPointer } from '@vkontakte/vkjs';
+import { hasMouse as _hasPointer, canUseDOM } from '@vkontakte/vkjs';
 import { getSizeX, isCompactByViewHeight, isCompactByViewWidth } from '../../lib/adaptivity';
 import { HasChildren } from '../../types';
 import { AdaptivityContext, type AdaptivityProps } from './AdaptivityContext';
@@ -18,7 +18,7 @@ export const AdaptivityProvider = ({
   hasHover,
   children,
 }: AdaptivityProviderProps) => {
-  const hasPointer = hasPointerProp ?? _hasPointer;
+  const hasPointer = hasPointerProp ?? (canUseDOM ? _hasPointer : undefined);
 
   const adaptivity = React.useMemo(() => {
     const nextProps: AdaptivityProps = {

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -30,13 +30,10 @@ export const AdaptivityProvider = ({
       nextProps.sizeX = getSizeX(viewWidth);
     }
 
-    if (sizeYProp === undefined && (viewWidth !== undefined || viewHeight !== undefined)) {
-      if (
-        (viewWidth !== undefined && isCompactByViewWidth(viewWidth, hasPointer)) ||
-        (viewHeight !== undefined && isCompactByViewHeight(viewHeight))
-      ) {
+    if (sizeYProp === undefined) {
+      if (isCompactByViewWidth(viewWidth, hasPointer) || isCompactByViewHeight(viewHeight)) {
         nextProps.sizeY = 'compact';
-      } else {
+      } else if (viewWidth !== undefined || viewHeight !== undefined) {
         nextProps.sizeY = 'regular';
       }
     }

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { hasMouse as _hasPointer } from '@vkontakte/vkjs';
 import { getSizeX, isCompactByViewHeight, isCompactByViewWidth } from '../../lib/adaptivity';
 import { HasChildren } from '../../types';
 import { AdaptivityContext, type AdaptivityProps } from './AdaptivityContext';
@@ -14,7 +13,7 @@ export const AdaptivityProvider = ({
   viewHeight,
   sizeX: sizeXProp,
   sizeY: sizeYProp,
-  hasPointer: hasPointerProp,
+  hasPointer,
   hasHover,
   children,
 }: AdaptivityProviderProps) => {
@@ -24,7 +23,7 @@ export const AdaptivityProvider = ({
       viewHeight,
       sizeX: sizeXProp,
       sizeY: sizeYProp,
-      hasPointer: hasPointerProp,
+      hasPointer,
       hasHover,
     };
     if (sizeXProp === undefined && viewWidth !== undefined) {
@@ -33,8 +32,7 @@ export const AdaptivityProvider = ({
 
     if (sizeYProp === undefined && (viewWidth !== undefined || viewHeight !== undefined)) {
       if (
-        (viewWidth !== undefined &&
-          isCompactByViewWidth(viewWidth, hasPointerProp ?? _hasPointer)) ||
+        (viewWidth !== undefined && isCompactByViewWidth(viewWidth, hasPointer)) ||
         (viewHeight !== undefined && isCompactByViewHeight(viewHeight))
       ) {
         nextProps.sizeY = 'compact';
@@ -44,7 +42,7 @@ export const AdaptivityProvider = ({
     }
 
     return nextProps;
-  }, [viewWidth, viewHeight, sizeXProp, sizeYProp, hasPointerProp, hasHover]);
+  }, [viewWidth, viewHeight, sizeXProp, sizeYProp, hasPointer, hasHover]);
 
   return <AdaptivityContext.Provider value={adaptivity}>{children}</AdaptivityContext.Provider>;
 };

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -14,10 +14,12 @@ export const AdaptivityProvider = ({
   viewHeight,
   sizeX: sizeXProp,
   sizeY: sizeYProp,
-  hasPointer,
+  hasPointer: hasPointerProp,
   hasHover,
   children,
 }: AdaptivityProviderProps) => {
+  const hasPointer = hasPointerProp ?? _hasPointer;
+
   const adaptivity = React.useMemo(() => {
     const nextProps: AdaptivityProps = {
       viewWidth,
@@ -33,7 +35,7 @@ export const AdaptivityProvider = ({
 
     if (sizeYProp === undefined && (viewWidth !== undefined || viewHeight !== undefined)) {
       if (
-        (viewWidth !== undefined && isCompactByViewWidth(viewWidth, _hasPointer)) ||
+        (viewWidth !== undefined && isCompactByViewWidth(viewWidth, hasPointer)) ||
         (viewHeight !== undefined && isCompactByViewHeight(viewHeight))
       ) {
         nextProps.sizeY = 'compact';

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { hasMouse as _hasPointer } from '@vkontakte/vkjs';
-import { ViewHeight, ViewWidth } from '../../lib/adaptivity';
+import { getSizeX, isCompactByViewHeight, isCompactByViewWidth } from '../../lib/adaptivity';
 import { HasChildren } from '../../types';
 import { AdaptivityContext, type AdaptivityProps } from './AdaptivityContext';
 
@@ -28,22 +28,20 @@ export const AdaptivityProvider = ({
       hasHover,
     };
     if (sizeXProp === undefined && viewWidth !== undefined) {
-      if (viewWidth <= ViewWidth.MOBILE) {
-        nextProps.sizeX = 'compact';
-      } else {
-        nextProps.sizeX = 'regular';
-      }
+      nextProps.sizeX = getSizeX(viewWidth);
     }
-    if (sizeYProp === undefined && viewWidth !== undefined && viewHeight !== undefined) {
+
+    if (sizeYProp === undefined) {
       if (
-        (viewWidth >= ViewWidth.SMALL_TABLET && _hasPointer) ||
-        viewHeight <= ViewHeight.EXTRA_SMALL
+        (viewWidth !== undefined && isCompactByViewWidth(viewWidth, _hasPointer)) ||
+        (viewHeight !== undefined && isCompactByViewHeight(viewHeight))
       ) {
         nextProps.sizeY = 'compact';
-      } else {
+      } else if (viewHeight !== undefined && viewHeight !== undefined) {
         nextProps.sizeY = 'regular';
       }
     }
+
     return nextProps;
   }, [viewWidth, viewHeight, sizeXProp, sizeYProp, hasPointer, hasHover]);
 

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -31,13 +31,13 @@ export const AdaptivityProvider = ({
       nextProps.sizeX = getSizeX(viewWidth);
     }
 
-    if (sizeYProp === undefined) {
+    if (sizeYProp === undefined && (viewWidth !== undefined || viewHeight !== undefined)) {
       if (
         (viewWidth !== undefined && isCompactByViewWidth(viewWidth, _hasPointer)) ||
         (viewHeight !== undefined && isCompactByViewHeight(viewHeight))
       ) {
         nextProps.sizeY = 'compact';
-      } else if (viewHeight !== undefined && viewHeight !== undefined) {
+      } else {
         nextProps.sizeY = 'regular';
       }
     }

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { hasMouse as _hasPointer, canUseDOM } from '@vkontakte/vkjs';
+import { hasMouse as _hasPointer } from '@vkontakte/vkjs';
 import { getSizeX, isCompactByViewHeight, isCompactByViewWidth } from '../../lib/adaptivity';
 import { HasChildren } from '../../types';
 import { AdaptivityContext, type AdaptivityProps } from './AdaptivityContext';
@@ -18,15 +18,13 @@ export const AdaptivityProvider = ({
   hasHover,
   children,
 }: AdaptivityProviderProps) => {
-  const hasPointer = hasPointerProp ?? (canUseDOM ? _hasPointer : undefined);
-
   const adaptivity = React.useMemo(() => {
     const nextProps: AdaptivityProps = {
       viewWidth,
       viewHeight,
       sizeX: sizeXProp,
       sizeY: sizeYProp,
-      hasPointer,
+      hasPointer: hasPointerProp,
       hasHover,
     };
     if (sizeXProp === undefined && viewWidth !== undefined) {
@@ -35,7 +33,8 @@ export const AdaptivityProvider = ({
 
     if (sizeYProp === undefined && (viewWidth !== undefined || viewHeight !== undefined)) {
       if (
-        (viewWidth !== undefined && isCompactByViewWidth(viewWidth, hasPointer)) ||
+        (viewWidth !== undefined &&
+          isCompactByViewWidth(viewWidth, hasPointerProp ?? _hasPointer)) ||
         (viewHeight !== undefined && isCompactByViewHeight(viewHeight))
       ) {
         nextProps.sizeY = 'compact';
@@ -45,7 +44,7 @@ export const AdaptivityProvider = ({
     }
 
     return nextProps;
-  }, [viewWidth, viewHeight, sizeXProp, sizeYProp, hasPointer, hasHover]);
+  }, [viewWidth, viewHeight, sizeXProp, sizeYProp, hasPointerProp, hasHover]);
 
   return <AdaptivityContext.Provider value={adaptivity}>{children}</AdaptivityContext.Provider>;
 };

--- a/packages/vkui/src/lib/adaptivity/functions.ts
+++ b/packages/vkui/src/lib/adaptivity/functions.ts
@@ -77,7 +77,7 @@ export function getSizeX(viewWidth: ViewWidthType): SizeTypeValues {
   return viewWidth <= ViewWidth.MOBILE ? 'compact' : 'regular';
 }
 
-export function isCompactByViewWidth(viewWidth: ViewWidthType, hasPointer: boolean) {
+export function isCompactByViewWidth(viewWidth: ViewWidthType, hasPointer?: boolean) {
   return viewWidth >= ViewWidth.SMALL_TABLET && hasPointer;
 }
 

--- a/packages/vkui/src/lib/adaptivity/functions.ts
+++ b/packages/vkui/src/lib/adaptivity/functions.ts
@@ -77,12 +77,20 @@ export function getSizeX(viewWidth: ViewWidthType): SizeTypeValues {
   return viewWidth <= ViewWidth.MOBILE ? 'compact' : 'regular';
 }
 
+export function isCompactByViewWidth(viewWidth: ViewWidthType, hasPointer: boolean) {
+  return viewWidth >= ViewWidth.SMALL_TABLET && hasPointer;
+}
+
+export function isCompactByViewHeight(viewHeight: ViewHeightType) {
+  return viewHeight <= ViewHeight.EXTRA_SMALL;
+}
+
 export function getSizeY(
   viewWidth: ViewWidthType,
   viewHeight: ViewHeightType,
   hasPointer: boolean,
 ): SizeTypeValues {
-  if ((viewWidth >= ViewWidth.SMALL_TABLET && hasPointer) || viewHeight <= ViewHeight.EXTRA_SMALL) {
+  if (isCompactByViewWidth(viewWidth, hasPointer) || isCompactByViewHeight(viewHeight)) {
     return 'compact';
   }
   return 'regular';

--- a/packages/vkui/src/lib/adaptivity/functions.ts
+++ b/packages/vkui/src/lib/adaptivity/functions.ts
@@ -77,12 +77,12 @@ export function getSizeX(viewWidth: ViewWidthType): SizeTypeValues {
   return viewWidth <= ViewWidth.MOBILE ? 'compact' : 'regular';
 }
 
-export function isCompactByViewWidth(viewWidth: ViewWidthType, hasPointer?: boolean) {
-  return viewWidth >= ViewWidth.SMALL_TABLET && hasPointer;
+export function isCompactByViewWidth(viewWidth: ViewWidthType | undefined, hasPointer?: boolean) {
+  return viewWidth !== undefined && viewWidth >= ViewWidth.SMALL_TABLET && hasPointer;
 }
 
-export function isCompactByViewHeight(viewHeight: ViewHeightType) {
-  return viewHeight <= ViewHeight.EXTRA_SMALL;
+export function isCompactByViewHeight(viewHeight: ViewHeightType | undefined) {
+  return viewHeight !== undefined && viewHeight <= ViewHeight.EXTRA_SMALL;
 }
 
 export function getSizeY(


### PR DESCRIPTION
- close #6476 

---

- [x] Unit-тесты

## Описание


## Изменения
- переделаны условия вычисления sizeY. 
  - использованы идентичные с `useAdaptivityWithJSMediaQueries` функции из `lib/adoptivity/functions`.
   Если `viewWidth` и `hasPointer` переданы, то мы вычисляем `sizeY`. Раньше мы вычисляли sizeY только если заданы оба пропа: `viewWidth` и `viewHeight`.
  -`hasPointer`, передаваемый в контекст из `AdoptiveProvider` теперь используется в вычислении sizeY. Раньше мы этот проп не использовали, а брали hasPointer из библиотеки vkjs.
  - переработаны тесты, чтобы сравнить результат `AdoptiveProvider` и `useAdaptivityWithJSMediaQueries`. Может и не очень честно так сравнивать, ведь `useAdaptivityWithJSMediaQueries` использует контекст `AdoptiveProvider`, но мы должны быть уверены, что результаты идентичны.
