### PR TITLE
feat(Typography): add inline prop

### DIFF
--- a/packages/vkui/src/components/Typography/Caption/Caption.tsx
+++ b/packages/vkui/src/components/Typography/Caption/Caption.tsx
@@ -23,12 +23,14 @@ export const Caption = ({
   caps,
   Component = 'span',
   normalize = true,
+  inline = false,
   ...restProps
 }: CaptionProps) => {
   return (
     <Typography
       Component={Component}
       normalize={normalize}
+      inline={inline}
       className={classNames(className, caps && styles['Caption--caps'], stylesLevel[level])}
       {...restProps}
     />

--- a/packages/vkui/src/components/Typography/DisplayTitle/DisplayTitle.tsx
+++ b/packages/vkui/src/components/Typography/DisplayTitle/DisplayTitle.tsx
@@ -23,12 +23,14 @@ export const DisplayTitle = ({
   level = '1',
   Component = 'span',
   normalize = true,
+  inline = false,
   ...restProps
 }: DisplayTitleProps) => {
   return (
     <Typography
       Component={Component}
       normalize={normalize}
+      inline={inline}
       className={classNames(className, stylesLevel[level])}
       {...restProps}
     />

--- a/packages/vkui/src/components/Typography/Footnote/Footnote.tsx
+++ b/packages/vkui/src/components/Typography/Footnote/Footnote.tsx
@@ -14,11 +14,13 @@ export const Footnote = ({
   caps,
   Component = 'span',
   normalize = true,
+  inline = false,
   ...restProps
 }: FootnoteProps) => (
   <Typography
     Component={Component}
     normalize={normalize}
+    inline={inline}
     className={classNames(className, styles['Footnote'], caps && styles['Footnote--caps'])}
     {...restProps}
   />

--- a/packages/vkui/src/components/Typography/Headline/Headline.tsx
+++ b/packages/vkui/src/components/Typography/Headline/Headline.tsx
@@ -28,6 +28,7 @@ export const Headline = ({
   level = '1',
   Component = 'span',
   normalize = true,
+  inline = false,
   ...restProps
 }: HeadlineProps) => {
   const { sizeY = 'none' } = useAdaptivity();
@@ -36,6 +37,7 @@ export const Headline = ({
     <Typography
       Component={Component}
       normalize={normalize}
+      inline={inline}
       weight={weight}
       className={classNames(
         className,

--- a/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
@@ -13,12 +13,14 @@ export const Paragraph = ({
   className,
   Component = 'span',
   normalize = false,
+  inline = false,
   ...restProps
 }: ParagraphProps) => {
   return (
     <Typography
       Component={Component}
       normalize={normalize}
+      inline={inline}
       className={classNames(className, styles['Paragraph'])}
       {...restProps}
     />

--- a/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
+++ b/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
@@ -19,6 +19,7 @@ export const Subhead = ({
   className,
   Component = 'span',
   normalize = true,
+  inline = false,
   ...restProps
 }: SubheadProps) => {
   const { sizeY = 'none' } = useAdaptivity();
@@ -27,6 +28,7 @@ export const Subhead = ({
     <Typography
       Component={Component}
       normalize={normalize}
+      inline={inline}
       className={classNames(
         className,
         styles['Subhead'],

--- a/packages/vkui/src/components/Typography/Text/Text.tsx
+++ b/packages/vkui/src/components/Typography/Text/Text.tsx
@@ -19,6 +19,7 @@ export const Text = ({
   className,
   Component = 'span',
   normalize = true,
+  inline = false,
   ...restProps
 }: TextProps) => {
   const { sizeY = 'none' } = useAdaptivity();
@@ -27,6 +28,7 @@ export const Text = ({
     <Typography
       Component={Component}
       normalize={normalize}
+      inline={inline}
       className={classNames(
         className,
         styles['Text'],

--- a/packages/vkui/src/components/Typography/Title/Title.tsx
+++ b/packages/vkui/src/components/Typography/Title/Title.tsx
@@ -22,12 +22,14 @@ export const Title = ({
   level = '1',
   Component = 'span',
   normalize = true,
+  inline = false,
   ...restProps
 }: TitleProps) => {
   return (
     <Typography
       Component={Component}
       normalize={normalize}
+      inline={inline}
       className={classNames(className, stylesLevel[level])}
       {...restProps}
     />

--- a/packages/vkui/src/components/Typography/Typography.module.css
+++ b/packages/vkui/src/components/Typography/Typography.module.css
@@ -1,7 +1,14 @@
 .Typography--normalize {
-  display: block;
   margin: 0;
   padding: 0;
+}
+
+.Typography--normalize:not(.Typography--inline) {
+  display: block;
+}
+
+.Typography--inline {
+  display: inline-block;
 }
 
 /* Мы утяжеляем селектор, чтобы перебить другие селекторы */

--- a/packages/vkui/src/components/Typography/Typography.tsx
+++ b/packages/vkui/src/components/Typography/Typography.tsx
@@ -26,12 +26,17 @@ export interface TypographyProps
    * Убирает внешние отступы
    */
   normalize?: boolean;
+  /**
+   * Делает блок инлайновым
+   */
+  inline?: boolean;
 }
 
 export const Typography = ({
   weight,
   Component = 'span',
   normalize,
+  inline,
   ...restProps
 }: TypographyProps) => (
   <RootComponent
@@ -39,6 +44,7 @@ export const Typography = ({
     baseClassName={classNames(
       styles['Typography'],
       normalize && styles['Typography--normalize'],
+      inline && styles['Typography--inline'],
       weight && stylesWeight[weight],
     )}
     {...restProps}


### PR DESCRIPTION
- close #6814 

---
- [ ] Дизайн-ревью
- [x] Документация фичи

## Описание

Добавил пропс inline для компонента Typography, а также для всех компонентов, которые используют Typography.
При использовании inline=true добавляется свойство display: inline-block. Также данный пропс можно сочетать с normalize=true.
