### PR TITLE
fix(DatePicker, Popper, Popout): extend usePlacementChangeCallback logic

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -269,7 +269,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     () => props.value ?? defaultValue ?? (allowClearButton ? '' : undefined),
   );
   const [popperPlacement, setPopperPlacement] = React.useState<PlacementWithAuto | undefined>(
-    undefined,
+    popupDirection,
   );
   const [options, setOptions] = React.useState(optionsProp);
   const [selectedOptionIndex, setSelectedOptionIndex] = React.useState<number | undefined>(

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -219,7 +219,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     className,
     getRef,
     getRootRef,
-    popupDirection,
+    popupDirection = 'bottom',
     style,
     onChange,
     children,

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -119,7 +119,7 @@ export const OnboardingTooltip = ({
     'aria-describedby': shown ? tooltipId : undefined,
   });
 
-  usePlacementChangeCallback(resolvedPlacement, onPlacementChange);
+  usePlacementChangeCallback(placementProp, resolvedPlacement, onPlacementChange);
 
   let tooltip: React.ReactPortal | null = null;
   if (shown) {

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -200,7 +200,7 @@ export const Popover = ({
     onShownChange,
   });
 
-  usePlacementChangeCallback(resolvedPlacement, onPlacementChange);
+  usePlacementChangeCallback(expectedPlacement, resolvedPlacement, onPlacementChange);
 
   const [, child] = usePatchChildren<HTMLDivElement>(
     children,

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -145,7 +145,7 @@ export const Popper = ({
     },
   });
 
-  usePlacementChangeCallback(resolvedPlacement, onPlacementChange);
+  usePlacementChangeCallback(placementProp, resolvedPlacement, onPlacementChange);
 
   const { arrow: arrowCoords } = middlewareData;
 

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -136,7 +136,7 @@ export const Tooltip = ({
   });
   const tooltipRef = useExternRef<HTMLDivElement>(getRootRef, refs.setFloating);
 
-  usePlacementChangeCallback(placement, onPlacementChange);
+  usePlacementChangeCallback(placementProp, placement, onPlacementChange);
 
   let tooltip: React.ReactNode = null;
   if (shown) {

--- a/packages/vkui/src/lib/floating/usePlacementChangeCallback.test.ts
+++ b/packages/vkui/src/lib/floating/usePlacementChangeCallback.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { usePlacementChangeCallback } from './usePlacementChangeCallback';
+
+type HookArguments = Parameters<typeof usePlacementChangeCallback>;
+type RenderHookProps = {
+  initialPlacement: HookArguments[0];
+  resolvedPlacement: HookArguments[1];
+  onPlacementChange: HookArguments[2];
+};
+
+describe('usePlacementChangeCallback', () => {
+  it('calls callback on initial render when initial placement differ from resolvedPlacement', () => {
+    const onPlacementChangeStub = jest.fn();
+
+    renderHook<void, RenderHookProps>(
+      ({ initialPlacement, resolvedPlacement, onPlacementChange }) =>
+        usePlacementChangeCallback(initialPlacement, resolvedPlacement, onPlacementChange),
+      {
+        initialProps: {
+          initialPlacement: 'bottom',
+          resolvedPlacement: 'top',
+          onPlacementChange: onPlacementChangeStub,
+        },
+      },
+    );
+
+    expect(onPlacementChangeStub).toHaveBeenNthCalledWith(1, 'top');
+  });
+
+  it('it calls callback only when the placement changed', () => {
+    const onPlacementChangeStub = jest.fn();
+    const defaultProps: RenderHookProps = {
+      initialPlacement: 'bottom',
+      resolvedPlacement: 'bottom',
+      onPlacementChange: onPlacementChangeStub,
+    };
+
+    const { rerender } = renderHook<void, RenderHookProps>(
+      ({ initialPlacement, resolvedPlacement, onPlacementChange }) =>
+        usePlacementChangeCallback(initialPlacement, resolvedPlacement, onPlacementChange),
+      {
+        initialProps: defaultProps,
+      },
+    );
+
+    expect(onPlacementChangeStub).not.toHaveBeenCalled();
+
+    rerender({ ...defaultProps, resolvedPlacement: 'top' });
+
+    expect(onPlacementChangeStub).toHaveBeenNthCalledWith(1, 'top');
+
+    onPlacementChangeStub.mockReset();
+    rerender({ ...defaultProps, resolvedPlacement: 'top' });
+
+    expect(onPlacementChangeStub).not.toHaveBeenCalled();
+
+    onPlacementChangeStub.mockReset();
+    rerender({ ...defaultProps, resolvedPlacement: 'bottom' });
+
+    expect(onPlacementChangeStub).toHaveBeenNthCalledWith(1, 'bottom');
+  });
+});

--- a/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
+++ b/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
@@ -15,7 +15,8 @@ export function usePlacementChangeCallback(
     }
     const isInitialPlacementChanged =
       prevPlacement === undefined && initialPlacement !== resolvedPlacement;
-    const isResolvedPlacementChanged = prevPlacement !== resolvedPlacement;
+    const isResolvedPlacementChanged =
+      prevPlacement !== undefined && prevPlacement !== resolvedPlacement;
     if (isInitialPlacementChanged || isResolvedPlacementChanged) {
       onPlacementChange(resolvedPlacement);
     }

--- a/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
+++ b/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
@@ -1,19 +1,23 @@
 import { usePrevious } from '../../hooks/usePrevious';
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
-import { OnPlacementChange, Placement } from './types/common';
+import { OnPlacementChange, Placement, PlacementWithAuto } from './types/common';
 
 export function usePlacementChangeCallback(
-  placement: Placement,
+  initialPlacement: PlacementWithAuto,
+  resolvedPlacement: Placement,
   onPlacementChange: OnPlacementChange | undefined,
 ): void {
-  const prevPlacement = usePrevious(placement);
+  const prevPlacement = usePrevious(resolvedPlacement);
 
   useIsomorphicLayoutEffect(() => {
-    if (prevPlacement === undefined || !onPlacementChange) {
+    if (!onPlacementChange) {
       return;
     }
-    if (prevPlacement !== placement) {
-      onPlacementChange(placement);
+    const isInitialPlacementChanged =
+      prevPlacement === undefined && initialPlacement !== resolvedPlacement;
+    const isResolvedPlacementChanged = prevPlacement !== resolvedPlacement;
+    if (isInitialPlacementChanged || isResolvedPlacementChanged) {
+      onPlacementChange(resolvedPlacement);
     }
-  }, [prevPlacement, placement, onPlacementChange]);
+  }, [prevPlacement, initialPlacement, resolvedPlacement, onPlacementChange]);
 }


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6889
---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание
Исправляем поведение хука `usePlacementChangeCallbace`, который вызывает `onPlacemenChange` коллбэк при автоматическом изменении свойства `placement`.

Из-за того, что `onPlacementChange` не всегда вызывался когда это требовалось мы получали неправильно отрендеренные границы у `CustomSelect`, потому что `CustomSelect` мог считать что `placement = "bottom"` когда на самом деле дропдаун уже отрисовывался сверху.

## Изменения
- Исправляем вызов коллбэка при первом рендере.
Для этого учитываем значение пропа `placement` переданного библиотеке `floating-ui`. Раньше мы его игнорировали и могло быть так, что при первом рендере `CustomSelect` ожидает, что `placement="bottom"`, а `floating-ui` уже решил, что `resolvedPlacement="top"`, но так как это первый рендер, то коллбэк не вызывается и внутреннее состояние `CustomSelect` не меняется, от того границы рисуются будто `placement="bottom"`.

- устанавливаем значение `popupDirection` у `CustomSelect` по умолчанию `bottom` и используем значение этого пропа как значение по умолчанию для внутреннего состояния `popperPlacement`, чтобы `CustomSelect` было известно куда будет рендерится по умолчанию dropdown. Он и так сейчас рендерится вниз, так как это значение по умолчанию у `CustomSelectDropdown`, но `CustomSelect` об этом не знает.