### PR TITLE
fix(PullToRefresh): Stretch PullToRefresh horizontally

### DIFF
--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e-playground.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e-playground.tsx
@@ -42,9 +42,8 @@ export const PullToRefreshPlayground = (
 };
 
 export const PullToRefreshChildrenPositionPlayground = (props: ComponentPlaygroundProps) => {
-  const { ...playgroundProps } = props;
   return (
-    <ComponentPlayground {...playgroundProps} platform="vkcom">
+    <ComponentPlayground {...props} platform="vkcom">
       {({ ...props }: PullToRefreshProps) => (
         <Div style={{ width: '300px', height: '500px', display: 'flex' }}>
           <PullToRefresh {...props}>

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e-playground.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e-playground.tsx
@@ -4,35 +4,68 @@ import { Div } from '../Div/Div';
 import { PullToRefresh, type PullToRefreshProps } from './PullToRefresh';
 
 export const PullToRefreshPlayground = (
-  props: ComponentPlaygroundProps & { paddingLeft?: string },
+  props: ComponentPlaygroundProps & { paddingLeft?: string } & {
+    componentChildren?: PullToRefreshProps['children'];
+  },
 ) => {
-  const { paddingLeft, ...playgroundProps } = props;
+  const { paddingLeft, componentChildren, ...playgroundProps } = props;
   return (
     <ComponentPlayground {...playgroundProps} platform="vkcom">
       {({ ...props }: PullToRefreshProps) => (
         <Div style={{ width: '300px', paddingLeft }}>
           <PullToRefresh {...props}>
+            {componentChildren ?? (
+              <div
+                style={{
+                  /**
+                   * Playwright >= 1.40 (https://github.com/microsoft/playwright/releases/tag/v1.40.0)
+                   * В WebKit начал выделяется текст, поэтому отключаем выделение.
+                   *
+                   * > Note: необходимо именно использовать префикс `-webkit-*`, т.к. React не поллифилит.
+                   */
+                  WebkitUserSelect: 'none',
+                }}
+              >
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a sollicitudin lectus,
+                a commodo sapien. Vivamus a urna leo. Integer iaculis dignissim urna, sit amet
+                vestibulum diam bibendum a. Donec eu arcu ut augue porttitor faucibus. Vestibulum
+                nec pretium tortor, sit amet congue nunc. Aenean ullamcorper ex sem, sed interdum
+                quam consequat et. Vestibulum a ex non diam fringilla feugiat. Nunc eu tellus sed
+                leo elementum cursus. Mauris blandit porta egestas. Curabitur eget justo elementum,
+                malesuada lacus ut, congue mauris. Integer orci nisi, convallis vitae dapibus sit
+                amet, molestie a risus. Aenean ultricies lacus eros, sit amet condimentum urna
+                malesuada et. Sed quis dolor tempus orci fringilla volutpat in sed velit. Aenean
+                aliquet bibendum pretium.
+              </div>
+            )}
+          </PullToRefresh>
+        </Div>
+      )}
+    </ComponentPlayground>
+  );
+};
+
+export const PullToRefreshChildrenPositionPlayground = (
+  props: ComponentPlaygroundProps & {
+    componentChildren?: PullToRefreshProps['children'];
+  },
+) => {
+  const { componentChildren, ...playgroundProps } = props;
+  return (
+    <ComponentPlayground {...playgroundProps} platform="vkcom">
+      {({ ...props }: PullToRefreshProps) => (
+        <Div style={{ width: '300px', height: '500px', display: 'flex' }}>
+          <PullToRefresh {...props}>
             <div
               style={{
-                /**
-                 * Playwright >= 1.40 (https://github.com/microsoft/playwright/releases/tag/v1.40.0)
-                 * В WebKit начал выделяется текст, поэтому отключаем выделение.
-                 *
-                 * > Note: необходимо именно использовать префикс `-webkit-*`, т.к. React не поллифилит.
-                 */
-                WebkitUserSelect: 'none',
+                display: 'flex',
+                flexDirection: 'column',
+                textAlign: 'center',
+                justifyContent: 'center',
+                flex: '1 0',
               }}
             >
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a sollicitudin lectus, a
-              commodo sapien. Vivamus a urna leo. Integer iaculis dignissim urna, sit amet
-              vestibulum diam bibendum a. Donec eu arcu ut augue porttitor faucibus. Vestibulum nec
-              pretium tortor, sit amet congue nunc. Aenean ullamcorper ex sem, sed interdum quam
-              consequat et. Vestibulum a ex non diam fringilla feugiat. Nunc eu tellus sed leo
-              elementum cursus. Mauris blandit porta egestas. Curabitur eget justo elementum,
-              malesuada lacus ut, congue mauris. Integer orci nisi, convallis vitae dapibus sit
-              amet, molestie a risus. Aenean ultricies lacus eros, sit amet condimentum urna
-              malesuada et. Sed quis dolor tempus orci fringilla volutpat in sed velit. Aenean
-              aliquet bibendum pretium.
+              Smaller content can be centered vertically
             </div>
           </PullToRefresh>
         </Div>

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e-playground.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e-playground.tsx
@@ -4,40 +4,36 @@ import { Div } from '../Div/Div';
 import { PullToRefresh, type PullToRefreshProps } from './PullToRefresh';
 
 export const PullToRefreshPlayground = (
-  props: ComponentPlaygroundProps & { paddingLeft?: string } & {
-    componentChildren?: PullToRefreshProps['children'];
-  },
+  props: ComponentPlaygroundProps & { paddingLeft?: string },
 ) => {
-  const { paddingLeft, componentChildren, ...playgroundProps } = props;
+  const { paddingLeft, ...playgroundProps } = props;
   return (
     <ComponentPlayground {...playgroundProps} platform="vkcom">
       {({ ...props }: PullToRefreshProps) => (
         <Div style={{ width: '300px', paddingLeft }}>
           <PullToRefresh {...props}>
-            {componentChildren ?? (
-              <div
-                style={{
-                  /**
-                   * Playwright >= 1.40 (https://github.com/microsoft/playwright/releases/tag/v1.40.0)
-                   * В WebKit начал выделяется текст, поэтому отключаем выделение.
-                   *
-                   * > Note: необходимо именно использовать префикс `-webkit-*`, т.к. React не поллифилит.
-                   */
-                  WebkitUserSelect: 'none',
-                }}
-              >
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a sollicitudin lectus,
-                a commodo sapien. Vivamus a urna leo. Integer iaculis dignissim urna, sit amet
-                vestibulum diam bibendum a. Donec eu arcu ut augue porttitor faucibus. Vestibulum
-                nec pretium tortor, sit amet congue nunc. Aenean ullamcorper ex sem, sed interdum
-                quam consequat et. Vestibulum a ex non diam fringilla feugiat. Nunc eu tellus sed
-                leo elementum cursus. Mauris blandit porta egestas. Curabitur eget justo elementum,
-                malesuada lacus ut, congue mauris. Integer orci nisi, convallis vitae dapibus sit
-                amet, molestie a risus. Aenean ultricies lacus eros, sit amet condimentum urna
-                malesuada et. Sed quis dolor tempus orci fringilla volutpat in sed velit. Aenean
-                aliquet bibendum pretium.
-              </div>
-            )}
+            <div
+              style={{
+                /**
+                 * Playwright >= 1.40 (https://github.com/microsoft/playwright/releases/tag/v1.40.0)
+                 * В WebKit начал выделяется текст, поэтому отключаем выделение.
+                 *
+                 * > Note: необходимо именно использовать префикс `-webkit-*`, т.к. React не поллифилит.
+                 */
+                WebkitUserSelect: 'none',
+              }}
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a sollicitudin lectus, a
+              commodo sapien. Vivamus a urna leo. Integer iaculis dignissim urna, sit amet
+              vestibulum diam bibendum a. Donec eu arcu ut augue porttitor faucibus. Vestibulum nec
+              pretium tortor, sit amet congue nunc. Aenean ullamcorper ex sem, sed interdum quam
+              consequat et. Vestibulum a ex non diam fringilla feugiat. Nunc eu tellus sed leo
+              elementum cursus. Mauris blandit porta egestas. Curabitur eget justo elementum,
+              malesuada lacus ut, congue mauris. Integer orci nisi, convallis vitae dapibus sit
+              amet, molestie a risus. Aenean ultricies lacus eros, sit amet condimentum urna
+              malesuada et. Sed quis dolor tempus orci fringilla volutpat in sed velit. Aenean
+              aliquet bibendum pretium.
+            </div>
           </PullToRefresh>
         </Div>
       )}
@@ -45,12 +41,8 @@ export const PullToRefreshPlayground = (
   );
 };
 
-export const PullToRefreshChildrenPositionPlayground = (
-  props: ComponentPlaygroundProps & {
-    componentChildren?: PullToRefreshProps['children'];
-  },
-) => {
-  const { componentChildren, ...playgroundProps } = props;
+export const PullToRefreshChildrenPositionPlayground = (props: ComponentPlaygroundProps) => {
+  const { ...playgroundProps } = props;
   return (
     <ComponentPlayground {...playgroundProps} platform="vkcom">
       {({ ...props }: PullToRefreshProps) => (

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { test } from '@vkui-e2e/test';
-import { PullToRefreshPlayground } from './PullToRefresh.e2e-playground';
+import {
+  PullToRefreshChildrenPositionPlayground,
+  PullToRefreshPlayground,
+} from './PullToRefresh.e2e-playground';
 
 test.describe('PullToRefresh', () => {
   // we are interested in VKCOM only as we need to test here mostly
@@ -40,6 +43,20 @@ test.describe('PullToRefresh', () => {
     await page.mouse.down();
     await page.mouse.move(200, 380, { steps: 10 });
 
+    await expectScreenshotClippedToContent();
+  });
+
+  test.only('takes whole parent height and allow smaller content to center vertically', async ({
+    page,
+    mount,
+    expectScreenshotClippedToContent,
+    componentPlaygroundProps,
+  }) => {
+    const result = await mount(
+      <PullToRefreshChildrenPositionPlayground {...componentPlaygroundProps} />,
+    );
+    await result.waitFor();
+    await page.evaluate(() => new Promise((resolve) => setTimeout(resolve, 500)));
     await expectScreenshotClippedToContent();
   });
 });

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.e2e.tsx
@@ -46,7 +46,7 @@ test.describe('PullToRefresh', () => {
     await expectScreenshotClippedToContent();
   });
 
-  test.only('takes whole parent height and allow smaller content to center vertically', async ({
+  test('takes whole parent height and allow smaller content to center vertically', async ({
     page,
     mount,
     expectScreenshotClippedToContent,

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.module.css
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.module.css
@@ -1,4 +1,6 @@
 .PullToRefresh {
+  display: flex;
+  flex-direction: column;
   flex-grow: 1;
 }
 
@@ -67,6 +69,9 @@
 }
 
 .PullToRefresh__content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
   overflow: hidden;
   transition: transform 400ms var(--vkui--animation_easing_platform);
 }

--- a/packages/vkui/src/components/PullToRefresh/__image_snapshots__/pulltorefresh-takes-whole-parent-height-and-allow-smaller-content-to-center-vertically-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/PullToRefresh/__image_snapshots__/pulltorefresh-takes-whole-parent-height-and-allow-smaller-content-to-center-vertically-vkcom-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6bdf0099a1ecab9981cd47ddc9c67af40ffee0d5022ed7ea5a6d9f7155c572e
+size 5190

--- a/packages/vkui/src/components/PullToRefresh/__image_snapshots__/pulltorefresh-takes-whole-parent-height-and-allow-smaller-content-to-center-vertically-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/PullToRefresh/__image_snapshots__/pulltorefresh-takes-whole-parent-height-and-allow-smaller-content-to-center-vertically-vkcom-firefox-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:594561ffc8633c02ed43b1663492e776d5642a49a763463575aa4c69d62b9a7c
+size 9495

--- a/packages/vkui/src/components/PullToRefresh/__image_snapshots__/pulltorefresh-takes-whole-parent-height-and-allow-smaller-content-to-center-vertically-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/PullToRefresh/__image_snapshots__/pulltorefresh-takes-whole-parent-height-and-allow-smaller-content-to-center-vertically-vkcom-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596aa8f157b3432c7a0a8ffcacb446b88cbf5cd923536f0fb9294b50b9da5059
+size 4626


### PR DESCRIPTION

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [ ] Unit-тесты
- [x] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи

## Описание
Растягиваем PullToRefresh по высоте, чтобы контент мог занимать всю высоту панели.
Одна из проблем была с `Placeholder` в режиме `stretched`, который переставал выравниваться по центру, если был обернут в `PullToRefresh`. Без жесткого кастома нельзя отцентрировать по вертикали `Placeholder` `stretched` при наличии `PullToRefresh`
Пример где `PullToRefresh` ломал поведение `Placeholder` https://codesandbox.io/p/sandbox/bold-feather-hfjx23

Раньше мы уже исправляли это в https://github.com/VKCOM/VKUI/commit/4a0f71301c110b86c5a1c0910726a98d534ab37c, но в какой-то момент поведение сломалось.
В v5 это тоже нужно занести.

