### PR TITLE
ci(pull_request_common): check to open state before add patch label

### DIFF
--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -16,7 +16,7 @@ jobs:
     name: Add labels
     steps:
       - name: Patch
-        if: ${{ startsWith(github.event.pull_request.title, 'fix') }}
+        if: ${{ startsWith(github.event.pull_request.title, 'fix') && github.event.pull_request.state == 'open' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Описание

Проверяем на `github.event.pull_request.state == 'open'`, чтобы `patch` добавлялся только при открытии PR. Бывает случае, что нам не нужен этот лейбел, мы его удаляем, но как только стоит запушить в ветку, то лейбел заново добавляется.

- caused by #5495