### PR TITLE
fix(Tappable): Remove will-change hack from ripple effect layer

### DIFF
--- a/packages/vkui/src/components/Calendar/__image_snapshots__/calendar-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Calendar/__image_snapshots__/calendar-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0548a2a50d5eeecf34749608fd201fd35ff684462348727ba17e1243672d05da
-size 284466
+oid sha256:feb3c44a0ef7aac6f72b12a839d85d09d48150e6370d0868548a8d63d46eee24
+size 283558

--- a/packages/vkui/src/components/Tappable/Tappable.module.css
+++ b/packages/vkui/src/components/Tappable/Tappable.module.css
@@ -46,8 +46,6 @@ https://github.com/VKCOM/VKUI/pull/3641
   overflow: hidden;
   border-radius: inherit;
   transition: background-color 0.15s ease-out;
-  /* Fix for Safari: css animation + border-radius + overflow ignores parent border-radius */
-  will-change: transform;
 }
 
 /**


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [ ] Завести задачу для фикса border-radius у stateLayer в iOS.


## Описание
Убираем хак для Tappable с использованием `will-change: transform`. 

1. Это создаёт дополнительные композитные слои и нагружает браузер.
2. Это приводит к тому, что при переходе на страницу с большом количестве элементов с `Tappable` внутри, например, `SimpleCell`, наблюдаются блики элементов, видно как браузер старается снова перерисовать эти элементы. Отсутствие `will-change: transform` убирает такой эффект.
3. Этот хак был добавлен не для оптимизации анимации, а для того, чтобы исправить `border-radius: inherit` у `stateLayer` в iOS. В iOS скругление не работает. К сожаление и с этим хаком в последних версиях iOS, в том числе и в симуляторе, наблюдаются прямые углы у `Tappable` при наведении или при тапе, хотя они должны быть скругленными.


https://github.com/VKCOM/VKUI/assets/5443359/6aaf67a2-5823-4917-a4c9-06a46c67f28d



Чтобы проработать эту проблему заведём новое issue на подумать. Так то можно явно задать тот же border-radius что и у `Tappable`, но всё равно не будет работать режим `borderRadiusMode: "inherit"`.

5. С этим свойством надо быть осторожнее и добавлять только действительно для [оптимизации анимаций](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change).

