### PR TITLE
fix(Popover): revert `customMiddlewares` prop

### DIFF
--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -74,6 +74,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'children'
   | 'zIndex'
   | 'disableFlipMiddleware'
+  | 'customMiddlewares'
 >;
 
 /**
@@ -145,6 +146,7 @@ export const Popover = ({
   disableCloseOnClickOutside,
   disableCloseOnEscKey,
   keepMounted = false,
+  customMiddlewares,
   // uncontrolled
   defaultShown = false,
   // controlled
@@ -181,6 +183,7 @@ export const Popover = ({
     sameWidth,
     hideWhenReferenceHidden,
     disableFlipMiddleware,
+    customMiddlewares,
   });
   const {
     placement: resolvedPlacement,


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7117

---

## Описание

Возвращаем параметр, который удалили в v6.0.0.

---

- caused by #6212