### PR TITLE
ci(publish_complete): устанавливаем значения по умолчанию для `close_milestone`

### DIFF
--- a/.github/workflows/publish_complete.yml
+++ b/.github/workflows/publish_complete.yml
@@ -63,7 +63,7 @@ jobs:
     name: Complete @vkontakte/vkui
     steps:
       - name: Close milestone, comment on issues and release notes
-        uses: VKCOM/gh-actions/VKUI/complete-publish@imirdzhamolov/fix/VKUI-complete-publish-refactor
+        uses: VKCOM/gh-actions/VKUI/complete-publish@main
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           releaseTag: ${{ needs.payload.outputs.git_release_tag }}


### PR DESCRIPTION
Из-за того, что при ручном запуске `close_milestone` не определён, `fromJson()` падает с ошибкой.

Для определения значения по умолчанию используем `github.event_name == 'workflow_dispatch'`, чтобы `close_milestone` был `true` по умолчанию только при ручном запуске.

- caused by #6969
- blocked by #366

Ну и пропущенный `name` для шага `package_vkui_complete` объявил.

---

Запустил из ветки `imirdzhamolov/tech/fix-publish_complete`.

<img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/ebe718c5-6730-47ac-8995-880a98d0a334"> <img width="320" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/e2c58d9d-095e-4f1b-addb-192117513d3e">

_https://github.com/VKCOM/VKUI/actions/runs/9271809417_

✅ Недостающие комментарии о релизе создались в issues по v6.1.0.