### PR TITLE
docs: Fix Panel layout

### DIFF
--- a/packages/vkui/src/components/Panel/Readme.md
+++ b/packages/vkui/src/components/Panel/Readme.md
@@ -1,6 +1,6 @@
 `Panel` – это контейнер для контента.
 
-```jsx { "props": { "layout": false, "showLayoutSelect": true, "adaptivity": true } }
+```jsx { "props": { "showLayoutSelect": true, "adaptivity": true } }
 const Example = () => {
   const [activePanel, setActivePanel] = React.useState('panel1');
 


### PR DESCRIPTION
## Описание

- caused by #6678

Из-за того, что перестали оборачивать пример с `Panel` в обертку, получали вот такую поехавшую верстку (ширина рассчитывалась относительно корневого `SplitCol`):

<img width="509" alt="image" src="https://github.com/VKCOM/VKUI/assets/7431217/b0166bf3-0148-48a8-a4c3-80a28b94bde2">


## Изменения

Убираем проп, который убирает обертку 🙃 
