### PR TITLE
feat(FloatingArrow): Apply offset according to the placement Align

### DIFF
--- a/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
+++ b/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
@@ -86,10 +86,8 @@ function getArrowPositionData(
     }
   };
 
-  let xOffsetProp = placement.endsWith('end') && isStaticOffset ? 'right' : 'left';
-  let yOffsetProp = placement.endsWith('end') && isStaticOffset ? 'bottom' : 'top';
-
   if (placement.startsWith('top')) {
+    const xOffsetProp = getXOffsetProp(placement, isStaticOffset);
     return [
       'bottom',
       {
@@ -98,6 +96,7 @@ function getArrowPositionData(
       },
     ];
   } else if (placement.startsWith('right')) {
+    const yOffsetProp = getYOffsetProp(placement, isStaticOffset);
     return [
       'left',
       {
@@ -106,6 +105,7 @@ function getArrowPositionData(
       },
     ];
   } else if (placement.startsWith('bottom')) {
+    const xOffsetProp = getXOffsetProp(placement, isStaticOffset);
     return [
       undefined,
       {
@@ -114,6 +114,7 @@ function getArrowPositionData(
       },
     ];
   } else {
+    const yOffsetProp = getYOffsetProp(placement, isStaticOffset);
     return [
       'right',
       {
@@ -122,4 +123,12 @@ function getArrowPositionData(
       },
     ];
   }
+}
+
+function getXOffsetProp(placement: Placement, isStaticOffset: boolean) {
+  return placement.endsWith('end') && isStaticOffset ? 'right' : 'left';
+}
+
+function getYOffsetProp(placement: Placement, isStaticOffset: boolean) {
+  return placement.endsWith('end') && isStaticOffset ? 'bottom' : 'top';
 }

--- a/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
+++ b/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
@@ -86,67 +86,38 @@ function getArrowPositionData(
     }
   };
 
-  if (placement === 'top' || placement === 'top-start') {
+  let xOffsetProp = placement.endsWith('end') && isStaticOffset ? 'right' : 'left';
+  let yOffsetProp = placement.endsWith('end') && isStaticOffset ? 'bottom' : 'top';
+
+  if (placement.startsWith('top')) {
     return [
       'bottom',
       {
         top: '100%',
-        left: withOffset(false),
+        [xOffsetProp]: withOffset(false),
       },
     ];
-  } else if (placement === 'top-end') {
-    return [
-      'bottom',
-      {
-        top: '100%',
-        [isStaticOffset ? 'right' : 'left']: withOffset(false),
-      },
-    ];
-  } else if (placement === 'right' || placement === 'right-start') {
+  } else if (placement.startsWith('right')) {
     return [
       'left',
       {
-        top: withOffset(true),
+        [yOffsetProp]: withOffset(true),
         left: 0,
       },
     ];
-  } else if (placement === 'right-end') {
-    return [
-      'left',
-      {
-        [isStaticOffset ? 'bottom' : 'top']: withOffset(true),
-        left: 0,
-      },
-    ];
-  } else if (placement === 'bottom' || placement === 'bottom-start') {
+  } else if (placement.startsWith('bottom')) {
     return [
       undefined,
       {
         bottom: '100%',
-        left: withOffset(false),
-      },
-    ];
-  } else if (placement === 'bottom-end') {
-    return [
-      undefined,
-      {
-        bottom: '100%',
-        [isStaticOffset ? 'right' : 'left']: withOffset(false),
-      },
-    ];
-  } else if (placement === 'left' || placement === 'left-start') {
-    return [
-      'right',
-      {
-        top: withOffset(true),
-        right: 0,
+        [xOffsetProp]: withOffset(false),
       },
     ];
   } else {
     return [
       'right',
       {
-        [isStaticOffset ? 'bottom' : 'top']: withOffset(true),
+        [yOffsetProp]: withOffset(true),
         right: 0,
       },
     ];

--- a/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
+++ b/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
@@ -86,7 +86,7 @@ function getArrowPositionData(
     }
   };
 
-  if (placement.startsWith('top')) {
+  if (placement === 'top' || placement === 'top-start') {
     return [
       'bottom',
       {
@@ -94,7 +94,15 @@ function getArrowPositionData(
         left: withOffset(false),
       },
     ];
-  } else if (placement.startsWith('right')) {
+  } else if (placement === 'top-end') {
+    return [
+      'bottom',
+      {
+        top: '100%',
+        right: withOffset(false),
+      },
+    ];
+  } else if (placement === 'right' || placement === 'right-start') {
     return [
       'left',
       {
@@ -102,12 +110,28 @@ function getArrowPositionData(
         left: 0,
       },
     ];
-  } else if (placement.startsWith('bottom')) {
+  } else if (placement === 'right-end') {
+    return [
+      'left',
+      {
+        bottom: withOffset(true),
+        left: 0,
+      },
+    ];
+  } else if (placement === 'bottom' || placement === 'bottom-start') {
     return [
       undefined,
       {
         bottom: '100%',
         left: withOffset(false),
+      },
+    ];
+  } else if (placement === 'bottom-end') {
+    return [
+      undefined,
+      {
+        bottom: '100%',
+        right: withOffset(false),
       },
     ];
   } else {

--- a/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
+++ b/packages/vkui/src/components/FloatingArrow/FloatingArrow.tsx
@@ -99,7 +99,7 @@ function getArrowPositionData(
       'bottom',
       {
         top: '100%',
-        right: withOffset(false),
+        [isStaticOffset ? 'right' : 'left']: withOffset(false),
       },
     ];
   } else if (placement === 'right' || placement === 'right-start') {
@@ -114,7 +114,7 @@ function getArrowPositionData(
     return [
       'left',
       {
-        bottom: withOffset(true),
+        [isStaticOffset ? 'bottom' : 'top']: withOffset(true),
         left: 0,
       },
     ];
@@ -131,14 +131,22 @@ function getArrowPositionData(
       undefined,
       {
         bottom: '100%',
-        right: withOffset(false),
+        [isStaticOffset ? 'right' : 'left']: withOffset(false),
+      },
+    ];
+  } else if (placement === 'left' || placement === 'left-start') {
+    return [
+      'right',
+      {
+        top: withOffset(true),
+        right: 0,
       },
     ];
   } else {
     return [
       'right',
       {
-        top: withOffset(true),
+        [isStaticOffset ? 'bottom' : 'top']: withOffset(true),
         right: 0,
       },
     ];

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.e2e-playground.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.e2e-playground.tsx
@@ -22,7 +22,16 @@ export const OnboardingTooltipPlayground = (props: ComponentPlaygroundProps) => 
           arrowOffset: [15, -15],
         },
         {
-          placement: ['top'],
+          placement: [
+            'top-start',
+            'top-end',
+            'bottom-start',
+            'bottom-end',
+            'left-start',
+            'left-end',
+            'right-start',
+            'right-end',
+          ],
           arrowOffset: [10, -1],
           isStaticArrowOffset: [true],
         },

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.e2e-playground.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.e2e-playground.tsx
@@ -22,16 +22,7 @@ export const OnboardingTooltipPlayground = (props: ComponentPlaygroundProps) => 
           arrowOffset: [15, -15],
         },
         {
-          placement: [
-            'top-start',
-            'top-end',
-            'bottom-start',
-            'bottom-end',
-            'left-start',
-            'left-end',
-            'right-start',
-            'right-end',
-          ],
+          placement: ['top-start', 'top-end', 'bottom-start', 'bottom-end'],
           arrowOffset: [10, -1],
           isStaticArrowOffset: [true],
         },

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0df25788cf8d91af1d9208cf55eb8b2152fdfe732c75716e9244d887a1d43cf
-size 63488
+oid sha256:130770859f6bbea273f471df58b0aac8ef7955e44e0a0668d066243f00c4da54
+size 104431

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ffd4fc2f5b90c9d59d1930fdf94c5a09baa931342df2b2de0b0999a64e6cfbe
-size 68451
+oid sha256:d693331c3ccb2c01b233381e1c860c1b08c8b4766f6224ff41d15a0176888ad4
+size 114544

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e7922afecf835836df5691b2fa0588ef129ada4c5667aab10a40e0829f06908
-size 58992
+oid sha256:0223d86db72ce0818d416630de40c08d71b1a13fcbfcb9bb10ad2d995fa87480
+size 106217

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44753c2b0c39f3391583b33879ff3170e899ebe186e5293ad58a6dc00e8ec35d
-size 65327
+oid sha256:ab6751397570cea398fc52d475b38e5acfe57b9cfee1f5f960cf3835f0f4263f
+size 115827

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a96970c15e3032a69211c914301ecb037c00eab647685ef309559e0da75ca74a
-size 62718
+oid sha256:2a05b58e0051e68e2fc5de00b0481b4bf5e2102f5ea335927aee62f4442d19d8
+size 100092

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e63d12702f855a5594ada78097785aa52258e3997c169d7cb0f8c906e4f91e38
-size 68113
+oid sha256:9fa04c0fb70fbfe36708436efd64925ab3a7da1438702d7ab00674eeaf78a08b
+size 109329

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7bef67a2b3e1c44ecd865601818f25e6ed68f5e71ad954aceb2d64134dbee69
-size 84216
+oid sha256:09ad861c4ec462c2677b7b8ce11acacb189d1989d59aaf099e8aa651f36725bd
+size 152611

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:571ae9140c99c4f49401381f8c8ce3290aceafc7e8031c9501f5265ae7cdcf55
-size 93813
+oid sha256:2da2e35591e4506ace60f4047eabc347dd967645808abcf34779f25025ecefcc
+size 173763

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b9e6c6c9ae32412795312159da08a1d896c4234a58755afbc095d1bdcf12c76
-size 57569
+oid sha256:5c95f6bc65fe4e3c7aa90c00329d00678a7185df797bdd0f01f3c415033f169c
+size 100684

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9053f395b99a0268739498845521480826e4f5bb2d51d1071bfe71dfb7c7a06
-size 63401
+oid sha256:cf28370f48f308d2bca0b284e8a6fe1f2814adc0c535d946f602e8e54fcf1600
+size 109991


### PR DESCRIPTION
- [x] Unit-тесты
- [x] e2e-тесты

## Описание
Добавляем возможность при передаче пропа для статичного позиционирования `isStaticOffset` применять отступ `offset` от противоположного края, если в placement есть `Align` часть с `-end`, то есть `top-end`, `right-end`, `bottom-end`, `left-end`.

Это позволит более гибко настраивать положение стрелочки.
#### Например 

Наш элемент прибит к правому краю и мы над ним хотим показать попап, да так, чтобы стрелочка было близко к краю. Для этого мы передаем `placement: "top-end"`, а в `arrowProps`: {{ isStaticOffset, offset: 20}}
Раньше, чтобы это сделать надо было знать ширину всего попапа, чтобы задать `offset` практически равный этой ширине, потому что отсчёт позиции стрелочки был от левого края.
Теперь, если в placement `top-end`, то отсчёт при `isStaticOffset` будет от правого края.

<img width="527" alt="Screenshot 2024-06-26 at 14 02 38" src="https://github.com/VKCOM/VKUI/assets/5443359/3afb774c-1f5c-4386-a27f-0b304ee9ac32">


## Изменения

