### PR TITLE
fix(useExternRef): rm useMemo

### DIFF
--- a/packages/vkui/src/hooks/useExternRef.ts
+++ b/packages/vkui/src/hooks/useExternRef.ts
@@ -1,26 +1,48 @@
 import * as React from 'react';
 import { setRef } from '../lib/utils';
 
+class ExternalRef<T> implements React.MutableRefObject<T | null> {
+  #element: T | null = null;
+  readonly #externRefs = new Set<React.Ref<T>>();
+
+  constructor(externRefs: Array<React.Ref<T> | undefined | false> = []) {
+    externRefs.forEach((ref) => {
+      if (ref) {
+        this.#externRefs.add(ref);
+      }
+    });
+  }
+
+  updateExternRefs(refs: Array<React.Ref<T> | undefined | false>) {
+    refs.forEach((ref) => {
+      if (!ref || this.#externRefs.has(ref)) {
+        return;
+      }
+
+      setRef(this.#element, ref);
+      this.#externRefs.add(ref);
+    });
+  }
+
+  get current() {
+    return this.#element;
+  }
+
+  set current(el) {
+    this.#element = el;
+    this.#externRefs.forEach((ref) => setRef(el, ref));
+  }
+}
+
 export function useExternRef<T>(
   ...externRefs: Array<React.Ref<T> | undefined | false>
 ): React.MutableRefObject<T | null> {
-  const stableRef = React.useRef<T | null>(null);
+  const ref = React.useRef<ExternalRef<T> | null>(null);
+  if (ref.current === null) {
+    ref.current = new ExternalRef(externRefs);
+  } else {
+    ref.current.updateExternRefs(externRefs);
+  }
 
-  return React.useMemo(
-    () => ({
-      get current() {
-        return stableRef.current;
-      },
-      set current(el) {
-        stableRef.current = el;
-        externRefs.forEach((ref) => {
-          if (ref) {
-            setRef(el, ref);
-          }
-        });
-      },
-    }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    externRefs,
-  );
+  return ref.current;
 }


### PR DESCRIPTION
- see #6920

---

## Описание

Для компилятора требуется знать точные зависимости в useMemo

## Изменение

Избавился от useMemo, написал отдельный класс реализующий MutableRefObject
