### PR TITLE
docs(StyleGuide): disablePortal

### DIFF
--- a/styleguide/Components/Preview.css
+++ b/styleguide/Components/Preview.css
@@ -1,4 +1,5 @@
 .Preview {
+  isolation: isolate;
   position: relative;
   border-radius: 14px;
 }

--- a/styleguide/Components/StyleGuide/StyleGuideRenderer.js
+++ b/styleguide/Components/StyleGuide/StyleGuideRenderer.js
@@ -166,7 +166,7 @@ let StyleGuideRenderer = ({ children, toc }) => {
         transitionMotionEnabled={false}
         hasCustomPanelHeaderAfter={false}
       >
-        <AppRoot>
+        <AppRoot disablePortal>
           <Component
             toc={toc}
             popout={popout}


### PR DESCRIPTION

## Описание

Попауты(например списки) могут быть выше чем заголовок документации.

## Изменения

Отключаем портал, изолируем плейграунд
