### PR TITLE
fix: selector global vkuiInternalEpic--hasTabbar is not pure

### DIFF
--- a/packages/vkui/src/components/Epic/Epic.module.css
+++ b/packages/vkui/src/components/Epic/Epic.module.css
@@ -4,7 +4,7 @@
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-:global(.vkuiInternalEpic--hasTabbar) {
+:global(.vkuiInternalEpic--hasTabbar).Epic {
   --vkui_internal--snackbar_safe_area_inset_bottom: calc(
     var(--vkui_internal--tabbar_height) + var(--vkui_internal--safe_area_inset_bottom)
   );


### PR DESCRIPTION
## Описание

next.js при cssm сборке ругается на глобальный селектор без локального

>./node_modules/@vkontakte/vkui/dist/cssm/components/Epic/Epic.module.css:8:1
> Syntax error: Selector ":global(.vkuiInternalEpic--hasTabbar)" is not pure (pure selectors must contain at least one local class or id)

## Изменения

Добавляем локальный селектор