### PR TITLE
chore: fix token for dedupe action

### DIFF
--- a/.github/workflows/dedupe_deps.yml
+++ b/.github/workflows/dedupe_deps.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Create pull request with deduped deps
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           title: 'chore: Deduplicate dependencies on ${{ github.ref_name }}'
           branch: ${{ github.ref_name }}-dedupe-deps
           commit-message: 'chore: deduplicate dependencies'


### PR DESCRIPTION
## Описание

Сейчас PR от лица `github-action` не триггерит CI 

## Изменения

Заменяем гитхабовский токен на наш сервисный (как сказано в [этой дискуссии](https://github.com/orgs/community/discussions/65321))
