### PR TITLE
fix: remove maxHeight props from DateRangeInput, DateInput and CustomSelect

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -128,7 +128,7 @@ export type { CustomSelectClearButtonProps };
 export interface SelectProps<
   OptionInterfaceT extends CustomSelectOptionInterface = CustomSelectOptionInterface,
 > extends NativeSelectProps,
-    FormFieldProps,
+    Omit<FormFieldProps, 'maxHeight'>,
     TrackerOptionsProps,
     Pick<
       CustomSelectDropdownProps,

--- a/packages/vkui/src/components/CustomSelect/CustomSelectInput.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelectInput.tsx
@@ -23,7 +23,7 @@ export interface CustomSelectInputProps
     HasRef<HTMLInputElement>,
     HasRootRef<HTMLDivElement>,
     HasAlign,
-    Omit<FormFieldProps, 'mode' | 'type'> {
+    Omit<FormFieldProps, 'mode' | 'type' | 'maxHeight'> {
   selectType?: SelectType;
   multiline?: boolean;
   labelTextTestId?: string;

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -55,7 +55,7 @@ export interface DateInputProps
       | 'maxDateTime'
     >,
     HasRootRef<HTMLDivElement>,
-    FormFieldProps {
+    Omit<FormFieldProps, 'maxHeight'> {
   calendarPlacement?: PlacementWithAuto;
   closeOnChange?: boolean;
   clearFieldLabel?: string;

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -45,7 +45,7 @@ export interface DateRangeInputProps
       | 'nextMonthIcon'
     >,
     HasRootRef<HTMLDivElement>,
-    FormFieldProps {
+    Omit<FormFieldProps, 'maxHeight'> {
   calendarPlacement?: PlacementWithAuto;
   closeOnChange?: boolean;
   clearFieldLabel?: string;

--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -44,7 +44,6 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
     nativeSelectTestId,
     after,
     mode,
-    maxHeight,
     getSelectInputRef,
     overscrollBehavior,
     beforeAlign,


### PR DESCRIPTION
## Описание

Убрал проп maxHeight в компонентах DateRangeInput, DateInput и CustomSelect так как он там не нужен и только смущает пользователей
