### PR TITLE
tech(dependabot.yml): extend playwright patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,7 @@ updates:
       playwright:
         patterns:
           - '@playwright/*'
+          - 'playwright'
       eslint:
         patterns:
           - 'eslint*'


### PR DESCRIPTION
`playwright`, который был транзитивной завивимостью вместе с `@playwright/experimental-ct-react` и обновлялся вместе с ним, теперь есть в вокрспейсе `benchmark/`, поэтому нужно, чтобы **Dependabot** обновлял и `playwright`.

---

- caused by #7128