### PR TITLE
feat: create `UnstyledTextField` component

### DIFF
--- a/packages/vkui/src/components/Input/Input.module.css
+++ b/packages/vkui/src/components/Input/Input.module.css
@@ -13,34 +13,15 @@
 }
 
 .Input__el {
-  block-size: var(--vkui--size_field_height--regular);
-  margin: 0;
-  inline-size: 100%;
-  box-sizing: border-box;
-  box-shadow: none;
-  border: 0;
-  border-radius: inherit;
-  appearance: none;
-  color: var(--vkui--color_text_primary);
-  padding-block: 0;
-  padding-inline: 12px;
   position: relative;
   z-index: var(--vkui_internal--z_index_form_field_element);
-  background: transparent;
-}
-
-/*
- * Отключаем нативные элементы для <input type="number" />
- *
- * см. https://www.w3schools.com/howto/howto_css_hide_arrow_number.asp
- */
-.Input__el::-webkit-outer-spin-button,
-.Input__el::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-}
-
-.Input__el[type='number'] {
-  -moz-appearance: textfield;
+  padding-block: 0;
+  padding-inline: 12px;
+  inline-size: 100%;
+  block-size: var(--vkui--size_field_height--regular);
+  box-sizing: border-box;
+  border-radius: inherit;
+  color: var(--vkui--color_text_primary);
 }
 
 .Input--sizeY-compact .Input__el {

--- a/packages/vkui/src/components/Input/Input.tsx
+++ b/packages/vkui/src/components/Input/Input.tsx
@@ -3,7 +3,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { HasAlign, HasRef, HasRootRef } from '../../types';
 import { FormField, FormFieldProps } from '../FormField/FormField';
-import { Text } from '../Typography/Text/Text';
+import { UnstyledTextField } from '../UnstyledTextField/UnstyledTextField';
 import styles from './Input.module.css';
 
 const sizeYClassNames = {
@@ -55,10 +55,9 @@ export const Input = ({
       mode={mode}
       status={status}
     >
-      <Text
+      <UnstyledTextField
         {...restProps}
-        Component="input"
-        normalize={false}
+        as="input"
         type={type}
         className={styles['Input__el']}
         getRootRef={getRef}

--- a/packages/vkui/src/components/Textarea/Textarea.module.css
+++ b/packages/vkui/src/components/Textarea/Textarea.module.css
@@ -3,19 +3,14 @@
 }
 
 .Textarea__el {
-  margin: 0;
-  inline-size: 100%;
-  display: block;
-  box-sizing: border-box;
-  resize: none;
-  appearance: none;
-  color: var(--vkui--color_text_primary);
-  padding: 12px;
-  max-block-size: 204px;
-  border: 0;
-  z-index: var(--vkui_internal--z_index_form_field_element);
   position: relative;
-  background: transparent;
+  z-index: var(--vkui_internal--z_index_form_field_element);
+  display: block;
+  padding: 12px;
+  inline-size: 100%;
+  max-block-size: 204px;
+  box-sizing: border-box;
+  color: var(--vkui--color_text_primary);
 }
 
 .Textarea__el[cols] {

--- a/packages/vkui/src/components/Textarea/Textarea.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.tsx
@@ -5,7 +5,7 @@ import { useExternRef } from '../../hooks/useExternRef';
 import { callMultiple } from '../../lib/callMultiple';
 import { HasAlign, HasRef, HasRootRef } from '../../types';
 import { FormField, FormFieldProps } from '../FormField/FormField';
-import { Text } from '../Typography/Text/Text';
+import { UnstyledTextField } from '../UnstyledTextField/UnstyledTextField';
 import styles from './Textarea.module.css';
 
 const sizeYClassNames = {
@@ -78,10 +78,9 @@ export const Textarea = ({
       status={status}
       mode={mode}
     >
-      <Text
+      <UnstyledTextField
         {...restProps}
-        Component="textarea"
-        normalize={false}
+        as="textarea"
         style={{ maxHeight }}
         rows={rows}
         className={styles['Textarea__el']}

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.module.css
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.module.css
@@ -1,4 +1,5 @@
 .UnstyledTextField {
+  margin: 0;
   border: 0;
   box-shadow: none;
   background: transparent;
@@ -8,8 +9,7 @@
   resize: none;
 }
 
-.UnstyledTextField--noGaps {
-  margin: 0;
+.UnstyledTextField--noPadding {
   padding: 0;
 }
 

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.module.css
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.module.css
@@ -1,0 +1,32 @@
+.UnstyledTextField {
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+  appearance: none;
+  -webkit-tap-highlight-color: transparent;
+  outline: none;
+  resize: none;
+}
+
+.UnstyledTextField--noGaps {
+  margin: 0;
+  padding: 0;
+}
+
+.UnstyledTextField:focus {
+  outline: none;
+}
+
+/*
+ * Отключаем нативные элементы для <input type="number" />
+ *
+ * см. https://www.w3schools.com/howto/howto_css_hide_arrow_number.asp
+ */
+.UnstyledTextField::-webkit-outer-spin-button,
+.UnstyledTextField::-webkit-inner-spin-button {
+  appearance: none;
+}
+
+.UnstyledTextField[type='number'] {
+  appearance: textfield;
+}

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.stories.mdx
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
+import { UnstyledTextField } from './UnstyledTextField';
+
+<Meta title="Service/UnstyledTextField" />
+
+<Title>UnstyledTextField</Title>
+
+<Description of={UnstyledTextField} />
+
+<ArgTypes of={UnstyledTextField} />

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.test.tsx
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.test.tsx
@@ -33,7 +33,7 @@ describe(UnstyledTextField, () => {
   );
 
   it('accepts noPadding prop', () => {
-    const result = render(<UnstyledTextField as="input" noPadding />);
-    expect(result.container).toHaveClass(`.${styles['UnstyledTextField--noPadding']}`);
+    const result = render(<UnstyledTextField as="input" data-testid="test" noPadding />);
+    expect(result.getByTestId('test')).toHaveClass(styles['UnstyledTextField--noPadding']);
   });
 });

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.test.tsx
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.test.tsx
@@ -32,8 +32,8 @@ describe(UnstyledTextField, () => {
     'baseline (as="textarea")',
   );
 
-  it('accepts noGaps prop', () => {
-    const result = render(<UnstyledTextField as="input" noGaps />);
-    expect(result.container).toHaveClass(`.${styles['UnstyledTextField--noGaps']}`);
+  it('accepts noPadding prop', () => {
+    const result = render(<UnstyledTextField as="input" noPadding />);
+    expect(result.container).toHaveClass(`.${styles['UnstyledTextField--noPadding']}`);
   });
 });

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.test.tsx
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.test.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { baselineComponent } from '../../testing/utils';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
+import { UnstyledTextField } from './UnstyledTextField';
+import styles from './UnstyledTextField.module.css';
+
+describe(UnstyledTextField, () => {
+  baselineComponent(
+    (props) => (
+      <>
+        <VisuallyHidden Component="label" id="input">
+          Input
+        </VisuallyHidden>
+        <UnstyledTextField as="input" aria-labelledby="input" {...props} />
+      </>
+    ),
+    undefined,
+    'baseline (as="input")',
+  );
+
+  baselineComponent(
+    (props) => (
+      <>
+        <VisuallyHidden Component="label" id="textarea">
+          Textarea
+        </VisuallyHidden>
+        <UnstyledTextField as="textarea" aria-labelledby="textarea" {...props} />
+      </>
+    ),
+    undefined,
+    'baseline (as="textarea")',
+  );
+
+  it('accepts noGaps prop', () => {
+    const result = render(<UnstyledTextField as="input" noGaps />);
+    expect(result.container).toHaveClass(`.${styles['UnstyledTextField--noGaps']}`);
+  });
+});

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.tsx
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.tsx
@@ -10,11 +10,9 @@ export interface UnstyledTextFieldBaseProps {
    */
   as: 'input' | 'textarea';
   /**
-   * Сбрасывает `margin` и `padding`.
-   *
    * По умолчанию отключено во избежание проблем из-за очередности загрузки стилей.
    */
-  noGaps?: boolean;
+  noPadding?: boolean;
 }
 
 export interface UnstyledTextFieldAsInputProps
@@ -45,7 +43,7 @@ export type UnstyledTextFieldProps =
  */
 export const UnstyledTextField = ({
   as,
-  noGaps = false,
+  noPadding = false,
   className,
   ...restProps
 }: UnstyledTextFieldProps) => (
@@ -54,7 +52,7 @@ export const UnstyledTextField = ({
     normalize={false}
     className={classNames(
       styles.UnstyledTextField,
-      noGaps && styles['UnstyledTextField--noGaps'],
+      noPadding && styles['UnstyledTextField--noPadding'],
       className,
     )}
     {...restProps}

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.tsx
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.tsx
@@ -37,7 +37,7 @@ export type UnstyledTextFieldProps =
  * Компонент сбрасывает [User-agent stylesheets](https://www.geeksforgeeks.org/what-is-a-user-agent-stylesheet/)
  * полей ввода.
  *
- * Используется в [Input](?path=/story/forms-input--playground) и [Textarea](?path=/story/forms-textarea--playground).
+ * Используется в <a href="?path=/story/forms-input--playground" data-prod-href="https://vkcom.github.io/VKUI/playground/?path=/story/forms-input--playground">Input</a> и <a href="?path=/story/forms-textarea--playground" data-prod-href="https://vkcom.github.io/VKUI/playground/?path=/story/forms-textarea--playground">Textarea</a>.
  *
  * @since 6.1.0
  */

--- a/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.tsx
+++ b/packages/vkui/src/components/UnstyledTextField/UnstyledTextField.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { classNames } from '@vkontakte/vkjs';
+import { HasRootRef } from '../../types';
+import { Text } from '../Typography/Text/Text';
+import styles from './UnstyledTextField.module.css';
+
+export interface UnstyledTextFieldBaseProps {
+  /**
+   * Задаёт какой из DOM-элементов для ввода текста использовать.
+   */
+  as: 'input' | 'textarea';
+  /**
+   * Сбрасывает `margin` и `padding`.
+   *
+   * По умолчанию отключено во избежание проблем из-за очередности загрузки стилей.
+   */
+  noGaps?: boolean;
+}
+
+export interface UnstyledTextFieldAsInputProps
+  extends UnstyledTextFieldBaseProps,
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HasRootRef<HTMLInputElement> {
+  as: 'input';
+}
+
+export interface UnstyledTextFieldAsTextareaProps
+  extends UnstyledTextFieldBaseProps,
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    HasRootRef<HTMLTextAreaElement> {
+  as: 'textarea';
+}
+
+export type UnstyledTextFieldProps =
+  | UnstyledTextFieldAsInputProps
+  | UnstyledTextFieldAsTextareaProps;
+
+/**
+ * Компонент сбрасывает [User-agent stylesheets](https://www.geeksforgeeks.org/what-is-a-user-agent-stylesheet/)
+ * полей ввода.
+ *
+ * Используется в [Input](?path=/story/forms-input--playground) и [Textarea](?path=/story/forms-textarea--playground).
+ *
+ * @since 6.1.0
+ */
+export const UnstyledTextField = ({
+  as,
+  noGaps = false,
+  className,
+  ...restProps
+}: UnstyledTextFieldProps) => (
+  <Text
+    Component={as}
+    normalize={false}
+    className={classNames(
+      styles.UnstyledTextField,
+      noGaps && styles['UnstyledTextField--noGaps'],
+      className,
+    )}
+    {...restProps}
+  />
+);

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -31,6 +31,13 @@ export type { CaptionProps } from './components/Typography/Caption/Caption';
 /**
  * Service
  */
+export { UnstyledTextField } from './components/UnstyledTextField/UnstyledTextField';
+export type {
+  UnstyledTextFieldAsInputProps,
+  UnstyledTextFieldAsTextareaProps,
+  UnstyledTextFieldBaseProps,
+  UnstyledTextFieldProps,
+} from './components/UnstyledTextField/UnstyledTextField';
 export { Tappable } from './components/Tappable/Tappable';
 export type { TappableProps } from './components/Tappable/Tappable';
 export { FixedLayout } from './components/FixedLayout/FixedLayout';


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6496

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- [x] Документация фичи

## Изменения

- Не стал сбрасывать стили `color`, `font`, `box-sizing`, `display`, во избежание проблем с порядком загрузки стилей, ибо большая вероятность, что эти св-ва будут использованы пользователем (в нашем случае задаются в `Input` и `Textarea`). Свойство `padding` под тем же причинам вынес в `noPadding`, который по умолчанию `false`.
- Целенаправлено документацию создал только в сторибук, т.к. это сервисный компонент чисто для разработки.

