### PR TITLE
ci: create publish_complete workflow

### DIFF
--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -27,10 +27,9 @@ inputs:
   disable_git_tag_with_namespace:
     required: false
     default: false
-
-outputs:
-  git_release_tag:
-    value: ${{ steps.git_release_tag.outputs.value }}
+  close_milestone:
+    required: false
+    default: false
 
 runs:
   using: composite
@@ -73,6 +72,9 @@ runs:
         mkdir -p publish_workflow_payload
         echo ${{ inputs.next_version }} > publish_workflow_payload/next_version.txt
         echo ${{ inputs.package_name }} > publish_workflow_payload/package_name.txt
+        echo ${{ inputs.npm_tag }} > publish_workflow_payload/npm_tag.txt
+        echo ${{ steps.git_release_tag.outputs.value }} > publish_workflow_payload/git_release_tag.txt
+        echo ${{ inputs.close_milestone }} > publish_workflow_payload/close_milestone.txt
       shell: bash
 
     - name: Upload payload data to artifact for deploy workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,6 @@ on:
 jobs:
   publish:
     concurrency: ci-gh-pages
-    outputs:
-      release_tag: ${{ steps.complete_publish.outputs.git_release_tag }}
     permissions:
       id-token: write
     runs-on: ubuntu-latest
@@ -74,16 +72,5 @@ jobs:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           npm_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
           npm_tag: ${{ inputs.latest == true && 'latest' || 'legacy' }}
+          close_milestone: ${{ inputs.close_milestone == true }}
           disable_git_tag_with_namespace: ${{ inputs.package_name == '@vkontakte/vkui' }}
-
-  close_milestone:
-    needs: ['publish']
-    if: ${{ fromJson(inputs.close_milestone) == true }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Close milestone, comment on issues and release notes
-        uses: VKCOM/gh-actions/VKUI/complete-publish@main
-        with:
-          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
-          releaseTag: ${{ needs.publish.outputs.release_tag }}
-          latest: ${{ inputs.latest }}

--- a/.github/workflows/publish_complete.yml
+++ b/.github/workflows/publish_complete.yml
@@ -1,0 +1,69 @@
+name: 'Publish: Complete (⚠️ use manually call only if necessary)'
+# Note: display_title не задокументирован из-за чего в IDE может подчёркиваться строка
+run-name: "${{ github.event_name == 'workflow_run' && format('{0}: Complete • {1} • {2}', github.event.workflow_run.display_title, github.event.workflow_run.head_branch, github.event.workflow_run.id) || format('Publish {0} {1} ({2}): Complete (⚠️ manually run)', inputs.package_name, inputs.git_release_tag, inputs.npm_tag) }}"
+
+on:
+  workflow_run:
+    workflows: ['Publish release']
+    types: [completed]
+  # Note: только на случай, если потребуется ручной запуск
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: "package's name:"
+        required: true
+        type: choice
+        options:
+          - '@vkontakte/vkui'
+      git_release_tag:
+        description: 'git release tag (ex: `v6.0.0`):'
+        required: true
+        type: string
+      npm_tag:
+        description: 'npm tag:'
+        required: true
+        type: choice
+        options:
+          - 'latest'
+          - 'legacy'
+
+jobs:
+  payload:
+    name: Prepare payload data
+    runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.publish_workflow_payload.outputs.package_name || inputs.package_name }}
+      npm_tag: ${{ steps.publish_workflow_payload.outputs.npm_tag || inputs.npm_tag }}
+      git_release_tag: ${{ steps.publish_workflow_payload.outputs.git_release_tag || inputs.git_release_tag }}
+      close_milestone: ${{ steps.publish_workflow_payload.outputs.close_milestone }}
+    steps:
+      - name: Download artifact (if it is 'workflow_run')
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success' }}
+        id: artifact
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          name: publish_workflow_payload
+          path: publish_workflow_payload/
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Parse artifact
+        if: ${{ steps.artifact.conclusion == 'success' }}
+        id: publish_workflow_payload
+        run: |
+          echo "package_name=$(cat publish_workflow_payload/package_name.txt)" >> $GITHUB_OUTPUT
+          echo "npm_tag=$(cat publish_workflow_payload/npm_tag.txt)" >> $GITHUB_OUTPUT
+          echo "git_release_tag=$(cat publish_workflow_payload/git_release_tag.txt)" >> $GITHUB_OUTPUT
+          echo "close_milestone=$(cat publish_workflow_payload/close_milestone.txt)" >> $GITHUB_OUTPUT
+
+  package_vkui_complete:
+    needs: ['payload']
+    if: ${{ success() && fromJson(needs.payload.outputs.close_milestone) == true && needs.payload.outputs.package_name == '@vkontakte/vkui' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close milestone, comment on issues and release notes
+        uses: VKCOM/gh-actions/VKUI/complete-publish@main
+        with:
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
+          releaseTag: ${{ needs.payload.outputs.git_release_tag }}
+          latest: ${{ needs.payload.outputs.npm_tag == 'latest' }}

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -39,8 +39,6 @@ on:
 jobs:
   publish:
     concurrency: ci-gh-pages
-    outputs:
-      release_tag: ${{ steps.complete_publish.outputs.git_release_tag }}
     permissions:
       id-token: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Выносим шаг `close_milestone` из `publish.yml` в отдельный воркфлоу, чтобы можно было вызывать этот шаг вручную.

Сделано по аналогии с `publish_deploy.yml`.

- blocked by https://github.com/VKCOM/gh-actions/pull/364