### PR TITLE
docs: don't mount icons on start

### DIFF
--- a/styleguide/Components/Frame/Frame.js
+++ b/styleguide/Components/Frame/Frame.js
@@ -13,23 +13,26 @@ const FrameDomProvider = ({ platform, appearanceOptions, themeName, children }) 
   const loaded = useLoadThemeTokens(themeName, appearanceOptions, frame.document);
 
   React.useEffect(() => {
+    const hotObservers = [];
+
     // Пихаем в iFrame с примером спрайты для иконок
     const sprite = document.getElementById('__SVG_SPRITE_NODE__');
-    const masks = document.getElementById('__SVG_MASKS_NODE__');
 
     if (sprite) {
       frame.document.body.appendChild(sprite.cloneNode(true));
     }
 
-    if (masks) {
-      frame.document.body.appendChild(masks.cloneNode(true));
-    }
+    const hotIconChange = new MutationObserver(() => {
+      frame.document.getElementById('__SVG_SPRITE_NODE__').remove();
+      frame.document.body.appendChild(sprite.cloneNode(true));
+    });
+    hotIconChange.observe(sprite, { characterData: true, childList: true });
+    hotObservers.push(hotIconChange);
 
     frame.document.querySelector('.frame-content').setAttribute('id', 'root');
 
     // Пихаем в iFrame vkui стили
     const frameAssets = document.createDocumentFragment();
-    const hotObservers = [];
     Array.from(document.getElementsByClassName('vkui-style')).map((style) => {
       const frameStyle = style.cloneNode(true);
       frameAssets.appendChild(frameStyle);

--- a/styleguide/setup.js
+++ b/styleguide/setup.js
@@ -32,15 +32,7 @@ for (let name in ui) {
 
 Object.getOwnPropertyNames(Icons).forEach((name) => {
   if (name.startsWith('Icon')) {
-    const icon = Icons[name];
-    window[name] = icon;
-
-    if (typeof icon.mountIcon === 'function') {
-      // Нужно смонтировать символ иконки до того, как общий спрайт будет клонирован во все iframe предпросмотры компонентов.
-      // Раньше код для добавления SVG-символа в спрайт находился в корне модуля,
-      // а теперь по-умолчанию символ добавляется только во время первого рендера иконки.
-      icon.mountIcon();
-    }
+    window[name] = Icons[name];
   }
 });
 


### PR DESCRIPTION
- closed #6686

## Описание

Сейчас в стайлгайде иконки монтируются сразу при открытии страницы. Это было сделано для копирования иконок в Frame. Данный способ серьезно замедляет открытие страницы и также монтирует очень большое количество DOM нод

<img width="1024" alt="image" src="https://github.com/VKCOM/VKUI/assets/14944123/ad9af04c-f5b9-4055-8f4c-eaa60b5c63f9">


## Изменения

Избавился от монтирование иконок на старте и добавил обсервер на спрайт

<img width="1242" alt="image" src="https://github.com/VKCOM/VKUI/assets/14944123/7501defd-007f-4207-86b1-f542846875e2">

LCP (замедление cpu x6, M1) 13 сек -> 5.5 сек
