### PR TITLE
fix(ActionSheetItem): fix navigation by arrows in selectable ActionSheetItem

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { act } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ViewWidth } from '../../lib/adaptivity';
 import {
   baselineComponent,
@@ -127,7 +127,14 @@ describe(ActionSheet, () => {
         </ActionSheet>,
       );
       await waitForFloatingPosition();
-      await userEvent.click(screen.getByTestId('item'));
+      fireEvent(
+        screen.getByTestId('item'),
+        new MouseEvent('click', {
+          clientX: 1,
+          clientY: 1,
+          bubbles: true,
+        }),
+      );
       act(jest.runAllTimers);
 
       if (onCloseHandler.mock.calls.length > 0) {

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -127,6 +127,8 @@ describe(ActionSheet, () => {
         </ActionSheet>,
       );
       await waitForFloatingPosition();
+      // эмулируем настоящее событие клика(отличается оно тем, что clientX и clientY != 0)
+      // @see packages/vkui/src/components/ActionSheetItem/helpers.ts
       fireEvent(
         screen.getByTestId('item'),
         new MouseEvent('click', {

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -88,7 +88,7 @@ export const ActionSheet = ({
       },
     [],
   );
-  const contextValue = useObjectMemo({ onItemClick, mode });
+  const contextValue = useObjectMemo({ onItemClick, mode, onClose: onCloseWithOther });
 
   const DropdownComponent = mode === 'menu' ? ActionSheetDropdownMenu : ActionSheetDropdownSheet;
 

--- a/packages/vkui/src/components/ActionSheet/ActionSheetContext.ts
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetContext.ts
@@ -11,6 +11,7 @@ export type ItemClickHandler<T extends Element = Element> = (options: {
 
 export type ActionSheetContextType<T extends Element = Element> = {
   onItemClick?: ItemClickHandler<T>;
+  onClose?: () => void;
   mode?: 'sheet' | 'menu';
 };
 

--- a/packages/vkui/src/components/ActionSheet/Readme.md
+++ b/packages/vkui/src/components/ActionSheet/Readme.md
@@ -32,8 +32,6 @@ const onClose = () => {
   setOpenedPopoutName(null);
 };
 
-const [filter, setFilter] = useState('best');
-const onChange = (e) => setFilter(e.target.value);
 const baseTargetRef = React.useRef(null);
 const iconsTargetRef = React.useRef(null);
 const subtitleTargetRef = React.useRef(null);
@@ -140,9 +138,13 @@ const openSubtitle = () =>
     </ActionSheet>,
   );
 
-const openSelectable = () =>
-  openActionSheet(
-    'selectable',
+const SelectableActionSheet = () => {
+  const [filter, setFilter] = useState('best');
+  const onChange = (e) => {
+    setFilter(e.target.value);
+  };
+
+  return (
     <ActionSheet onClose={onClose} toggleRef={selectableTargetRef}>
       <ActionSheetItem
         onChange={onChange}
@@ -189,8 +191,11 @@ const openSelectable = () =>
       >
         Друзья по вузу
       </ActionSheetItem>
-    </ActionSheet>,
+    </ActionSheet>
   );
+};
+
+const openSelectable = () => openActionSheet('selectable', <SelectableActionSheet />);
 
 const openTitle = () =>
   openActionSheet(

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.test.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.test.tsx
@@ -51,7 +51,7 @@ describe('ActionSheetItem', () => {
     expect(onCloseCallback).toHaveBeenCalledTimes(1);
   });
 
-  it('check call onItemClick callback when click to ActionSheetItem', async () => {
+  it('check call onItemClick callback when click to ActionSheetItem with selectable=true', async () => {
     const onItemClickCallback = jest.fn();
 
     render(
@@ -66,6 +66,7 @@ describe('ActionSheetItem', () => {
       </ActionSheetContext.Provider>,
     );
 
+    // эмулируем событие клика при навигации стрелочками
     await React.act(async () =>
       fireEvent(
         screen.getByTestId('action-item'),
@@ -79,6 +80,8 @@ describe('ActionSheetItem', () => {
 
     expect(onItemClickCallback).toHaveBeenCalledTimes(0);
 
+    // эмулируем настоящее событие клика(отличается оно тем, что clientX и clientY != 0)
+    // @see packages/vkui/src/components/ActionSheetItem/helpers.ts
     const newMouseEvent = new MouseEvent('click', {
       clientX: 1,
       clientY: 1,

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.test.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
+import { ActionSheetContext } from '../ActionSheet/ActionSheetContext';
 import { ActionSheetItem, ActionSheetItemProps } from './ActionSheetItem';
 
 const ActionSheetItemTest = (props: ActionSheetItemProps) => (
@@ -26,5 +28,64 @@ describe('ActionSheetItem', () => {
   it('Component: ActionSheetItem[selectable] is a label', () => {
     render(<ActionSheetItemTest selectable>ActionSheetItem</ActionSheetItemTest>);
     expect(item().tagName.toLowerCase()).toMatch('label');
+  });
+
+  it('should call close callback when Enter keydown', async () => {
+    const onCloseCallback = jest.fn();
+    render(
+      <ActionSheetContext.Provider
+        value={{
+          onClose: onCloseCallback,
+        }}
+      >
+        <ActionSheetItemTest selectable data-testid="action-item">
+          ActionSheetItem
+        </ActionSheetItemTest>
+      </ActionSheetContext.Provider>,
+    );
+
+    await React.act(async () =>
+      fireEvent.keyDown(screen.getByTestId('action-item'), { key: 'Enter', code: 'Enter' }),
+    );
+
+    expect(onCloseCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('check call onItemClick callback when click to ActionSheetItem', async () => {
+    const onItemClickCallback = jest.fn();
+
+    render(
+      <ActionSheetContext.Provider
+        value={{
+          onItemClick: onItemClickCallback,
+        }}
+      >
+        <ActionSheetItemTest selectable data-testid="action-item">
+          ActionSheetItem
+        </ActionSheetItemTest>
+      </ActionSheetContext.Provider>,
+    );
+
+    await React.act(async () =>
+      fireEvent(
+        screen.getByTestId('action-item'),
+        new MouseEvent('click', {
+          clientX: 0,
+          clientY: 0,
+          bubbles: true,
+        }),
+      ),
+    );
+
+    expect(onItemClickCallback).toHaveBeenCalledTimes(0);
+
+    const newMouseEvent = new MouseEvent('click', {
+      clientX: 1,
+      clientY: 1,
+      bubbles: true,
+    });
+    await React.act(async () => fireEvent(screen.getByTestId('action-item'), newMouseEvent));
+
+    expect(onItemClickCallback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/vkui/src/components/ActionSheetItem/helpers.ts
+++ b/packages/vkui/src/components/ActionSheetItem/helpers.ts
@@ -1,8 +1,10 @@
 /**
- * в React есть проблема: при навигации по radio кнопкам тригерится событие click
- * С помощью этой проверки можно отличить настоящее событие клика.
- * @see https://github.com/VKCOM/VKUI/issues/6954
+ * По дизайну `ActionSheet` должен закрывать при клике на `ActionSheetItem`.
+ * В режиме `selectable` в реализации используются нативный input type=radio
+ * И при навигации стрелочками по элементам происходит событие `click` из-за чего `ActionSheet` закрывается.
+ * Поэтому нужно как-то отличить реальное событие клика
  * @see https://github.com/facebook/react/issues/7407
+ * @see https://github.com/VKCOM/VKUI/issues/6954
  */
 export const isRealClickEvent = (event: React.MouseEvent) => {
   return event.type === 'click' && event.clientX !== 0 && event.clientY !== 0;

--- a/packages/vkui/src/components/ActionSheetItem/helpers.ts
+++ b/packages/vkui/src/components/ActionSheetItem/helpers.ts
@@ -1,0 +1,9 @@
+/**
+ * в React есть проблема: при навигации по radio кнопкам тригерится событие click
+ * С помощью этой проверки можно отличить настоящее событие клика.
+ * @see https://github.com/VKCOM/VKUI/issues/6954
+ * @see https://github.com/facebook/react/issues/7407
+ */
+export const isRealClickEvent = (event: React.MouseEvent) => {
+  return event.type === 'click' && event.clientX !== 0 && event.clientY !== 0;
+};


### PR DESCRIPTION
- close #6954 

---

- [x] Unit-тесты

## Описание

При навигации с помощью стрелочек по  `ActionSheetItems` с `selectable` флагом закрывается `ActionSheet`

## Изменения

- Поисследовал проблему с тригером события `click` при навигации по элементам. Нашел вариант как можно ее обойти https://github.com/facebook/react/issues/7407. С помощью проверки можно отличить реальное событие клика. 
- Добавил обработку нажатия кнопки `Enter`, при котором происходит закрытие `ActionSheet`
- Добавил тесты для нового функционала
