### PR TITLE
fix(docs): remove param from hook in useLoadThemeTokens

### DIFF
--- a/styleguide/lib/theme/useLoadThemeTokens.js
+++ b/styleguide/lib/theme/useLoadThemeTokens.js
@@ -12,7 +12,7 @@ export function useLoadThemeTokens(themeName, appearanceOptions, doc = document)
   const promiseRef = React.useRef(null);
 
   React.useEffect(() => {
-    if (pending || promiseRef.current !== null) {
+    if (promiseRef.current !== null) {
       return;
     }
 
@@ -43,7 +43,7 @@ export function useLoadThemeTokens(themeName, appearanceOptions, doc = document)
         promiseRef.current = null;
         setPending(false);
       });
-  }, [pending, themeName, appearanceOptions]);
+  }, [themeName, appearanceOptions]);
 
   return !pending;
 }


### PR DESCRIPTION
## Описание

Из-за завязки на `pending` внутри `useLoadThemeTokens` попадали на бесконечный цикл

https://github.com/VKCOM/VKUI/assets/7431217/597ec65b-0347-446b-9555-e392f45b9697

- caused by #6313

## Изменения

Убираем завязку на `pending`, кажется, что в случае чего `promiseRef.current !== null` будет достаточно
