### PR TITLE
fix(PanelHeaderButton, TabsItem): fix hover effect

### DIFF
--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -59,7 +59,7 @@ export const PanelHeaderButton = ({
 
   switch (platform) {
     case Platform.IOS:
-      hoverMode = 'background';
+      hoverMode = 'opacity';
       activeMode = 'opacity';
       break;
     case Platform.VKCOM:

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -59,7 +59,7 @@ export const PanelHeaderButton = ({
 
   switch (platform) {
     case Platform.IOS:
-      hoverMode = 'opacity';
+      hoverMode = '';
       activeMode = 'opacity';
       break;
     case Platform.VKCOM:

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -59,7 +59,7 @@ export const PanelHeaderButton = ({
 
   switch (platform) {
     case Platform.IOS:
-      hoverMode = '';
+      hoverMode = 'opacity';
       activeMode = 'opacity';
       break;
     case Platform.VKCOM:

--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -176,7 +176,7 @@ export const TabsItem = ({
         layoutFillMode !== 'auto' && fillModeClassNames[layoutFillMode],
         className,
       )}
-      hoverMode={platform !== Platform.IOS && styles['TabsItem--hover']}
+      hoverMode={platform === Platform.IOS ? '' : styles['TabsItem--hover']}
       activeMode=""
       focusVisibleMode="inside"
       hasActive={false}

--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
+import { usePlatform } from '../../hooks/usePlatform';
 import { usePrevious } from '../../hooks/usePrevious';
 import { SizeType } from '../../lib/adaptivity';
 import { useDOM } from '../../lib/dom';
+import { Platform } from '../../lib/platform';
 import { warnOnce } from '../../lib/warnOnce';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { TabsContextProps, TabsModeContext } from '../Tabs/Tabs';
@@ -82,6 +84,7 @@ export const TabsItem = ({
     withScrollToSelectedTab,
   }: TabsContextProps = React.useContext(TabsModeContext);
   let statusComponent = null;
+  const platform = usePlatform();
 
   const isTabFlow = role === 'tab';
 
@@ -173,7 +176,7 @@ export const TabsItem = ({
         layoutFillMode !== 'auto' && fillModeClassNames[layoutFillMode],
         className,
       )}
-      hoverMode={styles['TabsItem--hover']}
+      hoverMode={platform !== Platform.IOS && styles['TabsItem--hover']}
       activeMode=""
       focusVisibleMode="inside"
       hasActive={false}


### PR DESCRIPTION
- close #6330

---

## Описание

- caused by #6009 

По умолчанию начинаем проставлять `hasHover=true`, поэтому ловим артефакты из issue #6330

## Изменения

"Обнуляем" `hover`-эффекты на `iOS` 
