### PR TITLE
fix(focusVisible): revert animation duration

### DIFF
--- a/packages/vkui/src/styles/focusVisible.module.css
+++ b/packages/vkui/src/styles/focusVisible.module.css
@@ -29,7 +29,7 @@
 .-focus-visible.-focus-visible--focused.-focus-visible--mode-outside {
   outline: var(--vkui_internal--outline);
   outline-offset: var(--vkui_internal--outline_offset_to);
-  animation: animation-outline-offset 2s ease-in-out 0.01s forwards;
+  animation: animation-outline-offset 0.1s ease-in-out 0.01s forwards;
 }
 
 @media (--reduce-motion) {


### PR DESCRIPTION
## Описание

В #6979 для теста менял на `2s` и случайно закоммитил.

## Изменения

Вернул `0.1s`.

## Версия

#6979 ждёт релиза **v6.2.0**, поэтому фикс без майлстоун.

---

- caused by #6979