### PR TITLE
feat(HorizontalCellShowMore): add prop `centered`

### DIFF
--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.module.css
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.module.css
@@ -7,7 +7,7 @@
   margin-inline-start: calc(-1 * var(--vkui_internal--side_cell_gap));
 }
 
-.HorizontalCellShowMore--stretched {
+.HorizontalCellShowMore--centered {
   margin-block: auto;
 }
 

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.module.css
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.module.css
@@ -7,6 +7,10 @@
   margin-inline-start: calc(-1 * var(--vkui_internal--side_cell_gap));
 }
 
+.HorizontalCellShowMore--stretched {
+  margin-block: auto;
+}
+
 .HorizontalCellShowMore:last-child::after {
   content: '';
   min-inline-size: var(--vkui_internal--side_cell_gap);

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
@@ -32,6 +32,8 @@ describe('HorizontalCellShowMore', () => {
 
   it('should have specific className when stretched=true', () => {
     const component = render(<HorizontalCellShowMore data-testid="show-more" stretched={true} />);
-    expect(component.getByTestId('show-more').parentElement).toHaveClass(styles['HorizontalCellShowMore--stretched'])
-  })
+    expect(component.getByTestId('show-more').parentElement).toHaveClass(
+      styles['HorizontalCellShowMore--stretched'],
+    );
+  });
 });

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
@@ -30,10 +30,10 @@ describe('HorizontalCellShowMore', () => {
     expect(screen.queryByText('Показать все')).toBeFalsy();
   });
 
-  it('should have specific className when stretched=true', () => {
-    const component = render(<HorizontalCellShowMore data-testid="show-more" stretched={true} />);
+  it('should have specific className when centered=true', () => {
+    const component = render(<HorizontalCellShowMore data-testid="show-more" centered={true} />);
     expect(component.getByTestId('show-more').parentElement).toHaveClass(
-      styles['HorizontalCellShowMore--stretched'],
+      styles['HorizontalCellShowMore--centered'],
     );
   });
 });

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../../testing/utils';
 import { HorizontalCellShowMore } from './HorizontalCellShowMore';
+import styles from './HorizontalCellShowMore.module.css';
 
 describe('HorizontalCellShowMore', () => {
   baselineComponent(HorizontalCellShowMore);
@@ -28,4 +29,9 @@ describe('HorizontalCellShowMore', () => {
     expect(screen.queryByText('Все')).toBeFalsy();
     expect(screen.queryByText('Показать все')).toBeFalsy();
   });
+
+  it('should have specific className when stretched=true', () => {
+    const component = render(<HorizontalCellShowMore data-testid="show-more" stretched={true} />);
+    expect(component.getByTestId('show-more').parentElement).toHaveClass(styles['HorizontalCellShowMore--stretched'])
+  })
 });

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
@@ -43,6 +43,10 @@ export interface HorizontalCellShowMoreProps
    * Если `HorizontalCellShowMore` находится на одном уровне с остальными `HorizontalCell`, то этот проп использовать не нужно.
    */
   compensateLastCellIndent?: boolean;
+  /**
+   * Выравнивание по центру относительно родителя
+   */
+  stretched?: boolean,
 }
 
 export const HorizontalCellShowMore = ({
@@ -54,6 +58,7 @@ export const HorizontalCellShowMore = ({
   height,
   size = 's',
   children = size === 's' ? 'Все' : 'Показать все',
+  stretched = false,
   ...restProps
 }: HorizontalCellShowMoreProps): React.ReactNode => {
   return (
@@ -62,6 +67,7 @@ export const HorizontalCellShowMore = ({
       className={classNames(
         styles['HorizontalCellShowMore'],
         compensateLastCellIndent && styles['HorizontalCellShowMore--compensate-last-cell-indent'],
+        stretched && styles['HorizontalCellShowMore--stretched'],
         sizeClassNames[size],
         className,
       )}

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
@@ -46,7 +46,7 @@ export interface HorizontalCellShowMoreProps
   /**
    * Выравнивание по центру относительно родителя
    */
-  stretched?: boolean,
+  stretched?: boolean;
 }
 
 export const HorizontalCellShowMore = ({

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
@@ -46,7 +46,7 @@ export interface HorizontalCellShowMoreProps
   /**
    * Выравнивание по центру относительно родителя
    */
-  stretched?: boolean;
+  centered?: boolean;
 }
 
 export const HorizontalCellShowMore = ({
@@ -58,7 +58,7 @@ export const HorizontalCellShowMore = ({
   height,
   size = 's',
   children = size === 's' ? 'Все' : 'Показать все',
-  stretched = false,
+  centered = false,
   ...restProps
 }: HorizontalCellShowMoreProps): React.ReactNode => {
   return (
@@ -67,7 +67,7 @@ export const HorizontalCellShowMore = ({
       className={classNames(
         styles['HorizontalCellShowMore'],
         compensateLastCellIndent && styles['HorizontalCellShowMore--compensate-last-cell-indent'],
-        stretched && styles['HorizontalCellShowMore--stretched'],
+        centered && styles['HorizontalCellShowMore--centered'],
         sizeClassNames[size],
         className,
       )}


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6387 

---

- [x] Unit-тесты
- [x] Документация фичи

## Описание

Нужно добавить возможность выравнивания по центру для компонента `HorizontalCellShowMore`

## Изменения

Добавил проп `centered`. При передаче которого, компонент выравнивается по центру по вертикали относительно родителя
