### PR TITLE
fix(useFloatingWithInteractions): prevent mouse events when `willBeHide` is `true`

### DIFF
--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -1,4 +1,4 @@
-import { act } from 'react';
+import { act, type ComponentType, useState } from 'react';
 import { render, renderHook, waitFor } from '@testing-library/react';
 import {
   AppRootContext,
@@ -9,11 +9,29 @@ import { fireEventPatch, userEvent } from '../../../testing/utils';
 import type { ShownChangeReason } from './types';
 import { useFloatingWithInteractions } from './useFloatingWithInteractions';
 
+const DynamicContent = ({ onClose }: { onClose: VoidFunction }) => {
+  const [state, setState] = useState(false);
+  const handleClick = () => {
+    act(onClose);
+    setState((prev) => !prev);
+  };
+  return state ? (
+    <button data-testid="dynamic-content-item" onClick={handleClick}>
+      Удалить
+    </button>
+  ) : (
+    <button data-testid="dynamic-content-item" onClick={handleClick}>
+      Добавить
+    </button>
+  );
+};
+
 const TestComponent = ({
   restoreFocus,
   hookResultRef,
   keyboardInput = false,
   autoFocus = false, // for multiple trigger [click, focus]
+  Content,
 }: {
   restoreFocus?: boolean;
   hookResultRef: {
@@ -21,8 +39,9 @@ const TestComponent = ({
   };
   keyboardInput?: boolean;
   autoFocus?: boolean;
+  Content?: ComponentType<{ onClose: VoidFunction }>;
 }) => {
-  const { shown, refs, referenceProps, floatingProps } = hookResultRef.current;
+  const { shown, refs, referenceProps, floatingProps, onClose } = hookResultRef.current;
 
   return (
     <AppRootContext.Provider value={{ ...DEFAULT_APP_ROOT_CONTEXT_VALUE, keyboardInput }}>
@@ -30,7 +49,7 @@ const TestComponent = ({
         Reference
       </button>
       {shown ? (
-        <span ref={refs.floating} {...floatingProps}>
+        <span ref={refs.floating} data-testid="floating" {...floatingProps}>
           <FocusTrap
             autoFocus
             restoreFocus={restoreFocus ? hookResultRef.current.onRestoreFocus : restoreFocus}
@@ -42,6 +61,7 @@ const TestComponent = ({
               type="text"
               defaultValue="Reference"
             />
+            {Content ? <Content onClose={onClose} /> : null}
           </FocusTrap>
         </span>
       ) : null}
@@ -483,6 +503,40 @@ describe(useFloatingWithInteractions, () => {
         expect(onShownChange).toHaveBeenCalledWith(false, 'callback');
       });
     });
+
+    it.each(['mouseOver', 'mouseLeave'] as const)(
+      'should prevent %s events on floating ref',
+      async (mouseEvent) => {
+        const { result: hookResultRef } = renderHook(() =>
+          useFloatingWithInteractions<HTMLButtonElement>({
+            trigger: 'hover',
+            hoverDelay: 0,
+            defaultShown: false,
+          }),
+        );
+        const renderResult = render(
+          <TestComponent hookResultRef={hookResultRef} Content={DynamicContent} />,
+        );
+
+        await fireEventPatch(hookResultRef.current.refs.reference.current, 'mouseOver');
+        renderResult.rerender(
+          <TestComponent hookResultRef={hookResultRef} Content={DynamicContent} />,
+        );
+        await fireEventPatch(hookResultRef.current.refs.floating.current, 'animationStart');
+        await fireEventPatch(hookResultRef.current.refs.floating.current, 'animationEnd');
+        await waitFor(() => expect(hookResultRef.current.shown).toBeTruthy());
+
+        await fireEventPatch(hookResultRef.current.refs.floating.current, 'mouseOver');
+        await fireEventPatch(renderResult.getByTestId('dynamic-content-item'), 'click');
+        renderResult.rerender(
+          <TestComponent hookResultRef={hookResultRef} Content={DynamicContent} />,
+        );
+        await fireEventPatch(hookResultRef.current.refs.floating.current, 'animationStart');
+        await fireEventPatch(hookResultRef.current.refs.floating.current, mouseEvent);
+        await fireEventPatch(hookResultRef.current.refs.floating.current, 'animationEnd');
+        await waitFor(() => expect(hookResultRef.current.shown).toBeFalsy());
+      },
+    );
   });
 
   describe('tests with snapshot', () => {

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -176,7 +176,11 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
     commitShownLocalState(false, 'click');
   });
 
-  const handleMouseEnterOnBoth = useStableCallback(() => {
+  const handleMouseEnterOnBoth = useStableCallback((event: React.MouseEvent<HTMLElement>) => {
+    if (willBeHide && event.currentTarget === refs.floating.current) {
+      return;
+    }
+
     showWithDelay.cancel();
     hideWithDelay.cancel();
 
@@ -185,17 +189,23 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
     }
   });
 
-  const handleMouseLeaveOnBothForHoverAndFocusStates = useStableCallback(() => {
-    blockFocusRef.current = false;
-    blockMouseEnterRef.current = false;
+  const handleMouseLeaveOnBothForHoverAndFocusStates = useStableCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (willBeHide && event.currentTarget === refs.floating.current) {
+        return;
+      }
 
-    if (triggerOnHover) {
-      showWithDelay.cancel();
-      hideWithDelay.cancel();
+      blockFocusRef.current = false;
+      blockMouseEnterRef.current = false;
 
-      hideWithDelay();
-    }
-  });
+      if (triggerOnHover) {
+        showWithDelay.cancel();
+        hideWithDelay.cancel();
+
+        hideWithDelay();
+      }
+    },
+  );
 
   const handleFloatingAnimationStart = () => {
     hasCSSAnimation.current = true;


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7195

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

Игнорируем события наведения мыши (`onMouseOver`/`onMouseLeave`) на всплывающем окне в момент `willBeHide`.

С `onMouseLeave` проблемы нет, но на всякий тоже отключаю.

Затрагивает `Popover` и `Tooltip`.

---

- caused by #6150