### PR TITLE
fix(FocusTrap): fix autoFocus with dynamic content

### DIFF
--- a/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.test.tsx
@@ -109,6 +109,44 @@ describe(FocusTrap, () => {
     expect(screen.getByTestId('first')).toHaveFocus();
   });
 
+  it('no focus when autoFocus=false', async () => {
+    render(<ActionSheetTest autoFocus={false} />);
+    await mountActionSheetViaClick();
+
+    expect(screen.getByTestId('toggle')).toHaveFocus();
+  });
+
+  it('preserve focus when autoFocus=false with dynamic content', async () => {
+    const Template = (props: { childIds: string[] }) => {
+      return (
+        <>
+          <FocusTrap autoFocus={false}>
+            <div>
+              {props.childIds.map((childId) => (
+                <Button key={childId} data-testid={childId}>
+                  Кнопка {childId}
+                </Button>
+              ))}
+            </div>
+          </FocusTrap>
+          <input type="text" data-testid="element-to-focus" />
+        </>
+      );
+    };
+
+    const result = render(<Template childIds={['first', 'middle', 'last']} />);
+    const input = result.getByTestId('element-to-focus');
+
+    input.focus();
+    expect(input).toHaveFocus();
+
+    await act(async () => {
+      result.rerender(<Template childIds={['first', 'last']} />);
+    });
+
+    expect(input).toHaveFocus();
+  });
+
   it('always calls passed onClose on ESCAPE press', async () => {
     const onClose = jest.fn();
     render(<ActionSheetTest onClose={onClose} />);

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
@@ -84,7 +84,7 @@ export const FocusTrap = <T extends HTMLElement = HTMLElement>({
 
     recalculateFocusableNodesRef(parentNode);
 
-    if (arraysEquals(oldFocusableNodes, focusableNodesRef.current)) {
+    if (!autoFocus || arraysEquals(oldFocusableNodes, focusableNodesRef.current)) {
       return;
     }
 


### PR DESCRIPTION
- [x] Unit-тесты

## Описание

- caused by #7041

При `autoFocus=false` фокус все равно сетился на первый элемент, в случае, когда контент в `FocusTrap` динамически изменялся.

https://github.com/user-attachments/assets/1fec62da-e64a-4a8c-8652-b9bac885393f

## Изменения

Учитываем `autoFocus=false`:

https://github.com/user-attachments/assets/2b12f7d8-34b0-454d-a2e5-fe60f7d450e0


