### PR TITLE
fix(File): add empty title

### DIFF
--- a/packages/vkui/src/components/File/File.tsx
+++ b/packages/vkui/src/components/File/File.tsx
@@ -44,7 +44,7 @@ export const File = ({
       getRootRef={getRootRef}
       disabled={restProps.disabled}
     >
-      <VisuallyHidden {...restProps} Component="input" type="file" getRootRef={getRef} />
+      <VisuallyHidden title="" {...restProps} Component="input" type="file" getRootRef={getRef} />
       {children}
     </Button>
   );


### PR DESCRIPTION
- fixes #2562

## Описание

Браузер для input type="file" пишет свой текст("Выберите файл"). Из-за этого скринридер прочитает сначала что написано в label, а потом что написано в title

## Изменения

Добавляем пустой title