### PR TITLE
refactor(Touch): rm `useEventListener()`

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -49,40 +49,40 @@ yarn workspace benchmark runtime:start
 
 ### touch (single)
 
-| sampleCount | mean  | stdDev  | min  | median | max  |
-| ----------- | ----- | ------- | ---- | ------ | ---- |
-| 15          | 06.67 | ±00.9ms | 05.6 | 06.6   | 08.3 |
+| sampleCount | mean  | stdDev   | min  | median | max  |
+| ----------- | ----- | -------- | ---- | ------ | ---- |
+| 15          | 06.61 | ±00.81ms | 05.4 | 06.8   | 07.9 |
 
 | JSEventListeners | JSHeapTotalSize | JSHeapUsedSize | LayoutCount | LayoutDuration | RecalcStyleCount | RecalcStyleDuration | ScriptDuration | TaskDuration |
 | ---------------- | --------------- | -------------- | ----------- | -------------- | ---------------- | ------------------- | -------------- | ------------ |
-| 143              | 3.4 MiB         | 1.8 MiB        | 2           | 0.001832       | 2                | 0.001315            | 0.013624       | 0.030369     |
+| 140              | 3.4 MiB         | 1.8 MiB        | 2           | 0.001813       | 2                | 0.001409            | 0.013405       | 0.030949     |
 
 ### touch width providers (single)
 
-| sampleCount | mean  | stdDev   | min  | median | max  |
-| ----------- | ----- | -------- | ---- | ------ | ---- |
-| 15          | 11.19 | ±02.65ms | 07.6 | 15.3   | 15.3 |
+| sampleCount | mean  | stdDev  | min  | median | max  |
+| ----------- | ----- | ------- | ---- | ------ | ---- |
+| 15          | 10.99 | ±03.2ms | 07.4 | 07.4   | 18.5 |
 
 | JSEventListeners | JSHeapTotalSize | JSHeapUsedSize | LayoutCount | LayoutDuration | RecalcStyleCount | RecalcStyleDuration | ScriptDuration | TaskDuration |
 | ---------------- | --------------- | -------------- | ----------- | -------------- | ---------------- | ------------------- | -------------- | ------------ |
-| 149              | 3.4 MiB         | 1.9 MiB        | 2           | 0.002061       | 2                | 0.001949            | 0.015388       | 0.033263     |
+| 146              | 3.6 MiB         | 1.9 MiB        | 2           | 0.002033       | 2                | 0.001977            | 0.015241       | 0.034252     |
 
 ### touch (multiple)
 
 | sampleCount | mean  | stdDev   | min  | median | max  |
 | ----------- | ----- | -------- | ---- | ------ | ---- |
-| 15          | 61.48 | ±06.06ms | 54.7 | 59.6   | 77.7 |
+| 15          | 44.15 | ±01.66ms | 41.1 | 44.9   | 46.1 |
 
 | JSEventListeners | JSHeapTotalSize | JSHeapUsedSize | LayoutCount | LayoutDuration | RecalcStyleCount | RecalcStyleDuration | ScriptDuration | TaskDuration |
 | ---------------- | --------------- | -------------- | ----------- | -------------- | ---------------- | ------------------- | -------------- | ------------ |
-| 3140             | 27.0 MiB        | 9.2 MiB        | 3           | 0.012517       | 3                | 0.003371            | 0.040067       | 0.080648     |
+| 140              | 8.8 MiB         | 4.0 MiB        | 2           | 0.012301       | 2                | 0.003312            | 0.02725        | 0.065623     |
 
 ### touch with providers (multiple)
 
-| sampleCount | mean | stdDev   | min  | median | max  |
-| ----------- | ---- | -------- | ---- | ------ | ---- |
-| 15          | 61   | ±03.01ms | 57.6 | 59.6   | 67.2 |
+| sampleCount | mean  | stdDev   | min  | median | max   |
+| ----------- | ----- | -------- | ---- | ------ | ----- |
+| 15          | 56.35 | ±31.46ms | 44.5 | 47.3   | 173.4 |
 
 | JSEventListeners | JSHeapTotalSize | JSHeapUsedSize | LayoutCount | LayoutDuration | RecalcStyleCount | RecalcStyleDuration | ScriptDuration | TaskDuration |
 | ---------------- | --------------- | -------------- | ----------- | -------------- | ---------------- | ------------------- | -------------- | ------------ |
-| 3146             | 26.8 MiB        | 9.2 MiB        | 3           | 0.012233       | 3                | 0.003991            | 0.040436       | 0.080798     |
+| 146              | 8.8 MiB         | 4.0 MiB        | 2           | 0.012215       | 2                | 0.004027            | 0.029771       | 0.069578     |

--- a/packages/vkui/src/components/BaseGallery/BaseGallery.tsx
+++ b/packages/vkui/src/components/BaseGallery/BaseGallery.tsx
@@ -7,7 +7,7 @@ import { useDOM } from '../../lib/dom';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { ScrollArrow } from '../ScrollArrow/ScrollArrow';
-import { Touch, type TouchEvent } from '../Touch/Touch';
+import { type CustomTouchEvent, Touch } from '../Touch/Touch';
 import { calcMax, calcMin } from './helpers';
 import type { BaseGalleryProps, GallerySlidesState, LayoutState, ShiftingState } from './types';
 import styles from './BaseGallery.module.css';
@@ -205,7 +205,7 @@ export const BaseGallery = ({
   /*
    * Получает индекс слайда, к которому будет осуществлен переход
    */
-  const getTarget = (e: TouchEvent) => {
+  const getTarget = (e: CustomTouchEvent) => {
     const expectDeltaX = (shiftState.deltaX / e.duration) * 240 * 0.6;
     const shift =
       shiftState.shiftX + shiftState.deltaX + expectDeltaX - (layoutState.current.max ?? 0);
@@ -237,7 +237,7 @@ export const BaseGallery = ({
 
   const isDraggable = !dragDisabled && !layoutState.current.isFullyVisible;
 
-  const onStart = (e: TouchEvent) => {
+  const onStart = (e: CustomTouchEvent) => {
     e.originalEvent.stopPropagation();
     if (isDraggable) {
       onDragStart?.(e);
@@ -245,7 +245,7 @@ export const BaseGallery = ({
     }
   };
 
-  const onMoveX = (e: TouchEvent) => {
+  const onMoveX = (e: CustomTouchEvent) => {
     if (isDraggable) {
       e.originalEvent.preventDefault();
 
@@ -261,7 +261,7 @@ export const BaseGallery = ({
     }
   };
 
-  const onEnd = (e: TouchEvent) => {
+  const onEnd = (e: CustomTouchEvent) => {
     if (isDraggable) {
       const targetIndex = e.isSlide ? getTarget(e) : slideIndex ?? 0;
       onDragEnd?.(e, targetIndex);

--- a/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
@@ -8,7 +8,7 @@ import { useIsomorphicLayoutEffect } from '../../../lib/useIsomorphicLayoutEffec
 import { warnOnce } from '../../../lib/warnOnce';
 import { RootComponent } from '../../RootComponent/RootComponent';
 import { ScrollArrow } from '../../ScrollArrow/ScrollArrow';
-import { Touch, type TouchEvent } from '../../Touch/Touch';
+import { type CustomTouchEvent, Touch } from '../../Touch/Touch';
 import { type BaseGalleryProps, type GallerySlidesState } from '../types';
 import { ANIMATION_DURATION, CONTROL_ELEMENTS_STATE, SLIDES_MANAGER_STATE } from './constants';
 import { calculateIndent, getLoopPoints, getTargetIndex } from './helpers';
@@ -264,7 +264,7 @@ export const CarouselBase = ({
     onNextClick?.(event);
   };
 
-  const onStart = (e: TouchEvent) => {
+  const onStart = (e: CustomTouchEvent) => {
     e.originalEvent.stopPropagation();
     if (controlElementsState.isDraggable) {
       onDragStart?.(e);
@@ -273,7 +273,7 @@ export const CarouselBase = ({
     }
   };
 
-  const onMoveX = (e: TouchEvent) => {
+  const onMoveX = (e: CustomTouchEvent) => {
     if (controlElementsState.isDraggable) {
       e.originalEvent.preventDefault();
 
@@ -286,7 +286,7 @@ export const CarouselBase = ({
     }
   };
 
-  const onEnd = (e: TouchEvent) => {
+  const onEnd = (e: CustomTouchEvent) => {
     if (controlElementsState.isDraggable) {
       let targetIndex = slideIndex;
       if (e.isSlide) {

--- a/packages/vkui/src/components/BaseGallery/types.ts
+++ b/packages/vkui/src/components/BaseGallery/types.ts
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 import type { HasAlign, HasRef, HTMLAttributesWithRootRef } from '../../types';
 import type { ScrollArrowProps } from '../ScrollArrow/ScrollArrow';
-import type { TouchEvent, TouchEventHandler } from '../Touch/Touch';
+import type { CustomTouchEvent, CustomTouchEventHandler } from '../Touch/Touch';
 
 export interface GallerySlidesState {
   coordX: number;
@@ -31,8 +31,8 @@ export interface BaseGalleryProps
     HasRef<HTMLElement> {
   slideWidth?: string | number;
   slideIndex?: number;
-  onDragStart?: TouchEventHandler;
-  onDragEnd?: (e: TouchEvent, targetIndex: number) => void;
+  onDragStart?: CustomTouchEventHandler;
+  onDragEnd?: (e: CustomTouchEvent, targetIndex: number) => void;
   onChange?: (current: number) => void;
   /**
    * Будет вызвано при клике на кнопку-стрелку влево

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -9,7 +9,7 @@ import { rubber } from '../../lib/touch';
 import { warnOnce } from '../../lib/warnOnce';
 import { ConfigProviderContext } from '../ConfigProvider/ConfigProviderContext';
 import { FocusTrap } from '../FocusTrap/FocusTrap';
-import { Touch, type TouchEvent } from '../Touch/Touch';
+import { type CustomTouchEvent, Touch } from '../Touch/Touch';
 import TouchRootContext from '../Touch/TouchContext';
 import { ModalRootContext, type ModalRootContextInterface } from './ModalRootContext';
 import { MODAL_PAGE_DEFAULT_PERCENT_HEIGHT } from './constants';
@@ -242,7 +242,7 @@ class ModalRootTouchComponent extends React.Component<
     }
   }
 
-  onTouchMove = (e: TouchEvent) => {
+  onTouchMove = (e: CustomTouchEvent) => {
     if (this.props.exitingModal) {
       return;
     }
@@ -260,7 +260,7 @@ class ModalRootTouchComponent extends React.Component<
     }
   };
 
-  onPageTouchMove(event: TouchEvent, modalState: ModalsStateEntry) {
+  onPageTouchMove(event: CustomTouchEvent, modalState: ModalsStateEntry) {
     const { shiftY, originalEvent } = event;
     const target = originalEvent.target as HTMLElement;
 
@@ -317,7 +317,7 @@ class ModalRootTouchComponent extends React.Component<
     }
   }
 
-  onCardTouchMove(event: TouchEvent, modalState: ModalsStateEntry) {
+  onCardTouchMove(event: CustomTouchEvent, modalState: ModalsStateEntry) {
     const { originalEvent, shiftY } = event;
     const target = originalEvent.target as HTMLElement;
     if (modalState.innerElement?.contains(target)) {
@@ -336,7 +336,7 @@ class ModalRootTouchComponent extends React.Component<
     }
   }
 
-  onTouchEnd = (e: TouchEvent) => {
+  onTouchEnd = (e: CustomTouchEvent) => {
     const modalState = this.props.getModalState(this.props.activeModal);
 
     if (modalState?.type === 'page') {
@@ -348,7 +348,7 @@ class ModalRootTouchComponent extends React.Component<
     }
   };
 
-  onPageTouchEnd(event: TouchEvent, modalState: ModalsStateEntry) {
+  onPageTouchEnd(event: CustomTouchEvent, modalState: ModalsStateEntry) {
     const { startY, shiftY } = event;
 
     modalState.contentScrolled = false;
@@ -417,7 +417,7 @@ class ModalRootTouchComponent extends React.Component<
     );
   }
 
-  onCardTouchEnd({ duration }: TouchEvent, modalState: ModalsStateEntry) {
+  onCardTouchEnd({ duration }: CustomTouchEvent, modalState: ModalsStateEntry) {
     let setStateCallback;
 
     if (this.state.dragging) {

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
@@ -8,14 +8,14 @@ import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import type { AnyFunction, HasChildren } from '../../types';
 import { type ScrollContextInterface, useScroll } from '../AppRoot/ScrollContext';
 import { FixedLayout } from '../FixedLayout/FixedLayout';
-import { Touch, type TouchEvent as TouchEventInternal, type TouchProps } from '../Touch/Touch';
+import { type CustomTouchEvent, Touch, type TouchProps } from '../Touch/Touch';
 import TouchRootContext from '../Touch/TouchContext';
 import { PullToRefreshSpinner } from './PullToRefreshSpinner';
 import styles from './PullToRefresh.module.css';
 
 const WAIT_FETCHING_TIMEOUT_MS = 1000;
 
-function cancelEvent(event: TouchEventInternal) {
+function cancelEvent(event: CustomTouchEvent) {
   /* istanbul ignore if: неясно в какой ситуации `event` из `Touch` может быть не определён */
   if (!event) {
     return false;
@@ -160,7 +160,7 @@ export const PullToRefresh = ({
 
   const startYRef = React.useRef(0);
 
-  const onTouchStart = (event: TouchEventInternal) => {
+  const onTouchStart = (event: CustomTouchEvent) => {
     if (refreshing) {
       cancelEvent(event);
       return;
@@ -170,7 +170,7 @@ export const PullToRefresh = ({
   };
 
   const iosRefreshStartedRef = React.useRef(false);
-  const onTouchMove = (event: TouchEventInternal) => {
+  const onTouchMove = (event: CustomTouchEvent) => {
     const { isY, shiftY } = event;
     const { start, max } = initParams;
     const pageYOffset = scroll?.getScroll().y;

--- a/packages/vkui/src/components/Slider/Slider.test.tsx
+++ b/packages/vkui/src/components/Slider/Slider.test.tsx
@@ -10,7 +10,7 @@ import {
   userEvent,
   waitForFloatingPosition,
 } from '../../testing/utils';
-import type { TouchEvent } from '../Touch/Touch';
+import type { CustomTouchEvent } from '../Touch/Touch';
 import { Slider as SliderBase, type SliderMultipleProps, type SliderProps } from './Slider';
 
 const pointerPos = (x: number) => ({ clientX: x, clientY: 10 });
@@ -31,8 +31,10 @@ describe(Slider, () => {
 
   describe('uncontrolled', () => {
     it('uses min as fallback', () => {
-      const handleChangeForTypeCheck: jest.Mock<void, [number, TouchEvent | React.ChangeEvent]> =
-        jest.fn();
+      const handleChangeForTypeCheck: jest.Mock<
+        void,
+        [number, CustomTouchEvent | React.ChangeEvent]
+      > = jest.fn();
       render(<Slider onChange={handleChangeForTypeCheck} />);
       expect(screen.getByRole('slider')).toHaveValue('0');
     });
@@ -73,8 +75,10 @@ describe(Slider, () => {
 
   describe('controlled', () => {
     it('sets value', () => {
-      const handleChangeForTypeCheck: jest.Mock<void, [number, TouchEvent | React.ChangeEvent]> =
-        jest.fn();
+      const handleChangeForTypeCheck: jest.Mock<
+        void,
+        [number, CustomTouchEvent | React.ChangeEvent]
+      > = jest.fn();
       const { rerender } = render(<Slider value={5} onChange={handleChangeForTypeCheck} />);
       expect(screen.getByRole('slider')).toHaveValue('5');
 
@@ -101,7 +105,7 @@ describe(Slider, () => {
     it('should overrides defaultValue if value is exist (multiple)', () => {
       const handleChangeForTypeCheck: jest.Mock<
         void,
-        [[number, number], TouchEvent | React.ChangeEvent]
+        [[number, number], CustomTouchEvent | React.ChangeEvent]
       > = jest.fn();
       render(
         <Slider
@@ -119,7 +123,8 @@ describe(Slider, () => {
 
   describe('change with tap', () => {
     it('moves start', async () => {
-      const handleChange: jest.Mock<void, [number, TouchEvent | React.ChangeEvent]> = jest.fn();
+      const handleChange: jest.Mock<void, [number, CustomTouchEvent | React.ChangeEvent]> =
+        jest.fn();
       render(<Slider defaultValue={30} onChange={handleChange} />);
       await userEvent.pointer([
         { target: screen.getByTestId('root'), coords: pointerPos(20), keys: '[MouseLeft]' },
@@ -129,8 +134,10 @@ describe(Slider, () => {
     });
 
     it('moves start (multiple)', async () => {
-      const handleChange: jest.Mock<void, [[number, number], TouchEvent | React.ChangeEvent]> =
-        jest.fn();
+      const handleChange: jest.Mock<
+        void,
+        [[number, number], CustomTouchEvent | React.ChangeEvent]
+      > = jest.fn();
       render(<Slider multiple defaultValue={[30, 70]} onChange={handleChange} />);
       const [startSlider, endSlider] = screen.getAllByRole('slider');
       await userEvent.pointer([

--- a/packages/vkui/src/components/Slider/Slider.tsx
+++ b/packages/vkui/src/components/Slider/Slider.tsx
@@ -4,7 +4,7 @@ import { clamp } from '../../helpers/math';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
 import type { HTMLAttributesWithRootRef } from '../../types';
-import { Touch, type TouchEvent, type TouchEventHandler } from '../Touch/Touch';
+import { type CustomTouchEvent, type CustomTouchEventHandler, Touch } from '../Touch/Touch';
 import { SliderThumb } from './SliderThumb/SliderThumb';
 import {
   extractSliderAriaAttributesFromRestProps,
@@ -61,14 +61,14 @@ export interface SliderProps extends SliderBaseProps {
   multiple?: false;
   value?: number;
   defaultValue?: number;
-  onChange?: (value: number, event: TouchEvent | React.ChangeEvent) => void;
+  onChange?: (value: number, event: CustomTouchEvent | React.ChangeEvent) => void;
 }
 
 export interface SliderMultipleProps extends SliderBaseProps {
   multiple: true;
   value?: [number, number];
   defaultValue?: [number, number];
-  onChange?: (value: [number, number], event: TouchEvent | React.ChangeEvent) => void;
+  onChange?: (value: [number, number], event: CustomTouchEvent | React.ChangeEvent) => void;
 }
 
 /**
@@ -121,7 +121,10 @@ export const Slider = ({
   const { ariaLabel, ariaValueText, ariaLabelledBy, ...restPropsWithoutAriaAttributes } =
     extractSliderAriaAttributesFromRestProps(restProps);
 
-  const changeValue = (nextValue: InternalValueState, event: TouchEvent | React.ChangeEvent) => {
+  const changeValue = (
+    nextValue: InternalValueState,
+    event: CustomTouchEvent | React.ChangeEvent,
+  ) => {
     if (disabled || (value[0] === nextValue[0] && value[1] === nextValue[1])) {
       return;
     }
@@ -137,7 +140,7 @@ export const Slider = ({
     }
   };
 
-  const handlePointerStart: TouchEventHandler = (event: TouchEvent) => {
+  const handlePointerStart: CustomTouchEventHandler = (event: CustomTouchEvent) => {
     if (!thumbsContainerRef.current) {
       return;
     }
@@ -186,7 +189,7 @@ export const Slider = ({
     setActiveThumb(gesture.dragging);
   };
 
-  const handlePointerMove: TouchEventHandler = (event: TouchEvent) => {
+  const handlePointerMove: CustomTouchEventHandler = (event: CustomTouchEvent) => {
     const { startX, containerWidth, dragging } = gesture;
 
     const { shiftX = 0 } = event;
@@ -199,7 +202,7 @@ export const Slider = ({
     event.originalEvent.preventDefault();
   };
 
-  const handlePointerEnd: TouchEventHandler = (event) => {
+  const handlePointerEnd: CustomTouchEventHandler = (event) => {
     gesture.dragging = null;
     event.originalEvent.stopPropagation();
     setActiveThumb(null);

--- a/packages/vkui/src/components/Touch/Touch.stories.tsx
+++ b/packages/vkui/src/components/Touch/Touch.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
-import { Touch, type TouchEvent, type TouchProps } from './Touch';
+import { type CustomTouchEvent, Touch, type TouchProps } from './Touch';
 
 const story: Meta<TouchProps> = {
   title: 'Service/Touch',
@@ -68,7 +68,7 @@ export const Playground: Story = {
       return value > limit ? limit : value < -limit ? -limit : value;
     };
 
-    const onMove = (e: TouchEvent) => {
+    const onMove = (e: CustomTouchEvent) => {
       const shiftX = startX.current + e.shiftX;
       const shiftY = startY.current + e.shiftY;
 
@@ -76,7 +76,7 @@ export const Playground: Story = {
       setShiftY(getValueWithLimit(shiftY, limitY));
     };
 
-    const onEnd = (e: TouchEvent) => {
+    const onEnd = (e: CustomTouchEvent) => {
       const shiftX = startX.current + e.shiftX;
       const shiftY = startY.current + e.shiftY;
 

--- a/packages/vkui/src/components/Touch/Touch.test.tsx
+++ b/packages/vkui/src/components/Touch/Touch.test.tsx
@@ -62,6 +62,17 @@ afterEach(() => delete window['ontouchstart']);
 describe('Touch', () => {
   baselineComponent(Touch);
 
+  it.each([true, false])('use stopPropagation={%s}', (stopPropagation) => {
+    const onMouseDown = jest.fn();
+    const result = render(
+      <div data-testid="container" onMouseDown={onMouseDown}>
+        <Touch stopPropagation={stopPropagation} data-testid="touch" />
+      </div>,
+    );
+    fireEvent.mouseDown(result.getByTestId('touch'));
+    expect(onMouseDown).toHaveBeenCalledTimes(stopPropagation ? 0 : 1);
+  });
+
   it('does not leak listeners when unmounting during gesture', () => {
     let moved = false;
     const { unmount } = render(<Touch onMove={() => (moved = true)} data-testid="touch" />);

--- a/packages/vkui/src/components/Touch/Touch.tsx
+++ b/packages/vkui/src/components/Touch/Touch.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
-import { useEventListener } from '../../hooks/useEventListener';
-import { useExternRef } from '../../hooks/useExternRef';
-import { useDOM } from '../../lib/dom';
-import {
-  coordX,
-  coordY,
-  getSupportedEvents,
-  touchEnabled,
-  type VKUITouchEvent,
-} from '../../lib/touch';
-import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { useStableCallback } from '../../hooks/useStableCallback';
+import { getWindow, isHTMLElement } from '../../lib/dom';
+import { coordX, coordY, touchEnabled, type VKUITouchEvent } from '../../lib/touch';
 import type { HasComponent, HasRootRef } from '../../types';
+
+export interface CustomTouchEvent extends Gesture {
+  originalEvent: VKUITouchEvent;
+}
+
+export type HoverHandler = (outputEvent: MouseEvent) => void;
+
+export type CustomTouchEventHandler = (event: CustomTouchEvent) => void;
 
 export interface TouchProps
   extends React.AllHTMLAttributes<HTMLElement>,
@@ -23,17 +23,17 @@ export interface TouchProps
   useCapture?: boolean;
   slideThreshold?: number;
   noSlideClick?: boolean;
-  onEnter?: HoverHandler;
+  onEnter?: HoverHandler; // TODO [>=7] Заменить типы события в VKUITouchEvent на события из React
   onLeave?: HoverHandler;
-  onStart?: TouchEventHandler;
-  onStartX?: TouchEventHandler;
-  onStartY?: TouchEventHandler;
-  onMove?: TouchEventHandler;
-  onMoveX?: TouchEventHandler;
-  onMoveY?: TouchEventHandler;
-  onEnd?: TouchEventHandler;
-  onEndX?: TouchEventHandler;
-  onEndY?: TouchEventHandler;
+  onStart?: CustomTouchEventHandler; // TODO [>=7] Заменить типы события в VKUITouchEvent на события из React
+  onStartX?: CustomTouchEventHandler; // TODO [>=7] Заменить типы события в VKUITouchEvent на события из React
+  onStartY?: CustomTouchEventHandler; // TODO [>=7] Заменить типы события в VKUITouchEvent на события из React
+  onMove?: CustomTouchEventHandler;
+  onMoveX?: CustomTouchEventHandler;
+  onMoveY?: CustomTouchEventHandler;
+  onEnd?: CustomTouchEventHandler;
+  onEndX?: CustomTouchEventHandler;
+  onEndY?: CustomTouchEventHandler;
   stopPropagation?: boolean;
 }
 
@@ -56,15 +56,6 @@ export interface Gesture {
   shiftYAbs: number;
 }
 
-export interface TouchEvent extends Gesture {
-  originalEvent: VKUITouchEvent;
-}
-
-type HoverHandler = (outputEvent: MouseEvent) => void;
-export type TouchEventHandler = (e: TouchEvent) => void;
-export type ClickHandler = (e: React.MouseEvent<HTMLElement>) => void;
-export type DragHandler = (e: React.DragEvent<HTMLElement>) => void;
-
 /**
  * @see https://vkcom.github.io/VKUI/#/Touch
  */
@@ -72,12 +63,12 @@ export const Touch = ({
   onStart,
   onStartX,
   onStartY,
-  onMove: _onMove,
+  onMove,
   onMoveX,
   onMoveY,
-  onLeave,
   onEnter,
-  onEnd: _onEnd,
+  onLeave,
+  onEnd,
   onEndX,
   onEndY,
   onClickCapture,
@@ -89,189 +80,216 @@ export const Touch = ({
   noSlideClick = false,
   stopPropagation = false,
   ...restProps
-}: TouchProps): React.ReactNode => {
-  const { document } = useDOM();
-  const events = React.useMemo(getSupportedEvents, []);
+}: TouchProps) => {
+  const [isTouchEnabled] = React.useState(touchEnabled);
+  const gestureRef = React.useRef<Gesture | null>(null);
   const didSlide = React.useRef(false);
-  const gesture = React.useRef<Partial<Gesture> | null>(null);
-  const handle = (e: VKUITouchEvent, handlers: Array<TouchEventHandler | undefined | false>) => {
-    stopPropagation && e.stopPropagation();
-    handlers.forEach((cb) => {
-      const duration = Date.now() - (gesture.current?.startT?.getTime() ?? 0);
-      cb && cb({ ...(gesture.current as Gesture), duration, originalEvent: e });
-    });
+  const disposeTargetNativeGestureEvents = React.useRef<VoidFunction | null>(null);
+
+  const cleanupTargetNativeGestureEvents = () => {
+    gestureRef.current = null;
+    if (disposeTargetNativeGestureEvents.current) {
+      disposeTargetNativeGestureEvents.current();
+      disposeTargetNativeGestureEvents.current = null;
+    }
   };
 
-  const enterHandler = useEventListener(usePointerHover ? 'pointerenter' : 'mouseenter', onEnter);
-  const leaveHandler = useEventListener(usePointerHover ? 'pointerleave' : 'mouseleave', onLeave);
-  const startHandler = useEventListener(
-    events[0],
-    (e: VKUITouchEvent) => {
-      gesture.current = initGesture(coordX(e), coordY(e));
+  /**
+   * Note: используем `useStableCallback()`, чтобы не терялась область видимости `onEnd`/`onEndX`/`onEndY`.
+   */
+  const handleNativePointerUp = useStableCallback((event: MouseEvent | TouchEvent) => {
+    const gesture = gestureRef.current;
 
-      handle(e, [onStart, onStartX, onStartY]);
-      // 1 line, 2 bad specs, 2 workarounds:
-      subscribe(
-        touchEnabled()
-          ? // Touch events fire on initial target, and won't bubble if its removed
-            // see: #235, #1968, https://stackoverflow.com/a/45760014
-            (e.target as HTMLElement)
-          : // Mouse events fire on the element under pointer, so we lose move / end
-            // if pointer goes outside container.
-            // Can be fixed by PointerEvents' setPointerCapture later
-            document,
-      );
-    },
-    { capture: useCapture, passive: false },
-  );
-  const containerRef = useExternRef(getRootRef);
-
-  useIsomorphicLayoutEffect(() => {
-    const el = containerRef.current;
-    if (el) {
-      enterHandler.add(el);
-      leaveHandler.add(el);
-      startHandler.add(el);
-    }
-  }, [Component]);
-
-  function onMove(e: VKUITouchEvent) {
-    const { isPressed, isX, isY, startX = 0, startY = 0 } = gesture.current ?? {};
-
-    if (isPressed) {
-      const clientX = coordX(e);
-      const clientY = coordY(e);
-
-      // смещения
-      const shiftX = clientX - startX;
-      const shiftY = clientY - startY;
-
-      // абсолютные значения смещений
-      const shiftXAbs = Math.abs(shiftX);
-      const shiftYAbs = Math.abs(shiftY);
-
-      // Если определяем мультитач, то прерываем жест
-      if (!!e.touches && e.touches.length > 1) {
-        return onEnd(e);
-      }
-
-      // если мы ещё не определились
-      if (!isX && !isY) {
-        const willBeX = shiftXAbs >= slideThreshold && shiftXAbs > shiftYAbs;
-        const willBeY = shiftYAbs >= slideThreshold && shiftYAbs > shiftXAbs;
-        const willBeSlidedX = willBeX && (!!onMoveX || !!_onMove);
-        const willBeSlidedY = willBeY && (!!onMoveY || !!_onMove);
-
-        if (gesture.current) {
-          Object.assign(gesture.current, {
-            isY: willBeY,
-            isX: willBeX,
-            isSlideX: willBeSlidedX,
-            isSlideY: willBeSlidedY,
-            isSlide: willBeSlidedX || willBeSlidedY,
-          });
-        }
-      }
-
-      if (gesture.current?.isSlide) {
-        Object.assign(gesture.current, {
-          clientX,
-          clientY,
-          shiftX,
-          shiftY,
-          shiftXAbs,
-          shiftYAbs,
-        });
-
-        handle(e, [
-          _onMove,
-          gesture.current.isSlideX && onMoveX,
-          gesture.current.isSlideY && onMoveY,
-        ]);
-      }
-    }
-  }
-
-  function onEnd(e: VKUITouchEvent) {
-    const { isPressed, isSlide, isSlideX, isSlideY } = gesture.current ?? {};
-
-    if (isPressed) {
-      handle(e, [_onEnd, isSlideY && onEndY, isSlideX && onEndX]);
+    /* istanbul ignore if: нужно для Typescript */
+    if (!gesture) {
+      return;
     }
 
-    const isTouchEnabled = touchEnabled();
+    if (gesture.isPressed) {
+      dispatchUserHandlers(event, gesture, [onEnd, onEndX, onEndY], stopPropagation);
+    }
 
-    if (isTouchEnabled && isSlide) {
+    if (isTouchEnabled) {
       // https://github.com/VKCOM/VKUI/issues/4414
       // если тач-устройство и был зафиксирован touchmove,
       // то событие клика не вызывается
-      didSlide.current = false;
+      if (gesture.isSlide) {
+        didSlide.current = false;
+      }
+      // Если это был тач-евент, симулируем отмену hover
+      if (onLeave) {
+        onLeave(event as MouseEvent);
+      }
     } else {
-      didSlide.current = Boolean(isSlide);
+      didSlide.current = Boolean(gesture.isSlide);
     }
-    gesture.current = {};
 
-    // Если это был тач-евент, симулируем отмену hover
-    if (isTouchEnabled) {
-      onLeave && onLeave(e);
-    }
-    unsubscribe();
-  }
-
-  const listenerParams = { capture: useCapture, passive: false };
-  const listeners = [
-    useEventListener(events[1], onMove, listenerParams),
-    useEventListener(events[2], onEnd, listenerParams),
-    useEventListener(events[3], onEnd, listenerParams),
-  ];
-  function subscribe(el: HTMLElement | Document | null | undefined) {
-    if (el) {
-      listeners.forEach((l) => l.add(el));
-    }
-  }
-  function unsubscribe() {
-    listeners.forEach((l) => l.remove());
-  }
+    cleanupTargetNativeGestureEvents();
+  });
 
   /**
-   * Обработчик событий dragstart
+   * Note: используем `useStableCallback()`, чтобы не терялась область видимости `onMove`/`onMoveX`/`onMoveY`.
+   */
+  const handleNativePointerMove = useStableCallback((event: MouseEvent | TouchEvent) => {
+    const gesture = gestureRef.current;
+
+    /* istanbul ignore if: нужно для Typescript */
+    if (!gesture) {
+      return;
+    }
+
+    const clientX = coordX(event);
+    const clientY = coordY(event);
+
+    // смещения
+    const shiftX = clientX - gesture.startX;
+    const shiftY = clientY - gesture.startY;
+
+    // абсолютные значения смещений
+    const shiftXAbs = Math.abs(shiftX);
+    const shiftYAbs = Math.abs(shiftY);
+
+    // Если определяем мультитач, то прерываем жест
+    if ('touches' in event && event.touches.length > 1) {
+      return handleNativePointerUp(event);
+    }
+
+    // если мы ещё не определились
+    if (!gesture.isX && !gesture.isY) {
+      const willBeX = shiftXAbs >= slideThreshold && shiftXAbs > shiftYAbs;
+      const willBeY = shiftYAbs >= slideThreshold && shiftYAbs > shiftXAbs;
+      const willBeSlidedX = willBeX && (!!onMoveX || !!onMove);
+      const willBeSlidedY = willBeY && (!!onMoveY || !!onMove);
+
+      gesture.isY = willBeY;
+      gesture.isX = willBeX;
+      gesture.isSlideX = willBeSlidedX;
+      gesture.isSlideY = willBeSlidedY;
+      gesture.isSlide = willBeSlidedX || willBeSlidedY;
+    }
+
+    if (gesture.isSlide) {
+      gesture.clientX = clientX;
+      gesture.clientY = clientY;
+      gesture.shiftX = shiftX;
+      gesture.shiftY = shiftY;
+      gesture.shiftXAbs = shiftXAbs;
+      gesture.shiftYAbs = shiftYAbs;
+
+      dispatchUserHandlers(event, gesture, [onMove, onMoveX, onMoveY], stopPropagation);
+    }
+  });
+
+  const handlePointerDown = (
+    event: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>,
+  ) => {
+    const nativeEvent = event.nativeEvent;
+
+    gestureRef.current = initGesture(coordX(nativeEvent), coordY(nativeEvent));
+
+    dispatchUserHandlers(
+      event,
+      gestureRef.current,
+      [onStart, onStartX, onStartY],
+      stopPropagation,
+      false,
+    );
+
+    const eventOptions = { capture: useCapture, passive: false };
+
+    // FIXME: заменить touch/mouse-события ниже на pointer-события после того, как бразуеры из
+    // .browserslistrc начнут поддерживать его (см. https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#browser_compatibility).
+    if (isTouchEnabled) {
+      if (isHTMLElement(event.target)) {
+        // Тач-события не всплывают, поэтому навешиваем события на целевой элемент
+        // см. #235, #1968, https://stackoverflow.com/a/45760014
+        const target = event.target;
+
+        target.addEventListener('touchmove', handleNativePointerMove, eventOptions);
+        target.addEventListener('touchend', handleNativePointerUp, eventOptions);
+        target.addEventListener('touchcancel', handleNativePointerUp, eventOptions);
+
+        disposeTargetNativeGestureEvents.current = () => {
+          target.removeEventListener('touchmove', handleNativePointerMove, eventOptions);
+          target.removeEventListener('touchend', handleNativePointerUp, eventOptions);
+          target.removeEventListener('touchcancel', handleNativePointerUp, eventOptions);
+        };
+      }
+    } else {
+      // Используем события на Document, т.к. mouse-события на целевом элементе могут теряться при
+      // выходе за границы этого элемента.
+      const doc = getWindow(event.currentTarget).document;
+
+      doc.addEventListener('mousemove', handleNativePointerMove, eventOptions);
+      doc.addEventListener('mouseup', handleNativePointerUp, eventOptions);
+      doc.addEventListener('mouseleave', handleNativePointerUp, eventOptions);
+
+      disposeTargetNativeGestureEvents.current = () => {
+        doc.removeEventListener('mousemove', handleNativePointerMove, eventOptions);
+        doc.removeEventListener('mouseup', handleNativePointerUp, eventOptions);
+        doc.removeEventListener('mouseleave', handleNativePointerUp, eventOptions);
+      };
+    }
+  };
+
+  const handlePointerEnter = onEnter
+    ? (event: React.MouseEvent<HTMLElement>) => onEnter(event.nativeEvent)
+    : undefined;
+
+  const handlePointerLeave = onLeave
+    ? (event: React.MouseEvent<HTMLElement>) => onLeave(event.nativeEvent)
+    : undefined;
+
+  /**
    * Отменяет нативное браузерное поведение для вложенных ссылок и изображений
    */
-  const onDragStart = (e: React.DragEvent<HTMLElement>) => {
-    const target = e.target as HTMLElement;
+  const handleDragStart = (event: React.DragEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement;
     if (target.tagName === 'A' || target.tagName === 'IMG') {
-      e.preventDefault();
+      event.preventDefault();
     }
   };
 
   /**
-   * Обработчик клика по компоненту
    * Отменяет переход по вложенной ссылке, если был зафиксирован свайп
    */
-  const postGestureClick: typeof onClickCapture = (e) => {
+  const handleClickCapture: typeof onClickCapture = (event) => {
     if (!didSlide.current) {
-      return onClickCapture && onClickCapture(e);
+      return onClickCapture && onClickCapture(event);
     }
 
     if (noSlideClick) {
-      e.stopPropagation();
+      event.stopPropagation();
 
       // https://github.com/VKCOM/VKUI/issues/1977
       // https://github.com/VKCOM/VKUI/issues/3892
-      e.preventDefault();
+      event.preventDefault();
     } else {
-      onClickCapture && onClickCapture(e);
+      onClickCapture && onClickCapture(event);
     }
 
     didSlide.current = false;
   };
 
+  React.useEffect(() => cleanupTargetNativeGestureEvents, []);
+
   return (
     <Component
       {...restProps}
-      onDragStart={onDragStart}
-      onClickCapture={postGestureClick}
-      ref={containerRef}
+      ref={getRootRef}
+      onDragStart={handleDragStart}
+      onClickCapture={handleClickCapture}
+      // onEnter
+      onPointerEnter={usePointerHover ? handlePointerEnter : undefined}
+      onMouseEnter={!usePointerHover ? handlePointerEnter : undefined}
+      // onLeave
+      onPointerLeave={usePointerHover ? handlePointerLeave : undefined}
+      onMouseLeave={!usePointerHover ? handlePointerLeave : undefined}
+      // handlePointerDown
+      onTouchStartCapture={isTouchEnabled && useCapture ? handlePointerDown : undefined}
+      onTouchStart={isTouchEnabled && !useCapture ? handlePointerDown : undefined}
+      onMouseDownCapture={!isTouchEnabled && useCapture ? handlePointerDown : undefined}
+      onMouseDown={!isTouchEnabled && !useCapture ? handlePointerDown : undefined}
     />
   );
 };
@@ -295,4 +313,52 @@ function initGesture(startX: number, startY: number): Gesture {
     shiftXAbs: 0,
     shiftYAbs: 0,
   };
+}
+
+type Handlers = [
+  CustomTouchEventHandler | undefined,
+  CustomTouchEventHandler | undefined,
+  CustomTouchEventHandler | undefined,
+];
+
+function dispatchUserHandlers(
+  event: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent,
+  gesture: Gesture,
+  [handler, handlerX, handlerY]: Handlers,
+  stopPropagation?: boolean,
+  shouldCallDirectionHandlerOnlyIsSlide = true,
+) {
+  if (stopPropagation) {
+    event.stopPropagation();
+  }
+
+  const data = {
+    ...gesture,
+    originalEvent: event as unknown as VKUITouchEvent,
+    duration: Date.now() - gesture.startT.getTime(),
+  };
+
+  if (handler) {
+    handler(data);
+  }
+
+  if (handlerX) {
+    if (shouldCallDirectionHandlerOnlyIsSlide) {
+      if (gesture.isSlideX) {
+        handlerX(data);
+      }
+    } else {
+      handlerX(data);
+    }
+  }
+
+  if (handlerY) {
+    if (shouldCallDirectionHandlerOnlyIsSlide) {
+      if (gesture.isSlideY) {
+        handlerY(data);
+      }
+    } else {
+      handlerY(data);
+    }
+  }
 }

--- a/packages/vkui/src/components/Touch/Touch.tsx
+++ b/packages/vkui/src/components/Touch/Touch.tsx
@@ -94,6 +94,8 @@ export const Touch = ({
     }
   };
 
+  React.useEffect(() => cleanupTargetNativeGestureEvents, []);
+
   /**
    * Note: используем `useStableCallback()`, чтобы не терялась область видимости `onEnd`/`onEndX`/`onEndY`.
    */
@@ -187,12 +189,13 @@ export const Touch = ({
 
     gestureRef.current = initGesture(coordX(nativeEvent), coordY(nativeEvent));
 
+    const shouldCallDirectionHandlerOnlyIsSlide = false;
     dispatchUserHandlers(
       event,
       gestureRef.current,
       [onStart, onStartX, onStartY],
       stopPropagation,
-      false,
+      shouldCallDirectionHandlerOnlyIsSlide,
     );
 
     const eventOptions = { capture: useCapture, passive: false };
@@ -270,8 +273,6 @@ export const Touch = ({
 
     didSlide.current = false;
   };
-
-  React.useEffect(() => cleanupTargetNativeGestureEvents, []);
 
   return (
     <Component

--- a/packages/vkui/src/components/View/View.tsx
+++ b/packages/vkui/src/components/View/View.tsx
@@ -12,7 +12,7 @@ import { NavViewIdContext } from '../NavIdContext/NavIdContext';
 import { NavTransitionProvider } from '../NavTransitionContext/NavTransitionContext';
 import { NavTransitionDirectionProvider } from '../NavTransitionDirectionContext/NavTransitionDirectionContext';
 import { useSplitCol } from '../SplitCol/SplitColContext';
-import { Touch, type TouchEvent } from '../Touch/Touch';
+import { type CustomTouchEvent, Touch } from '../Touch/Touch';
 import { useLayoutEffectCall } from './useLayoutEffectCall';
 import {
   getSwipeBackPredicates,
@@ -186,7 +186,7 @@ export const View = ({
     }
   }, [onSwipeBackCancel, onSwipeBackSuccess, swipeBackResult]);
 
-  const handleTouchMoveXForNativeIOSSwipeBackOrSwipeNext = (event: TouchEvent) => {
+  const handleTouchMoveXForNativeIOSSwipeBackOrSwipeNext = (event: CustomTouchEvent) => {
     if (browserSwipe) {
       return;
     }
@@ -198,7 +198,7 @@ export const View = ({
     }
   };
 
-  const handleTouchMoveXForIOSSwipeBackSimulation = (event: TouchEvent) => {
+  const handleTouchMoveXForIOSSwipeBackSimulation = (event: CustomTouchEvent) => {
     if (swipeBackPrevented.current || swipeBackExcluded(event)) {
       return;
     }
@@ -259,7 +259,7 @@ export const View = ({
     }
   };
 
-  const handleTouchEndForIOSSwipeBackSimulation = (event: TouchEvent) => {
+  const handleTouchEndForIOSSwipeBackSimulation = (event: CustomTouchEvent) => {
     swipeBackPrevented.current = false;
     if (swipingBack) {
       const speed = (swipeBackShift / event.duration) * 1000;

--- a/packages/vkui/src/components/View/ViewInfinite.tsx
+++ b/packages/vkui/src/components/View/ViewInfinite.tsx
@@ -15,7 +15,7 @@ import { NavViewIdContext } from '../NavIdContext/NavIdContext';
 import { NavTransitionProvider } from '../NavTransitionContext/NavTransitionContext';
 import { NavTransitionDirectionProvider } from '../NavTransitionDirectionContext/NavTransitionDirectionContext';
 import { SplitColContext, type SplitColContextProps } from '../SplitCol/SplitColContext';
-import { Touch, type TouchEvent } from '../Touch/Touch';
+import { type CustomTouchEvent, Touch } from '../Touch/Touch';
 import {
   getSwipeBackPredicates,
   hasHorizontalScrollableElementWithScrolledToLeft,
@@ -401,7 +401,7 @@ class ViewInfiniteComponent extends React.Component<
     });
   }
 
-  handleTouchMoveXForNativeIOSSwipeBackOrSwipeNext = (event: TouchEvent) => {
+  handleTouchMoveXForNativeIOSSwipeBackOrSwipeNext = (event: CustomTouchEvent) => {
     if (this.state.browserSwipe) {
       return;
     }
@@ -413,7 +413,7 @@ class ViewInfiniteComponent extends React.Component<
     }
   };
 
-  handleTouchMoveXForIOSSwipeBackSimulation = (event: TouchEvent) => {
+  handleTouchMoveXForIOSSwipeBackSimulation = (event: CustomTouchEvent) => {
     if (this.swipeBackPrevented || swipeBackExcluded(event)) {
       return;
     }
@@ -480,7 +480,7 @@ class ViewInfiniteComponent extends React.Component<
     }
   };
 
-  handleTouchEndForIOSSwipeBackSimulation = (event: TouchEvent) => {
+  handleTouchEndForIOSSwipeBackSimulation = (event: CustomTouchEvent) => {
     this.swipeBackPrevented = false;
 
     if (this.state.swipingBack && this.window) {

--- a/packages/vkui/src/components/View/utils.ts
+++ b/packages/vkui/src/components/View/utils.ts
@@ -1,9 +1,9 @@
 import { getOverflowAncestors } from '../../lib/floating';
-import { type TouchEvent } from '../Touch/Touch';
+import { type CustomTouchEvent } from '../Touch/Touch';
 
 const swipeBackExcludedSelector = 'input, textarea, [data-vkui-swipe-back=false]';
 
-export function swipeBackExcluded(e: TouchEvent): boolean {
+export function swipeBackExcluded(e: CustomTouchEvent): boolean {
   const target = e.originalEvent.target as HTMLElement;
   // eslint-disable-next-line no-restricted-properties
   return Boolean(target?.closest?.(swipeBackExcludedSelector));

--- a/packages/vkui/src/hooks/useDraggableWithDomApi/types.ts
+++ b/packages/vkui/src/hooks/useDraggableWithDomApi/types.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import type { TouchEvent } from '../../components/Touch/Touch';
+import type { CustomTouchEvent } from '../../components/Touch/Touch';
 
 export type Direction = 'up' | 'down';
 
@@ -30,9 +30,9 @@ export interface UseDraggableProps<T extends HTMLElement = HTMLElement> {
 }
 
 export interface DraggableProps {
-  onDragStart: (this: void, event: TouchEvent) => void;
-  onDragEnd: (this: void, event: TouchEvent) => void;
-  onDragMove: (this: void, event: TouchEvent) => void;
+  onDragStart: (this: void, event: CustomTouchEvent) => void;
+  onDragEnd: (this: void, event: CustomTouchEvent) => void;
+  onDragMove: (this: void, event: CustomTouchEvent) => void;
 }
 
 export interface UseDraggable extends DraggableProps {

--- a/packages/vkui/src/hooks/useDraggableWithDomApi/useDraggableWithDomApi.ts
+++ b/packages/vkui/src/hooks/useDraggableWithDomApi/useDraggableWithDomApi.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { TouchEvent } from '../../components/Touch/Touch';
+import type { CustomTouchEvent } from '../../components/Touch/Touch';
 import { getBoundingClientRect, getNearestOverflowAncestor, getNodeScroll } from '../../lib/dom';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { createAutoScrollController, getAutoScrollingData } from './autoScroll';
@@ -192,12 +192,12 @@ export const useDraggableWithDomApi = <T extends HTMLElement>({
     }, AUTO_SCROLL_START_DELAY);
   };
 
-  const onDragStart = (event: TouchEvent) => {
+  const onDragStart = (event: CustomTouchEvent) => {
     event.originalEvent.stopPropagation();
     event.originalEvent.preventDefault();
   };
 
-  const onDragMove = (event: TouchEvent) => {
+  const onDragMove = (event: CustomTouchEvent) => {
     event.originalEvent.stopPropagation();
     event.originalEvent.preventDefault();
 
@@ -236,7 +236,7 @@ export const useDraggableWithDomApi = <T extends HTMLElement>({
     }
   };
 
-  const onDragEnd = (event: TouchEvent) => {
+  const onDragEnd = (event: CustomTouchEvent) => {
     event.originalEvent.stopPropagation();
     event.originalEvent.preventDefault();
 

--- a/packages/vkui/src/lib/touch/functions.ts
+++ b/packages/vkui/src/lib/touch/functions.ts
@@ -6,21 +6,21 @@ export type VKUITouchEventHandler = (e: VKUITouchEvent) => void;
 /*
  * Получает координату по оси абсцисс из touch- или mouse-события
  */
-const coordX = (e: VKUITouchEvent): number => {
-  if (e.clientX != null) {
-    return e.clientX;
+const coordX = (event: MouseEvent | TouchEvent): number => {
+  if ('clientX' in event) {
+    return event.clientX;
   }
-  return e.changedTouches && e.changedTouches[0].clientX;
+  return event.changedTouches && event.changedTouches[0].clientX;
 };
 
 /*
  * Получает координату по оси ординат из touch- или mouse-события
  */
-const coordY = (e: VKUITouchEvent): number => {
-  if (e.clientY != null) {
-    return e.clientY;
+const coordY = (event: MouseEvent | TouchEvent): number => {
+  if ('clientY' in event) {
+    return event.clientY;
   }
-  return e.changedTouches && e.changedTouches[0].clientY;
+  return event.changedTouches && event.changedTouches[0].clientY;
 };
 
 // eslint-disable-next-line no-restricted-globals


### PR DESCRIPTION
- close #7269

---

## Описание

см. #7269

### Нюансы

- `handleNativePointerUp` и `handleNativePointerMove` обернул в `useStableCallback()` – без этого терялась область видимости и коллбеки `onEnd`/`onEndX`/`onEndY` и `onMove`/`onMoveX`/`onMoveY` вызывались со старым состоянием. Особенно это было заментно в компонент `View`, в котором начало свайп срабатывало со второго раза, а сам свайп не заверашлся, т.к. `onEnd` вызывался с предыдущим состоянием;
- `handlePointerDown` теперь передаёт в `onStart`/`onStartX`/`onStartY` **React**-овское событие для правильной работы `preventDefault()` и `stopPropagation()`.

## Изменения

- `TouchEvent` переименован в `CustomTouchEvent` – из-за этого +14 файлов в изменениях 😅 ;
- события `pointerenter`/`pointerleave`/`mouseenter`/`mouseleave`/`touchstart`/`mousedown` теперь навешиваются через **React**;
- дописал тест на использование параметра `stopPropagation`;
- `benchmark/README.md` обновлён под рефактор – получилось улучшить показатели.

---

- related to #7128
