### PR TITLE
fix(Link): Remove ripple part of Link by disabling Tappable hoverMode

### DIFF
--- a/packages/vkui/src/components/Link/Link.tsx
+++ b/packages/vkui/src/components/Link/Link.tsx
@@ -27,6 +27,7 @@ export const Link = ({
       className={classNames(styles['Link'], hasVisited && styles['Link--has-visited'], className)}
       hasHover={false}
       activeMode="opacity"
+      hoverMode="none"
       focusVisibleMode="outside"
     >
       {children}


### PR DESCRIPTION
- close #7086

---
## Описание
Из-за того, что у компонентов Link всегда рендерится часть Tappable для ripple-эффекта, спозиционированная абсолютно, Link не прячется в Safari вместе с контентом если контент переполнил родительский элемент.

Это, конечно, странное поведение Safari, но и у нас довольно странно в DOM вставлять Ripple компонент, который для Link совсем не нужен.

## Изменения
Руководствуясь условием в `Tappable`, по которому мы рендерим Ripple компонент
https://github.com/VKCOM/VKUI/blob/92d8c0867892d718d6dfadcfbf3f78122d870583/packages/vkui/src/components/Tappable/Tappable.tsx#L74-L76
мы убираем hoverMode="none" у `Link`.

Это безопасно, потому что hoverMode="background" у `Tappable` есть по умолчанию и управляет он фоном, которого у Link нету. Так что на Link это никак не повлияет.
https://github.com/VKCOM/VKUI/blob/92d8c0867892d718d6dfadcfbf3f78122d870583/packages/vkui/src/components/Tappable/Tappable.module.css#L64-L67
https://github.com/VKCOM/VKUI/blob/92d8c0867892d718d6dfadcfbf3f78122d870583/packages/vkui/src/components/Link/Link.module.css#L4

## Изображения
<img width="567" alt="Screenshot 2024-06-27 at 10 36 03" src="https://github.com/VKCOM/VKUI/assets/5443359/588ebbd1-2dae-407f-8ab4-d31a79787c3f">
