### PR TITLE
fix: remove react useless imports

### DIFF
--- a/packages/vkui/src/components/ToolButton/ToolButton.e2e-playground.tsx
+++ b/packages/vkui/src/components/ToolButton/ToolButton.e2e-playground.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Icon20Add, Icon24Add } from '@vkontakte/icons';
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { ButtonGroup } from '../ButtonGroup/ButtonGroup';

--- a/packages/vkui/src/components/ToolButton/ToolButton.e2e.tsx
+++ b/packages/vkui/src/components/ToolButton/ToolButton.e2e.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { test } from '@vkui-e2e/test';
 import { ToolButtonPlayground } from './ToolButton.e2e-playground';
 

--- a/packages/vkui/src/components/ToolButton/ToolButton.test.tsx
+++ b/packages/vkui/src/components/ToolButton/ToolButton.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Icon20Add, Icon24Add } from '@vkontakte/icons';
 import { baselineComponent } from '../../testing/utils';

--- a/packages/vkui/src/components/ToolButton/ToolButton.tsx
+++ b/packages/vkui/src/components/ToolButton/ToolButton.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import {


### PR DESCRIPTION
## Описание

- caused by #6837
- caused by #6873

## Изменения

Убираем ненужный импорт `React`

