### PR TITLE
fix(Spacing): padding style wasn't applied

### DIFF
--- a/packages/vkui/src/components/Spacing/Spacing.e2e-playground.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.e2e-playground.tsx
@@ -1,7 +1,9 @@
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { Div } from '../Div/Div';
 import { Separator } from '../Separator/Separator';
-import { ALLOWED_SIZES, Spacing, SpacingProps } from './Spacing';
+import { sizesClassNames, Spacing, type SpacingProps, type SpacingSize } from './Spacing';
+
+const sizes = Object.keys(sizesClassNames) as SpacingSize[];
 
 export const SpacingPlayground = (props: ComponentPlaygroundProps) => {
   return (
@@ -9,7 +11,7 @@ export const SpacingPlayground = (props: ComponentPlaygroundProps) => {
       {...props}
       propSets={[
         {
-          size: [undefined, ...ALLOWED_SIZES, 8, 16, 24],
+          size: [undefined, ...sizes, 8, 16, 24],
         },
       ]}
     >

--- a/packages/vkui/src/components/Spacing/Spacing.module.css
+++ b/packages/vkui/src/components/Spacing/Spacing.module.css
@@ -1,4 +1,48 @@
 .Spacing {
+  --vkui_internal--Spacing_gap: 0;
+
   position: relative;
+  block-size: var(--vkui_internal--Spacing_gap);
+  padding-block: calc(1px * var(--vkui_internal--Spacing_gap) / 2);
   box-sizing: border-box;
+}
+
+.Spacing--3xs {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_3xs);
+}
+
+.Spacing--2xs {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_2xs);
+}
+
+.Spacing--xs {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_xs);
+}
+
+.Spacing--s {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_s);
+}
+
+.Spacing--m {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_m);
+}
+
+.Spacing--l {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_l);
+}
+
+.Spacing--xl {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_xl);
+}
+
+.Spacing--2xl {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_2xl);
+}
+
+.Spacing--3xl {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_3xl);
+}
+
+.Spacing--4xl {
+  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_4xl);
 }

--- a/packages/vkui/src/components/Spacing/Spacing.test.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.test.tsx
@@ -1,6 +1,42 @@
+import { render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
-import { Spacing } from './Spacing';
+import {
+  CUSTOM_CSS_TOKEN_FOR_USER_GAP,
+  sizesClassNames,
+  Spacing,
+  type SpacingSize,
+} from './Spacing';
+
+const sizes = Object.keys(sizesClassNames) as SpacingSize[];
 
 describe('Spacing', () => {
   baselineComponent(Spacing);
+
+  it('should use default size', () => {
+    const h = render(<Spacing />);
+    expect(h.container.firstElementChild).toHaveClass(sizesClassNames.m);
+  });
+
+  it('should preserve use className', () => {
+    const userClassName = 'test';
+    const h = render(<Spacing className={userClassName} />);
+    expect(h.container.firstElementChild).toHaveClass(`${sizesClassNames.m} ${userClassName}`);
+  });
+
+  it.each(sizes)('should use union sizes', (size) => {
+    const h = render(<Spacing size={size} />);
+    expect(h.container.firstElementChild).toHaveClass(sizesClassNames[size]);
+  });
+
+  it('should use custom size', () => {
+    const h = render(<Spacing size={16} />);
+    expect(h.container.firstElementChild).toHaveStyle(`${CUSTOM_CSS_TOKEN_FOR_USER_GAP}: 16`);
+  });
+
+  it('should preserve user style', () => {
+    const h = render(<Spacing size={16} style={{ fontSize: 12 }} />);
+    expect(h.container.firstElementChild).toHaveStyle(
+      `font-size: 12px; ${CUSTOM_CSS_TOKEN_FOR_USER_GAP}: 16`,
+    );
+  });
 });

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -1,49 +1,53 @@
-import * as React from 'react';
+import { classNames } from '@vkontakte/vkjs';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Spacing.module.css';
 
-export const ALLOWED_SIZES = [
-  '3xs',
-  '2xs',
-  'xs',
-  's',
-  'm',
-  'l',
-  'xl',
-  '2xl',
-  '3xl',
-  '4xl',
-] as const;
-type Size = (typeof ALLOWED_SIZES)[number];
+export const CUSTOM_CSS_TOKEN_FOR_USER_GAP = '--vkui_internal--Spacing_gap';
+
+export const sizesClassNames = {
+  '3xs': styles['Spacing--3xs'],
+  '2xs': styles['Spacing--2xs'],
+  'xs': styles['Spacing--xs'],
+  's': styles['Spacing--s'],
+  'm': styles['Spacing--m'],
+  'l': styles['Spacing--l'],
+  'xl': styles['Spacing--xl'],
+  '2xl': styles['Spacing--2xl'],
+  '3xl': styles['Spacing--3xl'],
+  '4xl': styles['Spacing--4xl'],
+};
+
+export type SpacingSize = keyof typeof sizesClassNames;
 
 export interface SpacingProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
   /**
    * Высота спэйсинга
    */
-  size?: number | Size;
+  size?: number | SpacingSize;
 }
 /**
  * @see https://vkcom.github.io/VKUI/#/Spacing
  */
-export const Spacing = ({ size = 'm', style: styleProp, ...restProps }: SpacingProps) => {
-  const style: React.CSSProperties = {
-    ...getSizeStyle(size),
-    ...styleProp,
-  };
+export const Spacing = ({ size = 'm', style, className, ...restProps }: SpacingProps) => {
+  if (typeof size === 'string') {
+    className = className ? classNames(sizesClassNames[size], className) : sizesClassNames[size];
+  } else {
+    if (style) {
+      // @ts-expect-error: TS7053 В React.CSSProperties не учитывается Custom Properties
+      style[CUSTOM_CSS_TOKEN_FOR_USER_GAP] = size;
+    } else {
+      // @ts-expect-error: TS2353 В React.CSSProperties не учитывается Custom Properties
+      style = { [CUSTOM_CSS_TOKEN_FOR_USER_GAP]: size };
+    }
+  }
 
-  return <RootComponent {...restProps} baseClassName={styles['Spacing']} style={style} />;
+  return (
+    <RootComponent
+      {...restProps}
+      style={style}
+      className={className}
+      baseClassName={styles['Spacing']}
+    />
+  );
 };
-
-function getSizeStyle(size: number | Size): React.CSSProperties {
-  const sizeValue = getSizeValue(size);
-
-  return {
-    height: sizeValue,
-    padding: `calc(${sizeValue} / 2px) 0`,
-  };
-}
-
-function getSizeValue(size: number | Size): `var(--vkui--spacing_size_${Size})` | number {
-  return typeof size === 'string' ? `var(--vkui--spacing_size_${size})` : size;
-}


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] e2e-тесты

## Описание

Не применялся padding из-за невалидного `calc()`. Но так как в `calc()` было деление на `2px`, это не срабатывало. Также к числу `sizeValue` не добавлялась единица измерения (`px`), что тоже считается не валидным. 

❌ `calc(16 / 2px)`
❌ `calc(16px / 2px)`
✅ `calc(16px / 2)`

> [!NOTE]
> **React**, перед тем как применить стили, высчитывает `calc()` перед ставкой если можно.
> `calc(16px / 2)` → `calc(8px)`

Решил сразу перенести всё в CSS, потому что:
- можно использовать CSS logical с последующим фоллбеком;
- более явно видим какие **vkui-tokens** применяются;
- убираем логику пересчёта из JS.

В JS модифицируем входящие `className` и `style`, дабы не создавать дополнительные переменные. В случае такого простого компонента `Spacing` лишние операции ни к чему.

---

- caused by #6925