### PR TITLE
fix: fetchPriority warning

### DIFF
--- a/packages/vkui/.eslintrc.js
+++ b/packages/vkui/.eslintrc.js
@@ -131,7 +131,7 @@ module.exports = {
     'import/no-default-export': 'error',
 
     'react/react-in-jsx-scope': 'off',
-    'react/no-unknown-property': ['error', { ignore: ['fetchPriority'] }], // https://github.com/jsx-eslint/eslint-plugin-react/pull/3697
+    'react/no-unknown-property': ['error', { ignore: ['fetchPriority', 'fetchpriority'] }], // https://github.com/jsx-eslint/eslint-plugin-react/pull/3697
 
     '@vkontakte/no-object-expression-in-arguments': [
       'error',

--- a/packages/vkui/src/components/ContentCard/ContentCard.tsx
+++ b/packages/vkui/src/components/ContentCard/ContentCard.tsx
@@ -100,7 +100,12 @@ export const ContentCard = ({
             referrerPolicy={referrerPolicy}
             sizes={sizes}
             useMap={useMap}
-            fetchPriority={fetchPriority}
+            // @ts-expect-error: TS2322 нужна новая версия реакта и замена свойства на fetchPriority
+            //
+            // TODO [react@>18.2.0]: Проверить работоспособность fetchPriority
+            //
+            // https://github.com/facebook/react/issues/25682
+            fetchpriority={fetchPriority}
             height={height}
             style={{ maxHeight }}
             width="100%"

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -188,7 +188,12 @@ export const ImageBase = ({
             height={heightImg}
             onLoad={handleImageLoad}
             onError={handleImageError}
-            fetchPriority={fetchPriority}
+            // @ts-expect-error: TS2322 нужна новая версия реакта и замена свойства на fetchPriority
+            //
+            // TODO [react@>18.2.0]: Проверить работоспособность fetchPriority
+            //
+            // https://github.com/facebook/react/issues/25682
+            fetchpriority={fetchPriority}
           />
         )}
         {fallbackIcon && <div className={styles['ImageBase__fallback']}>{fallbackIcon}</div>}


### PR DESCRIPTION
- see https://togithub.com/facebook/react/issues/25682

---

## Описание

Атрибут fetchPriority был добавлен в типизацию реакта, однако не вышло новой версии реакта, которая бы полноценно поддерживала данное свойство. В данный момент fetchPriority генерирует ворнинги.

## Изменения

Временно прокидываем `fetchpriority` как html свойство
