### PR TITLE
fix(PanelHeaderContext): remove init animation

### DIFF
--- a/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
+++ b/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.test.tsx
@@ -16,12 +16,11 @@ describe('PanelHeaderContext', () => {
     fakeTimers();
 
     it('does not close on mount', async () => {
-      const result = render(
+      render(
         <PanelHeaderContext opened={false} onClose={noop}>
           <div data-testid="xxx" />
         </PanelHeaderContext>,
       );
-      await waitCSSKeyframesAnimation(result.getByTestId('content'));
       expect(screen.queryByTestId('xxx')).toBeNull();
     });
 

--- a/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.tsx
+++ b/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.tsx
@@ -35,6 +35,8 @@ export const PanelHeaderContext = ({
   const elementRef = React.useRef<HTMLDivElement>(null);
   const [animationState, animationHandlers] = useCSSKeyframesAnimationController(
     opened ? 'enter' : 'exit',
+    undefined,
+    true,
   );
   const visible = animationState !== 'exited';
 


### PR DESCRIPTION
- caused by #6979

---

- [x] Unit-тесты

## Описание

Если контекст был изначально скрыт - видели блинкуюущую менюшку:

| Было  | Стало |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/dc5eafab-a38c-45cd-8344-3b4141e6ef0f">  | <video src="https://github.com/user-attachments/assets/9fc720a4-02af-4309-9614-3a5c9d167cfe">|

## Изменения

Передаем флажок `disableInitAnimation` и исправляем тест
