### PR TITLE
docs: resolve @since comments

### DIFF
--- a/packages/vkui/src/components/Mark/Mark.tsx
+++ b/packages/vkui/src/components/Mark/Mark.tsx
@@ -9,7 +9,7 @@ export type MarkProps = HTMLAttributesWithRootRef<HTMLDivElement>;
  * Компонент используется для выделения фрагментов текста,
  * например при поиске определенных слов или выделения текста в цитате.
  *
- * @since v6.1.0
+ * @since 6.1.0
  * @see https://vkcom.github.io/VKUI/#/Mark
  */
 export const Mark = (props: MarkProps) => (

--- a/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.tsx
+++ b/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.tsx
@@ -18,6 +18,7 @@ export interface EllipsisTextProps
 
 /** Компонент ограничивает текстовый контент убирая его в многоточие.
  *
+ * @since 6.1.0
  * @see https://vkcom.github.io/VKUI/#/EllipsisText
  */
 const EllipsisText = ({

--- a/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/vkui/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -9,7 +9,7 @@ export type VisuallyHiddenProps<T> = RootComponentProps<T>;
  * Компонент-обертка. Позволяет скрыть контент визуально, но оставить его
  * доступным для ассистивных технологий. По умолчанию — `span`.
  *
- * @since v5.4.0
+ * @since 5.4.0
  * @see https://vkcom.github.io/VKUI/#/VisuallyHidden
  */
 export const VisuallyHidden = <T,>({


### PR DESCRIPTION
- related to #6692

## Изменения

- добавляем `6.1.0` для `EllipsisText`
- удаляем префикс `v` у `Mark` и `VisualHidden`
