### PR TITLE
fix(CustomSelectOption): add nbsp

### DIFF
--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -108,7 +108,10 @@ export const CustomSelectOption = ({
         <div className={styles['CustomSelectOption__children']}>{children}</div>
         {hasReactNode(description) && (
           <>
-            <Footnote className={styles['CustomSelectOption__description']}><VisuallyHidden>&nbsp;</VisuallyHidden>{description}</Footnote>
+            <Footnote className={styles['CustomSelectOption__description']}>
+              <VisuallyHidden>&nbsp;</VisuallyHidden>
+              {description}
+            </Footnote>
           </>
         )}
       </div>

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -108,8 +108,7 @@ export const CustomSelectOption = ({
         <div className={styles['CustomSelectOption__children']}>{children}</div>
         {hasReactNode(description) && (
           <>
-            <VisuallyHidden>&nbsp;</VisuallyHidden>
-            <Footnote className={styles['CustomSelectOption__description']}>{description}</Footnote>
+            <Footnote className={styles['CustomSelectOption__description']}><VisuallyHidden>&nbsp;</VisuallyHidden>{description}</Footnote>
           </>
         )}
       </div>

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -5,6 +5,7 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { Paragraph } from '../Typography/Paragraph/Paragraph';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './CustomSelectOption.module.css';
 
 const sizeYClassNames = {
@@ -106,7 +107,10 @@ export const CustomSelectOption = ({
       <div className={styles['CustomSelectOption__main']}>
         <div className={styles['CustomSelectOption__children']}>{children}</div>
         {hasReactNode(description) && (
-          <Footnote className={styles['CustomSelectOption__description']}>{description}</Footnote>
+          <>
+            <VisuallyHidden>&nbsp;</VisuallyHidden>
+            <Footnote className={styles['CustomSelectOption__description']}>{description}</Footnote>
+          </>
         )}
       </div>
       <div className={styles['CustomSelectOption__after']}>

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -107,12 +107,10 @@ export const CustomSelectOption = ({
       <div className={styles['CustomSelectOption__main']}>
         <div className={styles['CustomSelectOption__children']}>{children}</div>
         {hasReactNode(description) && (
-          <>
-            <Footnote className={styles['CustomSelectOption__description']}>
-              <VisuallyHidden>&nbsp;</VisuallyHidden>
-              {description}
-            </Footnote>
-          </>
+          <Footnote className={styles['CustomSelectOption__description']}>
+            <VisuallyHidden>&nbsp;</VisuallyHidden>
+            {description}
+          </Footnote>
         )}
       </div>
       <div className={styles['CustomSelectOption__after']}>


### PR DESCRIPTION
## Описание

Cкринридер читает заголовок с описанием слитно

<img width="602" alt="image" src="https://github.com/VKCOM/VKUI/assets/14944123/6d481458-1c60-4f86-a8e8-6441b8616f33">

## Изменения

Добавляем пробел для доступности
