### PR TITLE
fix(useCustomEnsuredControl/useFloatingWithInteractions): Initialize preservedControlledValueRef with value

### DIFF
--- a/packages/vkui/src/hooks/useEnsuredControl.ts
+++ b/packages/vkui/src/hooks/useEnsuredControl.ts
@@ -46,7 +46,7 @@ export function useCustomEnsuredControl<V = any>({
 }: UseCustomEnsuredControlProps<V>): [V, React.Dispatch<React.SetStateAction<V>>] {
   const isControlled = value !== undefined;
   const [localValue, setLocalValue] = React.useState(defaultValue);
-  const preservedControlledValueRef = React.useRef<V>();
+  const preservedControlledValueRef = React.useRef(value);
 
   useIsomorphicLayoutEffect(() => {
     preservedControlledValueRef.current = value;


### PR DESCRIPTION
## Описание

Мы получили репорт об ошибке от пользователей:
> TypeError: Uncaught TypeError: Cannot read properties of undefined (reading 'shown')

shown в объекте используется только в `useFloatingWithInteractions`, который управляется с помощью хука `useCustomEnsuredControl`.
Единственный момент когда бы состояние могло быть `undefined` это момент когда вызывается callback 
https://github.com/VKCOM/VKUI/blob/406784aa5bfa1d1dd0dd40f24f031faca8de5eca/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts#L93-L102

Тут мы вызываем `setShownLocalState` с функцией, у которой в аргументах может лежать предыдущее состояние стейта.
В этот момент у `useCustomEnsuredControl`, если компонент контролируемый и вызывает `onChange` с коллбэком, мы обращаемся к переменной `preservedControlledValueRef`.
https://github.com/VKCOM/VKUI/blob/406784aa5bfa1d1dd0dd40f24f031faca8de5eca/packages/vkui/src/hooks/useEnsuredControl.ts#L70-L73

Эта переменная может быть `undefined` только при инициализации, до тех пор пока в `value` не будет передано значение !== `undefined`.
https://github.com/VKCOM/VKUI/blob/7d4f104c0c6ea643d4a2e93a5305d17b252a8572/packages/vkui/src/hooks/useEnsuredControl.ts#L49-L53



## Изменения
Инициализируем ref сразу же со значением value.

## Воспроизведение
Мне никак не удалось довести компонент до состояния ошибки, ни локально, ни в тестовом окружении.
Возможно, что это вообще ложный след.
Возможно, что это также может происходить при изменении состояния компонента из неконтролируемого в контролируемое.

Потому что такая ошибка может возникнуть только если value был `undefined`, потом стал `defined` и был быстро вызван `onChange` , так быстро, что `preservedControlledValueRef` не успел обновится.

Возможно, что стектрейс, который привёл нас сюда не совсем верный. Его надо спрашивать в VK Teams.
