### PR TITLE
fix(Button/Link): reset user-agent styles

### DIFF
--- a/packages/vkui/src/components/Button/Button.module.css
+++ b/packages/vkui/src/components/Button/Button.module.css
@@ -2,12 +2,10 @@
   position: relative;
   display: inline-block;
   box-sizing: border-box;
-  text-decoration: none;
   border: 0;
   min-block-size: var(--vkui--size_button_small_height--compact);
   margin: 0;
   padding: 0;
-  user-select: none;
   border-radius: var(--vkui--size_border_radius--regular);
   max-inline-size: 100%;
   min-inline-size: var(--vkui--size_button_minimum_width--regular);

--- a/packages/vkui/src/components/Clickable/Clickable.module.css
+++ b/packages/vkui/src/components/Clickable/Clickable.module.css
@@ -2,6 +2,20 @@
   cursor: pointer;
 }
 
+.Clickable__resetButtonStyle {
+  appearance: none;
+  user-select: none;
+  -webkit-tap-highlight-color: none;
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
+}
+
+.Clickable__resetLinkStyle {
+  appearance: none;
+  -webkit-tap-highlight-color: none;
+  text-decoration: none;
+}
+
 .Clickable__host:focus,
 .Clickable__host:focus-visible {
   outline: none;

--- a/packages/vkui/src/components/Clickable/Clickable.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.tsx
@@ -150,6 +150,16 @@ function component<T>({
   return {};
 }
 
+const getUserAgentResetClassName = (Component?: React.ElementType) => {
+  if (Component === 'a') {
+    return styles.Clickable__resetLinkStyle;
+  }
+  if (Component === 'button') {
+    return styles.Clickable__resetButtonStyle;
+  }
+  return;
+};
+
 /**
  * Базовый кликабельный корневой компонент.
  *
@@ -169,7 +179,11 @@ export const Clickable = <T,>({
 }: ClickableProps<T>) => {
   const commonProps = component(restProps);
   const isClickable = checkClickable(restProps);
-  const baseClassName = classNames(baseClassNameProp, styles['Clickable__host']);
+  const baseClassName = classNames(
+    baseClassNameProp,
+    getUserAgentResetClassName(commonProps.Component),
+    styles['Clickable__host'],
+  );
 
   if (isClickable) {
     return (

--- a/packages/vkui/src/components/Link/Link.module.css
+++ b/packages/vkui/src/components/Link/Link.module.css
@@ -1,15 +1,14 @@
 .Link {
   color: var(--vkui_internal--link-color, var(--vkui--color_text_link));
-  text-decoration: none;
   border: 0;
   background: none;
   margin: 0;
   padding: 0;
-  cursor: pointer;
   font-size: inherit;
   font-weight: inherit;
   font-family: inherit;
   line-height: inherit;
+  text-align: inherit;
   display: inline;
   border-radius: 0;
 }


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6503

---

## Описание

Сбрасываем пропущенные св-ва по умолчанию (т.н. user agent). По задаче применялся `text-align: center`

## Изменения

Вынес некоторые св-ва сброса из `Button.module.css` и `Link.module.css` в `Clickable.module.css`, а также добавил недостающие:

- `appearance: none` – сбрасывает системные стили
- `-webkit-tap-highlight-color: none` – удаляет оверлей на кликабельных элементах в мобильных устройствах, в частности в Safari
- `-webkit-touch-callout: none` – отключает вызов контекстного меню
- `-webkit-user-drag: none` – отключает перетаскивание
