### PR TITLE
patch(v5): pr6489

### DIFF
--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import { hasMouse as _hasPointer } from '@vkontakte/vkjs';
 import { BridgeAdaptivity, useBridgeAdaptivity } from '../../hooks/useBridgeAdaptivity';
-import { BREAKPOINTS, SizeType, ViewHeight, ViewWidth } from '../../lib/adaptivity';
+import {
+  BREAKPOINTS,
+  getSizeX,
+  isCompactByViewHeight,
+  isCompactByViewWidth,
+  SizeType,
+  ViewHeight,
+  ViewWidth,
+} from '../../lib/adaptivity';
 import { warnOnce } from '../../lib/warnOnce';
 import { HasChildren } from '../../types';
 import { AdaptivityContext, type AdaptivityProps } from './AdaptivityContext';
@@ -116,19 +124,13 @@ function calculateAdaptivity(
     }
   } else {
     if (sizeX === undefined && viewWidth !== undefined) {
-      if (viewWidth <= ViewWidth.MOBILE) {
-        sizeX = SizeType.COMPACT;
-      } else {
-        sizeX = SizeType.REGULAR;
-      }
+      sizeX = getSizeX(viewWidth);
     }
-    if (sizeY === undefined && viewWidth !== undefined && viewHeight !== undefined) {
-      if (
-        (viewWidth >= ViewWidth.SMALL_TABLET && _hasPointer) ||
-        viewHeight <= ViewHeight.EXTRA_SMALL
-      ) {
+
+    if (sizeY === undefined) {
+      if (isCompactByViewWidth(viewWidth, hasPointer) || isCompactByViewHeight(viewHeight)) {
         sizeY = SizeType.COMPACT;
-      } else {
+      } else if (viewWidth !== undefined || viewHeight !== undefined) {
         sizeY = SizeType.REGULAR;
       }
     }

--- a/packages/vkui/src/lib/adaptivity/functions.ts
+++ b/packages/vkui/src/lib/adaptivity/functions.ts
@@ -75,12 +75,20 @@ export function getSizeX(viewWidth: ViewWidth): SizeType {
   return viewWidth <= ViewWidth.MOBILE ? SizeType.COMPACT : SizeType.REGULAR;
 }
 
+export function isCompactByViewWidth(viewWidth: ViewWidth | undefined, hasPointer?: boolean) {
+  return viewWidth !== undefined && viewWidth >= ViewWidth.SMALL_TABLET && hasPointer;
+}
+
+export function isCompactByViewHeight(viewHeight: ViewHeight | undefined) {
+  return viewHeight !== undefined && viewHeight <= ViewHeight.EXTRA_SMALL;
+}
+
 export function getSizeY(
   viewWidth: ViewWidth,
   viewHeight: ViewHeight,
   hasPointer: boolean,
 ): SizeType {
-  if ((viewWidth >= ViewWidth.SMALL_TABLET && hasPointer) || viewHeight <= ViewHeight.EXTRA_SMALL) {
+  if (isCompactByViewWidth(viewWidth, hasPointer) || isCompactByViewHeight(viewHeight)) {
     return SizeType.COMPACT;
   }
   return SizeType.REGULAR;


### PR DESCRIPTION
- [x] Unit-тесты

## Описание
Это черри пик merge коммита bf26ee0145f26a1ea622d079b6349f06dc474812 из #6489 
Попытка перенести исправления в подсчёте `sizeY` у `AdoptivityProvider`.

Готов закрыть этот PR, если в изменениях нету большого смысла. Хотя [баг](https://github.com/VKCOM/VKUI/issues/6476) был именно для v5.

## Изменения
- в целом мы полностью переносим логику затрагивающую работу `AdoptivityProvider` без `bridge`.
В то же время логику c `bridge` мы не трогаем. В том числе оставляем *неявное* использование `_hasPointer` из `vkjs` и игнорирование `hasPointer` свойства `AdoptivityProvider`. Сделано специально, чтобы никак не затронуть пользователей bridge, ведь на них баг не распространяется.
https://github.com/VKCOM/VKUI/blob/f361335092b365360b3b8ee65c145fb6b621a414/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx#L105-L112
https://github.com/VKCOM/VKUI/blob/f361335092b365360b3b8ee65c145fb6b621a414/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx#L2


```js
export const hasMouse = /*#__PURE__*/ (() => detect.hasMouse)();
```
[hasMouse source](https://github.com/VKCOM/vkjs/blob/3ab9216c6c9f7f48998176e9403eaba7450b9a31/src/InputUtils.ts#L48)

Также я заметил, что есть специльный тест, котороый реагирует именно на `_hasPointer` проверку, так что оставил, в v6 мы всё равно это убираем.
https://github.com/VKCOM/VKUI/blob/f361335092b365360b3b8ee65c145fb6b621a414/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.test.tsx#L300-L308

