### PR TITLE
fix(Popover): fix multiple trigger behavior

### DIFF
--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -193,9 +193,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
       showWithDelay.cancel();
       hideWithDelay.cancel();
 
-      if (shownLocalState.reason !== 'focus' && shownLocalState.reason !== 'click') {
-        hideWithDelay();
-      }
+      hideWithDelay();
     }
   });
 


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

Если мы задавали `trigger={['focus', 'click', 'hover']}`, то событие `mouseLeave` игнорировалось в случае, если триггером выступал `focus` или `click`, это приводило к путающему поведению:

| Было  | Стало |
| ------------- | ------------- |
| <video src="https://github.com/VKCOM/VKUI/assets/7431217/1b35c96e-939a-49df-8bd9-150b51ee1413">  | <video src="https://github.com/VKCOM/VKUI/assets/7431217/51d86a43-e3e3-4a02-8860-8d793aec2107">|

## Изменения

Убираем игнор `focus`/`click` событий, изменяем тесты на проверку взаимозаменяющего поведения
