### PR TITLE
feat(Slider): Add active/hover states for Slider Thumb

### DIFF
--- a/packages/vkui/src/components/Slider/Slider.test.tsx
+++ b/packages/vkui/src/components/Slider/Slider.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { act } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AppRoot } from '../../components/AppRoot/AppRoot';
 import { setRef } from '../../lib/utils';
 import {
   baselineComponent,
@@ -227,7 +228,11 @@ describe(Slider, () => {
     fakeTimers();
 
     it('shows tooltip on hover/focus', async () => {
-      render(<Slider defaultValue={30} withTooltip />);
+      render(
+        <AppRoot>
+          <Slider defaultValue={30} withTooltip />
+        </AppRoot>,
+      );
       const slider = screen.getByRole('slider');
 
       expect(screen.queryByText('30')).not.toBeInTheDocument();
@@ -243,6 +248,7 @@ describe(Slider, () => {
       expect(screen.queryByText('30')).not.toBeInTheDocument();
 
       // shows tooltip on focus
+      fireEvent.keyDown(document, { key: 'Tab', code: 'Tab' });
       act(() => slider.focus());
       await waitFor(() => expect(screen.queryByText('30')).toBeInTheDocument());
 

--- a/packages/vkui/src/components/Slider/Slider.tsx
+++ b/packages/vkui/src/components/Slider/Slider.tsx
@@ -16,7 +16,7 @@ import {
   updateInternalStateValue,
   updateInternalStateValueByNativeChange,
 } from './helpers';
-import type { InternalGestureRef, InternalValueState } from './types';
+import type { InternalDraggingType, InternalGestureRef, InternalValueState } from './types';
 import styles from './Slider.module.css';
 
 const sizeYClassNames = {
@@ -107,6 +107,7 @@ export const Slider = ({
   const multiple = multipleProp && endValue !== null;
   const startValueInPercent = toPercent(startValue, min, max);
   const endReversedValueInPercent = multiple ? toPercent(endValue, min, max) : 0;
+  const [activeThumb, setActiveThumb] = React.useState<InternalDraggingType | null>(null);
 
   const gesture = React.useRef<InternalGestureRef>({
     dragging: null,
@@ -182,6 +183,7 @@ export const Slider = ({
     changeValue(updatedInternalStateValue, event);
 
     event.originalEvent.stopPropagation();
+    setActiveThumb(gesture.dragging);
   };
 
   const handlePointerMove: TouchEventHandler = (event: TouchEvent) => {
@@ -200,6 +202,7 @@ export const Slider = ({
   const handlePointerEnd: TouchEventHandler = (event) => {
     gesture.dragging = null;
     event.originalEvent.stopPropagation();
+    setActiveThumb(null);
   };
 
   const handleChangeByNativeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -260,6 +263,7 @@ export const Slider = ({
             'aria-labelledby': ariaLabelledBy,
             'onChange': handleChangeByNativeInput,
           }}
+          isActive={activeThumb === 'start'}
         />
         {multiple && (
           <SliderThumb
@@ -280,6 +284,7 @@ export const Slider = ({
               'aria-labelledby': ariaLabelledBy,
               'onChange': handleChangeByNativeInput,
             }}
+            isActive={activeThumb === 'end'}
           />
         )}
       </div>

--- a/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.module.css
+++ b/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.module.css
@@ -6,15 +6,23 @@
   block-size: var(--vkui_internal--slider_thumb_size);
   border-radius: 50%;
   border: var(--vkui--size_border--regular) solid var(--vkui--color_separator_primary_alpha);
-  background: var(--vkui--color_background_contrast);
+  background-color: var(--vkui--color_background_contrast);
   box-shadow: var(--vkui--elevation3);
   user-select: none;
+  transition: background-color 0.15s ease-out;
 }
 
 .SliderThumb--focus-visible {
   outline: var(--vkui_internal--outline);
   outline-offset: calc(-1 * var(--vkui--size_border--regular));
-  z-index: 2;
+}
+
+.SliderThumb--hover {
+  background-color: var(--vkui--color_background_contrast--hover);
+}
+
+.SliderThumb--active {
+  background-color: var(--vkui--color_background_contrast--active);
 }
 
 /**

--- a/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.tsx
+++ b/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.tsx
@@ -23,6 +23,7 @@ interface SliderThumbProps extends HasRootRef<HTMLSpanElement>, HasDataAttribute
     React.RefAttributes<HTMLInputElement> &
     HasDataAttribute;
   withTooltip?: boolean;
+  isActive?: boolean;
 }
 
 export const SliderThumb = ({
@@ -30,9 +31,10 @@ export const SliderThumb = ({
   getRootRef,
   inputProps,
   withTooltip,
+  isActive,
   ...restProps
 }: SliderThumbProps) => {
-  const { focusVisible, onBlur, onFocus } = useFocusVisible(false);
+  const { focusVisible, onBlur, onFocus } = useFocusVisible();
   const focusVisibleClassNames = useFocusVisibleClassName({
     focusVisible,
     mode: styles['SliderThumb--focus-visible'],
@@ -74,7 +76,7 @@ export const SliderThumb = ({
 
   const handleRootRef = useExternRef<HTMLSpanElement>(getRootRef, refs.setReference);
 
-  const shouldShowTooltip = withTooltip && (focusVisible || isHovered);
+  const shouldShowTooltip = withTooltip && (focusVisible || isHovered || isActive);
 
   const inputValue = inputProps && inputProps.value;
   React.useEffect(
@@ -93,7 +95,13 @@ export const SliderThumb = ({
         ref={handleRootRef}
         onMouseEnter={setHoveredTrue}
         onMouseLeave={setHoveredFalse}
-        className={classNames(styles['SliderThumb'], focusVisibleClassNames, className)}
+        className={classNames(
+          styles['SliderThumb'],
+          focusVisibleClassNames,
+          isActive && styles['SliderThumb--active'],
+          isHovered && styles['SliderThumb--hover'],
+          className,
+        )}
       >
         <input
           {...inputProps}


### PR DESCRIPTION
- close #5050

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [ ] Дизайн-ревью


## Описание
Добавляем состояние hover и active для Slider.


## Изменения
`active` состояние специально берётся и устанавливается на уровне `Slider`, а не в самих `SliderThumb`, потому что это даёт возможность установить активное состояние даже когда пользователь нажимает не на сам `Thumb` а на часть `Slider`.

## Видео

https://github.com/VKCOM/VKUI/assets/5443359/e5b84f9e-0131-44c5-af98-d5c6f6ca0968

