### PR TITLE
fix(CustomSelect): bring back (not)flacky test

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.e2e-playground.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.e2e-playground.tsx
@@ -75,3 +75,30 @@ export const CustomSelectNoMaxHeightPlayground = (props: ComponentPlaygroundProp
     </ComponentPlayground>
   );
 };
+
+export const CustomSelectOptionScrollPlayground = (props: ComponentPlaygroundProps) => {
+  return (
+    <ComponentPlayground {...props} propSets={[{ value: [7] }]}>
+      {(props: SelectProps) => (
+        <div style={{ height: 200 }}>
+          <CustomSelect
+            data-testid="target-select"
+            {...props}
+            options={[
+              { value: 1, label: 'Гарри Поттер и философский камень' },
+              { value: 2, label: 'Гарри Поттер и Тайная комната' },
+              {
+                value: 3,
+                label: 'Гарри Поттер и узник Азкабана',
+              },
+              { value: 4, label: 'Гарри Поттер и Кубок Огня' },
+              { value: 5, label: 'Гарри Поттер и Орден Феникса' },
+              { value: 6, label: 'Гарри Поттер и Принц-полукровка' },
+              { value: 7, label: 'Гарри Поттер и Дары Смерти' },
+            ]}
+          />
+        </div>
+      )}
+    </ComponentPlayground>
+  );
+};

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.e2e.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.e2e.tsx
@@ -42,7 +42,7 @@ test.describe('CustomSelect', () => {
 test.describe('CustomSelect', () => {
   test.use({
     onlyForAppearances: [Appearance.LIGHT],
-    platform: 'android',
+    onlyForPlatforms: ['android'],
     onlyForBrowsers: ['chromium'],
   });
   test('scroll to option', async ({

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.e2e.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.e2e.tsx
@@ -2,6 +2,7 @@ import { test } from '@vkui-e2e/test';
 import { Appearance } from '../../lib/appearance';
 import {
   CustomSelectNoMaxHeightPlayground,
+  CustomSelectOptionScrollPlayground,
   CustomSelectPlayground,
 } from './CustomSelect.e2e-playground';
 
@@ -33,6 +34,26 @@ test.describe('CustomSelect', () => {
        * спрятан инпут, чтобы не появлялся тултип autosuggestion на iOS при клике на инпут.
        **/
       .click({ force: componentPlaygroundProps.platform === 'ios' });
+
+    await expectScreenshotClippedToContent();
+  });
+});
+
+test.describe('CustomSelect', () => {
+  test.use({
+    onlyForAppearances: [Appearance.LIGHT],
+    platform: 'android',
+    onlyForBrowsers: ['chromium'],
+  });
+  test('scroll to option', async ({
+    mount,
+    page,
+    expectScreenshotClippedToContent,
+    componentPlaygroundProps,
+  }) => {
+    await mount(<CustomSelectOptionScrollPlayground {...componentPlaygroundProps} />);
+
+    await page.getByTestId('target-select').click();
 
     await expectScreenshotClippedToContent();
   });

--- a/packages/vkui/src/components/CustomSelect/__image_snapshots__/customselect-scroll-to-option-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/CustomSelect/__image_snapshots__/customselect-scroll-to-option-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e99a0c20f437060a0adc968211bc06de3906b7826b555df6abc1fc9d36e2a41
+size 17061


### PR DESCRIPTION
- caused by #7131

---

- [x] e2e-тесты

## Описание

Из-за того, что использовалось `platform` вместо `onlyForPlatforms`, иногда тесты исполнялись и для `vkcom`-платформы

## Изменения

Добавляем исправленный `e2e`-тест