### PR TITLE
tech(playwright): fix docker warns

### DIFF
--- a/packages/vkui/docker-compose.yml
+++ b/packages/vkui/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   package_vkui:
     image: ${IMAGE}

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -39,7 +39,7 @@
     "build:types": "yarn run -T concurrently 'yarn:tsc:*'",
     "build:no-types": "yarn run -T concurrently 'yarn:swc:*' 'yarn:postcss'",
     "clear": "yarn run -T shx rm -rf dist/*",
-    "docker:clear-playwright-cache": "docker compose rm -f && docker volume rm vkui_package_vkui_playwright_cache",
+    "docker:clear-playwright-cache": "./scripts/generate_env_docker.sh && docker compose --env-file=./.env.docker rm -f && docker volume rm vkui_package_vkui_playwright_cache",
     "postcss": "yarn run -T cross-env NODE_ENV=production concurrently 'yarn:postcss:*'",
     "postcss:bundle": "yarn run -T webpack --config webpack.styles.config.js",
     "postcss:modules": "yarn run -T postcss './src/**/*.css' --base ./src --dir ./dist/cssm --config ./cssm",


### PR DESCRIPTION
## Изменения

- удалил поле `version` в `docker-compose.yml`, т.к. оно устарело

    ```sh
    WARN[0000] /packages/vkui/docker-compose.yml: `version` is obsolete 
    ```
- поправил NPM скрипт `docker:clear-playwright-cache` под изменение из #6717
