### PR TITLE
docs(storybook): add Source tab

### DIFF
--- a/packages/vkui/.storybook/addons/source-tab/SourceTab.tsx
+++ b/packages/vkui/.storybook/addons/source-tab/SourceTab.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import type { StoryId } from '@storybook/types';
+import { SNIPPET_RENDERED } from '@storybook/docs-tools';
+import { SyntaxHighlighter } from '@storybook/components';
+import { useChannel } from '@storybook/manager-api';
+
+type SnippetRenderedArgs = {
+  id: StoryId;
+  args: Record<string, any>;
+  source: string;
+};
+
+export const SourceTab = () => {
+  const [{ source }, handleSnippetRendered] = React.useState<SnippetRenderedArgs>({
+    id: '',
+    args: {},
+    source: '',
+  });
+
+  useChannel({ [SNIPPET_RENDERED]: handleSnippetRendered });
+
+  const sourceAvailable = Boolean(source);
+
+  return (
+    <SyntaxHighlighter
+      padded
+      wrapLongLines
+      language="tsx"
+      copyable={sourceAvailable}
+      bordered={sourceAvailable}
+    >
+      {sourceAvailable ? source : 'Compiling...'}
+    </SyntaxHighlighter>
+  );
+};

--- a/packages/vkui/.storybook/addons/source-tab/constants.ts
+++ b/packages/vkui/.storybook/addons/source-tab/constants.ts
@@ -1,0 +1,2 @@
+export const ADDON_ID = 'storybook/source-tab';
+export const PANEL_ID = `${ADDON_ID}/panel`;

--- a/packages/vkui/.storybook/addons/source-tab/register.tsx
+++ b/packages/vkui/.storybook/addons/source-tab/register.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { AddonPanel } from '@storybook/components';
+import { addons, types } from '@storybook/manager-api';
+import { SourceTab } from './SourceTab';
+import { ADDON_ID, PANEL_ID } from './constants';
+
+addons.register(ADDON_ID, () => {
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title: 'Source',
+    match: ({ viewMode }) => !!(viewMode && viewMode.match(/^story$/)),
+    render: ({ active = false }) => (
+      <AddonPanel active={active}>
+        <SourceTab />
+      </AddonPanel>
+    ),
+  });
+});

--- a/packages/vkui/.storybook/main.ts
+++ b/packages/vkui/.storybook/main.ts
@@ -19,6 +19,7 @@ function excludeCssRulesFromConfig(config: Configuration) {
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
+    './addons/source-tab',
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',

--- a/packages/vkui/.storybook/preview.ts
+++ b/packages/vkui/.storybook/preview.ts
@@ -36,9 +36,14 @@ const customViewports = Object.entries(BREAKPOINTS).reduce<Record<string, Custom
 
 const preview: Preview = {
   parameters: {
+    docs: {
+      expanded: true,
+      source: {
+        type: 'dynamic',
+      },
+    },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
-      expanded: true,
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/,

--- a/packages/vkui/src/components/Accordion/Accordion.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.tsx
@@ -58,5 +58,10 @@ export const Accordion = ({
   return <AccordionContext.Provider value={context}>{children}</AccordionContext.Provider>;
 };
 
+Accordion.displayName = 'Accordion';
+
 Accordion.Summary = AccordionSummary;
+Accordion.Summary.displayName = 'Accordion.Summary';
+
 Accordion.Content = AccordionContent;
+Accordion.Content.displayName = 'Accordion.Content';

--- a/packages/vkui/src/components/Accordion/AccordionContent.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionContent.tsx
@@ -84,3 +84,5 @@ export const AccordionContent = ({
     </div>
   );
 };
+
+AccordionContent.displayName = 'AccordionContent';

--- a/packages/vkui/src/components/Accordion/AccordionSummary.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionSummary.tsx
@@ -67,3 +67,5 @@ export const AccordionSummary = ({
     </SimpleCell>
   );
 };
+
+AccordionSummary.displayName = 'AccordionSummary';

--- a/packages/vkui/src/components/Avatar/Avatar.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.tsx
@@ -119,10 +119,15 @@ export const Avatar = ({
   );
 };
 
+Avatar.displayName = 'Avatar';
+
 Avatar.Badge = AvatarBadge;
+Avatar.Badge.displayName = 'Avatar.Badge';
 
 Avatar.BadgeWithPreset = AvatarBadgeWithPreset;
+Avatar.BadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';
 
 Avatar.Overlay = ImageBase.Overlay;
+Avatar.Overlay.displayName = 'Avatar.Overlay';
 
 Avatar.getInitialsFontSize = getInitialsFontSize;

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
@@ -18,3 +18,5 @@ export const AvatarBadge = ({ className, ...restProps }: AvatarBadgeProps) => {
     />
   );
 };
+
+AvatarBadge.displayName = 'Avatar.Badge';

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
@@ -42,3 +42,5 @@ export const AvatarBadgeWithPreset = ({
     </ImageBase.Badge>
   );
 };
+
+AvatarBadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';

--- a/packages/vkui/src/components/Image/Image.tsx
+++ b/packages/vkui/src/components/Image/Image.tsx
@@ -94,6 +94,10 @@ export const Image = ({
   );
 };
 
+Image.displayName = 'Image';
+
 Image.Badge = ImageBadge;
+Image.Badge.displayName = 'Image.Badge';
 
 Image.Overlay = ImageBase.Overlay;
+Image.Overlay.displayName = 'Image.Overlay';

--- a/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
+++ b/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
@@ -18,3 +18,5 @@ export const ImageBadge = ({ className, ...restProps }: ImageBadgeProps) => {
     />
   );
 };
+
+ImageBadge.displayName = 'ImageBadge';

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -204,6 +204,10 @@ export const ImageBase = ({
   );
 };
 
+ImageBase.displayName = 'ImageBase';
+
 ImageBase.Badge = ImageBaseBadge;
+ImageBase.Badge.displayName = 'ImageBase.Badge';
 
 ImageBase.Overlay = ImageBaseOverlay;
+ImageBase.Overlay.displayName = 'ImageBase.Overlay';

--- a/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
@@ -55,3 +55,5 @@ export const ImageBaseBadge = ({ background = 'shadow', ...restProps }: ImageBas
     />
   );
 };
+
+ImageBaseBadge.displayName = 'ImageBaseBadge';

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
@@ -91,3 +91,5 @@ export const ImageBaseOverlay = ({
     </Tappable>
   );
 };
+
+ImageBaseOverlay.displayName = 'ImageBaseOverlay';


### PR DESCRIPTION
## Описание

Добавляем самописный аддон для отображения кода сториса компонента.

> [!NOTE]
> Аддон [Storysource](https://storybook.js.org/addons/@storybook/addon-storysource) не подошёл, т.к. он рендерит весь файл `*.stories.tsx` и не показывает выбранные в панели **Controls** параметры.

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/cd5c4384-6280-4b94-b1e7-9a031b1f13e2"> <img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/052aac41-9414-4c8d-9190-c8154bb59d44">

<details><summary>Пример работы с **Controls**</summary>
<p>

https://github.com/VKCOM/VKUI/assets/5850354/048103dd-c321-4592-9aac-85ed0cf59312

</p>
</details> 

## Изменения

- Выставил `Source`, по умолчанию.
- Для подкомпонентов добавил `displayName` – без этого они показывается не как св-во родительского компонента.
- В `.storybook/preview.ts` устанавливаем `parameters.docs.source.type` в `'dynamic'`, чтобы отображались сторис, `render()` которых без аргументов (см. [доку](https://storybook.js.org/docs/api/doc-block-source#type)).