### PR TITLE
Change token for inactive issues/PRs workflow

### DIFF
--- a/.github/workflows/inactive_contributions.yml
+++ b/.github/workflows/inactive_contributions.yml
@@ -21,4 +21,4 @@ jobs:
           stale-pr-label: 'pr-needs-work'
           close-pr-message: 'PR закрыт из-за отсутствия активности в течение последних 14 дней. Если это произошло по ошибке или изменения все ещё актуальны, откройте PR повторно.'
           exempt-pr-labels: 'no-stale'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}


### PR DESCRIPTION
## Описание

Сейчас автоматическое закрытие `PR`а не триггерит очистку всего, что мы складываем в `S3`. Пробуем использовать нестандартный токен, как [написано в доке](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#:~:text=When%20you%20use%20the%20repository%27s)

