### PR TITLE
fix(Popover): fix multiple trigger behavior

### DIFF
--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -231,8 +231,8 @@ describe(useFloatingWithInteractions, () => {
       rerender(<TestComponent hookResultRef={result} />);
       await waitFor(() => {
         expect(result.current.shown).toBeTruthy();
-        expect(onShownChange).toHaveBeenCalledTimes(1);
-        expect(onShownChange).toHaveBeenLastCalledWith(true, 'focus');
+        expect(onShownChange).toHaveBeenCalledTimes(2); // focus and click
+        expect(onShownChange).toHaveBeenLastCalledWith(true, 'click');
       });
 
       jest.useFakeTimers();
@@ -245,7 +245,7 @@ describe(useFloatingWithInteractions, () => {
       rerender(<TestComponent hookResultRef={result} />);
       await waitFor(() => {
         expect(result.current.shown).toBeFalsy();
-        expect(onShownChange).toHaveBeenCalledTimes(2);
+        expect(onShownChange).toHaveBeenCalledTimes(3);
         expect(onShownChange).toHaveBeenLastCalledWith(false, 'escape-key');
       });
 
@@ -253,7 +253,7 @@ describe(useFloatingWithInteractions, () => {
       rerender(<TestComponent hookResultRef={result} />);
       await waitFor(() => {
         expect(result.current.shown).toBeTruthy();
-        expect(onShownChange).toHaveBeenCalledTimes(3);
+        expect(onShownChange).toHaveBeenCalledTimes(4);
         expect(onShownChange).toHaveBeenLastCalledWith(true, 'click');
       });
     });

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -158,6 +158,10 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   });
 
   const handleClickOnReference = useStableCallback(() => {
+    // Предыдущий триггер (фокус) уже вызвал открытие всплывающего окна, игнорируем повторное нажатие
+    if (shownLocalState.reason === 'focus' && shownLocalState.shown) {
+      return;
+    }
     commitShownLocalState(!shownLocalState.shown, 'click');
   });
 

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -91,7 +91,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   const commitShownLocalState = React.useCallback(
     (nextShown: boolean, reason: ShownChangeReason) => {
       setShownLocalState((prevState) => {
-        if (prevState.shown !== nextShown) {
+        if (prevState.shown !== nextShown || prevState.reason !== reason) {
           return {
             shown: nextShown,
             reason,
@@ -118,6 +118,11 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   );
 
   const handleFocusOnReference = useStableCallback(() => {
+    // Повторный вызов события фокуса - следствие клика на reference-элемент
+    if (shownLocalState.shown) {
+      commitShownLocalState(false, 'focus');
+      return;
+    }
     if (blockFocusRef.current) {
       /* istanbul ignore next: в Jest не воспроизводится баг на вебе (cм. onRestoreFocus) */
       blockFocusRef.current = false;
@@ -158,8 +163,9 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   });
 
   const handleClickOnReference = useStableCallback(() => {
-    // Предыдущий триггер (фокус) уже вызвал открытие всплывающего окна, игнорируем повторное нажатие
-    if (shownLocalState.reason === 'focus' && shownLocalState.shown) {
+    // Предыдущий триггер (фокус) уже вызвал открытие/закрытие всплывающего окна, игнорируем вызов
+    if (shownLocalState.reason === 'focus') {
+      commitShownLocalState(shownLocalState.shown, 'click');
       return;
     }
     commitShownLocalState(!shownLocalState.shown, 'click');


### PR DESCRIPTION
- close #6915

---

- [x] Unit-тесты

## Описание

Одновременное указание в качестве триггера `click` и `focus` приводило к проблеме, что всплывающее окно показывалось и сразу же скрывалось.

## Изменения

Игнорируем клик на элемент, если ранее был вызов события `focus`
