### PR TITLE
ci(publish_release, publish_deploy): fix workflows issues

### DIFF
--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -69,8 +69,8 @@ runs:
     - name: Prepare payload data
       run: |
         mkdir -p publish_workflow_payload
-        echo ${{ inputs.outputs.next_version }} > publish_workflow_payload/next_version.txt
-        echo ${{ inputs.outputs.package_name }} > publish_workflow_payload/package_name.txt
+        echo ${{ inputs.next_version }} > publish_workflow_payload/next_version.txt
+        echo ${{ inputs.package_name }} > publish_workflow_payload/package_name.txt
       shell: bash
 
     - name: Upload payload data to artifact for deploy workflow

--- a/.github/workflows/publish_deploy.yml
+++ b/.github/workflows/publish_deploy.yml
@@ -1,6 +1,6 @@
 name: 'Publish: Deploy (⚠️ use manually call only if necessary)'
-# Note: display_title не задокументирован
-run-name: '${{ github.event.workflow_run.display_title }} • ${{ github.event.workflow_run.head_branch }} • ${{ github.event.workflow_run.id }}'
+# Note: display_title не задокументирован из-за чего в IDE может подчёркиваться строка
+run-name: "${{ github.event_name == 'workflow_run' && format('{0}: Deploy • {1} • {2}', github.event.workflow_run.display_title, github.event.workflow_run.head_branch, github.event.workflow_run.id) || format('Publish {0} {1}@{2}: Deploy (⚠️ manually run)', inputs.publish_type, inputs.package_name, inputs.next_version) }}"
 
 on:
   # TODO Добавить также 'Publish release'.
@@ -22,39 +22,43 @@ on:
         description: "package's version (without 'v'):"
         required: true
         type: string
+      publish_type:
+        description: "⚠️ before change to 'release' make sure this is the case"
+        default: 'pre-release'
+        type: choice
+        options:
+          - 'release'
+          - 'pre-release'
 
 jobs:
   payload:
     name: Prepare payload data
     runs-on: ubuntu-latest
     outputs:
-      package_name: ${{ steps.payload.outputs.package_name }}
-      next_version: ${{ steps.payload.outputs.next_version }}
+      package_name: ${{ steps.publish_workflow_payload.outputs.package_name || inputs.package_name }}
+      next_version: ${{ steps.publish_workflow_payload.outputs.next_version || inputs.next_version }}
+      is_for_prerelease: ${{ contains(github.event.workflow_run.name, 'Publish pre-release') || contains(inputs.publish_type, 'pre-release') }}
     steps:
       - name: Download artifact (if it is 'workflow_run')
         if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success' }}
         id: artifact
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           name: publish_workflow_payload
+          path: publish_workflow_payload/
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Parse artifact (if it is 'workflow_run')
+      - name: Parse artifact
         if: ${{ steps.artifact.conclusion == 'success' }}
-        id: payload
+        id: publish_workflow_payload
         run: |
           echo "package_name=$(cat publish_workflow_payload/package_name.txt)" >> $GITHUB_OUTPUT
           echo "next_version=$(cat publish_workflow_payload/next_version.txt)" >> $GITHUB_OUTPUT
 
-      - name: Parse inputs (if it is 'workflow_dispatch')
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.package_name && inputs.next_version }}
-        run: |
-          echo ${{ inputs.package_name }} >> $GITHUB_OUTPUT
-          echo ${{ inputs.next_version }} >> $GITHUB_OUTPUT
-
   deploy_vkui_docs:
     needs: [payload]
-    if: ${{ success() && needs.payload.outputs.package_name == '@vkontakte/vkui' }}
+    if: ${{ success() && needs.payload.outputs.package_name == '@vkontakte/vkui' && needs.payload.outputs.next_version }}
     runs-on: ubuntu-latest
     name: Deploy @vkontakte/vkui docs
     steps:
@@ -65,13 +69,13 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Creating docs for pre-release
-        if: ${{ github.event.workflow_run.name == 'Publish pre-release' }}
+        if: ${{ fromJSON(needs.payload.outputs.is_for_prerelease) == true }}
         run: |
           yarn run docs:styleguide:build --dist dist/${{ needs.payload.outputs.next_version }}
           yarn run docs:storybook:build -o ../../styleguide/dist/${{ needs.payload.outputs.next_version }}/playground
 
       - name: Creating docs for release
-        if: ${{ github.event.workflow_run.name == 'Publish release' }}
+        if: ${{ fromJSON(needs.payload.outputs.is_for_prerelease) != true }}
         run: |
           yarn run docs:styleguide:build --dist dist
           yarn run docs:storybook:build -o ../../styleguide/dist/playground

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -1,4 +1,5 @@
 name: 'Publish pre-release'
+run-name: Publish pre-release ${{ github.event.inputs.package_name }} ${{ inputs.new_version }} ${{ inputs.custom_version }} (tag ${{ inputs.npm_tag_aka_pre_id }})
 
 on:
   workflow_dispatch:
@@ -34,8 +35,6 @@ on:
       custom_version:
         description: 'use syntax x.y.z-beta.0, without "v" (it will ignore "version type" & "NPM tag" parameters):'
         required: false
-
-run-name: Publish pre-release ${{ github.event.inputs.package_name }} ${{ inputs.new_version }} ${{ inputs.custom_version }} (tag ${{ inputs.npm_tag_aka_pre_id }})
 
 jobs:
   publish:


### PR DESCRIPTION
## Проблема

Упал `publish_deploy.yml` из-за ошибки в [actions/download-artifact@v4](https://github.com/actions/download-artifact/tree/v4/).

<img width="480" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/cf6abc39-f4f8-4d43-be7d-7061e844ff6b">

_https://github.com/VKCOM/VKUI/actions/runs/7831306942_

## Причина

@mendrew подсказал причину – в экшон, помимо `run-id`, надо передать ещё и `github-token`.

## Изменения

- `.github/workflows/publish_deploy.yml`
  - передаём `github-token` в `actions/download-artifact`;
  - создаём новое поле `publish_type`, чтобы при ручном запуске можно было указать какой-то типа релиз (до этого была бы бага, что ни одна из джоб сборки док не сработала бы);
  - в `run-name` учитываем, что воркфлоу может вызываться вручную.
- `.github/actions/publish-workflow-4-complete/action.yml`
  - удалил несуществующий ключ `outputs` у `inputs`.
- `.github/workflows/publish_prerelease.yml`
  - поднял поле `run-name` выше под `name`.

## Тест

Проверил в своём форке https://github.com/inomdzhon/VKUI.

<img width="480" alt="publish_prerelease" src="https://github.com/VKCOM/VKUI/assets/5850354/4d3dd332-7ed8-41ef-b8a4-46882ff1f07a">

_1) Запустили publish_prerelease.yml_

<img width="480" alt="publish_deploy" src="https://github.com/VKCOM/VKUI/assets/5850354/7510fdde-f392-488e-a500-2066da3de12e"> 

_2) Тригернули publish_deploy.yml (ниже два примера с ручным запуском)_

---

- caused by #6526
