### PR TITLE
fix: Change editor color in doc

### DIFF
--- a/styleguide/Components/Editor/Editor.css
+++ b/styleguide/Components/Editor/Editor.css
@@ -18,5 +18,5 @@
 }
 
 .Editor textarea {
-  color: blue !important;
+  color: var(--vkui--color_text_subhead) !important;
 }


### PR DESCRIPTION
- caused by #6447

На светлой теме исправилась подсветка, но на темной теме курсор терялся, подобрала более подходящий токен: 


https://github.com/VKCOM/VKUI/assets/7431217/3d5034fa-df17-409a-953c-6a67cb9ca6f2


https://github.com/VKCOM/VKUI/assets/7431217/189b0547-00f5-4fdd-9b35-fcef32132ed3

