### PR TITLE
fix(CalendarRange): onChange value is not undefined (v5)

### DIFF
--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -37,7 +37,7 @@ export interface CalendarRangeProps
   disablePickers?: boolean;
   changeDayAriaLabel?: string;
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-  onChange?(value?: DateRangeType): void;
+  onChange?(value: DateRangeType): void;
   shouldDisableDate?(value: Date): boolean;
   onClose?(): void;
 }

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -221,7 +221,7 @@ export const DateRangeInput = ({
   const handleRootRef = useExternRef(rootRef, getRootRef);
 
   const onCalendarChange = React.useCallback(
-    (newValue?: DateRangeType) => {
+    (newValue: DateRangeType) => {
       onChange?.(newValue);
       if (closeOnChange && newValue?.[1] && newValue[1] !== value?.[1]) {
         removeFocusFromField();


### PR DESCRIPTION
## Описание

В `onChange` не передается `undefined`

---

- Это черипик из #6664 в v5