### PR TITLE
fix(codemode): wait tooltip transform first before text-tooltip

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui-codemods",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Codemods for automatic VKUI major version upgrade",
   "repository": "https://github.com/VKCOM/VKUI",
   "homepage": "https://vkcom.github.io/VKUI/",

--- a/packages/codemods/src/getAvailableCodemods.ts
+++ b/packages/codemods/src/getAvailableCodemods.ts
@@ -4,12 +4,30 @@ export const TRANSFORM_DIR = `${__dirname}/transforms`;
 
 let CODEMODS: string[] = [];
 
-export default function getAvailableCodemods() {
+const swapElementsOfArray = (a: number, b: number, array: unknown[]) => {
+  if (a === -1 || b === -1) {
+    return;
+  }
+
+  const valueA = array[a];
+  const valueB = array[b];
+
+  array[b] = valueA;
+  array[a] = valueB;
+};
+
+export default function getAvailableCodemods(dirname = TRANSFORM_DIR) {
   if (CODEMODS.length === 0) {
     CODEMODS = fs
-      .readdirSync(TRANSFORM_DIR)
-      .filter((fname) => fname.endsWith('.js'))
+      .readdirSync(dirname)
+      .filter((fname) => fname.endsWith('.js') || fname.endsWith('.ts'))
       .map((fname) => fname.slice(0, -3));
+
+    swapElementsOfArray(
+      CODEMODS.findIndex((fname) => fname === 'text-tooltip'),
+      CODEMODS.findIndex((fname) => fname === 'tooltip'),
+      CODEMODS,
+    );
   }
 
   return CODEMODS;

--- a/packages/codemods/src/testHelpers/testHelper.ts
+++ b/packages/codemods/src/testHelpers/testHelper.ts
@@ -5,9 +5,23 @@
  */
 import fs from 'fs';
 import path from 'path';
-// @ts-expect-error: TS7016 no types for package
-import { defineSnapshotTest } from 'jscodeshift/dist/testUtils';
+import {
+  applyTransform,
+  defineSnapshotTest,
+  // @ts-expect-error: TS7016 no types for package
+} from 'jscodeshift/dist/testUtils';
 import { JSCodeShiftOptions } from '../types';
+
+export { applyTransform };
+
+export function getTestFixturesInputPath(
+  dirName: string,
+  testFilePrefix: string,
+  extension = 'tsx',
+) {
+  const fixtureDir = path.join(dirName, '..', '__testfixtures__');
+  return path.join(fixtureDir, testFilePrefix + `.input.${extension}`);
+}
 
 /**
  * Handles file-loading boilerplates, using same defaults as defineTest
@@ -21,8 +35,7 @@ export function defineSnapshotTestFromFixture(
 ) {
   // Assumes transform is one level up from __tests__ directory
   const module = require(path.join(dirName, '..', transformName));
-  const fixtureDir = path.join(dirName, '..', '__testfixtures__');
-  const inputPath = path.join(fixtureDir, testFilePrefix + `.input.${extension}`);
+  const inputPath = getTestFixturesInputPath(dirName, testFilePrefix, extension);
   const source = fs.readFileSync(inputPath, 'utf8');
   defineSnapshotTest(module, options, source, 'transforms correctly');
 }

--- a/packages/codemods/src/transforms/__tests__/__snapshots__/text-tooltip.ts.snap
+++ b/packages/codemods/src/transforms/__tests__/__snapshots__/text-tooltip.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`text-tooltip should apply after \`transforms/tooltip.ts\` 1`] = `
+"import { Tooltip as TextTooltip } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <React.Fragment>
+      <TextTooltip
+        offsetByCrossAxis={0}
+        offsetByMainAxis={0}
+        usePortal={someHTMLElement}
+        getRootRef={getRef}
+        hoverDelay={[5, 10]}>
+        123
+      </TextTooltip>
+
+      <TextTooltip hoverDelay={5}>123</TextTooltip>
+
+      <TextTooltip hoverDelay={[0, 5]}>123</TextTooltip>
+    </React.Fragment>
+  );
+};"
+`;
+
 exports[`text-tooltip transforms correctly 1`] = `
 "import { Tooltip as TextTooltip } from '@vkontakte/vkui';
 import React from 'react';

--- a/packages/codemods/src/transforms/__tests__/text-tooltip.ts
+++ b/packages/codemods/src/transforms/__tests__/text-tooltip.ts
@@ -1,12 +1,33 @@
 jest.autoMockOff();
 
-import { defineSnapshotTestFromFixture } from '../../testHelpers/testHelper';
+import fs from 'fs';
+import path from 'path';
+import getAvailableCodemods from '../../getAvailableCodemods';
+import {
+  applyTransform,
+  defineSnapshotTestFromFixture,
+  getTestFixturesInputPath,
+} from '../../testHelpers/testHelper';
 
 const name = 'text-tooltip';
 const fixtures = ['basic'] as const;
+const basicFixture = fixtures[0];
 
 describe(name, () => {
   fixtures.forEach((test) =>
     defineSnapshotTestFromFixture(__dirname, name, global.TRANSFORM_OPTIONS, `${name}/${test}`),
   );
+
+  it('should apply after `transforms/tooltip.ts`', () => {
+    const codemodes = getAvailableCodemods(path.resolve(__dirname, '../'));
+    const inputPath = getTestFixturesInputPath(__dirname, `${name}/${basicFixture}`);
+    let source = fs.readFileSync(inputPath, 'utf8');
+
+    codemodes.forEach((transformName) => {
+      const module = require(path.join(__dirname, '..', transformName));
+      source = applyTransform(module, global.TRANSFORM_OPTIONS, { source });
+    });
+
+    expect(source).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

Исправляет порядок срабатывания трансформации `transforms/tooltip` и `transforms/text-tooltip` при использовании флага `--all`. До этого сначала срабатывал `transforms/text-tooltip` и заменял `unstable_TextTooltip` на `Tooltip` из-за чего `transforms/tooltip` перетирал `Tooltip` на `OnboardingTooltip`.

## Изменения

Под unit-тесты были сделано следующее:

- Вынес получение пути до **fixtures** в фукнцию `getTestFixturesInputPath`.
- Экспортирую `applyTransform` из `jscodeshift/dist/testUtils`.
- В `getAvailableCodemods` добавил фильтрацию и по `'.ts'` расширению.