### PR TITLE
fix(PanelHeader): Replace FixedLayout with sticky position

### DIFF
--- a/packages/vkui/src/components/PanelHeader/PanelHeader.module.css
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.module.css
@@ -3,8 +3,8 @@
 }
 
 .PanelHeader--fixed {
-  inset-block-start: 0;
   position: sticky;
+  inset-block-start: 0;
   z-index: var(--vkui_internal--z_index_panel_header);
 }
 
@@ -240,7 +240,6 @@
  * VKCOM
  */
 .PanelHeader--vkcom {
-  position: relative;
   z-index: var(--vkui_internal--z_index_panel_header);
 }
 

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.module.css
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.module.css
@@ -2,18 +2,15 @@
   position: relative;
 }
 
-.PanelHeader--static.PanelHeader--fixed::before {
-  display: block;
-  content: '';
+.PanelHeader--fixed {
+  inset-block-start: 0;
+  position: sticky;
+  z-index: var(--vkui_internal--z_index_panel_header);
 }
 
 .PanelHeader:not(.PanelHeader--static):not(.PanelHeader--fixed) {
   block-size: 0;
   /* см. https://github.com/VKCOM/VKUI/issues/5571 */
-  z-index: var(--vkui_internal--z_index_panel_header);
-}
-
-.PanelHeader__fixed {
   z-index: var(--vkui_internal--z_index_panel_header);
 }
 
@@ -64,7 +61,6 @@
   font-family: var(--vkui--font_family_accent);
 }
 
-.PanelHeader::before,
 .PanelHeader__in {
   block-size: var(--vkui_internal--panel_header_height);
   padding-block-start: var(--vkui_internal--safe_area_inset_top);

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -3,9 +3,8 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditionalRender';
 import { usePlatform } from '../../hooks/usePlatform';
-import { HasComponent, HasDataAttribute, HasRef, HTMLAttributesWithRootRef } from '../../types';
+import { HasComponent, HasDataAttribute, HTMLAttributesWithRootRef } from '../../types';
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';
-import { FixedLayout } from '../FixedLayout/FixedLayout';
 import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { OnboardingTooltipContainer } from '../OnboardingTooltip/OnboardingTooltipContainer';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -30,9 +29,7 @@ const sizeYClassNames = {
   compact: styles['PanelHeader--sizeY-compact'],
 };
 
-export interface PanelHeaderProps
-  extends HTMLAttributesWithRootRef<HTMLDivElement>,
-    HasRef<HTMLDivElement> {
+export interface PanelHeaderProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
   before?: React.ReactNode;
   /**
    * Добавляет элемент справа.
@@ -124,7 +121,6 @@ export const PanelHeader = ({
   transparent = false,
   delimiter = 'auto',
   shadow,
-  getRef,
   getRootRef,
   fixed,
   typographyProps,
@@ -160,23 +156,11 @@ export const PanelHeader = ({
         sizeX !== 'compact' && sizeXClassNames[sizeX],
         sizeY !== 'regular' && sizeYClassNames[sizeY],
       )}
-      getRootRef={isFixed ? getRootRef : getRef}
+      getRootRef={getRootRef}
     >
-      {isFixed ? (
-        <FixedLayout
-          className={classNames(styles['PanelHeader__fixed'], 'vkuiInternalPanelHeader__fixed')}
-          vertical="top"
-          getRootRef={getRef}
-        >
-          <PanelHeaderIn before={before} after={after} typographyProps={typographyProps}>
-            {children}
-          </PanelHeaderIn>
-        </FixedLayout>
-      ) : (
-        <PanelHeaderIn before={before} after={after} typographyProps={typographyProps}>
-          {children}
-        </PanelHeaderIn>
-      )}
+      <PanelHeaderIn before={before} after={after} typographyProps={typographyProps}>
+        {children}
+      </PanelHeaderIn>
       {!isVKCOM && (
         <>
           {staticSeparatorVisible && adaptiveSizeX.compact && (

--- a/packages/vkui/src/storybook/VKUIDecorators.tsx
+++ b/packages/vkui/src/storybook/VKUIDecorators.tsx
@@ -58,7 +58,7 @@ const SimpleLayout = ({ children }: { children: React.ReactNode }) => {
   const isVKCOM = platform === 'vkcom';
 
   return (
-    <SplitLayout>
+    <SplitLayout header={!isVKCOM && <PanelHeader delimiter="none" />}>
       <SplitCol autoSpaced={!isVKCOM}>{children}</SplitCol>
     </SplitLayout>
   );

--- a/packages/vkui/src/storybook/VKUIDecorators.tsx
+++ b/packages/vkui/src/storybook/VKUIDecorators.tsx
@@ -58,7 +58,7 @@ const SimpleLayout = ({ children }: { children: React.ReactNode }) => {
   const isVKCOM = platform === 'vkcom';
 
   return (
-    <SplitLayout header={!isVKCOM && <PanelHeader delimiter="none" />}>
+    <SplitLayout>
       <SplitCol autoSpaced={!isVKCOM}>{children}</SplitCol>
     </SplitLayout>
   );


### PR DESCRIPTION
- close #6588 

related (по поводу использования `position sticky`): https://github.com/VKCOM/VKUI/issues/2422#issuecomment-1127388770 https://github.com/VKCOM/VKUI/pull/2414#issuecomment-1106027113

## Описание
Убираем использование `FixedLayout` из `PanelHeader`, так как это провоцирует ререндер и сдвиг контента из-за того, что `FixedLayout` адаптирует свою ширину под ширину `SplitCol` .

Только сейчас по браузерной поддержке мы можем использовать `position: sticky`.

## Изменения

- заменили `FixedLayout` на `position: sticky`.