### PR TITLE
feat: add close popper-elements when modal opened

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { Appearance } from '../../lib/appearance';
 import { Platform } from '../../lib/platform';
-import {createSignal} from "../../lib/signal";
+import { createSignal } from '../../lib/signal';
 import { DEFAULT_TOKENS_CLASS_NAMES } from '../../lib/tokens';
 import { baselineComponent } from '../../testing/utils';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';

--- a/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { Appearance } from '../../lib/appearance';
 import { Platform } from '../../lib/platform';
+import {createSignal} from "../../lib/signal";
 import { DEFAULT_TOKENS_CLASS_NAMES } from '../../lib/tokens';
 import { baselineComponent } from '../../testing/utils';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
@@ -68,8 +69,10 @@ describe('AppRoot', () => {
 
   it('should return expected context', () => {
     let portalRoot: React.RefObject<HTMLElement | null> = React.createRef();
+    let openModalsSignal = createSignal();
     const contextCallback = jest.fn().mockImplementation((ctx) => {
       portalRoot = ctx.portalRoot;
+      openModalsSignal = ctx.openModalsSignal;
       return null;
     });
     const result = render(
@@ -85,6 +88,7 @@ describe('AppRoot', () => {
       disablePortal: false,
       layout: undefined,
       keyboardInput: false,
+      openModalsSignal: openModalsSignal,
     });
   });
 

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -4,6 +4,7 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useKeyboardInputTracker } from '../../hooks/useKeyboardInputTracker';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { getDocumentBody } from '../../lib/dom';
+import { createSignal } from '../../lib/signal';
 import { useTokensClassName } from '../../lib/tokens';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';
@@ -198,6 +199,8 @@ export const AppRoot = ({
     [scroll],
   );
 
+  const openModalsSignal = React.useMemo(() => createSignal(), []);
+
   const content = (
     <AppRootContext.Provider
       value={{
@@ -210,6 +213,7 @@ export const AppRoot = ({
         get keyboardInput() {
           return isKeyboardInputActiveRef.current;
         },
+        openModalsSignal,
       }}
     >
       <ScrollController elRef={appRootRef}>{children}</ScrollController>

--- a/packages/vkui/src/components/AppRoot/AppRootContext.ts
+++ b/packages/vkui/src/components/AppRoot/AppRootContext.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { noop } from '@vkontakte/vkjs';
+import { Signal } from '../../lib/signal';
 
 export interface AppRootContextInterface {
   appRoot: React.RefObject<HTMLElement>;
@@ -8,6 +10,7 @@ export interface AppRootContextInterface {
   keyboardInput: boolean;
   disablePortal: boolean;
   layout?: 'card' | 'plain';
+  openModalsSignal: Signal;
 }
 
 /**
@@ -22,6 +25,7 @@ export const DEFAULT_APP_ROOT_CONTEXT_VALUE: AppRootContextInterface = {
   embedded: false,
   keyboardInput: false,
   disablePortal: false,
+  openModalsSignal: { subscribe: () => noop, dispatch: noop },
 };
 
 export const AppRootContext: React.Context<AppRootContextInterface> =

--- a/packages/vkui/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -1,5 +1,8 @@
+import { useContext, useEffect } from 'react';
 import * as React from 'react';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
+import { usePrevious } from '../../hooks/usePrevious';
+import { AppRootContext } from '../AppRoot/AppRootContext';
 import { useScrollLock } from '../AppRoot/ScrollContext';
 import { ModalRootTouch } from './ModalRoot';
 import { ModalRootDesktop } from './ModalRootDesktop';
@@ -10,8 +13,16 @@ import { ModalRootProps } from './types';
  */
 export const ModalRoot = (props: ModalRootProps): React.ReactNode => {
   const { isDesktop } = useAdaptivityWithJSMediaQueries();
+  const prevActiveModal = usePrevious(props.activeModal);
+  const { openModalsSignal } = useContext(AppRootContext);
 
   useScrollLock(!!props.activeModal);
+
+  useEffect(() => {
+    if (props.activeModal !== prevActiveModal) {
+      openModalsSignal.dispatch();
+    }
+  }, [props.activeModal, prevActiveModal, openModalsSignal]);
 
   const RootComponent = isDesktop ? ModalRootDesktop : ModalRootTouch;
 

--- a/packages/vkui/src/hooks/useHandleOpenModals.test.tsx
+++ b/packages/vkui/src/hooks/useHandleOpenModals.test.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import {
+  AppRootContext,
+  DEFAULT_APP_ROOT_CONTEXT_VALUE,
+} from '../components/AppRoot/AppRootContext';
+import { createSignal } from '../lib/signal';
+import { useHandleOpenModals } from './useHandleOpenModals';
+
+describe(useHandleOpenModals, () => {
+  it('check callback called when signal was dispatched', () => {
+    const openModalsSignal = createSignal();
+    const onOpenModals = jest.fn();
+    const Fixture = () => {
+      useHandleOpenModals(onOpenModals);
+      return <></>;
+    };
+
+    render(
+      <AppRootContext.Provider value={{ ...DEFAULT_APP_ROOT_CONTEXT_VALUE, openModalsSignal }}>
+        <Fixture />
+      </AppRootContext.Provider>,
+    );
+
+    React.act(() => openModalsSignal.dispatch());
+
+    expect(onOpenModals).toBeCalledTimes(1);
+  });
+});

--- a/packages/vkui/src/hooks/useHandleOpenModals.ts
+++ b/packages/vkui/src/hooks/useHandleOpenModals.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import { AppRootContext } from '../components/AppRoot/AppRootContext';
+import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
+import { useStableCallback } from './useStableCallback';
+
+/**
+ * Хук для отслеживания открытия модалок.
+ * Используется в кейсе закрытия popper-элементов при открытии модалок.
+ * Экспортируется, чтобы использовать для контроллируемого закрытия компонента Popper.
+ */
+export function useHandleOpenModals(handleFn: () => void) {
+  const { openModalsSignal } = useContext(AppRootContext);
+  const cb = useStableCallback(handleFn);
+
+  useIsomorphicLayoutEffect(() => openModalsSignal.subscribe(cb), [openModalsSignal, cb]);
+}

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -391,6 +391,7 @@ export { withPlatform } from './hoc/withPlatform';
  */
 export { usePlatform } from './hooks/usePlatform';
 export { useAdaptivity } from './hooks/useAdaptivity';
+export { useHandleOpenModals } from './hooks/useHandleOpenModals';
 export {
   type UseAdaptivityConditionalRender,
   useAdaptivityConditionalRender,

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
@@ -12,6 +12,7 @@ export type ManualTriggerType = 'manual';
 export type TriggerType = ManualTriggerType | InteractiveTriggerType | InteractiveTriggerType[];
 
 export type ShownChangeReason =
+  | 'open-modal'
   | 'click-outside'
   | 'escape-key'
   | 'click'

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -256,6 +256,7 @@ describe(useFloatingWithInteractions, () => {
       act(() => openModalsSignal.dispatch());
 
       expect(onShownChange).toBeCalledTimes(1);
+      expect(onShownChange).toBeCalledWith(false, 'open-modal')
     });
 
     it('should work correctly with trigger=[click, focus]', async () => {

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -276,7 +276,7 @@ describe(useFloatingWithInteractions, () => {
       act(() => openModalsSignal.dispatch());
 
       expect(onShownChange).toBeCalledTimes(1);
-      expect(onShownChange).toBeCalledWith(false, 'open-modal')
+      expect(onShownChange).toBeCalledWith(false, 'open-modal');
     });
 
     it('should work correctly with trigger=[click, focus]', async () => {

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -3,6 +3,7 @@ import { debounce } from '@vkontakte/vkjs';
 import { getWindow, isHTMLElement } from '@vkontakte/vkui-floating-ui/utils/dom';
 import { useCustomEnsuredControl } from '../../../hooks/useEnsuredControl';
 import { useGlobalOnClickOutside } from '../../../hooks/useGlobalOnClickOutside';
+import { useHandleOpenModals } from '../../../hooks/useHandleOpenModals';
 import { useStableCallback } from '../../../hooks/useStableCallback';
 import { contains, getActiveElementByAnotherElement } from '../../dom';
 import { useIsomorphicLayoutEffect } from '../../useIsomorphicLayoutEffect';
@@ -227,6 +228,8 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
     blockFocusRef.current = true;
     commitShownLocalState(false, 'click-outside');
   }, [commitShownLocalState]);
+
+  useHandleOpenModals(() => commitShownLocalState(false, 'open-modal'));
 
   useGlobalOnClickOutside(
     handleClickOutside,

--- a/packages/vkui/src/lib/signal.test.ts
+++ b/packages/vkui/src/lib/signal.test.ts
@@ -7,8 +7,8 @@ describe(createSignal, () => {
 
     const signal = createSignal();
 
-    expect(callback1).toBeCalledTimes(1);
-    expect(callback2).toBeCalledTimes(1);
+    expect(callback1).toBeCalledTimes(0);
+    expect(callback2).toBeCalledTimes(0);
 
     const unsub1 = signal.subscribe(callback1);
     const unsub2 = signal.subscribe(callback2);

--- a/packages/vkui/src/lib/signal.test.ts
+++ b/packages/vkui/src/lib/signal.test.ts
@@ -1,0 +1,32 @@
+import { createSignal } from './signal';
+
+describe(createSignal, () => {
+  it('check signal working', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+
+    const signal = createSignal();
+
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(1);
+
+    const unsub1 = signal.subscribe(callback1);
+    const unsub2 = signal.subscribe(callback2);
+
+    signal.dispatch();
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(1);
+
+    unsub1();
+
+    signal.dispatch();
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(2);
+
+    unsub2();
+
+    signal.dispatch();
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(2);
+  });
+});

--- a/packages/vkui/src/lib/signal.ts
+++ b/packages/vkui/src/lib/signal.ts
@@ -1,0 +1,22 @@
+export type Signal<T = void> = {
+  dispatch: (value: T) => void;
+  subscribe: (handleFn: (value: T) => void) => () => void;
+};
+
+export function createSignal<T = void>() {
+  const subscribers: Array<(value: T) => void> = [];
+  return {
+    dispatch: (value: T) => {
+      subscribers.forEach((handleFn) => handleFn(value));
+    },
+    subscribe: (handleFn: (value: T) => void) => {
+      subscribers.push(handleFn);
+      return () => {
+        const index = subscribers.indexOf(handleFn);
+        if (index !== -1) {
+          subscribers.splice(index, 1);
+        }
+      };
+    },
+  };
+}


### PR DESCRIPTION
- close #5429 

---

- [x] Unit-тесты

## Описание

Нужно придумать механизм закрытия Popper-элементов(Popover, Tooltip, Popper) при открытии модалок

## Изменения

- Реализовал механизм сигналов - механизм подписки и оповещения подписчиков
- Добавил в `AppRootContext` прокидывание сигнала `openModalsSignal`
- Добавил срабатывание сигнала при смене активной модалки
- Добавил хук `useHandleOpenModals`, который подписывается на сигнал открытия модалки и вызывает переданный колбэк
- Добавил использование `useHandleOpenModals` в `useFloatingWithInteraction`  для вызова закрытия поповера
- Экспортнул `useHandleOpenModals`, чтобы его могли использовать в связке с компонентом `Popper`(так как он всегда контролируемый пользователем)
- Покрыл новый функционал тестами
