### PR TITLE
docs: move anchor links to the right

### DIFF
--- a/styleguide/Components/SectionSubheading/SectionSubheading.css
+++ b/styleguide/Components/SectionSubheading/SectionSubheading.css
@@ -2,13 +2,12 @@
   margin-top: 36px;
   margin-bottom: 18px;
   position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .SectionSubheading__link {
-  position: absolute;
-  right: 100%;
-  padding-right: 6px;
-  top: 3px;
+  padding-left: 6px;
   color: var(--vkui--color_icon_secondary);
   opacity: 0;
 }

--- a/styleguide/Components/SectionSubheading/SectionSubheading.js
+++ b/styleguide/Components/SectionSubheading/SectionSubheading.js
@@ -9,6 +9,7 @@ export const SectionSubheading = ({ children, className, level = 2, href, ...res
 
   return (
     <Heading {...restProps} level={level} className={classNames('SectionSubheading', className)}>
+      <span className="SectionSubheading__text">{children}</span>
       {href && id && (
         <Fragment>
           <a className="SectionSubheading__link" href={href}>
@@ -17,7 +18,6 @@ export const SectionSubheading = ({ children, className, level = 2, href, ...res
           <a className="SectionSubheading__anchor" id={id} />
         </Fragment>
       )}
-      <span className="SectionSubheading__text">{children}</span>
     </Heading>
   );
 };


### PR DESCRIPTION
- close #7349

---

## Описание

Переносим якорную иконку вправо, чтобы было видно на мобилках
