### PR TITLE
chore(styleguide): use lodash-es

### DIFF
--- a/styleguide/lib/theme/functions.js
+++ b/styleguide/lib/theme/functions.js
@@ -1,4 +1,4 @@
-import escape from 'lodash/escape';
+import { escape } from 'lodash-es';
 import {
   DEFAULT_THEME_FOR_PLATFORM,
   DEFAULT_THEME_NAMES,

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -10,7 +10,7 @@
     "test:ci": "echo no test:ci"
   },
   "devDependencies": {
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "prop-types": "^15.8.1",
     "react": "*",
     "react-children-utilities": "^2.10.0",

--- a/styleguide/utils/index.js
+++ b/styleguide/utils/index.js
@@ -1,4 +1,4 @@
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'lodash-es';
 import { onlyText } from 'react-children-utilities';
 
 export const getDeprecatedFromComponentTags = (component) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2353,7 +2353,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@project-docs/styleguide@workspace:styleguide"
   dependencies:
-    lodash: "npm:^4.17.21"
+    lodash-es: "npm:^4.17.21"
     prop-types: "npm:^15.8.1"
     react: "npm:*"
     react-children-utilities: "npm:^2.10.0"
@@ -11694,6 +11694,13 @@ __metadata:
   dependencies:
     p-locate: "npm:^5.0.0"
   checksum: 10/72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 10/03f39878ea1e42b3199bd3f478150ab723f93cc8730ad86fec1f2804f4a07c6e30deaac73cad53a88e9c3db33348bb8ceeb274552390e7a75d7849021c02df43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Используем lodash-es вместо lodash для уменьшения размера документации