### PR TITLE
tech(generate_env_docker): mv `jq` to `cut`

### DIFF
--- a/packages/vkui/scripts/generate_env_docker.sh
+++ b/packages/vkui/scripts/generate_env_docker.sh
@@ -3,7 +3,17 @@
 rm -f .env.docker
 touch .env.docker
 
-PLAYWRIGHT_VERSION=$(yarn info @playwright/test --all --json | jq -r '.children' | jq -r '.Version');
+# Выдаёт версию зависимости в виде строки вида: '└─ @playwright/test@npm:1.44.1'
+YARN_INFO_OUTPUT=$(yarn info @playwright/test --all --name-only);
+
+# Делит строку по разделителю и берёт правую часть.
+#
+# В JavaScript это выглядило бы так:
+#
+# ```js
+# const PLAYWRIGHT_VERSION = '└─ @playwright/test@npm:1.44.1'.split(':')[1];
+# ```
+PLAYWRIGHT_VERSION=$(echo $YARN_INFO_OUTPUT | cut -f 2 -d :);
 
 # см. https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.focal
 echo "IMAGE=mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-focal" >> .env.docker;


### PR DESCRIPTION
## Описание

Утилита [jq](https://formulae.brew.sh/formula/jq) не является базовой утилитой, поэтому заменил на [cut](https://www.manpagez.com/man/1/cut/).

---

- caused by #6717