### PR TITLE
build: fix CSS source-map for postcss >= 8.4.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.2",
     "css-loader": "^6.8.1",
+    "css-minimizer-webpack-plugin": "^5.0.1",
     "cssnano": "^6.0.1",
     "dotenv": "^16.3.1",
     "eslint": "^8.45.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,6 +5508,7 @@ __metadata:
     concurrently: ^8.2.2
     cross-env: ^7.0.2
     css-loader: ^6.8.1
+    css-minimizer-webpack-plugin: ^5.0.1
     cssnano: ^6.0.1
     dotenv: ^16.3.1
     eslint: ^8.45.0


### PR DESCRIPTION
Перенос изменений беты [v5.10.1-beta.1](https://www.npmjs.com/package/@vkontakte/vkui/v/5.10.1-beta.1) (см. [comparing changes](https://github.com/VKCOM/VKUI/compare/5.10-stable...imirdzhamolov/tech/v5.10.1-beta.1/fix-css-source-map)).

> [!NOTE]
>
> `v5.10.1-beta.1` публиковал из ветки `imirdzhamolov/tech/v5.10.1-beta.1/fix-css-source-map`

---

- related to #7034
