### PR TITLE
feat(Snackbar): Let layout prop to take priority

### DIFF
--- a/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
@@ -2,19 +2,9 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ViewWidth } from '../../lib/adaptivity';
 import { baselineComponent } from '../../testing/utils';
+import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
 import { Snackbar } from './Snackbar';
 import styles from './Snackbar.module.css';
-
-const getViewWidthStub = jest.fn().mockReturnValue(ViewWidth.MOBILE);
-jest.mock('../../hooks/useAdaptivityWithJSMediaQueries', () => ({
-  useAdaptivityWithJSMediaQueries() {
-    return {
-      get viewWidth() {
-        return getViewWidthStub();
-      },
-    };
-  },
-}));
 
 describe('Snackbar', () => {
   baselineComponent((props) => <Snackbar onClose={jest.fn()} {...props} />);
@@ -26,11 +16,12 @@ describe('Snackbar', () => {
   });
 
   it('renders in horizontal layout on desktop if layout prop is set', () => {
-    getViewWidthStub.mockReturnValue(ViewWidth.DESKTOP);
     const { container, rerender } = render(
-      <Snackbar action="Close me" onClose={jest.fn()}>
-        Text message
-      </Snackbar>,
+      <AdaptivityProvider viewWidth={ViewWidth.DESKTOP}>
+        <Snackbar action="Close me" onClose={jest.fn()}>
+          Text message
+        </Snackbar>
+      </AdaptivityProvider>,
     );
 
     // renders in vertical layout on desktop by default

--- a/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
@@ -1,7 +1,20 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
+import { ViewWidth } from '../../lib/adaptivity';
 import { baselineComponent } from '../../testing/utils';
 import { Snackbar } from './Snackbar';
+import styles from './Snackbar.module.css';
+
+const getViewWidthStub = jest.fn().mockReturnValue(ViewWidth.MOBILE);
+jest.mock('../../hooks/useAdaptivityWithJSMediaQueries', () => ({
+  useAdaptivityWithJSMediaQueries() {
+    return {
+      get viewWidth() {
+        return getViewWidthStub();
+      },
+    };
+  },
+}));
 
 describe('Snackbar', () => {
   baselineComponent((props) => <Snackbar onClose={jest.fn()} {...props} />);
@@ -10,5 +23,27 @@ describe('Snackbar', () => {
     render(<Snackbar data-testid="snackbar" onClose={jest.fn()} offsetY={200} />);
 
     expect(screen.getByTestId('snackbar').style.bottom).toBe('200px');
+  });
+
+  it('renders in horizontal layout on desktop if layout prop is set', () => {
+    getViewWidthStub.mockReturnValue(ViewWidth.DESKTOP);
+    const { container, rerender } = render(
+      <Snackbar action="Close me" onClose={jest.fn()}>
+        Text message
+      </Snackbar>,
+    );
+
+    // renders in vertical layout on desktop by default
+    expect(container.querySelector(`.${styles['Snackbar--layout-vertical']}`)).not.toBeNull();
+    expect(container.querySelector(`.${styles['Snackbar--layout-horizontal']}`)).toBeNull();
+
+    rerender(
+      <Snackbar layout="horizontal" action="Close me" onClose={jest.fn()}>
+        Text message
+      </Snackbar>,
+    );
+    // renders in horizontal layout on desktop according to layout prop
+    expect(container.querySelector(`.${styles['Snackbar--layout-vertical']}`)).toBeNull();
+    expect(container.querySelector(`.${styles['Snackbar--layout-horizontal']}`)).not.toBeNull();
   });
 });

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -45,7 +45,7 @@ export interface SnackbarProps extends HTMLAttributesWithRootRef<HTMLElement>, B
  */
 export const Snackbar = ({
   children,
-  layout: layoutProps = 'horizontal',
+  layout: layoutProps,
   action,
   before,
   after,
@@ -95,7 +95,7 @@ export const Snackbar = ({
     }
   };
 
-  const closeTimeout = useTimeout(close, duration);
+  const closeTimeout = useTimeout(close, duration * 20);
 
   const setBodyTransform = (percent: number) => {
     if (animationFrameRef.current !== null) {
@@ -168,7 +168,7 @@ export const Snackbar = ({
 
   React.useEffect(() => closeTimeout.set(), [closeTimeout]);
 
-  const layout = after || isDesktop || subtitle ? 'vertical' : layoutProps;
+  const layout = layoutProps || (after || isDesktop || subtitle ? 'vertical' : 'horizontal');
 
   return (
     <AppRootPortal>

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -95,7 +95,7 @@ export const Snackbar = ({
     }
   };
 
-  const closeTimeout = useTimeout(close, duration * 20);
+  const closeTimeout = useTimeout(close, duration);
 
   const setBodyTransform = (percent: number) => {
     if (animationFrameRef.current !== null) {

--- a/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.tsx
+++ b/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.tsx
@@ -31,7 +31,7 @@ export interface BasicProps {
 
   /**
    * Варианты расположения кнопки действия
-   * По умолчанию на десктопах и при наличии элементов `after` или `subtitle`
+   * По умолчанию на десктопах, или при наличии элементов `after` или `subtitle`
    * имеет значение `vertical`, в остальных случаях `horizontal`
    */
   layout?: 'vertical' | 'horizontal';

--- a/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.tsx
+++ b/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.tsx
@@ -31,7 +31,8 @@ export interface BasicProps {
 
   /**
    * Варианты расположения кнопки действия
-   * Игнорируется на десктопах и при наличии элементов `after` или `subtitle`
+   * По умолчанию на десктопах и при наличии элементов `after` или `subtitle`
+   * имеет значение `vertical`, в остальных случаях `horizontal`
    */
   layout?: 'vertical' | 'horizontal';
 
@@ -58,7 +59,7 @@ export interface BasicProps {
 export interface SnackbarBasicProps extends HTMLAttributesWithRootRef<HTMLDivElement>, BasicProps {}
 
 export function Basic({
-  layout: layoutProps = 'horizontal',
+  layout: layoutProps,
   action,
   after,
   before,
@@ -68,7 +69,7 @@ export function Basic({
   ...restProps
 }: SnackbarBasicProps) {
   const { sizeY = 'none' } = useAdaptivity();
-  const layout = after || subtitle ? 'vertical' : layoutProps;
+  const layout = layoutProps || (after || subtitle ? 'vertical' : 'horizontal');
 
   return (
     <RootComponent


### PR DESCRIPTION
- close #6733 

- [x] Unit-тесты
- [x] e2e-тесты


## Описание
Из-за того, что свойство `layout` играет роль только если не выполнено одно из условий (в том числе `isDesktop`), то задать желаемый `layout` для того чтобы `action` был на десктопе горизонтально невозможно. Хотя нам ничего не мешает сохранить условие, но дать приоритет именно значению переданному через свойство `layout`.
https://github.com/VKCOM/VKUI/blob/cb0cc188b4d543062312f518102da266c56533f9/packages/vkui/src/components/Snackbar/Snackbar.tsx#L171

