### PR TITLE
feat(Popover): support arrow

### DIFF
--- a/packages/vkui/src/components/Popover/Popover.module.css
+++ b/packages/vkui/src/components/Popover/Popover.module.css
@@ -18,3 +18,7 @@
   border-radius: var(--vkui--size_border_radius--regular);
   box-shadow: var(--vkui--elevation3);
 }
+
+.Popover__arrow {
+  color: var(--vkui--color_background_modal);
+}

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -346,6 +346,7 @@ export { Popover } from './components/Popover/Popover';
 export type {
   PopoverProps,
   PopoverOnShownChange,
+  PopoverArrowProps,
   PopoverContentRenderProp,
 } from './components/Popover/Popover';
 


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6634

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~ – компонента утилитарный, его нет в Figma
- [x] Документация фичи

## Описание

На подобии `OnboardingTooltip` и `Popper`, добавил параметр `arrow`, `arrowPadding`, `arrowHeight`, `arrowProps`, `ArrowIcon`.

При `noStyling` также отключаем покраску.

<img width="171" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/d3dbb9f9-b1cc-47ab-8b42-f90ef809a377"> <img width="171" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/5129d813-b8b7-4a41-b2af-4c5add1e3659">

_Справа пример с `noStyling`, цвет работает через **currentColor** в SVG_

