### PR TITLE
fix(ChipsSelect): add disabled prop

### DIFF
--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -17,6 +17,7 @@ export type ChipOptionLabel = React.ReactElement | string | number;
 export type ChipOption = {
   value: ChipOptionValue;
   label: ChipOptionLabel;
+  disabled?: boolean;
   [index: string]: any;
 };
 

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.stories.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.stories.tsx
@@ -22,7 +22,7 @@ const groups = [
     value: '1',
     label: 'Arctic Monkeys',
   },
-  { value: '2', label: 'Звери' },
+  { value: '2', label: 'Звери', disabled: true },
   { value: '4', label: 'FACE' },
   {
     value: '3',

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -397,4 +397,46 @@ describe('ChipsSelect', () => {
       expect(onKeyDown).toHaveBeenCalled();
     },
   );
+
+  it('should ignore disabled option', async () => {
+    const onChange = jest.fn();
+    const result = render(
+      <ChipsSelect
+        options={[FIRST_OPTION, { ...SECOND_OPTION, disabled: true }, THIRD_OPTION]}
+        dropdownTestId="dropdown"
+        onChange={onChange}
+      />,
+    );
+
+    const inputLocator = result.getByRole('combobox');
+    await userEvent.click(inputLocator);
+    await waitForFloatingPosition();
+
+    const boundDropdownLocator = within(result.getByTestId('dropdown'));
+    const [firstOptionLocator, secondOptionLocator, thirdOptionLocator] = [
+      boundDropdownLocator.getByRole('option', {
+        name: withRegExp(FIRST_OPTION.label),
+      }),
+      boundDropdownLocator.getByRole('option', {
+        name: withRegExp(SECOND_OPTION.label),
+      }),
+      boundDropdownLocator.getByRole('option', {
+        name: withRegExp(THIRD_OPTION.label),
+      }),
+    ];
+
+    await userEvent.hover(secondOptionLocator);
+    await userEvent.hover(inputLocator);
+    await userEvent.click(secondOptionLocator);
+
+    expect(onChange).not.toHaveBeenCalled();
+    await userEvent.type(inputLocator, '{ArrowDown}');
+    expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
+
+    await userEvent.type(inputLocator, '{ArrowDown}');
+    expect(thirdOptionLocator).toHaveAttribute('data-hovered', 'true');
+
+    await userEvent.type(inputLocator, '{ArrowUp}');
+    expect(firstOptionLocator).toHaveAttribute('data-hovered', 'true');
+  });
 });

--- a/packages/vkui/src/components/ChipsSelect/Readme.md
+++ b/packages/vkui/src/components/ChipsSelect/Readme.md
@@ -16,7 +16,7 @@ const Uncontrolled = () => {
         label: 'Arctic Monkeys',
         src: getAvatarUrl('audio_arctic_monkeys'),
       },
-      { value: '2', label: 'Звери', src: getAvatarUrl('audio_leto_zveri') },
+      { value: '2', label: 'Звери', disabled: true, src: getAvatarUrl('audio_leto_zveri') },
       { value: '4', label: 'FACE', src: getAvatarUrl('audio_face') },
       {
         value: '3',

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -46,8 +46,8 @@ export interface CustomSelectOptionProps extends HTMLAttributesWithRootRef<HTMLD
   /**
    * Блокирует весь блок.
    *
-   * > ⚠️  Важно: если CustomSelectOption используется внутри [Select](https://vkcom.github.io/VKUI/#/Select) или [CustomSelect](https://vkcom.github.io/VKUI/#/CustomSelect), то свойство явно должно выставляться только через структуру `options`.
-   * > Запрещается выставлять `disabled` проп опциям в обход `options`, иначе [CustomSelect](https://vkcom.github.io/VKUI/#/CustomSelect) не будет знать об актуальном состоянии
+   * > ⚠️  Важно: если CustomSelectOption используется внутри [Select](https://vkcom.github.io/VKUI/#/Select), [CustomSelect](https://vkcom.github.io/VKUI/#/CustomSelect) или [ChipsSelect](https://vkcom.github.io/VKUI/#/ChipsSelect), то свойство явно должно выставляться только через структуру `options`.
+   * > Запрещается выставлять `disabled` проп опциям в обход `options`, иначе [CustomSelect](https://vkcom.github.io/VKUI/#/CustomSelect) и [ChipsSelect](https://vkcom.github.io/VKUI/#/ChipsSelect) не будут знать об актуальном состоянии
    * опции.
    */
   disabled?: boolean;


### PR DESCRIPTION
- close #6629 

---

- [x] Unit-тесты

## Описание

Потерялся проп `disabled` для опции

## Изменения

Добавляем возможность указать `disabled` + накладываем такие же ограничения, как и в `Select`/`CustomSelect`, чтобы значение всегда было актуальным
