### PR TITLE
feat(Snackbar): support close with swipe in any direction in mobile

### DIFF
--- a/packages/vkui/src/components/Snackbar/Snackbar.module.css
+++ b/packages/vkui/src/components/Snackbar/Snackbar.module.css
@@ -3,6 +3,7 @@
   --vkui_internal--snackbar_in_padding: 8px;
   --vkui_internal--snackbar_shift_x: 0;
   --vkui_internal--snackbar_shift_y: 0;
+  --vkui_internal--snackbar_direction: 0;
   --vkui_internal--snackbar_animation_from: translate3d(0, 0, 0);
   --vkui_internal--snackbar_animation_to: translate3d(0, 0, 0);
   --vkui_internal--snackbar_animation_duration: 340ms;
@@ -27,10 +28,22 @@
   inset-block-start: var(--vkui_internal--safe_area_inset_top);
 }
 
+.Snackbar--placement-bottom-start {
+  --vkui_internal--snackbar_direction: -1;
+}
+
+.Snackbar--placement-bottom-end {
+  --vkui_internal--snackbar_direction: 1;
+}
+
 .Snackbar--placement-bottom-start,
 .Snackbar--placement-bottom,
 .Snackbar--placement-bottom-end {
-  --vkui_internal--snackbar_animation_from: translate3d(-100%, 0, 0);
+  --vkui_internal--snackbar_animation_from: translate3d(
+    calc(var(--vkui_internal--snackbar_direction) * 100%),
+    0,
+    0
+  );
   --vkui_internal--snackbar_animation_to: translate3d(var(--vkui_internal--snackbar_shift_x), 0, 0);
 
   inset-block-end: var(--vkui_internal--snackbar_safe_area_inset_bottom);

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -139,7 +139,7 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
             : rootRef.current.style.setProperty('--vkui_internal--snackbar_shift_y', `${y}px`);
           direction === null
             ? rootRef.current.style.removeProperty('--vkui_internal--snackbar_direction')
-            : /* istanbul ignore: TODO чтобы протестировать кейс, нужно мокать useMediaQueries(), чтобы перебивать mediaQueries.smallTabletPlus.matches */
+            : /* istanbul ignore next: TODO чтобы протестировать кейс, нужно мокать useMediaQueries(), чтобы перебивать mediaQueries.smallTabletPlus.matches */
               rootRef.current.style.setProperty(
                 '--vkui_internal--snackbar_direction',
                 `${direction}`,

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -139,7 +139,8 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
             : rootRef.current.style.setProperty('--vkui_internal--snackbar_shift_y', `${y}px`);
           direction === null
             ? rootRef.current.style.removeProperty('--vkui_internal--snackbar_direction')
-            : rootRef.current.style.setProperty(
+            : /* istanbul ignore: TODO чтобы протестировать кейс, нужно мокать useMediaQueries(), чтобы перебивать mediaQueries.smallTabletPlus.matches */
+              rootRef.current.style.setProperty(
                 '--vkui_internal--snackbar_direction',
                 `${direction}`,
               );

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -49,8 +49,10 @@ export interface SnackbarProps
    * > Note: в мобильном режиме:
    * > - `"top-start"`/`"top-end"` перебивается на `"top"`, чтобы поведение было схожим с нативными
    * >   уведомлениями;
-   * > - `"bottom"`/`"bottom-end"` перебивается на "bottom-start", чтобы избежать вызова системных
+   * > - `"bottom"` перебивается на `"bottom-start"`, чтобы избежать вызова системных
    * >   функций, таких как **Pull To Refresh** и **Режим управления одной рукой**.
+   * > - `"bottom-start"`/`"bottom-end"` закрываются смахиванием в любое из направлений
+   * >   по горизонтальной оси.
    */
   placement?: SnackbarPlacement;
   /**
@@ -126,7 +128,7 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
   }, []);
 
   const updateShiftAxisCSSProperties = React.useCallback(
-    (x: number | null, y: number | null) => {
+    (x: number | null, y: number | null, direction: number | null) => {
       rafRef.current = requestAnimationFrame(() => {
         if (rootRef.current) {
           x === null
@@ -135,6 +137,12 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
           y === null
             ? rootRef.current.style.removeProperty('--vkui_internal--snackbar_shift_y')
             : rootRef.current.style.setProperty('--vkui_internal--snackbar_shift_y', `${y}px`);
+          direction === null
+            ? rootRef.current.style.removeProperty('--vkui_internal--snackbar_direction')
+            : rootRef.current.style.setProperty(
+                '--vkui_internal--snackbar_direction',
+                `${direction}`,
+              );
         }
       });
     },
@@ -174,7 +182,11 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
       );
 
       if (shiftDataRef.current.shifted) {
-        updateShiftAxisCSSProperties(shiftDataRef.current.x, shiftDataRef.current.y);
+        updateShiftAxisCSSProperties(
+          shiftDataRef.current.x,
+          shiftDataRef.current.y,
+          shiftDataRef.current.direction,
+        );
       }
     }
   };
@@ -218,7 +230,7 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
         panGestureRecognizer.current = null;
 
         if (open) {
-          updateShiftAxisCSSProperties(null, null);
+          updateShiftAxisCSSProperties(null, null, null);
         }
       }
     },

--- a/packages/vkui/src/components/Snackbar/types.ts
+++ b/packages/vkui/src/components/Snackbar/types.ts
@@ -9,6 +9,7 @@ export type SnackbarPlacement =
 export type ShiftData = {
   x: number;
   y: number;
+  direction: number | null;
   width: number;
   height: number;
   shifted: boolean;

--- a/packages/vkui/src/components/Snackbar/utils.ts
+++ b/packages/vkui/src/components/Snackbar/utils.ts
@@ -30,7 +30,8 @@ export function getInitialShiftData(
 ): ShiftData {
   return {
     shifted: false,
-    isDesktop: mediaQueries.smallTabletPlus.matches, // eslint-disable-line no-restricted-properties
+    direction: null,
+    isDesktop: mediaQueries.smallTabletPlus.matches, // eslint-disable-line no-restricted-properties,
     x: 0,
     y: 0,
     width,
@@ -55,7 +56,11 @@ export function getMovedShiftData(
       shiftData.y = rubberbandIfOutOfBounds(nextShift.y, 0, shiftData.height);
     }
   } else if (placement.startsWith('bottom')) {
-    shiftData.x = rubberbandIfOutOfBounds(nextShift.x, -shiftData.width, 0);
+    shiftData.x = nextShift.x;
+
+    const movingToLeft = nextShift.x < 0 ? -1 : null;
+    const movingToRight = nextShift.x > 0 ? 1 : null;
+    shiftData.direction = movingToLeft || movingToRight;
   }
 
   if (placement.startsWith('top')) {
@@ -100,9 +105,12 @@ export function shouldBeClosedByShiftData(
         relativeClientRect.y > 0 ? velocity.y > MINIMUM_PAN_GESTURE_FOR_TRIGGER_CLOSE : false;
     }
   } else if (placement.startsWith('bottom')) {
-    shouldBeClosedThreshold.x = relativeClientRect.x < -relativeClientRect.width / 2;
+    shouldBeClosedThreshold.x =
+      relativeClientRect.x < -relativeClientRect.width / 2 ||
+      relativeClientRect.x > relativeClientRect.width / 2;
     shouldBeClosedByVelocity.x =
-      relativeClientRect.x < 0 ? velocity.x < -MINIMUM_PAN_GESTURE_FOR_TRIGGER_CLOSE : false;
+      (relativeClientRect.x < 0 && velocity.x < -MINIMUM_PAN_GESTURE_FOR_TRIGGER_CLOSE) ||
+      (relativeClientRect.x > 0 && velocity.x > MINIMUM_PAN_GESTURE_FOR_TRIGGER_CLOSE);
   }
 
   if (placement.startsWith('top')) {


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7212

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Дизайн-ревью
- [x] Документация фичи

## Описание

В мобильном режиме `"bottom-end"` больше не перебивается на  `"bottom-start"`. Также теперь можно закрыть Snackbar свайпом в любое из направлений по горизонтали.
