### PR TITLE
fix(FlexItem): edit flex prop description

### DIFF
--- a/packages/vkui/src/components/Flex/FlexItem/FlexItem.tsx
+++ b/packages/vkui/src/components/Flex/FlexItem/FlexItem.tsx
@@ -24,10 +24,12 @@ export interface FlexItemProps extends HTMLAttributesWithRootRef<HTMLDivElement>
    */
   alignSelf?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
   /**
-   * Позволяет задать предопределенные значения шортката `flex`
-   * `grow` соответствует значению `1 0 auto`
-   * `shrink` соответствует значению `0 1 auto`
-   * `content` соответствует значению `0 0 auto`
+   * Позволяет задать предопределенные значения свойства `flex`:
+   *
+   * - `grow` соответствует значению `1 0 auto`
+   * - `shrink` соответствует значению `0 1 auto`
+   * - `content` соответствует значению `1 1 auto`
+   * - `fixed` соответствует значению `0 0 auto`
    */
   flex?: 'grow' | 'shrink' | 'content' | 'fixed';
   /**


### PR DESCRIPTION
У `content` было неправильно указано CSS значение.

Хаодно добавил про значение `fixed`.

---

- caused by #6226