### PR TITLE
feat(TextArea): add possibility to add after and before props. Add props to align after and before items in FormField

### DIFF
--- a/packages/vkui/src/components/FormField/FormField.module.css
+++ b/packages/vkui/src/components/FormField/FormField.module.css
@@ -54,6 +54,14 @@
   }
 }
 
+.FormField__icon--align-start {
+  align-self: flex-start;
+}
+
+.FormField__icon--align-end {
+  align-self: flex-end;
+}
+
 .FormField__before {
   color: var(--vkui--color_icon_accent);
 }

--- a/packages/vkui/src/components/FormField/FormField.test.tsx
+++ b/packages/vkui/src/components/FormField/FormField.test.tsx
@@ -1,6 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { Icon20User, Icon24WalletOutline } from '@vkontakte/icons';
 import { baselineComponent } from '../../testing/utils';
+import { IconButton } from '../IconButton/IconButton';
 import { FormField } from './FormField';
+import styles from './FormField.module.css';
 
 describe('FormField', () => {
   baselineComponent(FormField);
+
+  it('check align of after and before icons', () => {
+    render(
+      <FormField
+        after={
+          <IconButton data-testid="after">
+            <Icon24WalletOutline />
+          </IconButton>
+        }
+        before={
+          <IconButton data-testid="before">
+            <Icon20User />
+          </IconButton>
+        }
+        beforeAlign="start"
+        afterAlign="end"
+      >
+        <div></div>
+      </FormField>,
+    );
+
+    expect(screen.getByTestId('before').parentElement).toHaveClass(
+      styles['FormField__icon--align-start'],
+    );
+    expect(screen.getByTestId('after').parentElement).toHaveClass(
+      styles['FormField__icon--align-end'],
+    );
+  });
 });

--- a/packages/vkui/src/components/FormField/FormField.tsx
+++ b/packages/vkui/src/components/FormField/FormField.tsx
@@ -23,7 +23,7 @@ const iconAlignClassNames = {
   end: styles['FormField__icon--align-end'],
 };
 
-type FieldIconsAlign = 'start' | 'center' | 'end';
+export type FieldIconsAlign = 'start' | 'center' | 'end';
 
 export interface FormFieldProps {
   status?: 'default' | 'error' | 'valid';
@@ -50,7 +50,7 @@ export interface FormFieldProps {
    */
   after?: React.ReactNode;
   /**
-   * Вертикальное выравнивание иконки слева
+   * Вертикальное выравнивание иконки справа
    */
   afterAlign?: FieldIconsAlign;
   /**

--- a/packages/vkui/src/components/FormField/FormField.tsx
+++ b/packages/vkui/src/components/FormField/FormField.tsx
@@ -17,6 +17,14 @@ const stylesStatus = {
   valid: styles['FormField--status-valid'],
 };
 
+const iconAlignClassNames = {
+  center: undefined,
+  start: styles['FormField__icon--align-start'],
+  end: styles['FormField__icon--align-end'],
+};
+
+type FieldIconsAlign = 'start' | 'center' | 'end';
+
 export interface FormFieldProps {
   status?: 'default' | 'error' | 'valid';
   /**
@@ -29,6 +37,10 @@ export interface FormFieldProps {
    */
   before?: React.ReactNode;
   /**
+   * Вертикальное выравнивание иконки слева
+   */
+  beforeAlign?: FieldIconsAlign;
+  /**
    * Добавляет иконку справа.
    *
    * Рекомендации:
@@ -37,6 +49,10 @@ export interface FormFieldProps {
    * - Используйте [IconButton](https://vkcom.github.io/VKUI/#/IconButton), если вам нужна кликабельная иконка.
    */
   after?: React.ReactNode;
+  /**
+   * Вертикальное выравнивание иконки слева
+   */
+  afterAlign?: FieldIconsAlign;
   /**
    * Режим отображения.
    *
@@ -64,6 +80,8 @@ export const FormField = ({
   getRootRef,
   before,
   after,
+  beforeAlign = 'center',
+  afterAlign = 'center',
   disabled,
   mode = 'default',
   className,
@@ -106,10 +124,20 @@ export const FormField = ({
         className,
       )}
     >
-      {before && <span className={styles['FormField__before']}>{before}</span>}
+      {before && (
+        <span className={classNames(styles['FormField__before'], iconAlignClassNames[beforeAlign])}>
+          {before}
+        </span>
+      )}
       {children}
       {after && (
-        <span className={classNames(styles['FormField__after'], 'vkuiInternalFormField__after')}>
+        <span
+          className={classNames(
+            styles['FormField__after'],
+            iconAlignClassNames[afterAlign],
+            'vkuiInternalFormField__after',
+          )}
+        >
           {after}
         </span>
       )}

--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -46,6 +46,8 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
     mode,
     getSelectInputRef,
     overscrollBehavior,
+    beforeAlign,
+    afterAlign,
     ...restProps
   } = props;
 

--- a/packages/vkui/src/components/Textarea/Readme.md
+++ b/packages/vkui/src/components/Textarea/Readme.md
@@ -1,23 +1,49 @@
 Надстройка над `<textarea />`. Компонент принимает все валидные для этого элемента свойства.
 
 ```jsx
-<View activePanel="panel">
-  <Panel id="panel">
-    <PanelHeader>Textarea</PanelHeader>
-    <Group>
-      <FormItem top="Любимая музыка">
-        <Textarea placeholder="Группы, исполнители, продюсеры" />
-      </FormItem>
-      <FormItem top="Увлечения">
-        <Textarea
-          placeholder="Музыка, спорт"
-          defaultValue="Музыка\nСпорт\nФотография\nПлавание\nПрограммирование\nПутешествия\nКниги\nСериалы\nФильмы\nНастольные игры"
-        />
-      </FormItem>
-      <FormItem top="Прикидываемся Input">
-        <Textarea rows={1} placeholder="Once upon a time" />
-      </FormItem>
-    </Group>
-  </Panel>
-</View>
+const App = () => {
+  const textAreaRef = useRef(null);
+  return (
+    <View activePanel="panel">
+      <Panel id="panel">
+        <PanelHeader>Textarea</PanelHeader>
+        <Group>
+          <FormItem top="Любимая музыка">
+            <Textarea placeholder="Группы, исполнители, продюсеры" />
+          </FormItem>
+          <FormItem top="Увлечения">
+            <Textarea
+              placeholder="Музыка, спорт"
+              defaultValue="Музыка\nСпорт\nФотография\nПлавание\nПрограммирование\nПутешествия\nКниги\nСериалы\nФильмы\nНастольные игры"
+            />
+          </FormItem>
+          <FormItem top="Прикидываемся Input">
+            <Textarea rows={1} placeholder="Once upon a time" />
+          </FormItem>
+
+          <FormItem top="С кнопкой">
+            <Textarea
+              defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eget commodo lorem. Suspendisse convallis ligula vitae mi dictum ullamcorper. Fusce pulvinar quis sem vel tincidunt. Fusce lectus odio, dapibus at metus congue, mollis tempor lorem. Vivamus dictum iaculis turpis non tincidunt. Cras ornare venenatis mi, quis mollis mauris tempus at. Curabitur turpis metus, hendrerit a ligula quis, euismod fringilla neque. Cras pretium aliquet convallis. In et bibendum nulla. Maecenas iaculis commodo blandit. Phasellus semper nunc nec placerat dictum."
+              getRef={textAreaRef}
+              after={
+                <Tooltip text="Скопировать" placement="top">
+                  <IconButton
+                    label="Скопировать"
+                    onClick={() => navigator.clipboard.writeText(textAreaRef.current.value)}
+                  >
+                    <Icon20CopyOutline />
+                  </IconButton>
+                </Tooltip>
+              }
+              afterAlign="start"
+              readOnly
+            />
+          </FormItem>
+        </Group>
+      </Panel>
+    </View>
+  );
+};
+
+<App />;
 ```

--- a/packages/vkui/src/components/Textarea/Textarea.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.tsx
@@ -20,7 +20,7 @@ export interface TextareaProps
     HasRootRef<HTMLElement>,
     Pick<React.CSSProperties, 'maxHeight'>,
     HasAlign,
-    Pick<FormFieldProps, 'status' | 'mode'> {
+    FormFieldProps {
   grow?: boolean;
   onResize?: (el: HTMLTextAreaElement) => void;
   defaultValue?: string;
@@ -42,6 +42,10 @@ export const Textarea = ({
   onChange,
   align,
   mode,
+  after,
+  before,
+  afterAlign,
+  beforeAlign,
   ...restProps
 }: TextareaProps): React.ReactNode => {
   const { sizeY = 'none' } = useAdaptivity();
@@ -65,6 +69,10 @@ export const Textarea = ({
       disabled={restProps.disabled}
       status={status}
       mode={mode}
+      after={after}
+      before={before}
+      afterAlign={afterAlign}
+      beforeAlign={beforeAlign}
     >
       <UnstyledTextField
         {...restProps}

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -270,7 +270,7 @@ export type { FormItemTopLabelProps } from './components/FormItem/FormItemTop/Fo
 export type { FormItemTopAsideProps } from './components/FormItem/FormItemTop/FormItemTopAside';
 export type { FormItemProps } from './components/FormItem/FormItem';
 export { FormField } from './components/FormField/FormField';
-export type { FormFieldProps } from './components/FormField/FormField';
+export type { FormFieldProps, FieldIconsAlign } from './components/FormField/FormField';
 export { FormLayoutGroup } from './components/FormLayoutGroup/FormLayoutGroup';
 export type { FormLayoutGroupProps } from './components/FormLayoutGroup/FormLayoutGroup';
 export { FormStatus } from './components/FormStatus/FormStatus';


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6307 

---

- [x] Unit-тесты
- [x] Документация фичи

## Описание

Добавить пропс after для компонента `TextArea`

## Изменения

- Добавил пропсы `after` и `before` для компонента TextArea
- Добавил пропсы `afterAlign` и `beforeAlign` для компонента `FormField` для выравнивания компонентов по вертикали
- Дописал тесты для компонента `FormField`
- Добавил пример в документацию с компонентом `after` в `TextField` 