### PR TITLE
fix(CalendarRange): fix select view date in right part calendar

### DIFF
--- a/packages/vkui/src/components/CalendarRange/CalendarRange.test.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { CalendarRange } from './CalendarRange';
+import styles from './CalendarRange.module.css';
 
 describe('CalendarRange', () => {
   baselineComponent(CalendarRange);
@@ -16,5 +17,38 @@ describe('CalendarRange', () => {
 
     fireEvent.click(screen.getAllByText('6')[1]);
     expect(onChangeStub).not.toHaveBeenLastCalledWith([null, null]);
+  });
+
+  it('check left part date when change in right part', async () => {
+    const startDate = new Date(2024, 2, 1);
+    const endDate = new Date(2024, 2, 10);
+
+    const result = render(
+      <CalendarRange data-testid="calendar-range" value={[startDate, endDate]} />,
+    );
+
+    const getSelect = (index: number) => {
+      const headers = result.container.getElementsByClassName(styles['CalendarRange__header']);
+      expect(headers.length).toBe(2);
+      const header = headers[index];
+      return header.querySelector('select');
+    };
+
+    // Кликаем по дропдауну месяца в правой части, чтобы открылся дропдаун
+    const rightPartSelect = getSelect(1);
+    expect(rightPartSelect).not.toBeNull();
+    fireEvent.click(rightPartSelect!);
+
+    // Кликаем по месяцу Июнь в селекте
+    const unselectedOption = screen.getByRole('option', { selected: false, name: 'июнь' });
+    fireEvent.mouseEnter(unselectedOption);
+    fireEvent.click(unselectedOption);
+
+    // Кликаем по дропдауну месяца в левой части, чтобы открылся дропдаун
+    const leftPartSelect = getSelect(0);
+    expect(leftPartSelect).not.toBeNull();
+    fireEvent.click(leftPartSelect!);
+
+    expect(screen.getByRole('option', { selected: true, name: 'май' }));
   });
 });

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -10,6 +10,7 @@ import {
   isSameMonth,
   isWithinInterval,
   startOfDay,
+  subMonths,
 } from '../../lib/date';
 import { HTMLAttributesWithRootRef } from '../../types';
 import { CalendarDays, CalendarDaysProps } from '../CalendarDays/CalendarDays';
@@ -220,7 +221,7 @@ export const CalendarRange = ({
       <div className={styles['CalendarRange__inner']}>
         <CalendarHeader
           viewDate={secondViewDate}
-          onChange={setViewDate}
+          onChange={(newDate) => setViewDate(subMonths(newDate, 1))}
           prevMonthHidden
           onNextMonth={setNextMonth}
           disablePickers={disablePickers}

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -181,6 +181,11 @@ export const CalendarRange = ({
     [hintedDate],
   );
 
+  const onRightPartViewDateChange = React.useCallback(
+    (newDate: Date) => setViewDate(subMonths(newDate, 1)),
+    [setViewDate]
+  )
+
   return (
     <RootComponent {...props} baseClassName={styles['CalendarRange']}>
       <div className={styles['CalendarRange__inner']}>
@@ -221,7 +226,7 @@ export const CalendarRange = ({
       <div className={styles['CalendarRange__inner']}>
         <CalendarHeader
           viewDate={secondViewDate}
-          onChange={(newDate) => setViewDate(subMonths(newDate, 1))}
+          onChange={onRightPartViewDateChange}
           prevMonthHidden
           onNextMonth={setNextMonth}
           disablePickers={disablePickers}

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -183,8 +183,8 @@ export const CalendarRange = ({
 
   const onRightPartViewDateChange = React.useCallback(
     (newDate: Date) => setViewDate(subMonths(newDate, 1)),
-    [setViewDate]
-  )
+    [setViewDate],
+  );
 
   return (
     <RootComponent {...props} baseClassName={styles['CalendarRange']}>


### PR DESCRIPTION
- close #6897 

---

## Описание

Если раскрыть календарь DateRangeInput и менять месяц через дропдаун в правой половине календаря, то выбраный в дропдауне месяц может появится в левой пловине, хотя ожидается, что где месяц был выбран, там он появится.
То же относится и к CalendarRange


## Изменения

Доработал обработку выбора месяца и года в header-е календаря в правой части
