### PR TITLE
fix(NativeSelect): Don't pass unused props to NativeSelect

### DIFF
--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -31,12 +31,16 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
     icon,
     ClearButton,
     allowClearButton,
+    clearButtonTestId,
     dropdownOffsetDistance,
     dropdownAutoWidth,
     forceDropdownPortal,
     selectType,
+    noMaxHeight,
     autoHideScrollbar,
     autoHideScrollbarDelay,
+    labelTextTestId,
+    nativeSelectTestId,
     ...nativeProps // TODO: https://github.com/Microsoft/TypeScript/issues/12936
   } = props;
 


### PR DESCRIPTION
## Описание
Исключаем передачу неиспользуемых `Select` пропсов в `NativeSelect`.
Вот бы это как-нибудь автоматически ловить.