### PR TITLE
feat(FocusTrap): add autoFocus to root possibility

### DIFF
--- a/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
@@ -75,6 +75,12 @@ const ActionSheetTest = ({
   );
 };
 
+const mockElementFocus = (element: HTMLElement | null, focusFn: VoidFunction) => {
+  if (element) {
+    jest.spyOn(element, 'focus').mockImplementation(focusFn);
+  }
+};
+
 describe(FocusTrap, () => {
   fakeTimers();
   baselineComponent(FocusTrap);
@@ -302,11 +308,6 @@ describe(FocusTrap, () => {
     it('check autoFocus to root', async () => {
       const rootFocus = jest.fn();
       const buttonFocus = jest.fn();
-      const mockElementFocus = (element: HTMLElement | null, focusFn: VoidFunction) => {
-        if (element) {
-          jest.spyOn(element, 'focus').mockImplementation(focusFn);
-        }
-      };
 
       render(
         <>
@@ -326,6 +327,19 @@ describe(FocusTrap, () => {
       await waitFor(() => {
         expect(rootFocus).toHaveBeenCalledTimes(1);
         expect(buttonFocus).toHaveBeenCalledTimes(0);
+      });
+    });
+    it('should autofocus to container when dont have another active elements', async () => {
+      const rootFocus = jest.fn();
+      render(
+        <>
+          <FocusTrap autoFocus getRootRef={(element) => mockElementFocus(element, rootFocus)}>
+            <div />
+          </FocusTrap>
+        </>,
+      );
+      await waitFor(() => {
+        expect(rootFocus).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
@@ -298,5 +298,35 @@ describe(FocusTrap, () => {
 
       await waitFor(() => expect(result.getByTestId('button-show-trap')).toHaveFocus());
     });
+
+    it('check autoFocus to root', async () => {
+      const rootFocus = jest.fn();
+      const buttonFocus = jest.fn();
+      const mockElementFocus = (element: HTMLElement | null, focusFn: VoidFunction) => {
+        if (element) {
+          jest.spyOn(element, 'focus').mockImplementation(focusFn);
+        }
+      };
+
+      render(
+        <>
+          <FocusTrap
+            autoFocus="root"
+            getRootRef={(element) => mockElementFocus(element, rootFocus)}
+          >
+            <Button
+              data-testid="button-in-trap"
+              getRootRef={(element) => mockElementFocus(element, buttonFocus)}
+            >
+              Кнопка в FocusTrap
+            </Button>
+          </FocusTrap>
+        </>,
+      );
+      await waitFor(() => {
+        expect(rootFocus).toHaveBeenCalledTimes(1);
+        expect(buttonFocus).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 });

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
@@ -14,10 +14,10 @@ import { HasComponent, HasRootRef } from '../../types';
 
 const FOCUSABLE_ELEMENTS: string = FOCUSABLE_ELEMENTS_LIST.join();
 export interface FocusTrapProps<T extends HTMLElement = HTMLElement>
-  extends AllHTMLAttributes<T>,
+  extends Omit<AllHTMLAttributes<T>, 'autoFocus'>,
     HasRootRef<T>,
     HasComponent {
-  autoFocus?: boolean;
+  autoFocus?: boolean | 'root';
   restoreFocus?: boolean | (() => boolean);
   mount?: boolean;
   timeout?: number;
@@ -72,10 +72,6 @@ export const FocusTrap = <T extends HTMLElement = HTMLElement>({
       }
     });
 
-    if (nodes.length === 0) {
-      // Чтобы фокус был хотя бы на родителе
-      nodes.push(parentNode);
-    }
     focusableNodesRef.current = nodes;
   };
 
@@ -121,16 +117,20 @@ export const FocusTrap = <T extends HTMLElement = HTMLElement>({
         return;
       }
 
-      const autoFocusToFirstNode = () => {
+      const autoFocusToNode = () => {
         if (!ref.current || !focusableNodesRef.current.length) {
           return;
         }
         const activeElement = getActiveElementByAnotherElement(ref.current);
         if (!contains(ref.current, activeElement)) {
-          focusableNodesRef.current[0].focus();
+          if (autoFocus === 'root') {
+            ref.current?.focus();
+          } else {
+            focusableNodesRef.current[0].focus();
+          }
         }
       };
-      const timeoutId = setTimeout(autoFocusToFirstNode, timeout);
+      const timeoutId = setTimeout(autoFocusToNode, timeout);
       return () => {
         clearTimeout(timeoutId);
       };

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
@@ -71,7 +71,10 @@ export const FocusTrap = <T extends HTMLElement = HTMLElement>({
         nodes.push(focusableEl);
       }
     });
-
+    if (nodes.length === 0) {
+      // Чтобы фокус был хотя бы на родителе
+      nodes.push(parentNode);
+    }
     focusableNodesRef.current = nodes;
   };
 


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7268 

---

- [x] Unit-тесты

## Описание

Нужно добавить возможность фокуса на контейнер FocusTrap при первой отрисовке

## Изменения

Добавил в пропс `autoFocus` значение 'root' и использовал его при первой отрисовке, чтобы сфокусироваться на контейнере. Добавил тест проверяющий новый функционал