### PR TITLE
build(deps): Downgrade codecov/codecov-action from 4 to 3

### DIFF
--- a/.github/workflows/branch_test_coverage.yml
+++ b/.github/workflows/branch_test_coverage.yml
@@ -41,7 +41,7 @@ jobs:
           name: test-output
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/.github/workflows/pull_request_packages_deploy.yml
+++ b/.github/workflows/pull_request_packages_deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ steps.artifact.outputs.found_artifact == 'true' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests


### PR DESCRIPTION
## Описание

После обновления до **v4**, перестало выгружаться покрытие. Сбрасываем до **v3**.

- caused by #6500
- related to https://github.com/codecov/codecov-action/issues/1284