### PR TITLE
doc(Settings): don't show hint when setting disabled

### DIFF
--- a/styleguide/Components/Setting/Setting.css
+++ b/styleguide/Components/Setting/Setting.css
@@ -8,7 +8,8 @@
 }
 
 .Setting--disabled .Setting__value,
-.Setting--disabled .Setting__select {
+.Setting--disabled .Setting__select,
+.Setting--disabled .Setting__label--has-hint {
   cursor: default;
 }
 

--- a/styleguide/Components/Setting/Setting.js
+++ b/styleguide/Components/Setting/Setting.js
@@ -39,13 +39,12 @@ export const Setting = ({
       className={classNames('Setting', className, disabled && 'Setting--disabled')}
       weight="3"
     >
-      {hint ? (
+      {hint && !disabled ? (
         <Tooltip
           placement="top"
           enableInteractive
           text={hint}
           maxWidth={hintMaxWidth}
-          shown={disabled ? false : undefined}
         >
           <span className="Setting__label Setting__label--has-hint">
             {label} <Icon12InfoCircle className="Setting__labelHint" />

--- a/styleguide/Components/Setting/Setting.js
+++ b/styleguide/Components/Setting/Setting.js
@@ -40,7 +40,13 @@ export const Setting = ({
       weight="3"
     >
       {hint ? (
-        <Tooltip placement="top" enableInteractive text={hint} maxWidth={hintMaxWidth}>
+        <Tooltip
+          placement="top"
+          enableInteractive
+          text={hint}
+          maxWidth={hintMaxWidth}
+          shown={disabled ? false : undefined}
+        >
           <span className="Setting__label Setting__label--has-hint">
             {label} <Icon12InfoCircle className="Setting__labelHint" />
             :&nbsp;

--- a/styleguide/Components/Setting/Setting.js
+++ b/styleguide/Components/Setting/Setting.js
@@ -40,12 +40,7 @@ export const Setting = ({
       weight="3"
     >
       {hint && !disabled ? (
-        <Tooltip
-          placement="top"
-          enableInteractive
-          text={hint}
-          maxWidth={hintMaxWidth}
-        >
+        <Tooltip placement="top" enableInteractive text={hint} maxWidth={hintMaxWidth}>
           <span className="Setting__label Setting__label--has-hint">
             {label} <Icon12InfoCircle className="Setting__labelHint" />
             :&nbsp;


### PR DESCRIPTION
- close #7357 

---

## Описание

Hint у настройки в документации тоже перенимает на себя `opacity` когда настройка задизаблена

## Изменения

Подумав над решением проблемы пришел к выводу, что тултип не должен вообще показываться когда настройка заблокирована. Поэтому добавил проверку `disabled` прежде чем показывать тултип. А также поправил отображение курсора при наведении на настройку в заблокированном состоянии