### PR TITLE
docs(CustomSelect): fix token

### DIFF
--- a/packages/vkui/src/components/CustomSelect/Readme.md
+++ b/packages/vkui/src/components/CustomSelect/Readme.md
@@ -201,7 +201,7 @@ const CustomSearchLogicSelect = ({ id }) => {
       onInputChange={onCustomSearchInputChange}
       renderOption={({ option, ...restProps }) => (
         <CustomSelectOption
-          style={option.value === '0' ? { color: 'var(--vkui--color_background_accent)' } : {}}
+          style={option.value === '0' ? { color: 'var(--vkui--color_text_accent)' } : {}}
           {...restProps}
         >
           {option.label}


### PR DESCRIPTION
В примере для текста выставлен токен фона, вместо текста

color_background_accent -> color_text_accent
