### PR TITLE
fix(Cell): Ignore falsy explicit undefined Component value with href

### DIFF
--- a/packages/vkui/src/components/Cell/Cell.test.tsx
+++ b/packages/vkui/src/components/Cell/Cell.test.tsx
@@ -50,7 +50,7 @@ describe('Cell', () => {
       </Cell>,
     );
 
-    // Явное значение Component = div приоритетней автоматической логике по установлению тэга a
+    // Явное значение Component = div приоритетней автоматической логики по установке тэга a
     expect(document.querySelector('a[href="http://the.link"]')).toBeFalsy();
     expect(document.querySelector('div[href="http://the.link"]')).toBeTruthy();
 

--- a/packages/vkui/src/components/Cell/Cell.test.tsx
+++ b/packages/vkui/src/components/Cell/Cell.test.tsx
@@ -43,6 +43,23 @@ describe('Cell', () => {
     });
   });
 
+  test('has "a" tag by default if href is defined', () => {
+    const { rerender } = render(
+      <Cell Component="div" href="http://the.link">
+        Саша Колобов
+      </Cell>,
+    );
+
+    // Явное значение Component = div приоритетней автоматической логике по установлению тэга a
+    expect(document.querySelector('a[href="http://the.link"]')).toBeFalsy();
+    expect(document.querySelector('div[href="http://the.link"]')).toBeTruthy();
+
+    rerender(<Cell href="http://the.link">Саша Колобов</Cell>);
+
+    // без явного значения в Component компонент будет иметь тэг 'a' из-за переданного значения href
+    expect(document.querySelector('a[href="http://the.link"]')).toBeTruthy();
+  });
+
   describe("mode='removable'", () => {
     test('handles click', () => {
       const removeStub = jest.fn();

--- a/packages/vkui/src/components/Cell/Cell.tsx
+++ b/packages/vkui/src/components/Cell/Cell.tsx
@@ -125,7 +125,11 @@ export const Cell: React.FC<CellProps> & {
     hasHover: hasActive && !removable,
     ...restProps,
     className: styles['Cell__content'],
-    Component: Component,
+    // чтобы свойство, если не определено, не присутствовало в
+    // restProps явно как {'Component': undefined} и ниже не переопределяло
+    // возможное значение commonProps.Component = 'a' при слияние двух объектов, как
+    // {...commonProps, ...restProps}
+    ...(Component && { Component }),
     before: (
       <React.Fragment>
         {draggable && platform !== 'ios' && dragger}

--- a/packages/vkui/src/components/Cell/Cell.tsx
+++ b/packages/vkui/src/components/Cell/Cell.tsx
@@ -127,7 +127,7 @@ export const Cell: React.FC<CellProps> & {
     className: styles['Cell__content'],
     // чтобы свойство, если не определено, не присутствовало в
     // restProps явно как {'Component': undefined} и ниже не переопределяло
-    // возможное значение commonProps.Component = 'a' при слияние двух объектов, как
+    // возможное значение commonProps.Component = 'a' при слиянии двух объектов, как
     // {...commonProps, ...restProps}
     ...(Component && { Component }),
     before: (


### PR DESCRIPTION
- [x] Unit-тесты

## Описание
Из-за того, что мы явно устанавливали значение свойства `Component` в `simpleCellProps`, то оно становилось явным и переопределяло значение Component позже в Clickable.
https://github.com/VKCOM/VKUI/blob/7f0a1694094434c2676af8969ab4ce964cd8972a/packages/vkui/src/components/Cell/Cell.tsx#L79
https://github.com/VKCOM/VKUI/blob/7f0a1694094434c2676af8969ab4ce964cd8972a/packages/vkui/src/components/Cell/Cell.tsx#L128
https://github.com/VKCOM/VKUI/blob/7f0a1694094434c2676af8969ab4ce964cd8972a/packages/vkui/src/components/Clickable/Clickable.tsx#L192-L193
