### PR TITLE
fix(FocusTrap): preventDefault on Escape

### DIFF
--- a/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
@@ -149,6 +149,7 @@ export const FocusTrap = <T extends HTMLElement = HTMLElement>({
         }
         case Keys.ESCAPE: {
           if (onClose) {
+            event.preventDefault();
             onClose();
           }
         }


### PR DESCRIPTION
## Описание

В сафари в открытой модалке при нажатии на <kbd>Esc</kbd> браузер переходит из развернутого в оконный режим

## Изменения

Вызываем `preventDefault` при нажатии на <kbd>Esc</kbd>