### PR TITLE
fix(List): avoid Cell content to overflow parent

### DIFF
--- a/packages/vkui/src/components/List/List.e2e-playground.tsx
+++ b/packages/vkui/src/components/List/List.e2e-playground.tsx
@@ -1,0 +1,35 @@
+import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
+import { Avatar } from '../Avatar/Avatar';
+import { Cell } from '../Cell/Cell';
+import { List, ListProps } from './List';
+
+export const ListPlayground = (props: ComponentPlaygroundProps) => {
+  return (
+    <ComponentPlayground
+      {...props}
+      propSets={[
+        {
+          gap: [0, 20],
+        },
+      ]}
+    >
+      {(props: ListProps) => (
+        <div style={{ padding: 20 }}>
+          <List {...props}>
+            <Cell before={<Avatar />} draggable mode="removable">
+              Lorem
+            </Cell>
+            <Cell before={<Avatar />} draggable mode="removable">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+              exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+              dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+              mollit anim id est laborum.
+            </Cell>
+          </List>
+        </div>
+      )}
+    </ComponentPlayground>
+  );
+};

--- a/packages/vkui/src/components/List/List.e2e.tsx
+++ b/packages/vkui/src/components/List/List.e2e.tsx
@@ -1,0 +1,7 @@
+import { test } from '@vkui-e2e/test';
+import { ListPlayground } from './List.e2e-playground';
+
+test('List', async ({ mount, expectScreenshotClippedToContent, componentPlaygroundProps }) => {
+  await mount(<ListPlayground {...componentPlaygroundProps} />);
+  await expectScreenshotClippedToContent();
+});

--- a/packages/vkui/src/components/List/List.module.css
+++ b/packages/vkui/src/components/List/List.module.css
@@ -1,5 +1,6 @@
 .List {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .List__placeholder {

--- a/packages/vkui/src/components/List/__image_snapshots__/list-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-android-chromium-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3dc2d0ebd528ca86534c5c80e1d3a2a90059e023af25de70ccdb2b0bcea0a12
+size 13866

--- a/packages/vkui/src/components/List/__image_snapshots__/list-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c0552696c433e7f009ecd114344bdb41ebcdf9a52a6df9801d6039d6ab946e1
+size 13355

--- a/packages/vkui/src/components/List/__image_snapshots__/list-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-ios-webkit-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cca542edf27c70d1f70c7536fe74ae6580fa9a15964bbae6ebf93868379a1d44
+size 14647

--- a/packages/vkui/src/components/List/__image_snapshots__/list-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-ios-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c8da6b815c3af8078fae84ee0dd03637bb4d91ede93d6298df96763072379b
+size 14036

--- a/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-chromium-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4aee6056bf4cbff5e3f9e2e3d6f0393f4f234a1f6635256bc0d365a33f0ea7c6
+size 22404

--- a/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30fa87f22e05158ad5b88b383e62db4f6a181704fb27b6e5cf277cbba9d6ca0e
+size 22293

--- a/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-firefox-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2b29b7345d93abbcc4eb135b5853d8d31a5a8ddc98a8529104d9e5d0d5fe50c
+size 41672

--- a/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-firefox-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24b7147ac9784dada9bc1f0c2648a179f7aca2f79657d528cd815ceea3d784cc
+size 38209

--- a/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-webkit-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83f5a7f4e009c112085942c39934a89a17f5ce7c5a23df2a6327f15db97e2ceb
+size 22855

--- a/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/List/__image_snapshots__/list-vkcom-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03c9d3f311740f6592ec942e4df2d6e3d9abf63eeaa5628f611dbe33c6255733
+size 22616


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] e2e-тесты

## Описание
По умолчанию grid item имеет ширину минимум равную минимальной ширине контента (`minmax(auto, 1fr)`). 
По этой причине контент может вылезать за пределы родителя, если контента много.


## Изменения
- меняем правила для grid колонки на `minmax(0, 1fr)`
- добавляем скриншотные тесты именно для этой проблемы.

| До | После |
|----|--------|
| <img width="1034" alt="Screenshot 2024-07-31 at 18 44 19" src="https://github.com/user-attachments/assets/fc35c832-1bca-4f40-bd7e-50ea6ab3eae3"> |<img width="1034" alt="Screenshot 2024-07-31 at 18 44 23" src="https://github.com/user-attachments/assets/2810dcb7-ef63-4258-a3ea-a5610a4fa68f">|