### PR TITLE
feat(CustomSelect): export CustomSelectClearButtonProps

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -21,7 +21,10 @@ import { NativeSelectProps } from '../NativeSelect/NativeSelect';
 import { SelectType } from '../Select/Select';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
-import { CustomSelectClearButton, CustomSelectClearButtonProps } from './CustomSelectClearButton';
+import {
+  CustomSelectClearButton,
+  type CustomSelectClearButtonProps,
+} from './CustomSelectClearButton';
 import { CustomSelectInput } from './CustomSelectInput';
 import styles from './CustomSelect.module.css';
 
@@ -119,6 +122,8 @@ export interface CustomSelectRenderOption<T extends CustomSelectOptionInterface>
   extends CustomSelectOptionProps {
   option: T;
 }
+
+export type { CustomSelectClearButtonProps };
 
 export interface SelectProps<
   OptionInterfaceT extends CustomSelectOptionInterface = CustomSelectOptionInterface,

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -299,6 +299,7 @@ export type {
   SelectProps,
   CustomSelectOptionInterface,
   CustomSelectRenderOption,
+  CustomSelectClearButtonProps,
 } from './components/CustomSelect/CustomSelect';
 export { CustomSelectOption } from './components/CustomSelectOption/CustomSelectOption';
 export type { CustomSelectOptionProps } from './components/CustomSelectOption/CustomSelectOption';


### PR DESCRIPTION
## Описание

Добавляем экспорт `CustomSelectClearButtonProps`, нужный для кастомного компонента кнопки очистки.