### PR TITLE
tech: fix jest deprecation and warnings

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { ViewWidth } from '../../lib/adaptivity';
 import {
   baselineComponent,

--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { ViewWidth } from '../../lib/adaptivity';
 import { Platform } from '../../lib/platform';

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { ViewWidth } from '../../lib/adaptivity';
 import {
   baselineComponent,

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { baselineComponent, userEvent } from '../../testing/utils';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent, mountTest, userEvent } from '../../testing/utils';
 import { ModalCard } from '../ModalCard/ModalCard';
 import { ModalPage } from '../ModalPage/ModalPage';

--- a/packages/vkui/src/components/ModalRoot/useModalManager.test.tsx
+++ b/packages/vkui/src/components/ModalRoot/useModalManager.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { modalTransitionReducer, useModalManager } from './useModalManager';
 

--- a/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.test.tsx
+++ b/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { fakeTimers } from '../../testing/utils';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { Panel } from '../Panel/Panel';

--- a/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
+++ b/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { ViewWidth } from '../../lib/adaptivity';
 import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
@@ -1,4 +1,5 @@
-import { act, render } from '@testing-library/react';
+import { act } from 'react';
+import { render } from '@testing-library/react';
 import { baselineComponent, fakeTimers } from '../../testing/utils';
 import { PopoutWrapper } from './PopoutWrapper';
 import styles from './PopoutWrapper.module.css';

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { Platform, type PlatformType } from '../../lib/platform';
 import { baselineComponent, fakeTimers } from '../../testing/utils';

--- a/packages/vkui/src/components/Root/Root.test.tsx
+++ b/packages/vkui/src/components/Root/Root.test.tsx
@@ -1,4 +1,5 @@
-import { act, render } from '@testing-library/react';
+import { act } from 'react';
+import { render } from '@testing-library/react';
 import { baselineComponent, fakeTimers, mockScrollContext, mountTest } from '../../testing/utils';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { View } from '../View/View';

--- a/packages/vkui/src/components/Search/Search.test.tsx
+++ b/packages/vkui/src/components/Search/Search.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';
 import { Search } from './Search';
 import styles from './Search.module.css';
@@ -68,6 +69,12 @@ describe(Search, () => {
       expect(getInput()).toHaveValue('update');
     });
     it('value overrides defaultValue', () => {
+      jest.spyOn(global.console, 'error').mockImplementationOnce((message) => {
+        if (message.includes('with both value and defaultValue props.')) {
+          return;
+        }
+        global.console.error(message);
+      });
       render(<Search defaultValue="def" value="val" />);
       expect(getInput()).toHaveValue('val');
     });
@@ -114,6 +121,7 @@ describe(Search, () => {
     const cb = jest.fn();
     render(<Search icon={<div data-testid="icon" />} onIconClick={cb} />);
     await userEvent.click(screen.getByTestId('icon'));
+    act(jest.runAllTimers);
     expect(cb).toHaveBeenCalled();
   });
 

--- a/packages/vkui/src/components/Slider/Slider.test.tsx
+++ b/packages/vkui/src/components/Slider/Slider.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { setRef } from '../../lib/utils';
 import {
   baselineComponent,

--- a/packages/vkui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.test.tsx
@@ -1,5 +1,5 @@
-import { ComponentProps, useState } from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, ComponentProps, useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { Group } from '../Group/Group';
 import { TabsItem } from '../TabsItem/TabsItem';

--- a/packages/vkui/src/components/Textarea/Textarea.test.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.test.tsx
@@ -70,6 +70,12 @@ describe(Textarea, () => {
       expect(getInput()).toHaveValue('update');
     });
     it('value overrides defaultValue', () => {
+      jest.spyOn(global.console, 'error').mockImplementationOnce((message) => {
+        if (message.includes('with both value and defaultValue props.')) {
+          return;
+        }
+        global.console.error(message);
+      });
       render(<Textarea defaultValue="def" value="val" />);
       expect(getInput()).toHaveValue('val');
     });

--- a/packages/vkui/src/components/View/View.test.tsx
+++ b/packages/vkui/src/components/View/View.test.tsx
@@ -1,5 +1,5 @@
-import { type ComponentType, Fragment, type ReactNode } from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, type ComponentType, Fragment, type ReactNode } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { getRandomUsers } from '../../testing/mock';
 import { baselineComponent, fakeTimers, mockScrollContext, mountTest } from '../../testing/utils';
 import { HasChildren } from '../../types';

--- a/packages/vkui/src/components/View/ViewInfinite.test.tsx
+++ b/packages/vkui/src/components/View/ViewInfinite.test.tsx
@@ -1,5 +1,5 @@
-import { type ComponentType, Fragment, type ReactNode } from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, type ComponentType, Fragment, type ReactNode } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { getRandomUsers } from '../../testing/mock';
 import { baselineComponent, fakeTimers, mockScrollContext, mountTest } from '../../testing/utils';
 import { HasChildren } from '../../types';

--- a/packages/vkui/src/helpers/getMergedSameEventsByProps.test.ts
+++ b/packages/vkui/src/helpers/getMergedSameEventsByProps.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import { getMergedSameEventsByProps } from './getMergedSameEventsByProps';
 
 const getMockedArgs = () => ({

--- a/packages/vkui/src/hooks/useAutoDetectAppearance.test.ts
+++ b/packages/vkui/src/hooks/useAutoDetectAppearance.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { Appearance } from '../lib/appearance';
 import * as LibDOM from '../lib/dom';

--- a/packages/vkui/src/hooks/useBooleanState.test.tsx
+++ b/packages/vkui/src/hooks/useBooleanState.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import { useBooleanState } from './useBooleanState';
 
 describe('useBooleanState', () => {

--- a/packages/vkui/src/hooks/useFocusVisible.test.tsx
+++ b/packages/vkui/src/hooks/useFocusVisible.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import {
   AppRootContext,
   DEFAULT_APP_ROOT_CONTEXT_VALUE,

--- a/packages/vkui/src/hooks/useFocusVisibleClassName.test.ts
+++ b/packages/vkui/src/hooks/useFocusVisibleClassName.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import { classNames } from '@vkontakte/vkjs';
 import {
   focusVisiblePresetModeClassNames as modeClassNames,

--- a/packages/vkui/src/hooks/useFocusWithin.test.tsx
+++ b/packages/vkui/src/hooks/useFocusWithin.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import { useFocusWithin } from './useFocusWithin';
 
 describe(useFocusWithin, () => {

--- a/packages/vkui/src/hooks/useKeyboardInputTracker.test.ts
+++ b/packages/vkui/src/hooks/useKeyboardInputTracker.test.ts
@@ -1,4 +1,5 @@
-import { act, fireEvent, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { fireEvent, renderHook } from '@testing-library/react';
 import { FOCUS_ALLOW_LIST_KEYS, Keys } from '../lib/accessibility';
 import {
   DISABLE_KEYBOARD_INPUT_EVENT_NAME,

--- a/packages/vkui/src/hooks/usePatchChildren.test.tsx
+++ b/packages/vkui/src/hooks/usePatchChildren.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { act, fireEvent, render } from '@testing-library/react';
+import { act } from 'react';
+import { fireEvent, render } from '@testing-library/react';
 import { setRef } from '../lib/utils';
 import type { HasRootRef } from '../types';
 import { usePatchChildren } from './usePatchChildren';

--- a/packages/vkui/src/hooks/useTimeout.test.ts
+++ b/packages/vkui/src/hooks/useTimeout.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { fakeTimers } from '../testing/utils';
 import { useTimeout } from './useTimeout';

--- a/packages/vkui/src/lib/animation/useCSSKeyframesAnimationController.test.ts
+++ b/packages/vkui/src/lib/animation/useCSSKeyframesAnimationController.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
 import { matchMediaReduceMotionMock } from '../../testing/utils';
 import { useCSSKeyframesAnimationController } from './useCSSKeyframesAnimationController';
 

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import {
   AppRootContext,
   DEFAULT_APP_ROOT_CONTEXT_VALUE,

--- a/packages/vkui/src/testing/utils.tsx
+++ b/packages/vkui/src/testing/utils.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
-import {
-  act,
-  type EventType,
-  fireEvent,
-  render,
-  RenderResult,
-  screen,
-} from '@testing-library/react';
+import { act } from 'react';
+import { type EventType, fireEvent, render, RenderResult, screen } from '@testing-library/react';
 // eslint-disable-next-line no-restricted-imports -- используем здесь setup
 import userEventLib from '@testing-library/user-event';
 import { noop } from '@vkontakte/vkjs';


### PR DESCRIPTION
- `act()` из `@testing-library/react` теперь `@deprecated` – рекомендуется использовать `act()` из `react`.
- отключил React варнинги в `Textarea` и `Search`, т.к. в тестах специально передаются `value` и `defaultValue` одновременно.
- в `Search` поправил варнинг, что не хватает вызова `act()`.