### PR TITLE
ci: deploy next release docs

### DIFF
--- a/.github/workflows/deploy_docs_on_branch_push.yml
+++ b/.github/workflows/deploy_docs_on_branch_push.yml
@@ -1,0 +1,118 @@
+name: 'Deploy next version docs'
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '.husky/**'
+      - '.codesandbox/**'
+      - '.github/**'
+      - '!.github/actions/**'
+      - '.github/actions/**/*.yml'
+      - '**/*.md'
+      - '!packages/vkui/src/**/*.md'
+      - '!styleguide/pages/**/*.md'
+      - '**/__image_snapshots__/*.png'
+
+env:
+  AWS_S3_URL: https://${{ vars.AWS_BUCKET }}.${{ vars.AWS_ENDPOINT }}
+
+concurrency:
+  group: deploy-docs-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  changed_files:
+    runs-on: ubuntu-latest
+    name: Detect what files changed
+    outputs:
+      docs_styleguide: ${{ steps.changes.outputs.docs_styleguide }}
+      docs_storybook: ${{ steps.changes.outputs.docs_storybook }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Find changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: .github/file-filters.yml
+
+  build_and_deploy_styleguide:
+    if: ${{ !cancelled() && needs.changed_files.outputs.docs_styleguide == 'true' }}
+    runs-on: ubuntu-latest
+    name: Deploy docs (styleguide)
+    needs: changed_files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
+
+      - name: Build
+        run: yarn docs:styleguide:build
+
+      - name: Upload to S3
+        id: deploy
+        uses: VKCOM/gh-actions/VKUI/s3@main
+        with:
+          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
+          awsBucket: ${{ vars.AWS_BUCKET }}
+          awsEndpoint: https://${{ vars.AWS_ENDPOINT }}
+          command: upload
+          commandUploadSrc: styleguide/dist
+          commandUploadDist: next/styleguide
+
+      - name: Create doc url
+        if: ${{ steps.deploy.outcome == 'success' }}
+        id: url
+        run: echo "${{ env.AWS_S3_URL }}/next/styleguide/index.html"
+
+  build_and_deploy_storybook:
+    if: ${{ !cancelled() && needs.changed_files.outputs.docs_storybook == 'true' }}
+    runs-on: ubuntu-latest
+    name: Deploy docs (storybook)
+    needs: changed_files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
+
+      - name: Build
+        run: yarn docs:storybook:build
+
+      - name: Upload to S3
+        id: deploy
+        uses: VKCOM/gh-actions/VKUI/s3@main
+        with:
+          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.AWS_SECRET_KEY }}
+          awsBucket: ${{ vars.AWS_BUCKET }}
+          awsEndpoint: https://${{ vars.AWS_ENDPOINT }}
+          command: upload
+          commandUploadSrc: packages/vkui/storybook-static
+          commandUploadDist: next/storybook
+
+      - name: Create doc url
+        if: ${{ steps.deploy.outcome == 'success' }}
+        id: url
+        run: echo "${{ env.AWS_S3_URL }}/next/storybook/index.html"


### PR DESCRIPTION
## Описание

Добавляем экшон, который собирает доки (пока `styleguide`/`storybook`) на основе актуальной ветки `master` и деплоит их на `S3` (`url` будет всегда статичный)

Используем `dorny/paths-filter@v3` и стандартный `paths-ignore` для того, чтобы пересобирать доки, когда это действительно необходимо