### PR TITLE
feat(Tooltip): disable trigger on focus with disableTriggerOnFocus prop

### DIFF
--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -31,6 +31,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'usePortal'
   | 'onPlacementChange'
   | 'disableFlipMiddleware'
+  | 'trigger'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -75,6 +76,7 @@ export const Tooltip = ({
   shown: shownProp,
   onShownChange,
   hoverDelay = 150,
+  trigger = ['hover', 'focus'],
 
   // инверсированные св-ва для useFloatingWithInteractions
   enableInteractive = false,
@@ -131,7 +133,7 @@ export const Tooltip = ({
     shown: shownProp,
     onShownChange,
     placement: strictPlacement,
-    trigger: ['hover', 'focus'],
+    trigger,
     hoverDelay,
     closeAfterClick: !disableCloseAfterClick,
     disableInteractive: !enableInteractive,

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -55,6 +55,10 @@ export interface TooltipProps extends AllowedFloatingComponentProps, AllowedTool
    * Отключает закрытие по клику.
    */
   disableCloseAfterClick?: boolean;
+  /**
+   * Отключает появление при фокусе.
+   */
+  disableTriggerOnFocus?: boolean;
 }
 
 /**
@@ -69,6 +73,7 @@ export const Tooltip = ({
   offsetByCrossAxis = 0,
   hideWhenReferenceHidden,
   disableFlipMiddleware = false,
+  disableTriggerOnFocus = false,
 
   // useFloatingWithInteractions
   defaultShown,
@@ -131,7 +136,7 @@ export const Tooltip = ({
     shown: shownProp,
     onShownChange,
     placement: strictPlacement,
-    trigger: ['hover', 'focus'],
+    trigger: disableTriggerOnFocus ? 'hover' : ['hover', 'focus'],
     hoverDelay,
     closeAfterClick: !disableCloseAfterClick,
     disableInteractive: !enableInteractive,

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -31,7 +31,6 @@ type AllowedFloatingComponentProps = Pick<
   | 'usePortal'
   | 'onPlacementChange'
   | 'disableFlipMiddleware'
-  | 'trigger'
 >;
 
 type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
@@ -76,7 +75,6 @@ export const Tooltip = ({
   shown: shownProp,
   onShownChange,
   hoverDelay = 150,
-  trigger = ['hover', 'focus'],
 
   // инверсированные св-ва для useFloatingWithInteractions
   enableInteractive = false,
@@ -133,7 +131,7 @@ export const Tooltip = ({
     shown: shownProp,
     onShownChange,
     placement: strictPlacement,
-    trigger,
+    trigger: ['hover', 'focus'],
     hoverDelay,
     closeAfterClick: !disableCloseAfterClick,
     disableInteractive: !enableInteractive,


### PR DESCRIPTION
## Описание

Добавляем новое свойство disableTriggerOnFocus, чтобы запретить появление при фокусе.
Иногда, если `Tooltip` на элементе внутри модалки, при открытии модалки появляется `Tooltip`, что не желательно.

В то же время лучше избегать использования такого свойство чтобы следовать паттерну [Tooltip](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)