### PR TITLE
feat(AppRoot): add userSelectMode

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRoot.module.css
+++ b/packages/vkui/src/components/AppRoot/AppRoot.module.css
@@ -3,15 +3,15 @@
   inline-size: 100%;
 }
 
-.AppRoot--pointer-has-not {
+.AppRoot--user-select-none {
   user-select: none;
 }
 
-/** 
- * Хак для webkit-based браузеров, потому что на версиях iOS <= 14.* исчезает возможность 
- * редактировать contenteditable элементы, если выше по дереву задан user-select: none; 
+/**
+ * Хак для webkit-based браузеров, потому что на версиях iOS <= 14.* исчезает возможность
+ * редактировать contenteditable элементы, если выше по дереву задан user-select: none;
  */
-.AppRoot--pointer-has-not [contenteditable] {
+.AppRoot--user-select-none [contenteditable] {
   user-select: text;
 }
 

--- a/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
@@ -16,20 +16,35 @@ import styles from './AppRoot.module.css';
 describe('AppRoot', () => {
   baselineComponent(AppRoot, { getRootRef: false });
 
-  it('should setup pointer class by hasPointer from AdaptivityProvider', () => {
+  it('should setup user-select mode by hasPointer from AdaptivityProvider', () => {
     const Template = (props: { hasPointer?: boolean }) => (
       <AdaptivityProvider {...props}>
-        <AppRoot mode="full" data-testid="app-root" />
+        <AppRoot mode="full" data-testid="app-root" userSelectMode="enabled-with-pointer" />
       </AdaptivityProvider>
     );
     const result = render(<Template />);
     expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--pointer-none']);
     result.rerender(<Template hasPointer={false} />);
-    expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--pointer-has-not']);
+    expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
     result.rerender(<Template hasPointer={true} />);
     expect(result.getByTestId('app-root')).not.toHaveClass(
       styles['AppRoot--pointer-none'],
-      styles['AppRoot--pointer-has-not'],
+      styles['AppRoot--user-select-none'],
+    );
+  });
+
+  it('should setup user-select mode class by isWebView from ConfigProvider', () => {
+    const Template = (props: { isWebView?: boolean }) => (
+      <ConfigProvider {...props}>
+        <AppRoot mode="full" data-testid="app-root" userSelectMode="disabled-in-webview" />
+      </ConfigProvider>
+    );
+    const result = render(<Template isWebView />);
+    expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
+    result.rerender(<Template isWebView={false} />);
+    expect(result.getByTestId('app-root')).not.toHaveClass(
+      styles['AppRoot--pointer-none'],
+      styles['AppRoot--user-select-none'],
     );
   });
 

--- a/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
@@ -34,22 +34,14 @@ describe('AppRoot', () => {
       );
     });
 
-    it('controlled by isWebView from ConfigProvider in disabled-in-webview ', () => {
-      const Template = ({
-        userSelectMode,
-        isWebView,
-      }: {
-        isWebView?: boolean;
-        userSelectMode?: AppRootProps['userSelectMode'];
-      }) => (
+    it('controlled by isWebView from ConfigProvider by default', () => {
+      const Template = ({ isWebView }: { isWebView?: boolean }) => (
         <ConfigProvider isWebView={isWebView}>
-          <AppRoot mode="full" data-testid="app-root" userSelectMode={userSelectMode} />
+          <AppRoot mode="full" data-testid="app-root" />
         </ConfigProvider>
       );
       // по умолчанию userSelectMode='disabled-in-webview'
       const result = render(<Template isWebView />);
-      expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
-      result.rerender(<Template isWebView userSelectMode="disabled-in-webview" />);
       expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
 
       result.rerender(<Template isWebView={false} />);

--- a/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
@@ -16,36 +16,62 @@ import styles from './AppRoot.module.css';
 describe('AppRoot', () => {
   baselineComponent(AppRoot, { getRootRef: false });
 
-  it('should setup user-select mode by hasPointer from AdaptivityProvider', () => {
-    const Template = (props: { hasPointer?: boolean }) => (
-      <AdaptivityProvider {...props}>
-        <AppRoot mode="full" data-testid="app-root" userSelectMode="enabled-with-pointer" />
-      </AdaptivityProvider>
-    );
-    const result = render(<Template />);
-    expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--pointer-none']);
-    result.rerender(<Template hasPointer={false} />);
-    expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
-    result.rerender(<Template hasPointer={true} />);
-    expect(result.getByTestId('app-root')).not.toHaveClass(
-      styles['AppRoot--pointer-none'],
-      styles['AppRoot--user-select-none'],
-    );
-  });
+  describe('userSelectMode', () => {
+    it('controlled by hasPointer in enalbe-with-pointer from AdaptivityProvider', () => {
+      const Template = (props: { hasPointer?: boolean }) => (
+        <AdaptivityProvider {...props}>
+          <AppRoot mode="full" data-testid="app-root" userSelectMode="enabled-with-pointer" />
+        </AdaptivityProvider>
+      );
+      const result = render(<Template />);
+      expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--pointer-none']);
+      result.rerender(<Template hasPointer={false} />);
+      expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
+      result.rerender(<Template hasPointer={true} />);
+      expect(result.getByTestId('app-root')).not.toHaveClass(
+        styles['AppRoot--pointer-none'],
+        styles['AppRoot--user-select-none'],
+      );
+    });
 
-  it('should setup user-select mode class by isWebView from ConfigProvider', () => {
-    const Template = (props: { isWebView?: boolean }) => (
-      <ConfigProvider {...props}>
-        <AppRoot mode="full" data-testid="app-root" userSelectMode="disabled-in-webview" />
-      </ConfigProvider>
-    );
-    const result = render(<Template isWebView />);
-    expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
-    result.rerender(<Template isWebView={false} />);
-    expect(result.getByTestId('app-root')).not.toHaveClass(
-      styles['AppRoot--pointer-none'],
-      styles['AppRoot--user-select-none'],
-    );
+    it('controlled by isWebView from ConfigProvider in disabled-in-webview ', () => {
+      const Template = ({
+        userSelectMode,
+        isWebView,
+      }: {
+        isWebView?: boolean;
+        userSelectMode?: AppRootProps['userSelectMode'];
+      }) => (
+        <ConfigProvider isWebView={isWebView}>
+          <AppRoot mode="full" data-testid="app-root" userSelectMode={userSelectMode} />
+        </ConfigProvider>
+      );
+      // по умолчанию userSelectMode='disabled-in-webview'
+      const result = render(<Template isWebView />);
+      expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
+      result.rerender(<Template isWebView userSelectMode="disabled-in-webview" />);
+      expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
+
+      result.rerender(<Template isWebView={false} />);
+      expect(result.getByTestId('app-root')).not.toHaveClass(
+        styles['AppRoot--pointer-none'],
+        styles['AppRoot--user-select-none'],
+      );
+    });
+
+    it('should setup user-select-none class when user-select mode is disalbed', () => {
+      const result = render(
+        <AppRoot mode="full" data-testid="app-root" userSelectMode="enabled" />,
+      );
+
+      expect(result.getByTestId('app-root')).not.toHaveClass(
+        styles['AppRoot--pointer-none'],
+        styles['AppRoot--user-select-none'],
+      );
+
+      result.rerender(<AppRoot mode="full" data-testid="app-root" userSelectMode="disabled" />);
+      expect(result.getByTestId('app-root')).toHaveClass(styles['AppRoot--user-select-none']);
+    });
   });
 
   it('should return expected context', () => {

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -16,7 +16,13 @@ import {
   getUserSelectModeClassName,
   setSafeAreaInsets,
 } from './helpers';
-import type { AppRootLayout, AppRootMode, AppRootScroll, SafeAreaInsets } from './types';
+import type {
+  AppRootLayout,
+  AppRootMode,
+  AppRootScroll,
+  AppRootUserSelectMode,
+  SafeAreaInsets,
+} from './types';
 import styles from './AppRoot.module.css';
 
 export interface AppRootProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -53,7 +59,7 @@ export interface AppRootProps extends React.HTMLAttributes<HTMLDivElement> {
    * [Panel](https://vkcom.github.io/VKUI/#/Panel) и [Group](https://vkcom.github.io/VKUI/#/Group).
    */
   layout?: AppRootLayout;
-  userSelectMode?: 'disabled-in-webview' | 'disabled-by-pointer' | 'enabled' | 'disabled';
+  userSelectMode?: AppRootUserSelectMode;
 }
 
 /**

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -62,8 +62,8 @@ export interface AppRootProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Задаёт режим выбора текста (выделения текста) для всего приложения.
    *
-   * - `disabled-in-webview` – запрещает выбор текста только если приложение запущено в webview (по значению свойства `isWebView` из [ConfigProvider](https://vkcom.github.io/VKUI/#/ConfigProvider));
-   * - `enabled-with-pointer` – разрешает выбор текста если устройство ввода типа `pointer` (например `мышь`), в остальных случаях запрещает;
+   * - `disabled-in-webview` – запрещает выбор текста в приложениях, запущенных в webview (по значению свойства `isWebView` из [ConfigProvider](https://vkcom.github.io/VKUI/#/ConfigProvider))
+   * - `enabled-with-pointer` – разрешает выбор текста, если устройство ввода типа `pointer` (например, `мышь`), в остальных случаях запрещает;
    * - `disabled` – запрещает выбор текста;
    * - `enabled` – разрешает выбор текста.
    *

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -61,8 +61,9 @@ export interface AppRootProps extends React.HTMLAttributes<HTMLDivElement> {
   layout?: AppRootLayout;
   /**
    * Задаёт режим выбора текста (выделения текста) для всего приложения.
+   * По умолчанию, если режим не задан, запрещает выбор текста в приложениях,
+   * запущенных в webview (по значению свойства `isWebView` из [ConfigProvider](https://vkcom.github.io/VKUI/#/ConfigProvider)).
    *
-   * - `disabled-in-webview` – запрещает выбор текста в приложениях, запущенных в webview (по значению свойства `isWebView` из [ConfigProvider](https://vkcom.github.io/VKUI/#/ConfigProvider))
    * - `enabled-with-pointer` – разрешает выбор текста, если устройство ввода типа `pointer` (например, `мышь`), в остальных случаях запрещает;
    * - `disabled` – запрещает выбор текста;
    * - `enabled` – разрешает выбор текста.
@@ -85,7 +86,7 @@ export const AppRoot = ({
   className,
   safeAreaInsets: safeAreaInsetsProp,
   layout,
-  userSelectMode = 'disabled-in-webview',
+  userSelectMode,
   ...props
 }: AppRootProps) => {
   const { hasPointer, sizeX = 'none', sizeY = 'none' } = useAdaptivity();

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -62,10 +62,12 @@ export interface AppRootProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Задаёт режим выбора текста (выделения текста) для всего приложения.
    *
-   * - `disabled-in-webview` – запрещает выбор текста, если приложение запущено в webview;
-   * - `enabled-with-pointer` – разрешает выбор текста, если устройство ввода типа `pointer` (например `мышь`), в остальных случаях запрещает;
+   * - `disabled-in-webview` – запрещает выбор текста только если приложение запущено в webview (по значению свойства `isWebView` из [ConfigProvider](https://vkcom.github.io/VKUI/#/ConfigProvider));
+   * - `enabled-with-pointer` – разрешает выбор текста если устройство ввода типа `pointer` (например `мышь`), в остальных случаях запрещает;
    * - `disabled` – запрещает выбор текста;
    * - `enabled` – разрешает выбор текста.
+   *
+   * @since 6.2.0
    */
   userSelectMode?: AppRootUserSelectMode;
 }

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -13,6 +13,7 @@ import {
   extractPortalRootByProp,
   getClassNamesByMode,
   getParentElement,
+  getUserSelectModeClassName,
   setSafeAreaInsets,
 } from './helpers';
 import type { AppRootLayout, AppRootMode, AppRootScroll, SafeAreaInsets } from './types';
@@ -217,32 +218,3 @@ export const AppRoot = ({
     </div>
   );
 };
-
-function getUserSelectModeClassName({
-  userSelectMode,
-  isWebView,
-  hasPointer,
-}: {
-  userSelectMode: AppRootProps['userSelectMode'];
-  isWebView: boolean;
-  hasPointer: boolean | undefined;
-}): string | null {
-  switch (userSelectMode) {
-    case 'disabled-in-webview': {
-      return isWebView ? styles['AppRoot--user-select-none'] : null;
-    }
-    case 'disabled-by-pointer': {
-      return hasPointer === undefined
-        ? styles['AppRoot--pointer-none']
-        : !hasPointer
-        ? styles['AppRoot--user-select-none']
-        : null;
-    }
-    case 'enabled':
-      return null;
-    case 'disabled':
-      return styles['AppRoot--user-select-none'];
-    default:
-      return null;
-  }
-}

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -59,6 +59,14 @@ export interface AppRootProps extends React.HTMLAttributes<HTMLDivElement> {
    * [Panel](https://vkcom.github.io/VKUI/#/Panel) и [Group](https://vkcom.github.io/VKUI/#/Group).
    */
   layout?: AppRootLayout;
+  /**
+   * Задаёт режим выбора текста (выделения текста) для всего приложения.
+   *
+   * - `disabled-in-webview` – запрещает выбор текста, если приложение запущено в webview;
+   * - `enabled-with-pointer` – разрешает выбор текста, если устройство ввода типа `pointer` (например `мышь`), в остальных случаях запрещает;
+   * - `disabled` – запрещает выбор текста;
+   * - `enabled` – разрешает выбор текста.
+   */
   userSelectMode?: AppRootUserSelectMode;
 }
 

--- a/packages/vkui/src/components/AppRoot/helpers.ts
+++ b/packages/vkui/src/components/AppRoot/helpers.ts
@@ -93,22 +93,23 @@ export function getUserSelectModeClassName({
 }: {
   userSelectMode: AppRootUserSelectMode;
   isWebView: boolean;
-  hasPointer?: boolean;
-}) {
-  if (userSelectMode === 'disabled-in-webview') {
-    return isWebView ? styles['AppRoot--user-select-none'] : null;
+  hasPointer: boolean | undefined;
+}): string | null {
+  switch (userSelectMode) {
+    case 'disabled-in-webview': {
+      return isWebView ? styles['AppRoot--user-select-none'] : null;
+    }
+    case 'enabled-with-pointer': {
+      return hasPointer === undefined
+        ? styles['AppRoot--pointer-none']
+        : !hasPointer
+        ? styles['AppRoot--user-select-none']
+        : null;
+    }
+    case 'disabled':
+      return styles['AppRoot--user-select-none'];
+    case 'enabled':
+    default:
+      return null;
   }
-  if (userSelectMode === 'disabled-by-pointer') {
-    return hasPointer === undefined
-      ? styles['AppRoot--pointer-none']
-      : !hasPointer
-      ? styles['AppRoot--user-select-none']
-      : null;
-  }
-
-  if (userSelectMode === 'disabled') {
-    return styles['AppRoot--user-select-none'];
-  }
-
-  return null;
 }

--- a/packages/vkui/src/components/AppRoot/helpers.ts
+++ b/packages/vkui/src/components/AppRoot/helpers.ts
@@ -1,6 +1,7 @@
 import type { SizeTypeValues } from '../../lib/adaptivity';
 import { isRefObject } from '../../lib/isRefObject';
-import type { AppRootLayout, AppRootMode, SafeAreaInsets } from './types';
+import type { AppRootLayout, AppRootMode, AppRootUserSelectMode, SafeAreaInsets } from './types';
+import styles from './AppRoot.module.css';
 
 type ContainerClassNamesProps = {
   mode: AppRootMode;
@@ -84,3 +85,30 @@ export const setSafeAreaInsets = (
     }
   };
 };
+
+export function getUserSelectModeClassName({
+  userSelectMode,
+  isWebView,
+  hasPointer,
+}: {
+  userSelectMode: AppRootUserSelectMode;
+  isWebView: boolean;
+  hasPointer?: boolean;
+}) {
+  if (userSelectMode === 'disabled-in-webview') {
+    return isWebView ? styles['AppRoot--user-select-none'] : null;
+  }
+  if (userSelectMode === 'disabled-by-pointer') {
+    return hasPointer === undefined
+      ? styles['AppRoot--pointer-none']
+      : !hasPointer
+      ? styles['AppRoot--user-select-none']
+      : null;
+  }
+
+  if (userSelectMode === 'disabled') {
+    return styles['AppRoot--user-select-none'];
+  }
+
+  return null;
+}

--- a/packages/vkui/src/components/AppRoot/helpers.ts
+++ b/packages/vkui/src/components/AppRoot/helpers.ts
@@ -100,11 +100,16 @@ export function getUserSelectModeClassName({
       return isWebView ? styles['AppRoot--user-select-none'] : null;
     }
     case 'enabled-with-pointer': {
-      return hasPointer === undefined
-        ? styles['AppRoot--pointer-none']
-        : !hasPointer
-        ? styles['AppRoot--user-select-none']
-        : null;
+      if (hasPointer) {
+        return null;
+      }
+
+      const enableByHasPointerMediaQuery = hasPointer === undefined;
+      if (enableByHasPointerMediaQuery) {
+        return styles['AppRoot--pointer-none'];
+      }
+
+      return styles['AppRoot--user-select-none'];
     }
     case 'disabled':
       return styles['AppRoot--user-select-none'];

--- a/packages/vkui/src/components/AppRoot/helpers.ts
+++ b/packages/vkui/src/components/AppRoot/helpers.ts
@@ -91,14 +91,11 @@ export function getUserSelectModeClassName({
   isWebView,
   hasPointer,
 }: {
-  userSelectMode: AppRootUserSelectMode;
+  userSelectMode: AppRootUserSelectMode | undefined;
   isWebView: boolean;
   hasPointer: boolean | undefined;
 }): string | null {
   switch (userSelectMode) {
-    case 'disabled-in-webview': {
-      return isWebView ? styles['AppRoot--user-select-none'] : null;
-    }
     case 'enabled-with-pointer': {
       if (hasPointer) {
         return null;
@@ -114,7 +111,8 @@ export function getUserSelectModeClassName({
     case 'disabled':
       return styles['AppRoot--user-select-none'];
     case 'enabled':
-    default:
       return null;
+    default:
+      return isWebView ? styles['AppRoot--user-select-none'] : null;
   }
 }

--- a/packages/vkui/src/components/AppRoot/types.ts
+++ b/packages/vkui/src/components/AppRoot/types.ts
@@ -11,8 +11,4 @@ export type AppRootLayout = 'card' | 'plain';
 
 export type AppRootScroll = 'global' | 'contain';
 
-export type AppRootUserSelectMode =
-  | 'enabled'
-  | 'enabled-with-pointer'
-  | 'disabled-in-webview'
-  | 'disabled';
+export type AppRootUserSelectMode = 'enabled' | 'enabled-with-pointer' | 'disabled';

--- a/packages/vkui/src/components/AppRoot/types.ts
+++ b/packages/vkui/src/components/AppRoot/types.ts
@@ -12,7 +12,7 @@ export type AppRootLayout = 'card' | 'plain';
 export type AppRootScroll = 'global' | 'contain';
 
 export type AppRootUserSelectMode =
-  | 'disabled-in-webview'
-  | 'disabled-by-pointer'
   | 'enabled'
+  | 'enabled-with-pointer'
+  | 'disabled-in-webview'
   | 'disabled';

--- a/packages/vkui/src/components/AppRoot/types.ts
+++ b/packages/vkui/src/components/AppRoot/types.ts
@@ -10,3 +10,9 @@ export type AppRootMode = 'partial' | 'embedded' | 'full';
 export type AppRootLayout = 'card' | 'plain';
 
 export type AppRootScroll = 'global' | 'contain';
+
+export type AppRootUserSelectMode =
+  | 'disabled-in-webview'
+  | 'disabled-by-pointer'
+  | 'enabled'
+  | 'disabled';

--- a/packages/vkui/src/components/Header/Header.module.css
+++ b/packages/vkui/src/components/Header/Header.module.css
@@ -3,7 +3,6 @@
   align-items: flex-start;
   padding: 0;
   padding-inline: var(--vkui--size_base_padding_horizontal--regular);
-  user-select: text;
   font-family: var(--vkui--font_family_base);
 }
 


### PR DESCRIPTION
- closes #3507, 
- closes #5216,
-  closes #6835

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] документация фичи.

## Описание
Добавляем возможность выставлять режим выделения текста с помощью свойства userSelectMode у AppRoot: 
- `disabled-in-webview` режим для приложений, которые встраиваются в webview, где нужен запрет на выделение, в то же время в мобильных браузерах выделение следует оставить. Теперь по умолчанию.
  Если у приложения `isWebView=true` в ConfigProvider, то выделять текст будет запрещено.
- `enabled-with-pointer` режим в котором текст разрешается выделять только при наличии мыши. (То, что сейчас)
- `enabled` режим где выделять текст разрешено.
- `disabled` режим в котором выделать текст запрещается.
## Изменения
- убираем принудительно разрешение выделения Header. для #3507
- добавляем новое свойство `userSelectMode` для `AppRoot`.
- логику для работы нового свойства перенесли в helpers.