### PR TITLE
tech(dependabot.yml): fix playwright patterns order

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,8 +43,8 @@ updates:
           - 'css-loader'
       playwright:
         patterns:
-          - '@playwright/*'
           - 'playwright'
+          - '@playwright/*'
       eslint:
         patterns:
           - 'eslint*'


### PR DESCRIPTION
- caused by #7377
- related to #7399

---

Как видно в PR от **Dependabot** #7399, скорей всего в #7377 я в неправильном порядке указал `'playwright'` в поле **petterns**. По примеру группы `storybook` необходимо зависимость без `@` указать в начале.
