### PR TITLE
feat(PullToRefresh): prevent browser pull-to-refresh behavior

### DIFF
--- a/packages/vkui/src/lib/dom.test.ts
+++ b/packages/vkui/src/lib/dom.test.ts
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import { getFakeMouseEvent, getFakeTouchEvent } from '../testing/utils';
 import {
   contains,
@@ -8,6 +9,7 @@ import {
   getScrollHeight,
   getScrollRect,
   getTransformedParentCoords,
+  initializeBrowserGesturePreventionEffect,
   TRANSFORM_DEFAULT_VALUES,
   WILL_CHANGE_DEFAULT_VALUES,
 } from './dom';
@@ -243,5 +245,37 @@ describe(getFirstTouchEventData, () => {
     const { clientX, clientY } = getFirstTouchEventData(new UIEvent('unknown'));
     expect(clientX).toBe(0);
     expect(clientY).toBe(0);
+  });
+});
+
+describe(initializeBrowserGesturePreventionEffect, () => {
+  it('should set and unset CSS class to <html />', () => {
+    const dispose = jest.fn().mockImplementation(initializeBrowserGesturePreventionEffect(window));
+
+    expect(document.documentElement).toHaveClass('vkui--disable-overscroll-behavior');
+
+    dispose();
+
+    expect(document.documentElement).not.toHaveClass('vkui--disable-overscroll-behavior');
+    expect(dispose).toHaveBeenCalled();
+  });
+
+  it('should prevent touchmove event', () => {
+    const dispose = jest.fn().mockImplementation(initializeBrowserGesturePreventionEffect(window));
+
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+    const touchMoveEvent = new TouchEvent('touchmove');
+    Object.assign(touchMoveEvent, { preventDefault, stopPropagation });
+
+    fireEvent(window, touchMoveEvent);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+
+    dispose();
+
+    fireEvent(window, touchMoveEvent);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/vkui/src/lib/dom.tsx
+++ b/packages/vkui/src/lib/dom.tsx
@@ -235,3 +235,26 @@ export const getFirstTouchEventData = (
     pageY: dataRaw.pageY || 0,
   };
 };
+
+/**
+ * ⚠️ В частности, необходимо для iOS 15. Начиная с этой версии в Safari добавили
+ * pull-to-refresh. CSS св-во `overflow-behavior` появился только с iOS 16.
+ *
+ * Во вторую очередь, полезна блокированием скролла, чтобы пользователь дождался обновления
+ * данных.
+ */
+export const initializeBrowserGesturePreventionEffect = (window: Window): VoidFunction => {
+  const options: AddEventListenerOptions & EventListenerOptions = { passive: false };
+  const handleWindowTouchMove = (event: TouchEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  window.document.documentElement.classList.add('vkui--disable-overscroll-behavior'); // eslint-disable-line no-restricted-properties
+  window.addEventListener('touchmove', handleWindowTouchMove, options);
+
+  return function dispose() {
+    window.document.documentElement.classList.remove('vkui--disable-overscroll-behavior'); // eslint-disable-line no-restricted-properties
+    window.removeEventListener('touchmove', handleWindowTouchMove, options);
+  };
+};


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

Вынес логику выставления `'vkui--disable-overscroll-behavior'` в `lib/dom` под функцией `initializeBrowserGesturePreventionEffect`.

---

- вынес из #7135 в отдельный PR
