### PR TITLE
fix(ChipsSelect): Remove initialUpdate logic from floating Mutation observer callback

### DIFF
--- a/packages/vkui/src/lib/floating/adapters.ts
+++ b/packages/vkui/src/lib/floating/adapters.ts
@@ -48,14 +48,7 @@ export function autoUpdateFloatingElement(
   // код с `MutationObserver`.
   let observer: MutationObserver | null = null;
   if (elementResize) {
-    let initialUpdate = true;
-    observer = new MutationObserver(() => {
-      if (!initialUpdate) {
-        update();
-      }
-
-      initialUpdate = false;
-    });
+    observer = new MutationObserver(update);
 
     if (isHTMLElement(reference)) {
       observer.observe(reference, {


### PR DESCRIPTION
- close #5039 

---

- [ ] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи

## Описание
Убираем лишнюю оптимизацию из логики обновления позиции плавающего элемента.

У нас была дополнительная проверка на вызов коллбэка `MutationObserver`, с помощью которой мы пропускали обновление попапа при первом вызове коллбэка.
На сколько мы обсудили с @inomdzhon эта проверка была добавлена как оптимизация, чтобы не допустить лишнего ререндера при маунте.
Судя по результатам исследования у нас нету такой проблемы с ререндером из-за `MutationObserver` и эту проверку мы можем просто убрать.

А убрать нам её нужно, потому что она не даёт правильно спозиционировать опции `ChipsSelect`, если селект находится внизу окна, тем самым опции рендерятся сверху селекта. Если пользователь сразу после фокуса на селекте вводит текст, который оставляет одну-две опции в списке, то оставшиеся опции будут оторваны,  спозиционированы сильно выше селекта. Это происходит потому, что не срабатывает `update()` позиции опций, как раз из-за этой логики. И только при первом изменении размера списка опций. Если ввести текст, который вновь поменяет размер списка, позиционирование будет верным.