### PR TITLE
feat(Alert): Pass close callback to action

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -24,7 +24,7 @@ export interface AlertActionInterface
     AnchorHTMLAttributesOnly,
     HasDataAttribute {
   title: string;
-  action: (args: { close: VoidFunction }) => void;
+  action?: (args: { close: VoidFunction }) => void;
   /**
    * По умолчанию клик на опцию вызывает переданную в `Alert` функцию `onClose`, данное свойство
    * позволяет отключить такое поведение

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -24,7 +24,7 @@ export interface AlertActionInterface
     AnchorHTMLAttributesOnly,
     HasDataAttribute {
   title: string;
-  action?: VoidFunction;
+  action: (args: { close: VoidFunction }) => void;
   /**
    * По умолчанию клик на опцию вызывает переданную в `Alert` функцию `onClose`, данное свойство
    * позволяет отключить такое поведение
@@ -116,16 +116,16 @@ export const Alert = ({
           (e?: TransitionEvent) => {
             if (!e || e.propertyName === 'opacity') {
               onClose();
-              action && action();
+              action && action({ close });
             }
           },
           timeout,
         );
       } else {
-        action && action();
+        action && action({ close });
       }
     },
-    [elementRef, waitTransitionFinish, onClose, timeout],
+    [elementRef, waitTransitionFinish, onClose, close, timeout],
   );
 
   useScrollLock();

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -24,7 +24,12 @@ export interface AlertActionInterface
     AnchorHTMLAttributesOnly,
     HasDataAttribute {
   title: string;
-  action?: (args: { close: VoidFunction }) => void;
+  /**
+   * Обработчик клика на опцию. Если свойство `autoCloseDisabled` включено,
+   * то в аргументы `action` передаётся объект с функцией close,
+   * вызвав которую можно закрыть `action` вручную.
+   */
+  action?: (args?: { close?: VoidFunction }) => void;
   /**
    * По умолчанию клик на опцию вызывает переданную в `Alert` функцию `onClose`, данное свойство
    * позволяет отключить такое поведение
@@ -116,7 +121,7 @@ export const Alert = ({
           (e?: TransitionEvent) => {
             if (!e || e.propertyName === 'opacity') {
               onClose();
-              action && action({ close });
+              action && action();
             }
           },
           timeout,


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6727 

---


## Описание
Даём возможность закрыть Alert по клику на action, если `autoCloseDisabled: true`, передавая `close` функцию как аргумент в вызов `action`.
