### PR TITLE
fix(CustomSelect): fix select option in CustomSelect

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -337,9 +337,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     const dropdown = scrollBoxRef.current;
     const optionsWrapper = optionsWrapperRef.current;
     const item =
-      dropdown && optionsWrapper
-        ? (optionsWrapper.children[index] as HTMLElement)
-        : null;
+      dropdown && optionsWrapper ? (optionsWrapper.children[index] as HTMLElement) : null;
 
     if (!item || !dropdown) {
       return;
@@ -706,9 +704,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const resolvedContent = React.useMemo(() => {
     const defaultDropdownContent =
       options?.length > 0 ? (
-        <div ref={optionsWrapperRef}>
-          {options.map(renderOption)}
-        </div>
+        <div ref={optionsWrapperRef}>{options.map(renderOption)}</div>
       ) : (
         <Footnote className={styles['CustomSelect__empty']}>{emptyText}</Footnote>
       );

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -282,6 +282,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const handleRootRef = useExternRef(containerRef, getRootRef);
   const scrollBoxRef = React.useRef<HTMLDivElement | null>(null);
   const selectElRef = useExternRef(getRef);
+  const optionsWrapperRef = React.useRef<HTMLDivElement>(null);
 
   const [focusedOptionIndex, setFocusedOptionIndex] = React.useState<number | undefined>(-1);
   const [isControlledOutside, setIsControlledOutside] = React.useState(props.value !== undefined);
@@ -334,9 +335,10 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
   const scrollToElement = React.useCallback((index: number, center = false) => {
     const dropdown = scrollBoxRef.current;
+    const optionsWrapper = optionsWrapperRef.current;
     const item =
-      dropdown && dropdown.firstElementChild
-        ? (dropdown.firstElementChild.children[index] as HTMLElement)
+      dropdown && optionsWrapper
+        ? (optionsWrapper.children[index] as HTMLElement)
         : null;
 
     if (!item || !dropdown) {
@@ -704,7 +706,9 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const resolvedContent = React.useMemo(() => {
     const defaultDropdownContent =
       options?.length > 0 ? (
-        options.map(renderOption)
+        <div ref={optionsWrapperRef}>
+          {options.map(renderOption)}
+        </div>
       ) : (
         <Footnote className={styles['CustomSelect__empty']}>{emptyText}</Footnote>
       );


### PR DESCRIPTION
- close #7215 

---

- [x] Unit-тесты
- [x] e2e-тесты

## Описание

При нажатии на `option` в `CustomSelect` из-за того, что внутри контейнера с `options` есть `iframe` ломается логика определения index-а выбранного элемента

## Изменения

- Добавил обертку на до списком `options`, чтобы `iframe` не добавлялся на одном уровне с `options`
- Добавил ref на обертку, чтобы ее было удобнее получать
- Проверил, что доскролл до элемента работает корректно 
