### PR TITLE
fix(Search): hides clear button with external changes

### DIFF
--- a/packages/vkui/src/components/Search/Search.test.tsx
+++ b/packages/vkui/src/components/Search/Search.test.tsx
@@ -1,5 +1,5 @@
 import { act } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';
 import { Search } from './Search';
 import styles from './Search.module.css';
@@ -47,6 +47,30 @@ describe(Search, () => {
       screen.getByTestId<HTMLFormElement>('form').reset();
       expect(getInput()).toHaveValue('');
     });
+    it('handles clear button visibility correctly', async () => {
+      render(
+        <form data-testid="form">
+          <Search />
+          <input data-testid="reset" type="reset" />
+        </form>,
+      );
+      expect(getClearIcon()).toHaveAttribute('tabindex', '-1');
+      await userEvent.type(getInput(), 'user');
+      expect(getClearIcon()).not.toHaveAttribute('tabindex');
+      fireEvent.click(screen.getByTestId('reset'));
+      expect(getClearIcon()).toHaveAttribute('tabindex', '-1');
+    });
+    it('handles clear button visibility with default value correctly', async () => {
+      render(
+        <form data-testid="form">
+          <Search defaultValue="val" />
+          <input data-testid="reset" type="reset" />
+        </form>,
+      );
+      expect(getClearIcon()).not.toHaveAttribute('tabindex');
+      fireEvent.click(screen.getByTestId('reset'));
+      expect(getClearIcon()).not.toHaveAttribute('tabindex');
+    });
     it('form reset with defaultValue', async () => {
       render(
         <form data-testid="form">
@@ -83,6 +107,12 @@ describe(Search, () => {
       render(<Search value={value} onChange={(e) => (value = e.target.value)} />);
       await userEvent.type(getInput(), 'X');
       expect(value).toBe('initX');
+    });
+    it('handles clear button visibility correctly', () => {
+      const { rerender } = render(<Search value="init" />);
+      expect(getClearIcon()).not.toHaveAttribute('tabindex');
+      rerender(<Search value="" />);
+      expect(getClearIcon()).toHaveAttribute('tabindex', '-1');
     });
     // TODO (@SevereCloud): не понял почему тест сломался, на деле очистка работает
     it.skip('clears value', async () => {

--- a/packages/vkui/src/components/Search/Search.tsx
+++ b/packages/vkui/src/components/Search/Search.tsx
@@ -5,9 +5,11 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditionalRender';
 import { useBooleanState } from '../../hooks/useBooleanState';
 import { useExternRef } from '../../hooks/useExternRef';
+import { useNativeFormResetListener } from '../../hooks/useNativeFormResetListener';
 import { usePlatform } from '../../hooks/usePlatform';
 import { callMultiple } from '../../lib/callMultiple';
 import { touchEnabled } from '../../lib/touch';
+import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { HasRef, HasRootRef } from '../../types';
 import { Button } from '../Button/Button';
 import { IconButton } from '../IconButton/IconButton';
@@ -122,6 +124,16 @@ export const Search = ({
     },
     [inputRef, onCancel],
   );
+
+  useIsomorphicLayoutEffect(() => {
+    if (inputProps.value !== undefined) {
+      setHasValue(Boolean(inputProps.value));
+    }
+  }, [inputProps.value]);
+
+  useNativeFormResetListener(inputRef, () => {
+    setHasValue(Boolean(inputProps.defaultValue));
+  });
 
   return (
     <div


### PR DESCRIPTION
- close #6944 

---

- [x] Unit-тесты

## Описание

Иконка крестика хранила предыдущий стейт, если изменение поля было "извне" + нашла, что так же не работает очистка через `form.reset`

## Изменения

Для `controlled`-варианта используем useIsomorphicLayoutEffect, чтобы засинкать значение, для `uncontrolled`-варианты используем хук `useNativeFormResetListener`