### PR TITLE
fix(codemod): fix wrong codemod applying

### DIFF
--- a/packages/codemods/src/codemod-helpers.ts
+++ b/packages/codemods/src/codemod-helpers.ts
@@ -13,21 +13,19 @@ export function getImportInfo(
   file: FileInfo,
   componentName: string,
   alias: string,
-) {
+): { localName: string | null } {
   const source = j(file.source);
 
-  let localImportName = componentName;
+  let localImportName = null;
 
-  const componentImport = source
-    .find(j.ImportDeclaration)
-    .filter((path) => path.node.source.value === alias)
-    .find(j.ImportSpecifier, { imported: { name: componentName } });
-
-  componentImport.forEach((path) => {
-    if (path.node.local && path.node.local.name !== path.node.imported.name) {
-      localImportName = path.node.local.name;
-    }
-  });
+  source
+    .find(j.ImportDeclaration, { source: { value: alias } })
+    .find(j.ImportSpecifier, { imported: { name: componentName } })
+    .forEach((path) => {
+      if (path.node.local) {
+        localImportName = path.node.local.name;
+      }
+    });
 
   return { localName: localImportName };
 }

--- a/packages/codemods/src/transforms/__testfixtures__/action-sheet/alias.input.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/action-sheet/alias.input.tsx
@@ -1,0 +1,8 @@
+import { ActionSheet } from '@vkontakte-fake/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <ActionSheet popupDirection="top" />
+  );
+};

--- a/packages/codemods/src/transforms/__testfixtures__/alert/basic.input.tsx
+++ b/packages/codemods/src/transforms/__testfixtures__/alert/basic.input.tsx
@@ -1,4 +1,4 @@
-import { ActionSheet, ActionSheetItem } from '@vkontakte/vkui';
+import { Alert } from '@vkontakte/vkui';
 import React from 'react';
 import '@vkontakte/vkui/dist/vkui.css';
 

--- a/packages/codemods/src/transforms/__tests__/__snapshots__/action-sheet.ts.snap
+++ b/packages/codemods/src/transforms/__tests__/__snapshots__/action-sheet.ts.snap
@@ -15,3 +15,14 @@ const App = () => {
   );
 };"
 `;
+
+exports[`action-sheet transforms correctly 2`] = `
+"import { ActionSheet } from '@vkontakte-fake/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <ActionSheet popupDirection="top" />
+  );
+};"
+`;

--- a/packages/codemods/src/transforms/__tests__/__snapshots__/alert.ts.snap
+++ b/packages/codemods/src/transforms/__tests__/__snapshots__/alert.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`alert transforms correctly 1`] = `
-"import { ActionSheet, ActionSheetItem } from '@vkontakte/vkui';
+"import { Alert } from '@vkontakte/vkui';
 import React from 'react';
 import '@vkontakte/vkui/dist/vkui.css';
 

--- a/packages/codemods/src/transforms/__tests__/action-sheet.ts
+++ b/packages/codemods/src/transforms/__tests__/action-sheet.ts
@@ -3,7 +3,7 @@ jest.autoMockOff();
 import { defineSnapshotTestFromFixture } from '../../testHelpers/testHelper';
 
 const name = 'action-sheet';
-const fixtures = ['basic'] as const;
+const fixtures = ['basic', 'alias'] as const;
 
 describe(name, () => {
   fixtures.forEach((test) =>

--- a/packages/codemods/src/transforms/accordion.ts
+++ b/packages/codemods/src/transforms/accordion.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Accordion', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   renameProp(j, source, localName, { open: 'expanded' });
 
   const accordionComponents = source

--- a/packages/codemods/src/transforms/action-sheet-item.ts
+++ b/packages/codemods/src/transforms/action-sheet-item.ts
@@ -10,7 +10,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'ActionSheetItem', alias);
 
-  swapBooleanValue(api, source, localName, 'autoClose', 'autoCloseDisabled');
+  if (localName) {
+    swapBooleanValue(api, source, localName, 'autoClose', 'autoCloseDisabled');
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/action-sheet.ts
+++ b/packages/codemods/src/transforms/action-sheet.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'ActionSheet', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const openingTargetElements = source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/alert.ts
+++ b/packages/codemods/src/transforms/alert.ts
@@ -29,6 +29,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeshi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Alert', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/appearance-provider.ts
+++ b/packages/codemods/src/transforms/appearance-provider.ts
@@ -10,6 +10,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'AppearanceProvider', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/banner.ts
+++ b/packages/codemods/src/transforms/banner.ts
@@ -10,6 +10,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Banner', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const bannerComponent = source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/calendar-range.ts
+++ b/packages/codemods/src/transforms/calendar-range.ts
@@ -18,7 +18,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'CalendarRange', alias);
 
-  renameProp(j, source, localName, RENAME_MAP);
+  if (localName) {
+    renameProp(j, source, localName, RENAME_MAP);
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/calendar.ts
+++ b/packages/codemods/src/transforms/calendar.ts
@@ -20,7 +20,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Calendar', alias);
 
-  renameProp(j, source, localName, RENAME_MAP);
+  if (localName) {
+    renameProp(j, source, localName, RENAME_MAP);
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/card-scroll.ts
+++ b/packages/codemods/src/transforms/card-scroll.ts
@@ -10,7 +10,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'CardScroll', alias);
 
-  swapBooleanValue(api, source, localName, 'withSpaces', 'noSpaces');
+  if (localName) {
+    swapBooleanValue(api, source, localName, 'withSpaces', 'noSpaces');
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/chip.ts
+++ b/packages/codemods/src/transforms/chip.ts
@@ -14,7 +14,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Chip', alias);
 
-  renameProp(j, source, localName, RENAME_MAP);
+  if (localName) {
+    renameProp(j, source, localName, RENAME_MAP);
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/chips-input.ts
+++ b/packages/codemods/src/transforms/chips-input.ts
@@ -14,7 +14,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'ChipsInput', alias);
 
-  renameProp(j, source, localName, RENAME_MAP);
+  if (localName) {
+    renameProp(j, source, localName, RENAME_MAP);
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/config-provider.ts
+++ b/packages/codemods/src/transforms/config-provider.ts
@@ -18,6 +18,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   let changed = false;
   const { localName } = getImportInfo(j, file, 'ConfigProvider', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const attributes = source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/content-card.ts
+++ b/packages/codemods/src/transforms/content-card.ts
@@ -8,8 +8,11 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { alias } = options;
   const j = api.jscodeshift;
   const source = j(file.source);
-
   const { localName } = getImportInfo(j, file, 'ContentCard', alias);
+
+  if (!localName) {
+    return source.toSource();
+  }
 
   source
     .find(j.JSXOpeningElement)

--- a/packages/codemods/src/transforms/custom-scroll-view.ts
+++ b/packages/codemods/src/transforms/custom-scroll-view.ts
@@ -10,6 +10,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'CustomScrollView', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const unusedProps = source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/date-input.ts
+++ b/packages/codemods/src/transforms/date-input.ts
@@ -22,7 +22,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'DateInput', alias);
 
-  renameProp(j, source, localName, RENAME_MAP);
+  if (localName) {
+    renameProp(j, source, localName, RENAME_MAP);
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/date-range-input.ts
+++ b/packages/codemods/src/transforms/date-range-input.ts
@@ -26,7 +26,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'DateRangeInput', alias);
 
-  renameProp(j, source, localName, RENAME_MAP);
+  if (localName) {
+    renameProp(j, source, localName, RENAME_MAP);
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/fixed-layout.ts
+++ b/packages/codemods/src/transforms/fixed-layout.ts
@@ -10,6 +10,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'FixedLayout', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/form-item.ts
+++ b/packages/codemods/src/transforms/form-item.ts
@@ -8,8 +8,11 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { alias } = options;
   const j = api.jscodeshift;
   const source = j(file.source);
-
   const { localName } = getImportInfo(j, file, 'FormItem', alias);
+
+  if (!localName) {
+    return source.toSource();
+  }
 
   source
     .find(j.JSXOpeningElement)

--- a/packages/codemods/src/transforms/form-layout.ts
+++ b/packages/codemods/src/transforms/form-layout.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'FormLayout', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const components = source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/gallery.ts
+++ b/packages/codemods/src/transforms/gallery.ts
@@ -10,7 +10,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Gallery', alias);
 
-  swapBooleanValue(api, source, localName, 'isDraggable', 'dragDisabled');
+  if (localName) {
+    swapBooleanValue(api, source, localName, 'isDraggable', 'dragDisabled');
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/gradient-prop-change.ts
+++ b/packages/codemods/src/transforms/gradient-prop-change.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Gradient', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/image-base.ts
+++ b/packages/codemods/src/transforms/image-base.ts
@@ -12,9 +12,17 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName: imageLocalName } = getImportInfo(j, file, 'Image', alias);
   const { localName: avatarLocalName } = getImportInfo(j, file, 'Avatar', alias);
 
-  swapBooleanValue(api, source, imageBaseLocalName, 'withBorder', 'noBorder');
-  swapBooleanValue(api, source, imageLocalName, 'withBorder', 'noBorder');
-  swapBooleanValue(api, source, avatarLocalName, 'withBorder', 'noBorder');
+  if (imageBaseLocalName) {
+    swapBooleanValue(api, source, imageBaseLocalName, 'withBorder', 'noBorder');
+  }
+
+  if (imageLocalName) {
+    swapBooleanValue(api, source, imageLocalName, 'withBorder', 'noBorder');
+  }
+
+  if (avatarLocalName) {
+    swapBooleanValue(api, source, avatarLocalName, 'withBorder', 'noBorder');
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/modal-card.ts
+++ b/packages/codemods/src/transforms/modal-card.ts
@@ -14,12 +14,19 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName: localNameModalCard } = getImportInfo(j, file, 'ModalCard', alias);
   const { localName: localNameModalCardBase } = getImportInfo(j, file, 'ModalCardBase', alias);
 
+  const localNamesForChange: string[] = [];
+  if (localNameModalCard) {
+    localNamesForChange.push(localNameModalCard);
+  }
+  if (localNameModalCardBase) {
+    localNamesForChange.push(localNameModalCardBase);
+  }
   const modalCards = source
     .find(j.JSXOpeningElement)
     .filter(
       (path) =>
         path.value.name.type === 'JSXIdentifier' &&
-        [localNameModalCard, localNameModalCardBase].includes(path.value.name.name),
+        localNamesForChange.includes(path.value.name.name),
     );
 
   modalCards.forEach((path) => {

--- a/packages/codemods/src/transforms/modal-page-header.ts
+++ b/packages/codemods/src/transforms/modal-page-header.ts
@@ -10,6 +10,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'ModalPageHeader', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(
       j.JSXOpeningElement,

--- a/packages/codemods/src/transforms/pagination.ts
+++ b/packages/codemods/src/transforms/pagination.ts
@@ -17,6 +17,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Pagination', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   renameProp(j, source, localName, RENAME_MAP);
 
   source

--- a/packages/codemods/src/transforms/panel-header-content.ts
+++ b/packages/codemods/src/transforms/panel-header-content.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'PanelHeader', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const elements = source.find(j.JSXOpeningElement).filter((path) => {
     if (path.value.name.type === 'JSXMemberExpression') {
       const property = path.value.name;

--- a/packages/codemods/src/transforms/panel-header.ts
+++ b/packages/codemods/src/transforms/panel-header.ts
@@ -11,6 +11,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'PanelHeader', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   swapBooleanValue(api, source, localName, 'visor', 'float');
 
   source

--- a/packages/codemods/src/transforms/placeholder.ts
+++ b/packages/codemods/src/transforms/placeholder.ts
@@ -10,7 +10,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Placeholder', alias);
 
-  swapBooleanValue(api, source, localName, 'withPadding', 'noPadding');
+  if (localName) {
+    swapBooleanValue(api, source, localName, 'withPadding', 'noPadding');
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/popout-wrapper.ts
+++ b/packages/codemods/src/transforms/popout-wrapper.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'PopoutWrapper', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const components = source.find(
     j.JSXOpeningElement,
     (element) => element.name.type === 'JSXIdentifier' && element.name.name === localName,

--- a/packages/codemods/src/transforms/popover.ts
+++ b/packages/codemods/src/transforms/popover.ts
@@ -44,6 +44,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName } = getImportInfo(j, file, componentName, alias);
   const attributeReplacer = createAttributeManipulator(ATTRIBUTE_MANIPULATOR, api);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.ImportDeclaration)
     .filter((path) => path.node.source.value === alias)

--- a/packages/codemods/src/transforms/popper.ts
+++ b/packages/codemods/src/transforms/popper.ts
@@ -62,6 +62,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName } = getImportInfo(j, file, componentName, alias);
   const attributeReplacer = createAttributeManipulator(ATTRIBUTE_MANIPULATOR, api);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.ImportDeclaration)
     .filter((path) => path.node.source.value === alias)

--- a/packages/codemods/src/transforms/range-slider.ts
+++ b/packages/codemods/src/transforms/range-slider.ts
@@ -15,6 +15,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
     .filter((path) => path.node.source.value === alias)
     .find(j.ImportSpecifier, { imported: { name: 'RangeSlider' } });
 
+  if (componentImport.length === 0) {
+    return source.toSource();
+  }
+
   const sliderImport = source
     .find(j.ImportDeclaration)
     .filter((path) => path.node.source.value === alias)

--- a/packages/codemods/src/transforms/rich-tooltip.ts
+++ b/packages/codemods/src/transforms/rich-tooltip.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'RichTooltip', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   const richTooltipComponents = source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/search.ts
+++ b/packages/codemods/src/transforms/search.ts
@@ -15,7 +15,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Search', alias);
 
-  renameProp(j, source, localName, RENAME_MAP);
+  if (localName) {
+    renameProp(j, source, localName, RENAME_MAP);
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/select.ts
+++ b/packages/codemods/src/transforms/select.ts
@@ -12,9 +12,15 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName: customSelectLocalName } = getImportInfo(j, file, 'CustomSelect', alias);
   const { localName: chipsSelectLocalName } = getImportInfo(j, file, 'ChipsSelect', alias);
 
-  swapBooleanValue(api, source, selectLocalName, 'fixDropdownWidth', 'dropdownAutoWidth');
-  swapBooleanValue(api, source, customSelectLocalName, 'fixDropdownWidth', 'dropdownAutoWidth');
-  swapBooleanValue(api, source, chipsSelectLocalName, 'fixDropdownWidth', 'dropdownAutoWidth');
+  if (selectLocalName) {
+    swapBooleanValue(api, source, selectLocalName, 'fixDropdownWidth', 'dropdownAutoWidth');
+  }
+  if (customSelectLocalName) {
+    swapBooleanValue(api, source, customSelectLocalName, 'fixDropdownWidth', 'dropdownAutoWidth');
+  }
+  if (chipsSelectLocalName) {
+    swapBooleanValue(api, source, chipsSelectLocalName, 'fixDropdownWidth', 'dropdownAutoWidth');
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/simple-cell.ts
+++ b/packages/codemods/src/transforms/simple-cell.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'SimpleCell', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/split-col.ts
+++ b/packages/codemods/src/transforms/split-col.ts
@@ -10,6 +10,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'SplitCol', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/tabbar.ts
+++ b/packages/codemods/src/transforms/tabbar.ts
@@ -10,7 +10,9 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Tabbar', alias);
 
-  swapBooleanValue(api, source, localName, 'shadow', 'plain');
+  if (localName) {
+    swapBooleanValue(api, source, localName, 'shadow', 'plain');
+  }
 
   return source.toSource();
 }

--- a/packages/codemods/src/transforms/tappable.ts
+++ b/packages/codemods/src/transforms/tappable.ts
@@ -14,6 +14,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'Tappable', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/text-tooltip.ts
+++ b/packages/codemods/src/transforms/text-tooltip.ts
@@ -61,6 +61,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName } = getImportInfo(j, file, componentName, alias);
   const attributeReplacer = createAttributeManipulator(ATTRIBUTE_MANIPULATOR, api);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.ImportDeclaration)
     .filter((path) => path.node.source.value === alias)

--- a/packages/codemods/src/transforms/tooltip-container.ts
+++ b/packages/codemods/src/transforms/tooltip-container.ts
@@ -14,6 +14,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { localName } = getImportInfo(j, file, componentName, alias);
   let needRename = true;
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   // подменяем импорт
   source
     .find(j.ImportDeclaration)

--- a/packages/codemods/src/transforms/tooltip.ts
+++ b/packages/codemods/src/transforms/tooltip.ts
@@ -67,6 +67,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const attributeReplacer = createAttributeManipulator(ATTRIBUTE_REPLACER, api);
   let needRename = true;
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   swapBooleanValue(api, source, localName, 'arrow', 'disableArrow');
 
   // подменяем импорт

--- a/packages/codemods/src/transforms/users-stack.ts
+++ b/packages/codemods/src/transforms/users-stack.ts
@@ -12,6 +12,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const source = j(file.source);
   const { localName } = getImportInfo(j, file, 'UsersStack', alias);
 
+  if (!localName) {
+    return source.toSource();
+  }
+
   source
     .find(j.JSXOpeningElement)
     .filter(

--- a/packages/codemods/src/transforms/visually-hidden-input.ts
+++ b/packages/codemods/src/transforms/visually-hidden-input.ts
@@ -17,6 +17,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
     .filter((path) => path.node.imported.name === 'VisuallyHiddenInput')
     .at(0);
 
+  if (componentImport.length === 0) {
+    return source.toSource();
+  }
+
   componentImport.forEach((path) => {
     if (path.node.local && path.node.local.name !== path.node.imported.name) {
       localImportName = path.node.local.name;

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "resolveJsonModule": false,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "strict": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

Если нам попадался импорт компонента с названием, который совпадает с названием из нашей библиотеки, то мы ошибочно применяли изменения и для этого компонента. Например:

`import { Tooltip } from '@fake-ui-kit';` заменялся на `import { OnboardingTooltip } from '@fake-ui-kit';`

## Изменения

Теперь ориентируемся только на импорты, которые были сделаны по `alias` (дефолтово это `@vkontakte/vkui`)

Ещё у нас падала команда `build`, потому что мы обновили `typescript`, и он перестал быть толерантным к импорту типов без указания `type` (это `ast-types` должны поправить на своей стороне, пока в `tsconfig.json` оставила `"isolatedModules": false`)
