### PR TITLE
ci: publish deploy on specific branch

### DIFF
--- a/.github/workflows/publish_deploy.yml
+++ b/.github/workflows/publish_deploy.yml
@@ -27,6 +27,9 @@ on:
           - 'release'
           - 'pre-release'
 
+env:
+  CHECKOUT_BRANCH: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}   
+          
 jobs:
   payload:
     name: Prepare payload data
@@ -61,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_BRANCH }}
 
       - name: Setting up the repository environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Описание

Заметила, что после [последнего](https://github.com/VKCOM/VKUI/actions/runs/9464810732) релиза не обновилась текущая версия в доке, подумала на кеш, но повторный триггер GH-PAGES ничего не дал. Оказалось, что когда мы завязываемся на событие `workflow_run: types: [completed]` - оно запускается на дефолтной ветке по умолчанию, соответственно `checkout` мы делали на ней, а не на `stable`-ветке, с актуальной текущей версией

## Изменения

Добавила переменную, которую берем как `github.event.workflow_run.head_branch` для `workflow_run`, а по умолчанию будем брать `github.ref`

---

После мерджа как раз можно будет попробовать вручную запустить деплой доки на `stable`-ветке х)
