### PR TITLE
fix: fetchPriority React@19 support

### DIFF
--- a/packages/vkui/src/components/ContentCard/ContentCard.tsx
+++ b/packages/vkui/src/components/ContentCard/ContentCard.tsx
@@ -101,7 +101,7 @@ export const ContentCard = ({
             referrerPolicy={referrerPolicy}
             sizes={sizes}
             useMap={useMap}
-            {...{ [getFetchPriorityProp()]: fetchPriority }}
+            {...getFetchPriorityProp(fetchPriority)}
             height={height}
             style={{ maxHeight }}
             width="100%"

--- a/packages/vkui/src/components/ContentCard/ContentCard.tsx
+++ b/packages/vkui/src/components/ContentCard/ContentCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
+import { getFetchPriorityProp } from '../../lib/utils';
 import { HasRef, HasRootRef } from '../../types';
 import { Card, CardProps } from '../Card/Card';
 import { Tappable, TappableProps } from '../Tappable/Tappable';
@@ -100,7 +101,7 @@ export const ContentCard = ({
             referrerPolicy={referrerPolicy}
             sizes={sizes}
             useMap={useMap}
-            fetchPriority={fetchPriority}
+            {...{ [getFetchPriorityProp()]: fetchPriority }}
             height={height}
             style={{ maxHeight }}
             width="100%"

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';
 import { minOr } from '../../lib/comparing';
+import { getFetchPriorityProp } from '../../lib/utils';
 import type { AnchorHTMLAttributesOnly, HasRef, HasRootRef, LiteralUnion } from '../../types';
 import { Clickable } from '../Clickable/Clickable';
 import { ImageBaseBadge, type ImageBaseBadgeProps } from './ImageBaseBadge/ImageBaseBadge';
@@ -188,7 +189,7 @@ export const ImageBase = ({
             height={heightImg}
             onLoad={handleImageLoad}
             onError={handleImageError}
-            fetchPriority={fetchPriority}
+            {...{ [getFetchPriorityProp()]: fetchPriority }}
           />
         )}
         {fallbackIcon && <div className={styles['ImageBase__fallback']}>{fallbackIcon}</div>}

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -189,7 +189,7 @@ export const ImageBase = ({
             height={heightImg}
             onLoad={handleImageLoad}
             onError={handleImageError}
-            {...{ [getFetchPriorityProp()]: fetchPriority }}
+            {...getFetchPriorityProp(fetchPriority)}
           />
         )}
         {fallbackIcon && <div className={styles['ImageBase__fallback']}>{fallbackIcon}</div>}

--- a/packages/vkui/src/lib/utils.ts
+++ b/packages/vkui/src/lib/utils.ts
@@ -116,10 +116,10 @@ export function isForwardRefElement<
  * При использовании пропа fetchPriority генерируется warning "Invalid DOM property" (версия React 18.*)
  * Ворнинга нет в React версии 19.*, поэтому пока поддерживаем 2 версии наименования
  */
-export function getFetchPriorityProp() {
+export function getFetchPriorityProp(value: React.ImgHTMLAttributes<HTMLElement>['fetchPriority']) {
   // @ts-expect-error: TS2339 Появится только в версии React >= 19.*
   if (Boolean(React.use)) {
-    return 'fetchPriority';
+    return { fetchPriority: value };
   }
-  return 'fetchpriority';
+  return { fetchpriority: value };
 }

--- a/packages/vkui/src/lib/utils.ts
+++ b/packages/vkui/src/lib/utils.ts
@@ -111,3 +111,15 @@ export function isForwardRefElement<
   const typeOfOfType = children.type && children.type.$$typeof;
   return typeOfOfType === Symbol.for('react.forward_ref');
 }
+
+/**
+ * При использовании пропа fetchPriority генерируется warning "Invalid DOM property" (версия React 18.*)
+ * Ворнинга нет в React версии 19.*, поэтому пока поддерживаем 2 версии наименования
+ */
+export function getFetchPriorityProp() {
+  // @ts-expect-error: TS2339 Появится только в версии React >= 19.*
+  if (Boolean(React.use)) {
+    return 'fetchPriority';
+  }
+  return 'fetchpriority';
+}


### PR DESCRIPTION
## Описание

Сейчас ловим ворнинг:
![image](https://github.com/VKCOM/VKUI/assets/7431217/330f55e8-e7a4-4498-996a-24f8d8c6776c)

Ожидалось, что с версией 18.3.* это пофиксится, но не случилось 

## Изменения

Ориентируемся на версию реакта при выборе наименования для пропа, чтобы поддержать обе версии 🙃 
