### PR TITLE
docs(ModalRoot): ButtonGroup gap

### DIFF
--- a/packages/vkui/src/components/ModalRoot/Readme.md
+++ b/packages/vkui/src/components/ModalRoot/Readme.md
@@ -452,7 +452,7 @@ const App = () => {
         actions={
           <React.Fragment>
             <Spacing size={16} />
-            <ButtonGroup gap="s" stretched>
+            <ButtonGroup gap="m" stretched>
               <Button
                 key="deny"
                 size="l"
@@ -485,7 +485,7 @@ const App = () => {
         actions={
           <React.Fragment>
             <Spacing size={8} />
-            <ButtonGroup gap="l" mode="vertical" stretched>
+            <ButtonGroup gap="m" mode="vertical" stretched>
               <Button
                 key="join"
                 size="l"


### PR DESCRIPTION
- close #7347

---

## Описание

Ошибочно был указан несуществующий `gap="l"`. Меняем везде на значения из дизайн-системы.