### PR TITLE
feat(ChipsInput/ChipsSelect): reset state after `form.reset()`

### DIFF
--- a/packages/vkui/src/components/ChipsInput/useChipsInput.ts
+++ b/packages/vkui/src/components/ChipsInput/useChipsInput.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useCustomEnsuredControl, useEnsuredControl } from '../../hooks/useEnsuredControl';
+import { useNativeFormResetListener } from '../../hooks/useNativeFormResetListener';
 import { simulateReactInput, type SimulateReactInputTargetState } from '../../lib/react';
 import {
   DEFAULT_INPUT_VALUE,
@@ -131,6 +132,12 @@ export const useChipsInput = <O extends ChipOption>({
     },
     [addOption, clearInput],
   );
+
+  const reset = React.useCallback(() => {
+    setValue([]);
+  }, [setValue]);
+
+  useNativeFormResetListener(inputRef, reset);
 
   return {
     value,

--- a/packages/vkui/src/components/ChipsInput/useChipsInput.ts
+++ b/packages/vkui/src/components/ChipsInput/useChipsInput.ts
@@ -134,8 +134,8 @@ export const useChipsInput = <O extends ChipOption>({
   );
 
   const reset = React.useCallback(() => {
-    setValue([]);
-  }, [setValue]);
+    setValue(defaultValue);
+  }, [defaultValue, setValue]);
 
   useNativeFormResetListener(inputRef, reset);
 

--- a/packages/vkui/src/hooks/useNativeFormResetListener.test.tsx
+++ b/packages/vkui/src/hooks/useNativeFormResetListener.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { useNativeFormResetListener } from './useNativeFormResetListener';
+
+const CustomFormItemComponent = ({
+  defaultValue,
+  disabledRef,
+  hookCallback,
+  ...restProps
+}: {
+  defaultValue: string;
+  disabledRef?: boolean;
+  hookCallback: (event: Event) => void;
+}) => {
+  const [value, setValue] = React.useState(defaultValue);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  const reset = React.useCallback(
+    (event: Event) => {
+      setValue('');
+      hookCallback(event);
+    },
+    [hookCallback],
+  );
+
+  useNativeFormResetListener(ref, reset);
+
+  return (
+    <div ref={disabledRef ? undefined : ref} {...restProps}>
+      {value}
+    </div>
+  );
+};
+
+describe(useNativeFormResetListener, () => {
+  it('should reset state of custom form item component', () => {
+    const hookCallback = jest.fn();
+    const result = render(
+      <form>
+        <CustomFormItemComponent
+          defaultValue="text"
+          data-testid="custom-form-item"
+          hookCallback={hookCallback}
+        />
+        <input data-testid="reset" type="reset" />
+      </form>,
+    );
+    const customFormItemLocator = result.getByTestId('custom-form-item');
+
+    expect(customFormItemLocator).toHaveTextContent('text');
+
+    fireEvent.click(result.getByTestId('reset'));
+
+    expect(customFormItemLocator).toHaveTextContent('');
+    expect(hookCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isTrusted: true,
+      }),
+    );
+  });
+
+  it.each([
+    { Wrapper: 'form' as const, props: { disabledRef: true }, description: 'ref is null' },
+    { Wrapper: 'div' as const, props: {}, description: 'form is not exist' },
+  ])('should be disabled if $description', ({ Wrapper, props }) => {
+    const hookCallback = jest.fn();
+    const result = render(
+      <Wrapper>
+        <CustomFormItemComponent
+          {...props}
+          defaultValue="text"
+          data-testid="custom-form-item"
+          hookCallback={hookCallback}
+        />
+        <input data-testid="reset" type="reset" />
+      </Wrapper>,
+    );
+    const customFormItemLocator = result.getByTestId('custom-form-item');
+
+    expect(customFormItemLocator).toHaveTextContent('text');
+
+    fireEvent.click(result.getByTestId('reset'));
+
+    expect(customFormItemLocator).toHaveTextContent('text');
+    expect(hookCallback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vkui/src/hooks/useNativeFormResetListener.ts
+++ b/packages/vkui/src/hooks/useNativeFormResetListener.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
+
+export const useNativeFormResetListener = (
+  ref: React.RefObject<HTMLElement>,
+  handler: (event: Event) => void,
+) => {
+  useIsomorphicLayoutEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    // eslint-disable-next-line no-restricted-properties
+    const formEl = ref.current.closest('form');
+
+    if (!formEl) {
+      return;
+    }
+
+    formEl.addEventListener('reset', handler);
+
+    return () => {
+      formEl.removeEventListener('reset', handler);
+    };
+  }, [ref, handler]);
+};


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

- related to #6561, #6560

## Изменения

- Создал хук `useNativeFormResetListener()`.
- Применил хук в `useChipsInput()`.
