### PR TITLE
chore: yarn clean more warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@swc/cli": "^0.4.0",
     "@swc/core": "1.7.6",
     "@swc/jest": "^0.2.36",
+    "@testing-library/dom": "^10.1.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/vkui-floating-ui/package.json
+++ b/packages/vkui-floating-ui/package.json
@@ -86,7 +86,9 @@
     "@swc/core": "^1.7.6",
     "@swc/jest": "^0.2.36",
     "@types/jest": "^29.5.12",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -73,6 +73,8 @@
     "date-fns": "^3.6.0"
   },
   "devDependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "storybook": "8.2.7"
   },
   "size-limit": [

--- a/tools/storybook-addon-cartesian/package.json
+++ b/tools/storybook-addon-cartesian/package.json
@@ -30,6 +30,7 @@
     "@swc/core": "*",
     "react": "*",
     "react-dom": "*",
-    "storybook": "8.2.7"
+    "storybook": "8.2.7",
+    "typescript": "*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,6 +2434,7 @@ __metadata:
     react: "npm:*"
     react-dom: "npm:*"
     storybook: "npm:8.2.7"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -3379,7 +3380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:10.1.0":
+"@testing-library/dom@npm:10.1.0, @testing-library/dom@npm:^10.1.0":
   version: 10.1.0
   resolution: "@testing-library/dom@npm:10.1.0"
   dependencies:
@@ -4467,6 +4468,8 @@ __metadata:
     "@swc/jest": "npm:^0.2.36"
     "@types/jest": "npm:^29.5.12"
     jest: "npm:^29.7.0"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -4491,6 +4494,7 @@ __metadata:
     "@swc/cli": "npm:^0.4.0"
     "@swc/core": "npm:1.7.6"
     "@swc/jest": "npm:^0.2.36"
+    "@testing-library/dom": "npm:^10.1.0"
     "@testing-library/jest-dom": "npm:^6.4.8"
     "@testing-library/react": "npm:^16.0.0"
     "@testing-library/user-event": "npm:^14.5.2"
@@ -4606,6 +4610,8 @@ __metadata:
     "@vkontakte/vkjs": "npm:^1.3.0"
     "@vkontakte/vkui-floating-ui": "npm:^0.2.1"
     date-fns: "npm:^3.6.0"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
     storybook: "npm:8.2.7"
   peerDependencies:
     react: ^18.2.0


### PR DESCRIPTION
Исправляем ворнинги от yarn

```diff
➤ YN0000: ┌ Post-resolution validation
➤ YN0060: │ prettier is listed by your project with version 3.3.2 (p8eea9), which doesn't satisfy what @vkontakte/prettier-config and other dependencies request (but they have non-overlapping ranges!).
- ➤ YN0002: │ @project-tools/storybook-addon-cartesian@workspace:tools/storybook-addon-cartesian doesn't provide typescript (p400c4), requested by @storybook/react-webpack5 and other dependencies.
- ➤ YN0002: │ @vkontakte/vkui-floating-ui@workspace:packages/vkui-floating-ui doesn't provide react (pc9b97), requested by @floating-ui/react-dom.
- ➤ YN0002: │ @vkontakte/vkui-floating-ui@workspace:packages/vkui-floating-ui doesn't provide react-dom (pf7e9e), requested by @floating-ui/react-dom.
- ➤ YN0002: │ @vkontakte/vkui-monorepo@workspace:. doesn't provide @testing-library/dom (p352ae), requested by @testing-library/react and other dependencies.
- ➤ YN0002: │ @vkontakte/vkui@workspace:packages/vkui doesn't provide react (pe4d24), requested by @vkontakte/icons and other dependencies.
- ➤ YN0002: │ @vkontakte/vkui@workspace:packages/vkui doesn't provide react-dom (p9b37c), requested by @vkontakte/vkui-floating-ui.
➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
➤ YN0000: └ Completed
```

@vkontakte/prettier-config поправится с его обновлением(можно конечно пропачить, но лучше обновить)