### PR TITLE
test: use no memo

### DIFF
--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -1,3 +1,5 @@
+'use no memo';
+
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { DEFAULT_TOKENS_CLASS_NAMES } from '../../lib/tokens';

--- a/packages/vkui/src/components/LocaleProvider/LocaleProvider.test.tsx
+++ b/packages/vkui/src/components/LocaleProvider/LocaleProvider.test.tsx
@@ -1,3 +1,5 @@
+'use no memo';
+
 import { render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';

--- a/packages/vkui/src/components/PlatformProvider/PlatformProvider.test.tsx
+++ b/packages/vkui/src/components/PlatformProvider/PlatformProvider.test.tsx
@@ -1,3 +1,5 @@
+'use no memo';
+
 import { render } from '@testing-library/react';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import {

--- a/packages/vkui/src/components/Popover/Popover.test.tsx
+++ b/packages/vkui/src/components/Popover/Popover.test.tsx
@@ -1,3 +1,5 @@
+'use no memo';
+
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { baselineComponent, waitForFloatingPosition } from '../../testing/utils';

--- a/packages/vkui/src/hooks/useExternRef.test.tsx
+++ b/packages/vkui/src/hooks/useExternRef.test.tsx
@@ -1,3 +1,5 @@
+'use no memo';
+
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';

--- a/packages/vkui/src/hooks/useFocusWithin.test.tsx
+++ b/packages/vkui/src/hooks/useFocusWithin.test.tsx
@@ -1,3 +1,5 @@
+'use no memo';
+
 import * as React from 'react';
 import { act } from 'react';
 import { render, screen } from '@testing-library/react';


### PR DESCRIPTION
- see #6920

---

Используем  [`use no memo`](https://react.dev/learn/react-compiler#use-no-memo) для отключения компилятора в тестах
