### PR TITLE
feat: prepare components to tests coverage

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -65,7 +65,7 @@ export interface AlertProps extends React.HTMLAttributes<HTMLElement>, HasRootRe
  * @see https://vkcom.github.io/VKUI/#/Alert
  */
 export const Alert = ({
-  actions = [],
+  actions,
   actionsLayout = 'horizontal',
   children,
   className,

--- a/packages/vkui/src/components/Avatar/Avatar.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.tsx
@@ -14,7 +14,7 @@ export type {
   ImageBaseOverlayProps as AvatarOverlayProps,
 };
 
-export const AVATAR_DEFAULT_SIZE = 48;
+const AVATAR_DEFAULT_SIZE = 48;
 
 const COLORS_NUMBER_TO_TEXT_MAP = {
   1: 'red',

--- a/packages/vkui/src/components/Avatar/AvatarBadge/icons.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/icons.tsx
@@ -4,21 +4,22 @@ import {
   Icon12OnlineMobile as Icon12OnlineMobileLib,
 } from '@vkontakte/icons';
 
-export const Icon12Circle = ({
-  width = 12,
-  height = 12,
-  ...restProps
-}: React.ComponentProps<typeof Icon12CircleLib>): React.ReactNode => {
+type IconsProps = Omit<React.ComponentProps<typeof Icon12CircleLib>, 'width' | 'height'> & {
+  width: number;
+  height: number;
+};
+
+export const Icon12Circle = ({ width, height, ...restProps }: IconsProps): React.ReactNode => {
   return (
     <Icon12CircleLib {...restProps} width={width >= 24 ? 15 : 12} height={height >= 24 ? 15 : 12} />
   );
 };
 
 export const Icon12OnlineMobile = ({
-  width = 8,
-  height = 12,
+  width,
+  height,
   ...restProps
-}: React.ComponentProps<typeof Icon12OnlineMobileLib>): React.ReactNode => {
+}: IconsProps): React.ReactNode => {
   return (
     <Icon12OnlineMobileLib
       {...restProps}

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -116,8 +116,7 @@ export const CalendarRange = ({
         return [date, null];
       }
 
-      const start = value[0];
-      const end = value[1];
+      const [start, end] = value;
       if ((start && isSameDay(date, start)) || (end && isSameDay(date, end))) {
         return [setTimeEqual(date, start), setTimeEqual(date, end)];
       } else if (start && isBefore(date, start)) {

--- a/packages/vkui/src/components/ChipsInput/ChipsInput.tsx
+++ b/packages/vkui/src/components/ChipsInput/ChipsInput.tsx
@@ -1,10 +1,5 @@
 import { useExternRef } from '../../hooks/useExternRef';
 import { ChipsInputBase } from '../ChipsInputBase/ChipsInputBase';
-import {
-  getNewOptionDataDefault,
-  getOptionLabelDefault,
-  getOptionValueDefault,
-} from '../ChipsInputBase/constants';
 import type { ChipOption, ChipsInputBaseProps } from '../ChipsInputBase/types';
 import type { FormFieldProps } from '../FormField/FormField';
 import { useChipsInput, type UseChipsInputProps } from './useChipsInput';
@@ -33,9 +28,9 @@ export const ChipsInput = <Option extends ChipOption>({
   inputValue: inputValueProp,
   defaultInputValue: inputDefaultValueProp,
   onInputChange: onInputChangeProp,
-  getOptionValue = getOptionValueDefault,
-  getOptionLabel = getOptionLabelDefault,
-  getNewOptionData = getNewOptionDataDefault,
+  getOptionValue,
+  getOptionLabel,
+  getNewOptionData,
 
   // other
   disabled,

--- a/packages/vkui/src/components/ChipsInputBase/helpers.ts
+++ b/packages/vkui/src/components/ChipsInputBase/helpers.ts
@@ -48,11 +48,8 @@ export const getNextChipOptionIndexByNavigateToProp = (
   navigateTo: NavigateTo,
   length: number,
 ): number => {
-  const FIRST_INDEX = 0;
   const LAST_INDEX = length - 1;
   switch (navigateTo) {
-    case 'first':
-      return FIRST_INDEX;
     case 'prev':
       const prevIndex = currentIndex - 1;
       return prevIndex < 0 ? LAST_INDEX : prevIndex;

--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -9,7 +9,7 @@ import type {
 import { FormFieldProps } from '../FormField/FormField';
 import { FormFieldClearButtonProps } from '../FormFieldClearButton/FormFieldClearButton';
 
-export type NavigateTo = 'first' | 'prev' | 'next' | 'last';
+export type NavigateTo = 'prev' | 'next' | 'last';
 
 export type ChipOptionValue = string | number;
 

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -291,14 +291,6 @@ export const ChipsSelect = <Option extends ChipOption>({
   };
 
   const focusOptionByIndex = (index: number, oldIndex: number | null) => {
-    const length = options.length;
-
-    if (index < 0) {
-      index = length - 1;
-    } else if (index >= length) {
-      index = 0;
-    }
-
     if (index === oldIndex) {
       /* istanbul ignore next: нет представления как воспроизвести */
       return;

--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -47,7 +47,7 @@ interface StateHookProps extends StateProps {
 
 export const DEFAULT_ACTIVE_EFFECT_DELAY = 600;
 
-export const ACTIVE_DELAY = 70;
+const ACTIVE_DELAY = 70;
 
 /**
  * Управляет наведением на компонент, игнорирует тач события
@@ -125,7 +125,7 @@ export const ClickableLockStateContext: React.Context<((v: boolean) => void) | u
 /**
  * Блокирует стейт на всплытие
  */
-export function useLockState(): readonly [boolean, (v: boolean) => void, (...args: any[]) => void] {
+function useLockState(): readonly [boolean, (v: boolean) => void, (...args: any[]) => void] {
   const setLockBubbling = React.useContext(ClickableLockStateContext) || noop;
   const [lockState, setLockState] = React.useState(false);
 

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -109,8 +109,6 @@ const filter = <T extends CustomSelectOptionInterface>(
     : options;
 };
 
-const defaultOptions: CustomSelectOptionInterface[] = [];
-
 type SelectValue = React.SelectHTMLAttributes<HTMLSelectElement>['value'];
 
 export interface CustomSelectOptionInterface {
@@ -252,7 +250,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     autoHideScrollbarDelay,
     searchable = false,
     renderOption: renderOptionProp = defaultRenderOptionFn,
-    options: optionsProp = defaultOptions as OptionInterfaceT[],
+    options: optionsProp,
     emptyText = 'Ничего не найдено',
     filterFn = defaultFilterFn,
     icon: iconProp,
@@ -702,7 +700,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
   const resolvedContent = React.useMemo(() => {
     const defaultDropdownContent =
-      options?.length > 0 ? (
+      options.length > 0 ? (
         <div ref={optionsWrapperRef}>{options.map(renderOption)}</div>
       ) : (
         <Footnote className={styles['CustomSelect__empty']}>{emptyText}</Footnote>

--- a/packages/vkui/src/components/FixedLayout/FixedLayout.tsx
+++ b/packages/vkui/src/components/FixedLayout/FixedLayout.tsx
@@ -83,8 +83,8 @@ export const FixedLayout = ({
       setWidth(
         `${
           colRef.current.clientWidth -
-          parseFloat(computedStyle.paddingLeft) -
-          parseFloat(computedStyle.paddingRight)
+          parseFloat(computedStyle.paddingLeft || '0') -
+          parseFloat(computedStyle.paddingRight || '0')
         }px`,
       );
     } else {

--- a/packages/vkui/src/components/GridAvatar/GridAvatar.tsx
+++ b/packages/vkui/src/components/GridAvatar/GridAvatar.tsx
@@ -6,7 +6,7 @@ import styles from './GridAvatar.module.css';
 
 export { GridAvatarBadgeProps };
 
-export const GRID_AVATAR_DEFAULT_SIZE = 48;
+const GRID_AVATAR_DEFAULT_SIZE = 48;
 
 export const MAX_GRID_LENGTH = 4;
 

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -103,7 +103,7 @@ function doScroll({
   onScrollEnd,
   onScrollStart,
   initialScrollWidth,
-  scrollAnimationDuration = SCROLL_ONE_FRAME_TIME,
+  scrollAnimationDuration,
   textDirection,
 }: ScrollContext) {
   if (!scrollElement || !getScrollPosition) {
@@ -136,11 +136,6 @@ function doScroll({
   const startTime = now();
 
   (function scroll() {
-    if (!scrollElement) {
-      onScrollEnd();
-      return;
-    }
-
     const time = now();
     const elapsed = Math.min((time - startTime) / scrollAnimationDuration, 1);
 
@@ -182,10 +177,10 @@ export const HorizontalScroll = ({
 }: HorizontalScrollProps): React.ReactNode => {
   const [canScrollLeft, setCanScrollLeft] = React.useState(false);
   const [canScrollRight, setCanScrollRight] = React.useState(false);
-  const [directionRef, textDirection = 'ltr'] = useDirection<HTMLDivElement>();
-
-  const setCanScrollStart = textDirection === 'ltr' ? setCanScrollLeft : setCanScrollRight;
-  const setCanScrollEnd = textDirection === 'ltr' ? setCanScrollRight : setCanScrollLeft;
+  const [directionRef, textDirection] = useDirection<HTMLDivElement>();
+  const direction = textDirection || 'ltr';
+  const setCanScrollStart = direction === 'ltr' ? setCanScrollLeft : setCanScrollRight;
+  const setCanScrollEnd = direction === 'ltr' ? setCanScrollRight : setCanScrollLeft;
 
   const isCustomScrollingRef = React.useRef(false);
 
@@ -209,14 +204,14 @@ export const HorizontalScroll = ({
           onScrollStart: () => (isCustomScrollingRef.current = true),
           initialScrollWidth: scrollElement?.firstElementChild?.scrollWidth || 0,
           scrollAnimationDuration,
-          textDirection,
+          textDirection: direction,
         }),
       );
       if (animationQueue.current.length === 1) {
         animationQueue.current[0]();
       }
     },
-    [scrollerRef, scrollAnimationDuration, textDirection, setCanScrollEnd],
+    [scrollerRef, scrollAnimationDuration, direction, setCanScrollEnd],
   );
 
   const scrollToLeft = React.useCallback(() => {

--- a/packages/vkui/src/components/Image/Image.tsx
+++ b/packages/vkui/src/components/Image/Image.tsx
@@ -6,7 +6,7 @@ import styles from './Image.module.css';
 
 export type { ImageBadgeProps, ImageBaseOverlayProps as ImageOverlayProps };
 
-export const IMAGE_DEFAULT_SIZE = 48;
+const IMAGE_DEFAULT_SIZE = 48;
 
 export interface ImageProps extends Omit<ImageBaseProps, 'badge'> {
   /**

--- a/packages/vkui/src/components/ImageBase/validators.ts
+++ b/packages/vkui/src/components/ImageBase/validators.ts
@@ -96,7 +96,7 @@ export function validateFallbackIcon(imageSize: number, iconProp: IconProp): voi
 
 const mapOfExpectedSize = new Set<number>(imageBaseSizes);
 
-const arrayOfSizes = Object.keys(mapOfExpectedSize).map((str) => Number(str));
+const arrayOfSizes = Array.from(mapOfExpectedSize).map((str) => Number(str));
 const maxSize = arrayOfSizes.reduce((maxSize, size) => (size > maxSize ? size : maxSize), 0);
 
 export function validateSize(imageSize: number): void {


### PR DESCRIPTION
---

## Описание

Данный PR сделан, чтобы вынести изменения по компонентам из задач по улучшению покрытия тестами #7244, #7263, #7277. Сделано это, чтобы в тех PR были изменения касающиеся только тестов. Теперь по каждому файлу

## Изменения

- `Alert`. Убрано значение `actions` по умолчанию, так как нет мест, где `actions` не прокидывается
- `icons.tsx`. В иконках убраны значения по умолчанию для `width` и `height`, чтобы не покрывать кейсы, когда `width` и `height` не прокинуты
- `Avatar`. Убрал экспорт константы, так как она нигде за пределами не используется
- `CalendarRange`. Поменял способ получения `start` и `end` через деструктуризацию 
- `ChipsInput`. Убрал значения по умолчанию для `getOptionValue`, `getOptionLabel`, `getNewOptionData`. Так как эти пропы не используются на уровне этого компонента
- `ChipsInputBase`. Убрал логику получения индекса первого chip'а, так как она нигде не используется
- `ChipsSelect`. Убрал логику проверки на выход за границы массива `options`, так как эта проверка происходит ранее и здесь бесполезна.
- `useState.tsx`. Убрал экспорт неиспользующися  за пределами модуля функций и констант
- `CustomSelect`. Убрал значение по умолчанию `options`, так как `options` судя по типу не может быть `undefined`
- `FixedLayout`. Добавил дефолтные значения для `paddingLeft` и `paddingRight` при расчете ширины компонента относительно колонки. Проверка нужна в случае, если `paddingLeft` и `paddingRight` не установлены
- `HorizontalScroll`. Убрал ненужные проверки(куда никак не попасть в адекватных кейсах), Поправил получением direction, так как в старом варианте почему-то не всегда устанавливалось адекватное значение для `textDirection`
- `GridAvatar`. Убрал ненужный экспорт
- `Image`. Убрал ненужный экспорт
- `validators.ts`. Поправил расчет `arrayOfSizes`, так как раньше он работал неправильно(всегда был пустым массивом)