### PR TITLE
fix(ModalDismissButton): Changed transition from opacity to background

### DIFF
--- a/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.module.css
+++ b/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.module.css
@@ -7,7 +7,6 @@
   padding: 18px;
   box-sizing: border-box;
   color: var(--vkui--color_icon_contrast);
-  transition: opacity 0.15s ease-out;
 }
 
 .ModalDismissButton::before {
@@ -17,6 +16,7 @@
   background: var(--vkui--color_overlay_secondary);
   border-radius: 50%;
   position: absolute;
+  transition: background-color 0.15s ease-out;
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list -- fixes icon misplacement on Safari in some cases */
@@ -25,9 +25,9 @@
 }
 
 .ModalDismissButton--hover::before {
-  opacity: var(--vkui--opacity_disable_accessibility);
+  background: var(--vkui--color_overlay_secondary--hover);
 }
 
 .ModalDismissButton--active::before {
-  opacity: var(--vkui--opacity_disable);
+  background: var(--vkui--color_overlay_secondary--active);
 }

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4537384549b16e9c6fc49c1f98f57e475f0e1945484f661e5884e7bb3f0711c9
-size 2754
+oid sha256:c95e0a19d25db6dfe2dc1f206f0dd2449f392f61ec4a0a7a99a1744f884bf6de
+size 2965

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dffdfa392dff1d86669171a7808d6cef3d1c3e5ffb9181d6d3d9cf26d9938bb7
-size 3060
+oid sha256:3f5ad9cabc79ac14f2d223f27267648a1036a745e340242be5220c1e5538643f
+size 3309

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7dc2c9e57b111e22e44358585f67ee95a7c8a3a083798d56e755981044fc3e40
-size 2851
+oid sha256:267fd51e8b85c332c77d0eb4faa3453ea4fdce9a633a1fb0fb2e5b133173ec8d
+size 2987

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3a04829cac95b3527f0495d947af07c07ffc71530b674aa838d888a7f0cf1ce
-size 3129
+oid sha256:1fec24297231660e675ffdbc2219ffbd4068b318e23e3dd62fb58efe5e0d8cfd
+size 3323

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fc33cf9a605a4f014dc2a374712d70a79855cc2ff8291c765b9c3e87d277dab
-size 2230
+oid sha256:d96d5559f7d0acb684b316dc46bdb62cb1f3e6dcff6cd326a947882bf5b4c28c
+size 2311

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10ff992242396dc85c8b7098ebd2362b48a1be3fcf2f4c9053d557db55e89a94
-size 2499
+oid sha256:c8128fb7cdf4be58ea70b1e7556c0bb04702041a56d78805d74d87fb99aa8905
+size 2680

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ef6079c8ccde3eb8ee4f4bd5e0b7c5118d69a97573e8ff4f0840705c2926e86
-size 2124
+oid sha256:3bd9350e40eac5f888de98499eaf18472fddc4600a6d437ca112e5e7f34fb883
+size 2170

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c68dcfda7b21ee6e930b96e86bef739f5ab5699d62d044a8be6acbd94f7bd14
-size 2088
+oid sha256:2b934181e252bada08c4bd570c38decf88c1af75860610240cde7ddb7e922971
+size 2212

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a874cb9da65d8a0c912ecf76948321b5353a29cdf66acb3787bd51ed705d137
-size 2349
+oid sha256:8070531c5c85f6779aad829d4bfe253e3d272d2abe90579e8f6ae425e4df5f28
+size 2346

--- a/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ModalDismissButton/__image_snapshots__/modaldismissbutton-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dbe626cf71c144fa9091cc8831a330ccc3f6e8b63339c2ccd30766963fbb84a
-size 2570
+oid sha256:46f35167140fa2bbd1243a6d5d8a007122b4e6db934411ac410ba096034186f3
+size 2703


### PR DESCRIPTION
- [x] e2e-тесты
- [x] Дизайн-ревью


## Описание
При наведении на крестик навешивался токен --vkui--opacity--disable. Заменил на ховерные и активные варианты токена и починил анимацию, привязав её к :before.

Изменение состояния стало менее заметным визуально, отполируем её чуть позже через токены.