### PR TITLE
fix(doc): add example ActionSheetItem without autoClose prop

### DIFF
--- a/styleguide/pages/migration_v6.md
+++ b/styleguide/pages/migration_v6.md
@@ -211,6 +211,8 @@ npx @vkontakte/vkui-codemods --help
 +  <ActionSheetItem>Сохранить в закладках</ActionSheetItem>
 -  <ActionSheetItem autoClose={false}>Закрепить запись</ActionSheetItem>
 +  <ActionSheetItem autoCloseDisabled>Закрепить запись</ActionSheetItem>
+-  <ActionSheetItem>Закрепить запись</ActionSheetItem>
++  <ActionSheetItem autoCloseDisabled>Закрепить запись</ActionSheetItem>
  </ActionSheet>
 ```
 


### PR DESCRIPTION
## Описание

Попросили добавить ещё один вариант для демонстрации случая, когда `ActionSheetItem` не прокидывал параметра `autoClose`
