### PR TITLE
doc(CustomScrollView): use iframe to show documentation

### DIFF
--- a/packages/vkui/src/components/CustomScrollView/Readme.md
+++ b/packages/vkui/src/components/CustomScrollView/Readme.md
@@ -1,6 +1,6 @@
 Компонент, заменяющий браузерную полосу прокрутки на кастомную
 
-```jsx { "props": { "layout": false, "adaptivity": true, "iframe": false } }
+```jsx
 const WithVerticalScroll = () => {
   return (
     <CustomScrollView


### PR DESCRIPTION
## Описание

В документации CustomScrollView не отображается заголовок в примерах использования, из-за того, что там используется FixedLayout, для отображения примера не использовался iframe. Поэтому заголовок улетал вверх

## Изменения

Поправил доку CustomScrollView, чтобы в примере использовался iframe
