### PR TITLE
fix(CustomSelect): fix scroll to element

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.e2e-playground.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.e2e-playground.tsx
@@ -75,3 +75,30 @@ export const CustomSelectNoMaxHeightPlayground = (props: ComponentPlaygroundProp
     </ComponentPlayground>
   );
 };
+
+export const CustomSelectOptionScrollPlayground = (props: ComponentPlaygroundProps) => {
+  return (
+    <ComponentPlayground {...props} propSets={[{ value: [7] }]}>
+      {(props: SelectProps) => (
+        <div style={{ height: 200 }}>
+          <CustomSelect
+            data-testid="target-select"
+            {...props}
+            options={[
+              { value: 1, label: 'Гарри Поттер и философский камень' },
+              { value: 2, label: 'Гарри Поттер и Тайная комната' },
+              {
+                value: 3,
+                label: 'Гарри Поттер и узник Азкабана',
+              },
+              { value: 4, label: 'Гарри Поттер и Кубок Огня' },
+              { value: 5, label: 'Гарри Поттер и Орден Феникса' },
+              { value: 6, label: 'Гарри Поттер и Принц-полукровка' },
+              { value: 7, label: 'Гарри Поттер и Дары Смерти' },
+            ]}
+          />
+        </div>
+      )}
+    </ComponentPlayground>
+  );
+};

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.e2e.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.e2e.tsx
@@ -2,6 +2,7 @@ import { test } from '@vkui-e2e/test';
 import { Appearance } from '../../lib/appearance';
 import {
   CustomSelectNoMaxHeightPlayground,
+  CustomSelectOptionScrollPlayground,
   CustomSelectPlayground,
 } from './CustomSelect.e2e-playground';
 
@@ -33,6 +34,26 @@ test.describe('CustomSelect', () => {
        * спрятан инпут, чтобы не появлялся тултип autosuggestion на iOS при клике на инпут.
        **/
       .click({ force: componentPlaygroundProps.platform === 'ios' });
+
+    await expectScreenshotClippedToContent();
+  });
+});
+
+test.describe('CustomSelect', () => {
+  test.use({
+    onlyForAppearances: [Appearance.LIGHT],
+    platform: 'android',
+    onlyForBrowsers: ['chromium'],
+  });
+  test('scroll to option', async ({
+    mount,
+    page,
+    expectScreenshotClippedToContent,
+    componentPlaygroundProps,
+  }) => {
+    await mount(<CustomSelectOptionScrollPlayground {...componentPlaygroundProps} />);
+
+    await page.getByTestId('target-select').click();
 
     await expectScreenshotClippedToContent();
   });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -326,7 +326,10 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
   const scrollToElement = React.useCallback((index: number, center = false) => {
     const dropdown = scrollBoxRef.current;
-    const item = dropdown ? (dropdown.children[index] as HTMLElement) : null;
+    const item =
+      dropdown && dropdown.firstElementChild
+        ? (dropdown.firstElementChild.children[index] as HTMLElement)
+        : null;
 
     if (!item || !dropdown) {
       return;

--- a/packages/vkui/src/components/CustomSelect/__image_snapshots__/customselect-scroll-to-option-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/CustomSelect/__image_snapshots__/customselect-scroll-to-option-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a413eb47a70bee5e7d4c6837922dc7938ff83d28c64daaa443896815ece8640
+size 18021


### PR DESCRIPTION
- [x] e2e-тесты

## Описание

- caused by #7060 

Т.к. изменилась внутренняя структура `CustomScrollView`, в `CustomSelect` сломалось получение ссылки на конкретный айтем и не работал подскролл к нужному элементу при открытии дропдауна.

## Изменения

Получаем верную ссылку на элемент, покрываем тестом данный кейс.
