### PR TITLE
fix(Search): correct side margins of `after` element on iOS

### DIFF
--- a/packages/vkui/src/components/Search/Search.module.css
+++ b/packages/vkui/src/components/Search/Search.module.css
@@ -167,7 +167,6 @@
   transition: flex 0.3s var(--vkui--animation_easing_platform),
     transform 0.3s var(--vkui--animation_easing_platform);
   overflow: hidden;
-  margin-inline: 4px calc(4px - var(--vkui--size_base_padding_horizontal--regular));
 }
 
 .Search--focused .Search__after,
@@ -175,6 +174,7 @@
   flex: 1;
   transform: translate(0);
   pointer-events: initial;
+  margin-inline: 4px calc(4px - var(--vkui--size_base_padding_horizontal--regular));
 }
 
 .Search__afterText {

--- a/packages/vkui/src/components/Search/__image_snapshots__/search-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/Search/__image_snapshots__/search-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4cc6366cf61d1f825cda5a7edc80381e8cab50e05cbff46abc80be1950134226
-size 47568
+oid sha256:09c30da11365f6009ba30f315438c29875b6c63123ac1a8a507870346d2ef283
+size 47667

--- a/packages/vkui/src/components/Search/__image_snapshots__/search-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Search/__image_snapshots__/search-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ed8534ef37ed0878d4a38d713a24f525e261fd2df50fd4389d704bffe097022
-size 47644
+oid sha256:376f4e9f9cd3dbc11ee5dbbbe1f83c00d855ed53381f984d000a225ffa7d463f
+size 47707


### PR DESCRIPTION
- close #6719

---

- [x] e2e-тесты

## Описание
На `iOS` кнопка в `after` выезжает если есть текст или фокус у инпута.
Но пока эта кнопка не видна, она всё ещё влияет на верстку `Search`, за счёт своих марджинов.
Задаём `margin` только когда кнопка видна. 

На анимацию появления это никак не повлияло.

## Изображения

Diff из Playwright для демонстрации до и после: 
<img width="414" alt="Screenshot 2024-03-19 at 17 20 46" src="https://github.com/VKCOM/VKUI/assets/5443359/8dbaa973-d105-4fe6-9ec6-deffec248a89">

