### PR TITLE
fix(ChipsSelect/CustomSelect): Change key back to option.value

### DIFF
--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -242,7 +242,7 @@ export const ChipsInputBase = <O extends ChipOption>({
         onKeyDown={disabled ? undefined : handleListboxKeyDown}
       >
         {value.map((option, index) => (
-          <React.Fragment key={`${typeof option.value}-${option.label}`}>
+          <React.Fragment key={`${typeof option.value}-${option.value}`}>
             {renderChip(
               {
                 'Component': 'div',

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -522,7 +522,7 @@ export const ChipsSelect = <Option extends ChipOption>({
               );
             }
             return (
-              <React.Fragment key={`${typeof option.value}-${option.label}`}>
+              <React.Fragment key={`${typeof option.value}-${option.value}`}>
                 {renderOption(
                   {
                     id: dropdownItemId,

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -668,7 +668,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
       const selected = index === selectedOptionIndex;
 
       return (
-        <React.Fragment key={`${option.value}`}>
+        <React.Fragment key={`${typeof option.value}-${option.value}`}>
           {renderOptionProp({
             option,
             hovered,


### PR DESCRIPTION
## Описание
В момент когда делали ChipsSelect стабильным (https://github.com/VKCOM/VKUI/pull/6206), мы поменяли key на использование `option.label` вместо `option.value`. Это не совсем правильно, так как текстовое представление `label` может совпадать, в то время как `value` должно быть уникальным.

Пример с воспроизведением: https://codesandbox.io/p/sandbox/muddy-water-4jxc78?file=/src/App.tsx:13,1

## Изменения
Поменял key в `ChipsInput` при рендере `Chips` и в `ChipsSelect` при рендере options.
Обновил key в `CustomSelect` для единообразия по аналогии с ChipsSelect.