### PR TITLE
fix(FocusTrap): fix autoFocus with dynamic content

### DIFF
--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -70,8 +70,7 @@
     "@vkontakte/icons": "^2.115.0",
     "@vkontakte/vkjs": "^1.3.0",
     "@vkontakte/vkui-floating-ui": "^0.2.1",
-    "dayjs": "^1.11.12",
-    "mitt": "^3.0.1"
+    "dayjs": "^1.11.12"
   },
   "devDependencies": {
     "storybook": "8.2.7"

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
@@ -109,6 +109,44 @@ describe(FocusTrap, () => {
     expect(screen.getByTestId('first')).toHaveFocus();
   });
 
+  it('no focus when autoFocus=false', async () => {
+    render(<ActionSheetTest autoFocus={false} />);
+    await mountActionSheetViaClick();
+
+    expect(screen.getByTestId('toggle')).toHaveFocus();
+  });
+
+  it('preserve focus when autoFocus=false with dynamic content', async () => {
+    const Template = (props: { childIds: string[] }) => {
+      return (
+        <>
+          <FocusTrap autoFocus={false}>
+            <div>
+              {props.childIds.map((childId) => (
+                <Button key={childId} data-testid={childId}>
+                  Кнопка {childId}
+                </Button>
+              ))}
+            </div>
+          </FocusTrap>
+          <input type="text" data-testid="element-to-focus" />
+        </>
+      );
+    };
+
+    const result = render(<Template childIds={['first', 'middle', 'last']} />);
+    const input = result.getByTestId('element-to-focus');
+
+    input.focus();
+    expect(input).toHaveFocus();
+
+    await act(async () => {
+      result.rerender(<Template childIds={['first', 'last']} />);
+    });
+
+    expect(input).toHaveFocus();
+  });
+
   it('always calls passed onClose on ESCAPE press', async () => {
     const onClose = jest.fn();
     render(<ActionSheetTest onClose={onClose} />);

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
@@ -84,7 +84,7 @@ export const FocusTrap = <T extends HTMLElement = HTMLElement>({
 
     recalculateFocusableNodesRef(parentNode);
 
-    if (arraysEquals(oldFocusableNodes, focusableNodesRef.current)) {
+    if (arraysEquals(oldFocusableNodes, focusableNodesRef.current) || !autoFocus) {
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4606,7 +4606,6 @@ __metadata:
     "@vkontakte/vkjs": "npm:^1.3.0"
     "@vkontakte/vkui-floating-ui": "npm:^0.2.1"
     dayjs: "npm:^1.11.12"
-    mitt: "npm:^3.0.1"
     storybook: "npm:8.2.7"
   peerDependencies:
     react: ^18.2.0
@@ -12230,13 +12229,6 @@ __metadata:
     minipass: "npm:^3.0.0"
     yallist: "npm:^4.0.0"
   checksum: 10/ae0f45436fb51344dcb87938446a32fbebb540d0e191d63b35e1c773d47512e17307bf54aa88326cc6d176594d00e4423563a091f7266c2f9a6872cdc1e234d1
-  languageName: node
-  linkType: hard
-
-"mitt@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mitt@npm:3.0.1"
-  checksum: 10/287c70d8e73ffc25624261a4989c783768aed95ecb60900f051d180cf83e311e3e59865bfd6e9d029cdb149dc20ba2f128a805e9429c5c4ce33b1416c65bbd14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

- caused by #7041

При `autoFocus=false` фокус все равно сетился на первый элемент, в случае, когда контент в `FocusTrap` динамически изменялся.

https://github.com/user-attachments/assets/1fec62da-e64a-4a8c-8652-b9bac885393f

## Изменения

Учитываем `autoFocus=false`:

https://github.com/user-attachments/assets/2b12f7d8-34b0-454d-a2e5-fe60f7d450e0


