### PR TITLE
add allowHorizontalScroll for modals

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPage.module.css
+++ b/packages/vkui/src/components/ModalPage/ModalPage.module.css
@@ -119,6 +119,10 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.ModalPage--allow-horizontal-scroll .ModalPage__content {
+  overflow-x: auto;
+}
+
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
 .ModalPage--desktop .ModalPage__content-in,
 :global(.vkuiInternalModalRoot__modal--expandable) .ModalPage__content-in {

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -75,6 +75,10 @@ export interface ModalPageProps extends HTMLAttributesWithRootRef<HTMLDivElement
    * ⚠️ ВНИМАНИЕ: использование этой опции негативно сказывается на пользовательском опыте
    */
   preventClose?: boolean;
+  /**
+   * Разрешаем на свой страх и риск использовать горизонтальный скрол внутри модалки
+   * */
+  allowHorizontalScroll?: boolean;
 }
 
 const warn = warnOnce('ModalPage');
@@ -101,6 +105,7 @@ export const ModalPage = ({
   modalDismissButtonTestId,
   getRootRef,
   preventClose,
+  allowHorizontalScroll,
   ...restProps
 }: ModalPageProps): React.ReactNode => {
   const generatingId = React.useId();
@@ -141,6 +146,7 @@ export const ModalPage = ({
           styles['ModalPage'],
           platform === 'ios' && styles['ModalPage--ios'],
           isDesktop && styles['ModalPage--desktop'],
+          allowHorizontalScroll && styles['ModalPage--allow-horizontal-scroll'],
           sizeX === 'regular' && 'vkuiInternalModalPage--sizeX-regular',
           typeof size === 'string' && sizeClassName[size],
         )}

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -295,7 +295,7 @@ class ModalRootTouchComponent extends React.Component<
     const { shiftY, originalEvent } = event;
     const target = originalEvent.target as HTMLElement;
 
-    if (!event.isY) {
+    if (!event.isY && !modalState.allowHorizontalScroll) {
       if (this.viewportRef.current?.contains(target)) {
         originalEvent.preventDefault();
       }

--- a/packages/vkui/src/components/ModalRoot/types.ts
+++ b/packages/vkui/src/components/ModalRoot/types.ts
@@ -70,6 +70,7 @@ export interface ModalsStateEntry extends ModalElements {
    * Отключает возможность закрыть модалку стандартными способами
    */
   preventClose?: boolean;
+  allowHorizontalScroll?: boolean;
 }
 
 export interface ModalRootProps {

--- a/packages/vkui/src/components/ModalRoot/useModalManager.tsx
+++ b/packages/vkui/src/components/ModalRoot/useModalManager.tsx
@@ -101,6 +101,7 @@ export function useModalManager(
       id: id ?? null,
     };
 
+    state.allowHorizontalScroll = Modal.props.allowHorizontalScroll;
     state.onOpen = Modal.props.onOpen;
     state.onOpened = Modal.props.onOpened;
     state.onClose = Modal.props.onClose;


### PR DESCRIPTION
## Описание
В некоторых случаях нужно прокручивать контент модальных окон горизонтально

## Изменения
Добавил параметр `allowHorizontalScroll`, если `true`, то можно горизонтально скролить, если `false` - нельзя