### PR TITLE
fix(Calendar): restrict min and max years

### DIFF
--- a/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
@@ -5,7 +5,7 @@ import {
   Icon20ChevronRightOutline,
 } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
-import { getMonths, getYears } from '../../lib/calendar';
+import { DEFAULT_MAX_YEAR, DEFAULT_MIN_YEAR, getMonths, getYears } from '../../lib/calendar';
 import { addMonths, setMonth, setYear, subMonths } from '../../lib/date';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
@@ -53,8 +53,8 @@ export interface CalendarHeaderProps
 export const CalendarHeader = ({
   viewDate,
   onChange,
-  prevMonthHidden = false,
-  nextMonthHidden = false,
+  prevMonthHidden: prevMonthHiddenProp = false,
+  nextMonthHidden: nextMonthHiddenProp = false,
   disablePickers = false,
   onNextMonth,
   onPrevMonth,
@@ -102,6 +102,7 @@ export const CalendarHeader = ({
   );
 
   const currentYear = viewDate.getFullYear();
+  const currentMonth = viewDate.getMonth();
 
   const years = React.useMemo(() => getYears(currentYear, 100), [currentYear]);
 
@@ -112,6 +113,11 @@ export const CalendarHeader = ({
 
   const { className: prevMonthClassName, ...restPrevMonthProps } = prevMonthProps;
   const { className: nextMonthClassName, ...restNextMonthProps } = nextMonthProps;
+
+  const nextMonthHidden =
+    nextMonthHiddenProp || (currentMonth === 11 && currentYear === DEFAULT_MAX_YEAR);
+  const prevMonthHidden =
+    prevMonthHiddenProp || (currentMonth === 0 && currentYear === DEFAULT_MIN_YEAR);
 
   return (
     <RootComponent baseClassName={styles['CalendarHeader']} {...restProps}>
@@ -164,7 +170,7 @@ export const CalendarHeader = ({
                 styles['CalendarHeader__picker'],
                 'vkuiInternalCalendarHeader__picker',
               )}
-              value={viewDate.getMonth()}
+              value={currentMonth}
               options={months}
               dropdownOffsetDistance={4}
               dropdownAutoWidth
@@ -179,7 +185,7 @@ export const CalendarHeader = ({
                 styles['CalendarHeader__picker'],
                 'vkuiInternalCalendarHeader__picker',
               )}
-              value={viewDate.getFullYear()}
+              value={currentYear}
               options={years}
               dropdownOffsetDistance={4}
               dropdownAutoWidth

--- a/packages/vkui/src/lib/calendar.test.tsx
+++ b/packages/vkui/src/lib/calendar.test.tsx
@@ -61,6 +61,34 @@ describe('calendar utils', () => {
         },
       ]);
     });
+    it('respects min year', () => {
+      const result = getYears(100, 1);
+
+      expect(result).toEqual([
+        {
+          label: '0100',
+          value: 100,
+        },
+        {
+          label: '0101',
+          value: 101,
+        },
+      ]);
+    });
+    it('respects max year', () => {
+      const result = getYears(9999, 1);
+
+      expect(result).toEqual([
+        {
+          label: '9998',
+          value: 9998,
+        },
+        {
+          label: '9999',
+          value: 9999,
+        },
+      ]);
+    });
   });
   describe(isDayMinMaxRestricted, () => {
     const minDate = new Date('2023-09-15T10:35:00.000Z');

--- a/packages/vkui/src/lib/calendar.ts
+++ b/packages/vkui/src/lib/calendar.ts
@@ -1,3 +1,4 @@
+import { clamp as clampNumber } from '../helpers/math';
 import {
   addDays,
   addWeeks,
@@ -15,13 +16,20 @@ import {
   subWeeks,
 } from './date';
 
+export const DEFAULT_MAX_YEAR = 9999;
+// 100 - из-за ограничений dayjs https://github.com/iamkun/dayjs/issues/2591
+export const DEFAULT_MIN_YEAR = 100;
+
 export const getYears = (currentYear: number, range: number) => {
   const years: Array<{
     value: number;
     label: string;
   }> = [];
 
-  for (let i = currentYear - range; i <= currentYear + range; i++) {
+  const minYear = clampNumber(currentYear - range, DEFAULT_MIN_YEAR, DEFAULT_MAX_YEAR);
+  const maxYear = clampNumber(currentYear + range, DEFAULT_MIN_YEAR, DEFAULT_MAX_YEAR);
+
+  for (let i = minYear; i <= maxYear; i++) {
     years.push({ label: String(i).padStart(4, '0'), value: i });
   }
 


### PR DESCRIPTION
- close #6921

---

- [x] Unit-тесты

## Описание

В `dayjs` есть [проблемы](https://github.com/iamkun/dayjs/issues/2591) с годами `< 100`, поэтому ограничиваем нижнюю границу этим числом
Верхнюю границу ограничила `9999`, потому что есть проблемы с визуальным отображением на некоторых мобильных устройствах 
