### PR TITLE
docs(storybook): revert expanded prop for controls addon

### DIFF
--- a/packages/vkui/.storybook/preview.ts
+++ b/packages/vkui/.storybook/preview.ts
@@ -37,13 +37,13 @@ const customViewports = Object.entries(BREAKPOINTS).reduce<Record<string, Custom
 const preview: Preview = {
   parameters: {
     docs: {
-      expanded: true,
       source: {
         type: 'dynamic',
       },
     },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
+      expanded: true,
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/,


### PR DESCRIPTION
## Описание

В #6658 переносил св-во `expanded` из аддона `controls` в `docs`, думаю что параметр отвечает за приоритет открытия, а оказывается он совсем о другом =)

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/f14b4284-1bb1-4a94-bade-e899c9c9cfee">

_из-за этого пропала описание во вкладке **Controls**_

В PR возвращаю как было.

- caused by #6658 