### PR TITLE
fix(HorizontalScroll): disable navigation to arrow by keyboard

### DIFF
--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -293,6 +293,7 @@ export const HorizontalScroll = ({
           offsetY={arrowOffsetY}
           direction="left"
           aria-hidden
+          tabIndex={-1}
           className={classNames(
             styles['HorizontalScroll__arrow'],
             styles['HorizontalScroll__arrowLeft'],
@@ -307,6 +308,7 @@ export const HorizontalScroll = ({
           offsetY={arrowOffsetY}
           direction="right"
           aria-hidden
+          tabIndex={-1}
           className={classNames(
             styles['HorizontalScroll__arrow'],
             styles['HorizontalScroll__arrowRight'],


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6661

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~

## Изменения

Передаём `tabIndex={-1}` в `ScrollArrow`.
