### PR TITLE
fix(CustomSelectOption): add word-break: break-word

### DIFF
--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.module.css
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.module.css
@@ -52,6 +52,7 @@
 
 .CustomSelectOption__children {
   min-inline-size: 0;
+  word-break: break-all;
 }
 
 .CustomSelectOption__after {

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.module.css
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.module.css
@@ -52,7 +52,7 @@
 
 .CustomSelectOption__children {
   min-inline-size: 0;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .CustomSelectOption__after {


### PR DESCRIPTION
- close #7062 

---

## Описание

Добавил для текста в CustomSelectOption свойство `word-break: break-word`
Свойство `word-break: break-word` не поддерживается в старых версиях Firefox, но поскольку у нас есть несколько мест, где уже используется, решил заиспользовать
