### PR TITLE
feat(Panel): Allow to use gradient in Panel background

### DIFF
--- a/packages/vkui/src/components/Panel/Panel.module.css
+++ b/packages/vkui/src/components/Panel/Panel.module.css
@@ -4,15 +4,6 @@
   block-size: 100%;
 }
 
-.Panel::before {
-  position: absolute;
-  inline-size: 100%;
-  block-size: 100%;
-  inset-inline-start: 0;
-  inset-block-start: 0;
-  content: '';
-}
-
 .Panel__in {
   position: relative;
   box-sizing: border-box;
@@ -98,20 +89,16 @@
 }
 
 .Panel--mode-none .Panel__in,
-.Panel--mode-none::before,
-.Panel--mode-plain .Panel__in,
-.Panel--mode-plain::before {
-  background-color: var(--vkui--color_background_content);
+.Panel--mode-plain .Panel__in {
+  background: var(--vkui--color_background_content);
 }
 
-.Panel--mode-card .Panel__in,
-.Panel--mode-card::before {
-  background-color: var(--vkui--color_background);
+.Panel--mode-card .Panel__in {
+  background: var(--vkui--color_background);
 }
 
 @media (--sizeX-regular) {
-  .Panel--mode-none .Panel__in,
-  .Panel--mode-none::before {
-    background-color: var(--vkui--color_background);
+  .Panel--mode-none .Panel__in {
+    background: var(--vkui--color_background);
   }
 }


### PR DESCRIPTION

<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6327 

---

- [x] e2e-тесты

## Описание

- Чтобы была возможность применить градиент к фону `Panel` через токен используем свойство `background` вместо `background-color`.
- Убираем `Panel::before`, так как не несет за собой никакой функции. Описывая фон, её полностью перекрывает `Panel__in`, в том числе не видно разницы в режиме нескольких колонок, со скролом на странице, с разным значением `aria-inset`.
