### PR TITLE
feat(Popover): add disablePlacementFlip prop

### DIFF
--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -33,6 +33,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'shown'
   | 'children'
   | 'onPlacementChange'
+  | 'forcePlacement'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -82,6 +83,7 @@ export const OnboardingTooltip = ({
   getRootRef,
   disableArrow = false,
   onPlacementChange,
+  forcePlacement,
   ...restProps
 }: OnboardingTooltipProps) => {
   const generatedId = React.useId();
@@ -101,6 +103,7 @@ export const OnboardingTooltip = ({
     arrow: !disableArrow,
     arrowHeight,
     arrowPadding,
+    forcePlacement,
   });
   const {
     x: floatingDataX,

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -33,7 +33,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'shown'
   | 'children'
   | 'onPlacementChange'
-  | 'forcePlacement'
+  | 'disablePlacementFlip'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -83,7 +83,7 @@ export const OnboardingTooltip = ({
   getRootRef,
   disableArrow = false,
   onPlacementChange,
-  forcePlacement,
+  disablePlacementFlip = false,
   ...restProps
 }: OnboardingTooltipProps) => {
   const generatedId = React.useId();
@@ -103,7 +103,7 @@ export const OnboardingTooltip = ({
     arrow: !disableArrow,
     arrowHeight,
     arrowPadding,
-    forcePlacement,
+    disablePlacementFlip,
   });
   const {
     x: floatingDataX,

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -33,7 +33,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'shown'
   | 'children'
   | 'onPlacementChange'
-  | 'disablePlacementFlip'
+  | 'disableFlipMiddleware'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -83,7 +83,7 @@ export const OnboardingTooltip = ({
   getRootRef,
   disableArrow = false,
   onPlacementChange,
-  disablePlacementFlip = false,
+  disableFlipMiddleware = false,
   ...restProps
 }: OnboardingTooltipProps) => {
   const generatedId = React.useId();
@@ -103,7 +103,7 @@ export const OnboardingTooltip = ({
     arrow: !disableArrow,
     arrowHeight,
     arrowPadding,
-    disablePlacementFlip,
+    disableFlipMiddleware,
   });
   const {
     x: floatingDataX,

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -73,7 +73,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'restoreFocus'
   | 'children'
   | 'zIndex'
-  | 'forcePlacement'
+  | 'disablePlacementFlip'
 >;
 
 /**
@@ -127,7 +127,7 @@ export const Popover = ({
   arrowPadding = DEFAULT_ARROW_PADDING,
   placement: expectedPlacement = 'bottom-start',
   onPlacementChange,
-  forcePlacement = false,
+  disablePlacementFlip = false,
   trigger = 'click',
   content,
   hoverDelay = 150,
@@ -175,7 +175,7 @@ export const Popover = ({
     offsetByCrossAxis,
     sameWidth,
     hideWhenReferenceHidden,
-    forcePlacement,
+    disablePlacementFlip,
   });
   const {
     placement: resolvedPlacement,

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -73,6 +73,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'restoreFocus'
   | 'children'
   | 'zIndex'
+  | 'forcePlacement'
 >;
 
 /**
@@ -126,6 +127,7 @@ export const Popover = ({
   arrowPadding = DEFAULT_ARROW_PADDING,
   placement: expectedPlacement = 'bottom-start',
   onPlacementChange,
+  forcePlacement = false,
   trigger = 'click',
   content,
   hoverDelay = 150,
@@ -173,6 +175,7 @@ export const Popover = ({
     offsetByCrossAxis,
     sameWidth,
     hideWhenReferenceHidden,
+    forcePlacement,
   });
   const {
     placement: resolvedPlacement,

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -73,7 +73,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'restoreFocus'
   | 'children'
   | 'zIndex'
-  | 'disablePlacementFlip'
+  | 'disableFlipMiddleware'
 >;
 
 /**
@@ -127,7 +127,7 @@ export const Popover = ({
   arrowPadding = DEFAULT_ARROW_PADDING,
   placement: expectedPlacement = 'bottom-start',
   onPlacementChange,
-  disablePlacementFlip = false,
+  disableFlipMiddleware = false,
   trigger = 'click',
   content,
   hoverDelay = 150,
@@ -175,7 +175,7 @@ export const Popover = ({
     offsetByCrossAxis,
     sameWidth,
     hideWhenReferenceHidden,
-    disablePlacementFlip,
+    disableFlipMiddleware,
   });
   const {
     placement: resolvedPlacement,

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -48,7 +48,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'usePortal'
   | 'customMiddlewares'
   | 'onPlacementChange'
-  | 'forcePlacement'
+  | 'disablePlacementFlip'
 >;
 
 export interface PopperCommonProps
@@ -96,7 +96,7 @@ export const Popper = ({
   arrowHeight = DEFAULT_ARROW_HEIGHT,
   arrowPadding = DEFAULT_ARROW_PADDING,
   customMiddlewares,
-  forcePlacement,
+  disablePlacementFlip = false,
 
   // UseFloatingProps
   autoUpdateOnTargetResize = false,
@@ -127,7 +127,7 @@ export const Popper = ({
     offsetByCrossAxis,
     hideWhenReferenceHidden,
     customMiddlewares,
-    forcePlacement,
+    disablePlacementFlip,
   });
 
   const {

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -48,6 +48,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'usePortal'
   | 'customMiddlewares'
   | 'onPlacementChange'
+  | 'forcePlacement'
 >;
 
 export interface PopperCommonProps
@@ -95,6 +96,7 @@ export const Popper = ({
   arrowHeight = DEFAULT_ARROW_HEIGHT,
   arrowPadding = DEFAULT_ARROW_PADDING,
   customMiddlewares,
+  forcePlacement,
 
   // UseFloatingProps
   autoUpdateOnTargetResize = false,
@@ -125,6 +127,7 @@ export const Popper = ({
     offsetByCrossAxis,
     hideWhenReferenceHidden,
     customMiddlewares,
+    forcePlacement,
   });
 
   const {

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -48,7 +48,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'usePortal'
   | 'customMiddlewares'
   | 'onPlacementChange'
-  | 'disablePlacementFlip'
+  | 'disableFlipMiddleware'
 >;
 
 export interface PopperCommonProps
@@ -96,7 +96,7 @@ export const Popper = ({
   arrowHeight = DEFAULT_ARROW_HEIGHT,
   arrowPadding = DEFAULT_ARROW_PADDING,
   customMiddlewares,
-  disablePlacementFlip = false,
+  disableFlipMiddleware = false,
 
   // UseFloatingProps
   autoUpdateOnTargetResize = false,
@@ -127,7 +127,7 @@ export const Popper = ({
     offsetByCrossAxis,
     hideWhenReferenceHidden,
     customMiddlewares,
-    disablePlacementFlip,
+    disableFlipMiddleware,
   });
 
   const {

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -30,7 +30,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'zIndex'
   | 'usePortal'
   | 'onPlacementChange'
-  | 'disablePlacementFlip'
+  | 'disableFlipMiddleware'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -68,7 +68,7 @@ export const Tooltip = ({
   offsetByMainAxis = 8,
   offsetByCrossAxis = 0,
   hideWhenReferenceHidden,
-  disablePlacementFlip = false,
+  disableFlipMiddleware = false,
 
   // useFloatingWithInteractions
   defaultShown,
@@ -115,7 +115,7 @@ export const Tooltip = ({
     arrowRef,
     arrowPadding,
     arrowHeight,
-    disablePlacementFlip,
+    disableFlipMiddleware,
   });
   const {
     shown,

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -30,6 +30,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'zIndex'
   | 'usePortal'
   | 'onPlacementChange'
+  | 'forcePlacement'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -67,6 +68,7 @@ export const Tooltip = ({
   offsetByMainAxis = 8,
   offsetByCrossAxis = 0,
   hideWhenReferenceHidden,
+  forcePlacement,
 
   // useFloatingWithInteractions
   defaultShown,
@@ -113,6 +115,7 @@ export const Tooltip = ({
     arrowRef,
     arrowPadding,
     arrowHeight,
+    forcePlacement,
   });
   const {
     shown,

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -30,7 +30,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'zIndex'
   | 'usePortal'
   | 'onPlacementChange'
-  | 'forcePlacement'
+  | 'disablePlacementFlip'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -68,7 +68,7 @@ export const Tooltip = ({
   offsetByMainAxis = 8,
   offsetByCrossAxis = 0,
   hideWhenReferenceHidden,
-  forcePlacement,
+  disablePlacementFlip = false,
 
   // useFloatingWithInteractions
   defaultShown,
@@ -115,7 +115,7 @@ export const Tooltip = ({
     arrowRef,
     arrowPadding,
     arrowHeight,
-    forcePlacement,
+    disablePlacementFlip,
   });
   const {
     shown,

--- a/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
+++ b/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
@@ -13,9 +13,13 @@ import type { ArrowOptions, PlacementWithAuto, UseFloatingMiddleware } from '../
 
 export interface UseFloatingMiddlewaresBootstrapOptions {
   /**
-   * По умолчанию компонент выберет наилучшее расположение сам. Но его можно задать извне с помощью этого свойства.
+   * По умолчанию компонент выберет наилучшее расположение сам, но приоритетное можно задать с помощью этого свойства.
    */
   placement?: PlacementWithAuto;
+  /**
+   * Указанное значение `placement` форсируется, даже если для выпадающего элемента недостаточно места.
+   */
+  forcePlacement?: boolean;
   /**
    * Отступ по главной оси.
    */
@@ -62,6 +66,7 @@ export const useFloatingMiddlewaresBootstrap = ({
   offsetByCrossAxis = 0,
   customMiddlewares,
   hideWhenReferenceHidden,
+  forcePlacement = false,
 }: UseFloatingMiddlewaresBootstrapOptions) => {
   return React.useMemo(() => {
     const isNotAutoPlacement = checkIsNotAutoPlacement(placement);
@@ -72,15 +77,17 @@ export const useFloatingMiddlewaresBootstrap = ({
       }),
     ];
 
-    // см. https://floating-ui.com/docs/flip#conflict-with-autoplacement
-    if (isNotAutoPlacement) {
-      middlewares.push(
-        flipMiddleware({
-          fallbackAxisSideDirection: 'start',
-        }),
-      );
-    } else {
-      middlewares.push(autoPlacementMiddleware({ alignment: getAutoPlacementAlign(placement) }));
+    if (!forcePlacement) {
+      // см. https://floating-ui.com/docs/flip#conflict-with-autoplacement
+      if (isNotAutoPlacement) {
+        middlewares.push(
+          flipMiddleware({
+            fallbackAxisSideDirection: 'start',
+          }),
+        );
+      } else {
+        middlewares.push(autoPlacementMiddleware({ alignment: getAutoPlacementAlign(placement) }));
+      }
     }
 
     middlewares.push(shiftMiddleware());
@@ -127,5 +134,6 @@ export const useFloatingMiddlewaresBootstrap = ({
     customMiddlewares,
     placement,
     hideWhenReferenceHidden,
+    forcePlacement,
   ]);
 };

--- a/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
+++ b/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
@@ -20,7 +20,7 @@ export interface UseFloatingMiddlewaresBootstrapOptions {
    * Указанное значение `placement` форсируется, даже если для выпадающего элемента недостаточно места.
    * Не оказывает влияния при `placement` значениях - `'auto' | 'auto-start' | 'auto-end'`
    */
-  disablePlacementFlip?: boolean;
+  disableFlipMiddleware?: boolean;
   /**
    * Отступ по главной оси.
    */
@@ -67,7 +67,7 @@ export const useFloatingMiddlewaresBootstrap = ({
   offsetByCrossAxis = 0,
   customMiddlewares,
   hideWhenReferenceHidden,
-  disablePlacementFlip = false,
+  disableFlipMiddleware = false,
 }: UseFloatingMiddlewaresBootstrapOptions) => {
   return React.useMemo(() => {
     const isAutoPlacement = !checkIsNotAutoPlacement(placement);
@@ -81,7 +81,7 @@ export const useFloatingMiddlewaresBootstrap = ({
     // см. https://floating-ui.com/docs/flip#conflict-with-autoplacement
     if (isAutoPlacement) {
       middlewares.push(autoPlacementMiddleware({ alignment: getAutoPlacementAlign(placement) }));
-    } else if (!disablePlacementFlip) {
+    } else if (!disableFlipMiddleware) {
       middlewares.push(
         flipMiddleware({
           fallbackAxisSideDirection: 'start',
@@ -133,6 +133,6 @@ export const useFloatingMiddlewaresBootstrap = ({
     customMiddlewares,
     placement,
     hideWhenReferenceHidden,
-    disablePlacementFlip,
+    disableFlipMiddleware,
   ]);
 };


### PR DESCRIPTION
- close #6917

---

- [x] Документация фичи

## Описание

Иногда требуется отключить автоматический расчет наиболее удачного расположения

## Изменения

Добавляем `disablePlacementFlip`, чтобы форсировать `placement`, отключая применение плагинов `flipMiddleware` и `autoPlacementMiddleware`
