### PR TITLE
fix(PullToRefresh): Prevent multiple calls of runRefreshing on iOS

### DIFF
--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
@@ -199,6 +199,7 @@ export const PullToRefresh = ({
     startYRef.current = event.startY;
   };
 
+  const iosRefreshStartedRef = React.useRef(false);
   const onTouchMove = (event: TouchEventInternal) => {
     const { isY, shiftY } = event;
     const { start, max } = initParams;
@@ -219,7 +220,10 @@ export const PullToRefresh = ({
       setCanRefresh(progress > 80);
       setContentShift((currentY + 10) * 2.3);
 
-      if (progress > 85 && !refreshing && platform === 'ios') {
+      const iosCanStartRefreshDuringGesture =
+        platform === 'ios' && progress > 85 && !refreshing && !iosRefreshStartedRef.current;
+      if (iosCanStartRefreshDuringGesture) {
+        iosRefreshStartedRef.current = true;
         runRefreshing();
       }
     } else if (isY && pageYOffset === 0 && shiftY > 0 && !refreshing && touchDown) {
@@ -235,6 +239,7 @@ export const PullToRefresh = ({
   const onTouchEnd = () => {
     setWatching(false);
     setTouchDown(false);
+    iosRefreshStartedRef.current = false;
   };
 
   const spinnerTransform = `translate3d(0, ${spinnerY}px, 0)`;


### PR DESCRIPTION
- close #6715

---

## Описание

На iOS мы вызываем `runRefreshing` внутри `onTouchMove` обработчика, который может вызываеться чаще чем обновляется состояние refreshing в стейте компонента.
https://github.com/VKCOM/VKUI/blob/78e4cb5a5fe44fda8bbe87d079156566b2aa6ce9/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx#L222-L224

Это в свою очередь влечет за собой двойной вызов `onRefresh`.
## Изменения
- добавляем состояние вызова `runRefreshing()` через ref, чтобы избежать повторного вызова `runRefreshing`. Cбрасываем состояние в обработчике onTouchEnd().
Это локальная проблема конкретного условия, что runRefreshing() на iOS вызывается в определённый момент ещё до конца жеста, поэтому и ref используем только в одном месте.