### PR TITLE
fix(ChipsSelect/ChipsInput): Pass option disabled and readonly to renderChip

### DIFF
--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { baselineComponent, userEvent, withRegExp } from '../../testing/utils';
 import { ChipsInputBase } from './ChipsInputBase';
 import type { ChipsInputBasePrivateProps } from './types';
@@ -320,4 +320,58 @@ describe(ChipsInputBase, () => {
       expect(onBlur).toHaveBeenCalled();
     },
   );
+
+  it('applies option readOnly and disabled to chips', () => {
+    render(
+      <ChipsInputBaseTest
+        value={[
+          { ...RED_OPTION, readOnly: true },
+          { ...BLUE_OPTION, disabled: true },
+          YELLOW_OPTION,
+        ]}
+        onAddChipOption={onAddChipOption}
+        onRemoveChipOption={onRemoveChipOption}
+      />,
+    );
+
+    const redOption = screen.getByRole('option', { name: /Красный/ });
+    expect(redOption.getAttribute('aria-readonly')).toBeTruthy();
+    expect(redOption.getAttribute('aria-disabled')).toBeFalsy();
+
+    const blueOption = screen.getByRole('option', { name: /Синий/ });
+    expect(blueOption.getAttribute('aria-readonly')).toBeFalsy();
+    expect(blueOption.getAttribute('aria-disabled')).toBeTruthy();
+
+    const yellowOption = screen.getByRole('option', { name: /Жёлтый/ });
+    expect(yellowOption.getAttribute('aria-readonly')).toBeFalsy();
+    expect(yellowOption.getAttribute('aria-disabled')).toBeFalsy();
+  });
+
+  it('applies input readOnly and disabled to chips: all readOnly and disabled', () => {
+    render(
+      <ChipsInputBaseTest
+        readOnly
+        disabled
+        value={[
+          { ...RED_OPTION, readOnly: true },
+          { ...BLUE_OPTION, disabled: true },
+          YELLOW_OPTION,
+        ]}
+        onAddChipOption={onAddChipOption}
+        onRemoveChipOption={onRemoveChipOption}
+      />,
+    );
+
+    const redOption = screen.getByRole('option', { name: /Красный/ });
+    expect(redOption.getAttribute('aria-readonly')).toBeTruthy();
+    expect(redOption.getAttribute('aria-disabled')).toBeTruthy();
+
+    const blueOption = screen.getByRole('option', { name: /Синий/ });
+    expect(blueOption.getAttribute('aria-readonly')).toBeTruthy();
+    expect(blueOption.getAttribute('aria-disabled')).toBeTruthy();
+
+    const yellowOption = screen.getByRole('option', { name: /Жёлтый/ });
+    expect(yellowOption.getAttribute('aria-readonly')).toBeTruthy();
+    expect(yellowOption.getAttribute('aria-disabled')).toBeTruthy();
+  });
 });

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -222,8 +222,8 @@ export const ChipsInputBase = <O extends ChipOption>({
                 'Component': 'div',
                 'value': option.value,
                 'label': option.label,
-                'disabled': disabled,
-                'readOnly': readOnly,
+                'disabled': option.disabled || disabled,
+                'readOnly': option.readOnly || readOnly,
                 'className': styles['ChipsInputBase__chip'],
                 'onRemove': handleChipRemove,
                 // чтобы можно было легче найти этот чип в DOM

--- a/packages/vkui/src/components/ChipsInputBase/constants.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/constants.tsx
@@ -26,9 +26,9 @@ export function getNewOptionDataDefault<O extends ChipOption>(
 }
 
 export function renderChipDefault(props: RenderChipProps): React.ReactNode {
-  const { disabled, label, ...rest } = props;
+  const { label, ...rest } = props;
   return (
-    <Chip removable={!disabled} {...rest}>
+    <Chip removable={!props.disabled} {...rest}>
       {label}
     </Chip>
   );


### PR DESCRIPTION
- [x] Unit-тесты

## Описание
Бывает, что хочется некоторые chips уже сразу сделать выбранными по умолчанию, не давая их убрать. Например, с помощью disabled и readOnly свойств.

Оказалось, что для ChipsInput мы позволяем задать `disabled` или `readOnly` только для всех chips разом.

![file NflMcn](https://github.com/VKCOM/VKUI/assets/5443359/22dc9fa9-278e-4f2e-9669-25c449afa461)


## Изменения
Используем значение `disabled`/`readOnly` из `option` при рендере chips.