### PR TITLE
fix(View): edit isSwipeBackTarget predicate

### DIFF
--- a/packages/vkui/src/components/View/View.test.tsx
+++ b/packages/vkui/src/components/View/View.test.tsx
@@ -214,7 +214,7 @@ describe(View, () => {
       fireEvent.mouseUp(view);
       expect(events.onSwipeBack).not.toHaveBeenCalled();
       expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
-      await waitCSSTransitionEnd(getViewPanelById('p1'), { propertyName: 'transform' });
+      await waitCSSTransitionEnd(getViewPanelById('p2'), { propertyName: 'transform' });
       expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
     });
     it('should swipe back by start touch anywhere', async () => {
@@ -231,7 +231,7 @@ describe(View, () => {
       expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
 
       fireEvent.mouseUp(view);
-      await waitCSSTransitionEnd(getViewPanelById('p1'), {
+      await waitCSSTransitionEnd(getViewPanelById('p2'), {
         propertyName: 'transform',
       });
 
@@ -343,7 +343,7 @@ describe(View, () => {
 
         scrollToLeftAndSwipe(100);
         expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
-        await waitCSSTransitionEnd(getViewPanelById('p1'), { propertyName: 'transform' });
+        await waitCSSTransitionEnd(getViewPanelById('p2'), { propertyName: 'transform' });
         expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
         expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
 
@@ -386,7 +386,7 @@ describe(View, () => {
 
         scrollToLeftAndSwipe(0);
         expect(events.onSwipeBackStart).toHaveBeenCalledTimes(1);
-        await waitCSSTransitionEnd(getViewPanelById('p1'), { propertyName: 'transform' });
+        await waitCSSTransitionEnd(getViewPanelById('p2'), { propertyName: 'transform' });
         expect(events.onSwipeBack).toHaveBeenCalledTimes(1);
         expect(events.onSwipeBackCancel).not.toHaveBeenCalled();
       });


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7371

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты

## Описание

Была проблема, что до #6979:

1. переменная `prevSwipeBackResult` использовалась в `React.useEffect()`, из-за чего она была всегда актуальная, т.к. обращались мы к ней после окончания рендера. В #6979 она переместилась в **render prop**, где мы обращаемся к переменной до окончания рендера, поэтому и получалось так, что свайп бёк срабатывал в первый раз, пока `prevSwipeBackResult` являлся `null`, а во второй раз уже не срабатывал, т.к. `prevSwipeBackResult` имел предыдущее состояние. Изучил, что проверку на `prevSwipeBackResult` в целом можно удалить.

2. Событие `transitionend` навешивалось в обход **React**, а также был фолбек на `setTimeout()`. В #6979 события навешиваются через **React** – `onTransitionEnd`. Иногда обработчик не вызывался. Чтобы исправить это, перенёс навешивания события на текущий элемент (`isSwipeBackPrev`) вместо последующего (`isSwipeBackNext`). Поправил тесты под это изменение.

## Изменения

- удалил `React.useCallback()` на обработчике события `onAnimationEnd`, т.к. это обычный `<div />` и мемоизация ни к чему;
- заодно отрефакторил `calcPanelSwipeStyles()` и `calcPanelSwipeBackOverlayStyles()`.

---

- caused by #6979
