### PR TITLE
fix(.github/actions/publish-workflow-4-complete): add missed `shell: bash`

### DIFF
--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -71,6 +71,7 @@ runs:
         mkdir -p publish_workflow_payload
         echo ${{ inputs.outputs.next_version }} > publish_workflow_payload/next_version.txt
         echo ${{ inputs.outputs.package_name }} > publish_workflow_payload/package_name.txt
+      shell: bash
 
     - name: Upload payload data to artifact for deploy workflow
       uses: actions/upload-artifact@v4

--- a/.github/workflows/publish_deploy.yml
+++ b/.github/workflows/publish_deploy.yml
@@ -56,7 +56,7 @@ jobs:
     needs: [payload]
     if: ${{ success() && needs.payload.outputs.package_name == '@vkontakte/vkui' }}
     runs-on: ubuntu-latest
-    name: Deploy ${{ needs.payload.outputs.package_name }} docs
+    name: Deploy @vkontakte/vkui docs
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Описание

1. Не добавил `shell: bash`:
    > ❌ [publish](https://github.com/VKCOM/VKUI/actions/runs/7830906758/job/21366046530#step:6:1) /home/runner/work/VKUI/VKUI/./.github/actions/publish-workflow-4-complete/action.yml (Line: 69, Col: 7): Required property is missing: shell
2. Заменил в `publish_deploy.yml` переменную на статичный текст `@vkontakte/vkui`
    <img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/47aa8efd-b5bd-4e99-9a15-929019e1281f">

---

- caused by https://github.com/VKCOM/VKUI/pull/6526