### PR TITLE
feat(CustomSelect): add prop getSelectInputRef

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -1106,4 +1106,21 @@ describe('CustomSelect', () => {
     const input = screen.getByTestId<HTMLInputElement>('inputTestId');
     expect(input.required).toBeFalsy();
   });
+
+  it('check getSelectInputRef: ref value not null', () => {
+    const inputRef: React.Ref<HTMLInputElement> = {
+      current: null,
+    };
+    render(
+      <CustomSelect
+        getSelectInputRef={inputRef}
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        placeholder="Не выбрано"
+      />,
+    );
+    expect(inputRef.current).not.toBeNull();
+  });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -131,6 +131,10 @@ export interface SelectProps<
     FormFieldProps,
     TrackerOptionsProps {
   /**
+   * ref на внутрений компонент input
+   */
+  getSelectInputRef?: React.Ref<HTMLInputElement>;
+  /**
    * Если `true`, то при клике на `CustomSelect` в нём появится текстовое поле для поиска по `options`. По умолчанию поиск
    * производится по `option.label`.
    */
@@ -256,6 +260,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     nativeSelectTestId,
     defaultValue,
     required,
+    getSelectInputRef,
     ...restProps
   } = props;
 
@@ -703,7 +708,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     }
   }, [emptyText, options, renderDropdown, renderOption]);
 
-  const selectInputRef = React.useRef<HTMLInputElement | null>(null);
+  const selectInputRef = useExternRef(getSelectInputRef);
   const focusOnInputTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
   const focusOnInput = React.useCallback(() => {
     clearTimeout(focusOnInputTimerRef.current);
@@ -711,7 +716,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     focusOnInputTimerRef.current = setTimeout(() => {
       selectInputRef.current && selectInputRef.current.focus();
     }, 0);
-  }, []);
+  }, [selectInputRef]);
   useIsomorphicLayoutEffect(function clearFocusOnInputTimer() {
     return () => {
       clearTimeout(focusOnInputTimerRef.current);
@@ -795,7 +800,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         }
       }
     },
-    [document, focusOnInput],
+    [document, focusOnInput, selectInputRef],
   );
 
   const preventInputBlurWhenClickInsideFocusedSelectArea = (

--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -44,6 +44,7 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
     nativeSelectTestId,
     after,
     mode,
+    getSelectInputRef,
     ...restProps
   } = props;
 


### PR DESCRIPTION
- close #7115 

---

- [x] Unit-тесты
- [x] Документация фичи

## Описание

Добавил пропс `getSelectInputRef` для получения ссылки на элемент input внутри `CustomSelect`
