### PR TITLE
ci(publish_prerelease): unify the workflow for all packages; separates deploy part

### DIFF
--- a/.github/actions/publish-workflow-1-setup/action.yml
+++ b/.github/actions/publish-workflow-1-setup/action.yml
@@ -1,0 +1,23 @@
+name: Publish Workflow / Setup
+description: It setting up the repository environment for publish
+
+runs:
+  using: composite
+  steps:
+    - name: Setup NodeJS
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'yarn'
+        always-auth: true
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
+      shell: bash
+
+    - name: Set Git credentials
+      run: |
+        git config --local user.email "actions@github.com"
+        git config --local user.name "GitHub Action"
+      shell: bash

--- a/.github/actions/publish-workflow-2-bump-version/action.yml
+++ b/.github/actions/publish-workflow-2-bump-version/action.yml
@@ -1,0 +1,42 @@
+name: Publish Workflow / Bump version
+description: It bump version of provided package
+
+inputs:
+  package_name:
+    description: package's name
+    required: true
+  new_version:
+    description: <newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease
+    required: true
+  pre_id:
+    description: tag for NPM artifact
+    required: false
+
+outputs:
+  prev_version:
+    value: ${{ steps.internal_id_prev_version.outputs.value }}
+  next_version:
+    value: ${{ steps.internal_id_next_version.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - name: Saving current version to env
+      id: internal_id_prev_version
+      run: echo "value=$(yarn workspace ${{ inputs.package_name }} node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Bump ${{ inputs.package_name }} package by version type
+      if: ${{ !inputs.pre_id }}
+      run: yarn workspace ${{ inputs.package_name }} run g:npm:version ${{ inputs.new_version }}
+      shell: bash
+
+    - name: Bump ${{ inputs.package_name }} package by version type (with --preid flag)
+      if: ${{ inputs.pre_id }}
+      run: yarn workspace ${{ inputs.package_name }} run g:npm:version ${{ inputs.new_version }} --preid ${{ inputs.pre_id }}
+      shell: bash
+
+    - name: Saving new version to env
+      id: internal_id_next_version
+      run: echo "value=$(yarn workspace ${{ inputs.package_name }} node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/publish-workflow-3-validation/action.yml
+++ b/.github/actions/publish-workflow-3-validation/action.yml
@@ -1,0 +1,22 @@
+name: Publish Workflow / Validation
+description: It runs pre-publish checks
+
+inputs:
+  package_name:
+    description: package's name
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run linters
+      run: yarn run lint
+      shell: bash
+
+    - name: Run build
+      run: yarn workspace ${{ inputs.package_name }} run build
+      shell: bash
+
+    - name: Run tests and linters
+      run: yarn workspace ${{ inputs.package_name }} run test
+      shell: bash

--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -1,0 +1,85 @@
+name: Publish Workflow / Complete
+description: It finish publishing
+
+inputs:
+  branch:
+    description: target branch for git push
+    required: true
+  prev_version:
+    description: package's prev version
+    required: true
+  next_version:
+    description: package's next version
+    required: true
+  package_name:
+    description: package's name
+    required: true
+  token:
+    description: token for write access to repository
+    required: true
+  npm_token:
+    description: token for publish package to NPM
+    required: true
+  npm_tag:
+    description: tag for NPM artifact
+    required: false
+    default: latest
+  use_git_tag_with_namespace:
+    required: false
+    default: true
+
+outputs:
+  prev_version:
+    description: Previous version of package
+    value: ${{ steps.internal_id_prev_version.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - name: Commit
+      run: |
+        git add -A
+        git commit -m 'bump(${{ inputs.package_name }}): from ${{ inputs.prev_version }} to ${{ inputs.next_version }}'
+      shell: bash
+
+    - name: Create tag for core package
+      if: ${{ inputs.use_git_tag_with_namespace }}
+      run: git tag v${{ inputs.next_version }}
+      shell: bash
+
+    - name: Create tag for other package
+      if: ${{ !inputs.use_git_tag_with_namespace }}
+      run: git tag ${{ inputs.package_name }}@${{ inputs.next_version }}
+      shell: bash
+
+    - name: Generate archive
+      # ../../ – это путь до корня из директории `packages/<name>`
+      run: yarn workspace ${{ inputs.package_name }} pack --out ../../artifact.tgz
+      shell: bash
+
+    - name: Publishing release
+      run: |
+        npm publish artifact.tgz --tag ${{ inputs.npm_tag }}
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+      shell: bash
+
+    - name: Pushing changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.token }}
+        branch: ${{ inputs.branch }}
+        tags: true
+
+    - name: Prepare payload data
+      run: |
+        mkdir -p publish_workflow_payload
+        echo ${{ inputs.outputs.next_version }} > publish_workflow_payload/next_version.txt
+        echo ${{ inputs.outputs.package_name }} > publish_workflow_payload/package_name.txt
+
+    - name: Upload payload data to artifact for deploy workflow
+      uses: actions/upload-artifact@v4
+      with:
+        name: publish_workflow_payload
+        path: publish_workflow_payload/
+        retention-days: 1

--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -28,11 +28,6 @@ inputs:
     required: false
     default: true
 
-outputs:
-  prev_version:
-    description: Previous version of package
-    value: ${{ steps.internal_id_prev_version.outputs.value }}
-
 runs:
   using: composite
   steps:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,17 @@
+name: Setup
+description: It setting up the repository environment
+
+runs:
+  using: composite
+  steps:
+    - name: Setup NodeJS
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'yarn'
+        always-auth: true
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
+      shell: bash

--- a/.github/workflows/publish_deploy.yml
+++ b/.github/workflows/publish_deploy.yml
@@ -1,0 +1,89 @@
+name: 'Publish: Deploy (⚠️ use manually call only if necessary)'
+# Note: display_title не задокументирован
+run-name: '${{ github.event.workflow_run.display_title }} • ${{ github.event.workflow_run.head_branch }} • ${{ github.event.workflow_run.id }}'
+
+on:
+  # TODO Добавить также 'Publish release'.
+  # Сейчас он называется 'Publish @vkontakte/vkui'. Надо будет переименовать в 'Publish release' и
+  # отвязать от @vkontakte/vkui.
+  workflow_run:
+    workflows: ['Publish pre-release']
+    types: [completed]
+  # Note: только на случай, если потребуется ручной запуск
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: "package's name:"
+        required: true
+        type: choice
+        options:
+          - '@vkontakte/vkui'
+      next_version:
+        description: "package's version (without 'v'):"
+        required: true
+        type: string
+
+jobs:
+  payload:
+    name: Prepare payload data
+    runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.payload.outputs.package_name }}
+      next_version: ${{ steps.payload.outputs.next_version }}
+    steps:
+      - name: Download artifact (if it is 'workflow_run')
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success' }}
+        id: artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: publish_workflow_payload
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Parse artifact (if it is 'workflow_run')
+        if: ${{ steps.artifact.conclusion == 'success' }}
+        id: payload
+        run: |
+          echo "package_name=$(cat publish_workflow_payload/package_name.txt)" >> $GITHUB_OUTPUT
+          echo "next_version=$(cat publish_workflow_payload/next_version.txt)" >> $GITHUB_OUTPUT
+
+      - name: Parse inputs (if it is 'workflow_dispatch')
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.package_name && inputs.next_version }}
+        run: |
+          echo ${{ inputs.package_name }} >> $GITHUB_OUTPUT
+          echo ${{ inputs.next_version }} >> $GITHUB_OUTPUT
+
+  deploy_vkui_docs:
+    needs: [payload]
+    if: ${{ success() && needs.payload.outputs.package_name == '@vkontakte/vkui' }}
+    runs-on: ubuntu-latest
+    name: Deploy ${{ needs.payload.outputs.package_name }} docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setting up the repository environment
+        uses: ./.github/actions/setup
+
+      - name: Creating docs for pre-release
+        if: ${{ github.event.workflow_run.name == 'Publish pre-release' }}
+        run: |
+          yarn run docs:styleguide:build --dist dist/${{ needs.payload.outputs.next_version }}
+          yarn run docs:storybook:build -o ../../styleguide/dist/${{ needs.payload.outputs.next_version }}/playground
+
+      - name: Creating docs for release
+        if: ${{ github.event.workflow_run.name == 'Publish release' }}
+        run: |
+          yarn run docs:styleguide:build --dist dist
+          yarn run docs:storybook:build -o ../../styleguide/dist/playground
+          mkdir -p styleguide/${{ needs.payload.outputs.next_version }}
+          cp -R styleguide/dist/* styleguide/${{ needs.payload.outputs.next_version }}
+          mv styleguide/${{ needs.payload.outputs.next_version }} styleguide/dist
+
+      - name: Publishing doc
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: styleguide/dist
+          clean: false
+          force: false

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -1,10 +1,19 @@
-name: 'Publish @vkontakte/vkui (pre-release)'
+name: 'Publish pre-release'
 
 on:
   workflow_dispatch:
     inputs:
-      type:
-        description: 'version type (prerelease for bumping pre-release version):'
+      package_name:
+        description: "package's name:"
+        required: true
+        type: choice
+        options:
+          - '@vkontakte/vkui'
+          - '@vkontakte/vkui-floating-ui'
+          - '@vkontakte/vkui-token-translator'
+          - '@vkontakte/vkui-codemods'
+      new_version:
+        description: 'version type (use prerelease for bumping pre-release version):'
         required: true
         type: choice
         default: 'prerelease'
@@ -13,25 +22,26 @@ on:
           - preminor
           - premajor
           - prerelease
-      tag:
+      npm_tag_aka_pre_id:
+        description: 'NPM tag:'
         required: true
-        description: 'tag ("beta" or "alpha"):'
         type: choice
         default: 'beta'
         options:
-          - beta
           - alpha
+          - beta
+          - rc
       custom_version:
-        description: 'custom version: x.y.z-beta.0 (without "v")'
+        description: 'use syntax x.y.z-beta.0, without "v" (it will ignore "version type" & "NPM tag" parameters):'
         required: false
 
-run-name: Publish pre-release ${{ inputs.type }} ${{ inputs.custom_version }} (tag ${{ inputs.tag }})
+run-name: Publish pre-release ${{ github.event.inputs.package_name }} ${{ inputs.new_version }} ${{ inputs.custom_version }} (tag ${{ inputs.npm_tag_aka_pre_id }})
 
 jobs:
   publish:
     concurrency: ci-gh-pages
     outputs:
-      release_tag: ${{ steps.updated_version.outputs.version }}
+      release_tag: ${{ steps.updated_versions_info.outputs.next_version }}
     permissions:
       id-token: write
     runs-on: ubuntu-latest
@@ -41,80 +51,31 @@ jobs:
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
 
-      - name: Setup NodeJS
-        uses: actions/setup-node@v4
+      - name: Setting up the repository environment
+        uses: ./.github/actions/publish-workflow-1-setup
+
+      - name: Bump version
+        id: updated_versions_info
+        uses: ./.github/actions/publish-workflow-2-bump-version
         with:
-          node-version: 20
-          cache: 'yarn'
-          always-auth: true
-          registry-url: 'https://registry.npmjs.org'
+          package_name: ${{ github.event.inputs.package_name }}
+          new_version: ${{ github.event.inputs.custom_version || github.event.inputs.new_version }}
+          # Ignore `pre_id` if `custom_version` is specified
+          pre_id: ${{ !github.event.inputs.custom_version && github.event.inputs.npm_tag_aka_pre_id || '' }}
 
-      - name: Install dependencies
-        run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
-
-      - name: Run linters
-        run: yarn run lint
-
-      - name: Run @vkontakte/vkui unit tests
-        run: yarn workspace @vkontakte/vkui run test
-
-      - name: Set Git credentials
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Action"
-
-      - name: Saving current version to env
-        id: prev_version
-        run: |
-          echo "version=$(yarn workspace @vkontakte/vkui node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-      - name: Bump by version type
-        if: ${{ !github.event.inputs.custom_version }}
-        run: yarn workspace @vkontakte/vkui run g:npm:version ${{ github.event.inputs.type }} --preid ${{ github.event.inputs.tag }}
-
-      - name: Bump by custom version
-        if: ${{ github.event.inputs.custom_version }}
-        run: yarn workspace @vkontakte/vkui run g:npm:version ${{ github.event.inputs.custom_version }} --preid ${{ github.event.inputs.tag }}
-
-      - name: Saving updated version to env
-        id: updated_version
-        run: |
-          echo "version=$(yarn workspace @vkontakte/vkui node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-      - name: Adding commit and tag with updated version number
-        run: |
-          git add -A
-          git commit -m 'bump(@vkontakte/vkui): from ${{ steps.prev_version.outputs.version }} to ${{ steps.updated_version.outputs.version }}'
-          git tag v${{ steps.updated_version.outputs.version }}
-
-      - name: Pushing changes
-        uses: ad-m/github-push-action@master
+      - name: Run pre-publish checks
+        uses: ./.github/actions/publish-workflow-3-validation
         with:
-          github_token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          package_name: ${{ github.event.inputs.package_name }}
+
+      - name: Complete publish
+        uses: ./.github/actions/publish-workflow-4-complete
+        with:
           branch: ${{ github.ref }}
-          tags: true
-
-      - name: Generate archive
-        working-directory: ./packages/vkui
-        run: yarn pack
-
-      - name: Publishing release
-        working-directory: ./packages/vkui
-        run: |
-          npm publish package.tgz --tag ${{ github.event.inputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
-
-      - name: Build styleguide
-        run: yarn run docs:styleguide:build --dist dist/${{ steps.updated_version.outputs.version }}
-      - name: Build storybook
-        run: yarn docs:storybook:build -o ../../styleguide/dist/${{ steps.updated_version.outputs.version }}/playground
-
-      - name: Publishing doc
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
+          prev_version: ${{ steps.updated_versions_info.outputs.prev_version }}
+          next_version: ${{ steps.updated_versions_info.outputs.next_version }}
+          package_name: ${{ github.event.inputs.package_name }}
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: styleguide/dist
-          clean: false
-          force: false
+          npm_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
+          npm_tag: ${{ github.event.inputs.npm_tag_aka_pre_id }}
+          use_git_tag_with_namespace: ${{ github.event.inputs.package_name != '@vkontakte/vkui' }}


### PR DESCRIPTION
## Изменения

### `publish_prerelease.yml`

Унифицируем воркфлоу под остальные пакеты.

Такое же решение применял в [vk-bridge/.github/workflows/publish_prerelease.yml](https://github.com/VKCOM/vk-bridge/blob/13d54fca1e5a5424da15c0bb91415cd9e78f17cd/.github/workflows/publish_prerelease.yml).

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/6d4987ef-0884-46fc-a259-550e8a8bd310"> <img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/6a147b2a-ed94-428c-883a-10ce6abda8da">


### `publish_deploy.yml`

Вынес шаги с созданием документации в отдельный вокрфлоу, чтобы была возможность отдельно контролировать выпуск документации.

Сейчас, если в процессе паблиша упадёт сборка доки, то нельзя безопасно перезапустить её.

По умолчанию, запускается на успешное окончание `publish_prerelease.yml` (в дальнейшем и на `publish_release.yml`). В крайнем случае можно будет запустить вручную передав название пакета и версию.

### `.github/actions/`

Выносим некоторые общие шаги в отдельные пользовательские экшены. В дальнейшем будет шарится между `publish_prerelease.yml` и `publish_release.yml`. В этой ветке используют только `publish_prerelease.yml` и `publish_deploy.yml`.

## TODO

Отрефакторить подобным образом и `publish.yml`.

Необходимо будет:
- вынести в новый воркфлоу `publish_release.yml`, а https://github.com/VKCOM/VKUI/actions/workflows/publish.yml задизейблить, т.к. привязан к `@vkontakte/vkui`;
- удалить [publish_codemods.yml](https://github.com/VKCOM/VKUI/blob/master/.github/workflows/publish_codemods.yml);
- удалить [publish_vkui_floating_ui_react_dom.yml](https://github.com/VKCOM/VKUI/blob/master/.github/workflows/publish_vkui_floating_ui_react_dom.yml);
- удалить [publish_token_translator.yml](https://github.com/VKCOM/VKUI/blob/master/.github/workflows/publish_token_translator.yml).