### PR TITLE
refactor(stylelint): mv to `tools/stylelint-plugin-vkui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@project-tools/eslint-plugin-vkui": "workspace:1.0.0",
     "@project-tools/postcss-restructure-variable": "workspace:1.0.0",
     "@project-tools/storybook-addon-cartesian": "workspace:1.0.0",
-    "@project-tools/stylelint-bad-multiplication": "workspace:1.0.0"
+    "@project-tools/stylelint-plugin-vkui": "workspace:1.0.0"
   },
   "devDependencies": {
     "@csstools/postcss-global-data": "2.1.1",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -4,7 +4,7 @@ const { VKUI_PACKAGE } = require('./shared');
 module.exports = {
   extends: ['stylelint-config-standard', '@vkontakte/stylelint-config'],
   plugins: [
-    '@project-tools/stylelint-bad-multiplication',
+    '@project-tools/stylelint-plugin-vkui',
     'stylelint-media-use-custom-media',
     'stylelint-value-no-unknown-custom-properties',
     'stylelint-use-logical',
@@ -69,7 +69,7 @@ module.exports = {
       },
     ],
     'selector-pseudo-class-disallowed-list': ['global'],
-    '@project-tools/stylelint-bad-multiplication': true,
+    'vkui-internal/bad-multiplication': true,
     'import-notation': null,
     'plugin/vkui': null,
     'plugin/selector-bem-pattern': null,

--- a/tools/stylelint-plugin-vkui/.eslintrc.mjs
+++ b/tools/stylelint-plugin-vkui/.eslintrc.mjs
@@ -1,0 +1,7 @@
+export default {
+  root: false,
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/tools/stylelint-plugin-vkui/index.js
+++ b/tools/stylelint-plugin-vkui/index.js
@@ -1,0 +1,6 @@
+import stylelint from 'stylelint';
+import rules from './rules/index.js';
+
+const rulesPlugins = rules.map((rule) => stylelint.createPlugin(rule.ruleName, rule));
+
+export default rulesPlugins;

--- a/tools/stylelint-plugin-vkui/jest.config.js
+++ b/tools/stylelint-plugin-vkui/jest.config.js
@@ -1,6 +1,6 @@
 export default {
   preset: 'jest-preset-stylelint',
   testEnvironment: 'node',
-  // для работы `assert { type: 'json' }`
+  setupFiles: ['./jest.setup.js'],
   transform: {},
 };

--- a/tools/stylelint-plugin-vkui/jest.setup.js
+++ b/tools/stylelint-plugin-vkui/jest.setup.js
@@ -1,0 +1,5 @@
+import { getTestRule, getTestRuleConfigs } from 'jest-preset-stylelint';
+import plugins from './index.js';
+
+global.testRule = getTestRule({ plugins });
+global.testRuleConfigs = getTestRuleConfigs({ plugins });

--- a/tools/stylelint-plugin-vkui/package.json
+++ b/tools/stylelint-plugin-vkui/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@project-tools/stylelint-bad-multiplication",
+  "name": "@project-tools/stylelint-plugin-vkui",
   "version": "1.0.0",
   "type": "module",
   "main": "index.js",

--- a/tools/stylelint-plugin-vkui/rules/bad-multiplication/index.js
+++ b/tools/stylelint-plugin-vkui/rules/bad-multiplication/index.js
@@ -1,10 +1,9 @@
 import valueParser from 'postcss-value-parser';
 import stylelint from 'stylelint';
-import pkg from './package.json' assert { type: 'json' };
 
 const MATCH_CALC = /((?:-(moz|webkit)-)?calc)/i;
 
-export const ruleName = pkg.name;
+export const ruleName = 'vkui-internal/bad-multiplication';
 const messages = stylelint.utils.ruleMessages(ruleName, {});
 const meta = {
   url: 'https://github.com/VKCOM/VKUI/pull/2741',
@@ -66,4 +65,4 @@ ruleFunction.ruleName = ruleName;
 ruleFunction.messages = messages;
 ruleFunction.meta = meta;
 
-export default stylelint.createPlugin(ruleName, ruleFunction);
+export default ruleFunction;

--- a/tools/stylelint-plugin-vkui/rules/bad-multiplication/index.test.js
+++ b/tools/stylelint-plugin-vkui/rules/bad-multiplication/index.test.js
@@ -1,7 +1,6 @@
 import { ruleName } from './index.js';
 
 testRule({
-  plugins: ['.'],
   ruleName,
   config: true,
 

--- a/tools/stylelint-plugin-vkui/rules/index.js
+++ b/tools/stylelint-plugin-vkui/rules/index.js
@@ -1,0 +1,3 @@
+import badMultiplication from './bad-multiplication/index.js';
+
+export default [badMultiplication];

--- a/tools/stylelint-plugin-vkui/tsconfig.json
+++ b/tools/stylelint-plugin-vkui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["**/*.js", ".eslintrc.js"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,9 +2470,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@project-tools/stylelint-bad-multiplication@workspace:1.0.0, @project-tools/stylelint-bad-multiplication@workspace:tools/stylelint-bad-multiplication":
+"@project-tools/stylelint-plugin-vkui@workspace:1.0.0, @project-tools/stylelint-plugin-vkui@workspace:tools/stylelint-plugin-vkui":
   version: 0.0.0-use.local
-  resolution: "@project-tools/stylelint-bad-multiplication@workspace:tools/stylelint-bad-multiplication"
+  resolution: "@project-tools/stylelint-plugin-vkui@workspace:tools/stylelint-plugin-vkui"
   languageName: unknown
   linkType: soft
 
@@ -5328,7 +5328,7 @@ __metadata:
     "@project-tools/eslint-plugin-vkui": "workspace:1.0.0"
     "@project-tools/postcss-restructure-variable": "workspace:1.0.0"
     "@project-tools/storybook-addon-cartesian": "workspace:1.0.0"
-    "@project-tools/stylelint-bad-multiplication": "workspace:1.0.0"
+    "@project-tools/stylelint-plugin-vkui": "workspace:1.0.0"
     "@size-limit/file": ^11.1.4
     "@size-limit/webpack": ^11.1.4
     "@size-limit/webpack-css": ^11.1.4


### PR DESCRIPTION
Теперь все внутренние правила нужно писать в папке `tools/stylelint-plugin-vkui/rules`.

Используем `.eslintrc.mjs`, т.к. в `package.json` установлено `"type": "module"`.

---

В рамках PR #6979 начал добавлять новое правило и пришёл к такой структуре. Решил перенести в отдельный PR.