### PR TITLE
feat(Popover): add onShownChanged prop

### DIFF
--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -62,6 +62,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'defaultShown'
   | 'shown'
   | 'onShownChange'
+  | 'onShownChanged'
   | 'usePortal'
   | 'sameWidth'
   | 'hideWhenReferenceHidden'
@@ -152,6 +153,7 @@ export const Popover = ({
   // controlled
   shown: shownProp,
   onShownChange,
+  onShownChanged,
 
   // Для AppRootPortal
   usePortal = true,
@@ -209,6 +211,7 @@ export const Popover = ({
     defaultShown,
     shown: shownProp,
     onShownChange,
+    onShownChanged,
   });
 
   usePlacementChangeCallback(expectedPlacement, resolvedPlacement, onPlacementChange);

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/types.ts
@@ -80,6 +80,10 @@ export interface UseFloatingWithInteractionsProps {
    * Вызывается при каждом изменении видимости всплывающего элемента.
    */
   onShownChange?: OnShownChange;
+  /**
+   * Вызывается при каждом изменении видимости всплывающего элемента, но после завершении анимации.
+   */
+  onShownChanged?: OnShownChange;
 }
 
 export type ReferenceProps<T = HTMLElement> = Omit<

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.test.tsx
@@ -87,17 +87,20 @@ describe(useFloatingWithInteractions, () => {
       'should shown by $openBy event and hidden by $closeBy event (trigger: $trigger)',
       async ({ trigger, openBy, closeBy }) => {
         const onShownChange = jest.fn();
+        const onShownChanged = jest.fn();
         const { result } = renderHook(() =>
           useFloatingWithInteractions<HTMLButtonElement>({
             defaultShown: false,
             trigger: trigger,
             onShownChange,
+            onShownChanged,
           }),
         );
         const { rerender } = render(<TestComponent hookResultRef={result} />);
         await waitFor(() => {
           expect(result.current.shown).toBeFalsy();
           expect(onShownChange).not.toHaveBeenCalled();
+          expect(onShownChanged).not.toHaveBeenCalled();
         });
 
         await fireEventPatch(result.current.refs.reference.current, openBy);
@@ -106,6 +109,8 @@ describe(useFloatingWithInteractions, () => {
           expect(result.current.shown).toBeTruthy();
           expect(onShownChange).toHaveBeenCalledTimes(1);
           expect(onShownChange).toHaveBeenLastCalledWith(true, trigger);
+          expect(onShownChanged).toHaveBeenCalledTimes(1);
+          expect(onShownChanged).toHaveBeenLastCalledWith(true, trigger);
         });
 
         let closeReason: ShownChangeReason = trigger;

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { debounce } from '@vkontakte/vkjs';
+import { debounce, noop } from '@vkontakte/vkjs';
 import { getWindow, isHTMLElement } from '@vkontakte/vkui-floating-ui/utils/dom';
 import { useCustomEnsuredControl } from '../../../hooks/useEnsuredControl';
 import { useGlobalOnClickOutside } from '../../../hooks/useGlobalOnClickOutside';
@@ -49,6 +49,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   // controlled
   shown: shownProp,
   onShownChange: onShownChangeProp,
+  onShownChanged: onShownChangedProp,
 }: UseFloatingWithInteractionsProps): UseFloatingWithInteractionsReturn<T> => {
   const memoizedValue = React.useMemo(
     () => (shownProp !== undefined ? { shown: shownProp } : undefined),
@@ -64,6 +65,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
       }
     }),
   });
+  const onShownChanged = useStableCallback(onShownChangedProp ? onShownChangedProp : noop);
   const [shownFinalState, setShownFinalState] = React.useState(() => shownLocalState.shown);
   const [willBeHide, setWillBeHide] = React.useState(false);
 
@@ -215,6 +217,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
     if (willBeHide) {
       setShownFinalState(false);
       setWillBeHide(false);
+      onShownChanged(false, shownLocalState.reason);
     }
   };
 
@@ -288,6 +291,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
 
       if (shownLocalState.shown) {
         setShownFinalState(true);
+        onShownChanged(true, shownLocalState.reason);
       } else if (hasCSSAnimation.current && !willBeHide) {
         setWillBeHide(true);
       } else {
@@ -298,7 +302,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
         clearTimeout(blurTimeoutRef.current);
       };
     },
-    [shownLocalState, shownFinalState, willBeHide],
+    [shownLocalState, shownFinalState, willBeHide, onShownChanged],
   );
 
   const referencePropsRef = React.useRef<ReferenceProps>({});


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7173

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Документация фичи

## Описание

С v6 у Popover появилась анимация закрытия и `onShownChange` не учитывает это и вызывается сразу. Для решения проблемы создал колбек `onShownChanged`, который ждёт завершения анимации.

---

- caused by #6150
- related to #7175