### PR TITLE
fix(PullToRefresh): rm global touchmove listener

### DIFF
--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.stories.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.stories.tsx
@@ -23,7 +23,7 @@ export default story;
 
 type Story = StoryObj<PullToRefreshProps>;
 
-const initUsers = getRandomUsers(10);
+const initUsers = getRandomUsers(20);
 
 export const Example: Story = {
   render: function Render() {

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
@@ -116,11 +116,6 @@ describe(PullToRefresh, () => {
       const hasDefaultStart = fireEvent.mouseDown(screen.getByTestId('xxx'), { clientY: 0 });
       expect(hasDefaultStart).toBe(toHaveDefault);
     };
-    it('prevents during refresh', () => {
-      renderRefresher();
-      firePull(screen.getByTestId('xxx'));
-      expectEvents(false);
-    });
     it('releases after refresh', () => {
       const { setFetching } = renderRefresher();
       firePull(screen.getByTestId('xxx'));
@@ -153,7 +148,7 @@ describe(PullToRefresh, () => {
   it('disables native pull-to-refresh while pulling', async () => {
     const component = render(
       <ConfigProvider platform="ios">
-        <PullToRefresh onRefresh={noop} data-testid="xxx" />
+        <PullToRefresh onRefresh={noop} isFetching={false} data-testid="xxx" />
       </ConfigProvider>,
       { baseElement: document.documentElement },
     );
@@ -162,12 +157,27 @@ describe(PullToRefresh, () => {
 
     // класс присутствует пока пуллим
     firePull(component.getByTestId('xxx'), { end: false });
-    act(jest.runAllTimers);
     expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeTruthy();
 
-    // класс удаляется когда отпускаем
+    component.rerender(
+      <ConfigProvider platform="ios">
+        <PullToRefresh onRefresh={noop} isFetching data-testid="xxx" />
+      </ConfigProvider>,
+    );
+
     fireEvent.mouseUp(component.getByTestId('xxx'), { clientY: 500 });
-    act(jest.runAllTimers);
+    expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeTruthy();
+
+    // пока идёт обновление, класс не удаляется, чтобы не вызывалось нативное поведение
+    firePull(component.getByTestId('xxx'), { end: true });
+    expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeTruthy();
+
+    component.rerender(
+      <ConfigProvider platform="ios">
+        <PullToRefresh onRefresh={noop} isFetching={false} data-testid="xxx" />
+      </ConfigProvider>,
+    );
+
     expect(document.querySelector('.vkui--disable-overscroll-behavior')).toBeFalsy();
   });
 });

--- a/packages/vkui/src/styles/common.css
+++ b/packages/vkui/src/styles/common.css
@@ -56,5 +56,6 @@
 /* отключаем нативный pull-to-refresh при взаимодействии с компонентом
  * PullToRefresh или при открывании модалки */
 .vkui--disable-overscroll-behavior {
+  /* Safari >= 16 */
   overscroll-behavior-y: none;
 }


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6530

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

Глобальный обработчик на `touchmove` влиял на поведение элементов с горизонтальным скроллом (например, `HorizontalScroll`) – нужно было проводить пальцем ровно по оси X, чтобы проскроллить по горизонтали.

<details><summary>Видео 1. Поправленный пример из issue6530</summary>
<p>

https://github.com/VKCOM/VKUI/assets/5850354/d3aa291f-6274-470b-9ccb-3e9e19e544ab

</p>
</details> 

После удаления проблемы, из-за которой был добавлен этот обработчик (#5967), не смог воспроизвести. Даже если такая проблема и есть, то думаю она не критичней, в отличие от блокировки горизонтального скролла. Удалил тест, который проверял глобальный обработчик, т.к. он больше не проходит.

Заодно поправил проблему, когда при работе спиннера можно было бы потянуть сверху вниз и вызвать нативный **pull-to-refresh** – для исправления, мы сохраняем св-во `overscroll-behavior` на `document.body` пока не закончится обновление. Вынес логику в эффект.

<details><summary>Видео 2. Базовый пример после изменений</summary>
<p>

Есть момент, что при обновлении можно проскроллить вниз. Не стал этот момент трогать, т.к. `PullToRefresh` работает локально под конкретный контейнер. Ввиду этого, не уверен, что стоит блокировать скролл на `document.body`.

https://github.com/VKCOM/VKUI/assets/5850354/b2baccc9-3cfa-415a-ab42-7ebd93c09114

</p>
</details> 

- caused by #5967

## Изменения

- Избавился от `useTimeout`, т.к. он скорее усложняет код, чем облегчает его.
- В `cancelEvent` убрал цикл `while`. Не понял для чего он. По истории коммитов, такая реализация была сразу https://github.com/VKCOM/VKUI/pull/181. Возможности, раньше по особенном работал `Touch`.
- Добавил больше данных в примере Storybook, чтобы увеличить высоту контента под скролл.

**UPD**

см. https://github.com/VKCOM/VKUI/pull/6540#issuecomment-1939282840