### PR TITLE
feat(useCSSKeyframesAnimationController): exclude first rerender

### DIFF
--- a/packages/vkui/src/lib/animation/useCSSKeyframesAnimationController.ts
+++ b/packages/vkui/src/lib/animation/useCSSKeyframesAnimationController.ts
@@ -1,111 +1,95 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { noop } from '@vkontakte/vkjs';
+import { usePrevious } from '../../hooks/usePrevious';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
 
 export type UseCSSAnimationControllerCallback = {
-  onEnter?: () => void;
-  onEntering?: () => void;
-  onEntered?: () => void;
-  onExit?: () => void;
-  onExiting?: () => void;
-  onExited?: () => void;
+  onEnter?: VoidFunction;
+  onEntering?: VoidFunction;
+  onEntered?: VoidFunction;
+  onExit?: VoidFunction;
+  onExiting?: VoidFunction;
+  onExited?: VoidFunction;
 };
 
 export type AnimationState = 'enter' | 'entering' | 'entered' | 'exit' | 'exiting' | 'exited';
 
-export type AnimationHandlers = { onAnimationStart: () => void; onAnimationEnd: () => void };
+export type AnimationHandlers = { onAnimationStart: VoidFunction; onAnimationEnd: VoidFunction };
 
 export const useCSSKeyframesAnimationController = (
   stateProp: 'enter' | 'exit',
   {
-    onEnter: onEnterProp = noop,
-    onEntering: onEnteringProp = noop,
-    onEntered: onEnteredProp = noop,
-    onExit: onExitProp = noop,
-    onExiting: onExitingProp = noop,
-    onExited: onExitedProp = noop,
+    onEnter: onEnterProp,
+    onEntering,
+    onEntered,
+    onExit: onExitProp,
+    onExiting,
+    onExited,
   }: UseCSSAnimationControllerCallback = {},
   disableInitAnimation = false,
 ): [AnimationState, AnimationHandlers] => {
-  const isFirstInitRef = React.useRef(disableInitAnimation);
-  const [state, setState] = React.useState<AnimationState>(stateProp);
-  const [willBeEnter, setWillBeEnter] = React.useState(stateProp === 'enter');
-  const [willBeExit, setWillBeExit] = React.useState(stateProp === 'exit');
-
-  const onEnter = useStableCallback(onEnterProp);
-  const onEntering = useStableCallback(onEnteringProp);
-  const onEntered = useStableCallback(onEnteredProp);
-  const onExit = useStableCallback(onExitProp);
-  const onExiting = useStableCallback(onExitingProp);
-  const onExited = useStableCallback(onExitedProp);
-
-  const entered = React.useCallback(() => {
-    setState('entered');
-    setWillBeEnter(false);
-    onEntered();
-  }, [onEntered]);
-
-  const exited = React.useCallback(() => {
-    setState('exited');
-    setWillBeExit(false);
-    onExited();
-  }, [onExited]);
+  const [state, setState] = useState<AnimationState>(() =>
+    disableInitAnimation ? (stateProp === 'enter' ? 'entered' : 'exited') : stateProp,
+  );
+  const prevState = usePrevious(stateProp);
 
   const onAnimationStart = () => {
-    if (state === 'enter' && willBeEnter) {
+    if (state === 'enter') {
       setState('entering');
-      onEntering();
-    } else if (state === 'exit' && willBeExit) {
+      if (onEntering) {
+        onEntering();
+      }
+    } else if (state === 'exit') {
       setState('exiting');
-      onExiting();
+      if (onExiting) {
+        onExiting();
+      }
     }
   };
 
   const onAnimationEnd = () => {
-    if (state === 'entering' && willBeEnter) {
-      entered();
-    } else if (state === 'exiting' && willBeExit) {
-      exited();
+    if (state === 'entering') {
+      setState('entered');
+      if (onEntered) {
+        onEntered();
+      }
+    } else if (state === 'exiting') {
+      setState('exited');
+      if (onExited) {
+        onExited();
+      }
     }
   };
 
+  const onEnter = useStableCallback(onEnterProp || noop);
+  const onExit = useStableCallback(onExitProp || noop);
+
   useIsomorphicLayoutEffect(
     function updateState() {
+      if (prevState === stateProp) {
+        return;
+      }
       switch (stateProp) {
         case 'enter':
-          if (isFirstInitRef.current && state === 'enter') {
-            entered();
-            break;
-          }
-
-          if (willBeEnter || state === 'entering' || state === 'entered') {
+          if (state === 'entering' || state === 'entered') {
             break;
           }
 
           setState('enter');
-          setWillBeEnter(true);
           onEnter();
           break;
         case 'exit':
-          if (isFirstInitRef.current && state === 'exit') {
-            exited();
-            break;
-          }
-
-          if (willBeExit || state === 'exiting' || state === 'exited') {
+          if (state === 'exiting' || state === 'exited') {
             break;
           }
 
           setState('exit');
-          setWillBeExit(true);
           onExit();
           break;
       }
-
-      isFirstInitRef.current = false;
     },
-    [state, stateProp, willBeEnter, willBeExit, entered, exited, onEnter, onExit],
+    [state, prevState, stateProp, onEnter, onExit],
   );
 
   return [state, { onAnimationStart, onAnimationEnd }];


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

Состояние `entered` выставлялось с ре-рендером при инициализации.

---

- caused by #6806