### PR TITLE
fix(CustomSelect): Fix input borders when CustomSelectDropdown is opened

### DIFF
--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import { Placement, useFloating } from '../../lib/floating';
 import {
   baselineComponent,
   fakeTimers,
@@ -8,6 +9,7 @@ import {
 } from '../../testing/utils';
 import type { ChipOption } from '../ChipsInputBase/types';
 import { ChipsSelect } from './ChipsSelect';
+import styles from './ChipsSelect.module.css';
 
 const FIRST_OPTION = { value: 'red', label: 'Красный' };
 
@@ -17,7 +19,27 @@ const THIRD_OPTION = { value: 'navarin', label: 'Наваринского пла
 
 const colors: ChipOption[] = [FIRST_OPTION, SECOND_OPTION, THIRD_OPTION];
 
+let placementStub: Placement | undefined = undefined;
+jest.mock('../../lib/floating', () => {
+  const originalModule = jest.requireActual('../../lib/floating');
+  return {
+    ...originalModule,
+    useFloating: (...args: Parameters<typeof useFloating>) => {
+      const result = originalModule['useFloating'](args);
+      return {
+        ...result,
+        get placement() {
+          return placementStub ?? result.placement;
+        },
+      };
+    },
+  };
+});
+
 describe('ChipsSelect', () => {
+  afterEach(() => {
+    placementStub = undefined;
+  });
   baselineComponent(ChipsSelect, { a11y: false });
 
   fakeTimers();
@@ -473,5 +495,36 @@ describe('ChipsSelect', () => {
     const inputLocator = screen.getByRole('combobox');
     fireEvent.click(inputLocator);
     expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+  });
+
+  it('checks ChipsSelect placement class for borders when dropdown is opened and closed during  placement change', async () => {
+    const component = render(<ChipsSelect options={[FIRST_OPTION, SECOND_OPTION, THIRD_OPTION]} />);
+    fireEvent.click(screen.getByRole('combobox'));
+    await waitForFloatingPosition();
+
+    // dropdown по умолчанию открыт вниз и класс для границ выставлен верно
+    expect(document.querySelector(`.${styles['ChipsSelect--pop-down']}`)).not.toBeNull();
+
+    // меняем позиционирование дропдауна вверх
+    placementStub = 'top';
+    component.rerender(<ChipsSelect options={[FIRST_OPTION, SECOND_OPTION, THIRD_OPTION]} />);
+
+    // dropdown открыт вверх и класс для границ выставлен верно
+    expect(document.querySelector(`.${styles['ChipsSelect--pop-up']}`)).not.toBeNull();
+
+    // закрываем дропдаун и меняем позиционирование вниз
+    await userEvent.click(document.body);
+    placementStub = 'bottom';
+    component.rerender(<ChipsSelect options={[FIRST_OPTION, SECOND_OPTION, THIRD_OPTION]} />);
+
+    // снова открываем дропдаун
+    // в этот момент внутренне состояние placement CustomSelect указывает вверх
+    // но floating-ui возвращает "bottom", а значит и внутренне состояние и
+    // границы CustomSelect должны быть выставлены соответственно вниз
+    fireEvent.click(screen.getByRole('combobox'));
+    await waitForFloatingPosition();
+
+    // дропдаун открыт вниз и класс для границ выставлен верно
+    expect(document.querySelector(`.${styles['ChipsSelect--pop-down']}`)).not.toBeNull();
   });
 });

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { Placement, useFloating } from '../../lib/floating';
+import type { Placement, useFloating } from '../../lib/floating';
 import {
   baselineComponent,
   fakeTimers,

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -578,7 +578,7 @@ export const ChipsSelect = <Option extends ChipOption>({
         <CustomSelectDropdown
           data-testid={dropdownTestId}
           targetRef={rootRef}
-          placement={placementProp}
+          placement={dropdownVerticalPlacement}
           scrollBoxRef={dropdownScrollBoxRef}
           onPlacementChange={onDropdownPlacementChange}
           onMouseLeave={onDropdownMouseLeave}

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -245,8 +245,17 @@ export const ChipsSelect = <Option extends ChipOption>({
 
   // Связано с CustomSelectDropdownProps
   const [dropdownVerticalPlacement, setDropdownVerticalPlacement] = React.useState<
-    Extract<Placement, 'top' | 'bottom'> | undefined
+    'top' | 'bottom'
   >(placementProp);
+
+  const onDropdownPlacementChange = React.useCallback((placement: Placement) => {
+    if (placement.startsWith('top')) {
+      setDropdownVerticalPlacement('top');
+    } else if (placement.startsWith('bottom')) {
+      setDropdownVerticalPlacement('bottom');
+    }
+  }, []);
+
   const dropdownId = React.useId();
   const dropdownCurrentItemId =
     focusedOptionIndex !== null ? `${dropdownId}-${focusedOptionIndex}` : undefined;
@@ -403,15 +412,6 @@ export const ChipsSelect = <Option extends ChipOption>({
     }
   }, [options, focusedOptionIndex, setFocusedOption]);
 
-  const onDropdownPlacementChange = React.useCallback((placement: Placement) => {
-    /* istanbul ignore next:  */
-    if (placement.startsWith('top')) {
-      setDropdownVerticalPlacement('top');
-    } else if (placement.startsWith('bottom')) {
-      setDropdownVerticalPlacement('bottom');
-    }
-  }, []);
-
   const onDropdownMouseLeave = React.useCallback(() => {
     setFocusedOptionIndex(null);
   }, [setFocusedOptionIndex]);
@@ -523,7 +523,7 @@ export const ChipsSelect = <Option extends ChipOption>({
     () =>
       (opened &&
         dropdownOffsetDistance === 0 &&
-        (dropdownVerticalPlacement?.includes('top')
+        (dropdownVerticalPlacement.includes('top')
           ? styles['ChipsSelect--pop-up']
           : styles['ChipsSelect--pop-down'])) ||
       undefined,

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
-import { Placement, useFloating } from '../../lib/floating';
+import type { Placement, useFloating } from '../../lib/floating';
 import { baselineComponent, userEvent, waitForFloatingPosition } from '../../testing/utils';
 import { Avatar } from '../Avatar/Avatar';
 import { CustomSelectOption } from '../CustomSelectOption/CustomSelectOption';

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -2,10 +2,29 @@ import * as React from 'react';
 import { useState } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
+import { Placement, useFloating } from '../../lib/floating';
 import { baselineComponent, userEvent, waitForFloatingPosition } from '../../testing/utils';
 import { Avatar } from '../Avatar/Avatar';
 import { CustomSelectOption } from '../CustomSelectOption/CustomSelectOption';
 import { CustomSelect, type CustomSelectRenderOption, type SelectProps } from './CustomSelect';
+import styles from './CustomSelectDropdown.module.css';
+
+let placementStub: Placement | undefined = undefined;
+jest.mock('../../lib/floating', () => {
+  const originalModule = jest.requireActual('../../lib/floating');
+  return {
+    ...originalModule,
+    useFloating: (...args: Parameters<typeof useFloating>) => {
+      const result = originalModule['useFloating'](args);
+      return {
+        ...result,
+        get placement() {
+          return placementStub ?? result.placement;
+        },
+      };
+    },
+  };
+});
 
 const checkCustomSelectLabelValue = (label: string) => {
   expect(screen.getByTestId('labelTextTestId').textContent).toEqual(label);
@@ -66,6 +85,9 @@ const mockPropertiesToScroll = (defaultScrollTop = 0) => {
 };
 
 describe('CustomSelect', () => {
+  afterEach(() => {
+    placementStub = undefined;
+  });
   baselineComponent((props) => (
     <CustomSelect aria-label="Choose your user" {...props} options={[]} />
   ));
@@ -1296,10 +1318,10 @@ describe('CustomSelect', () => {
       />,
     );
     fireEvent.change(inputRef.current!, { target: { value: 'Ка' } });
-    expect(onInputChange).toBeCalledTimes(1);
+    expect(onInputChange).toHaveBeenCalledTimes(1);
 
     fireEvent.change(inputRef.current!, { target: { value: 'Кат' } });
-    expect(onInputChange).toBeCalledTimes(2);
+    expect(onInputChange).toHaveBeenCalledTimes(2);
   });
 
   it('check scroll to bottom to element', async () => {
@@ -1328,7 +1350,7 @@ describe('CustomSelect', () => {
 
     const setScrollTop = mockPropertiesToScroll();
 
-    expect(setScrollTop).toBeCalledTimes(0);
+    expect(setScrollTop).toHaveBeenCalledTimes(0);
 
     await triggerKeydownEvent(inputRef.current!, 'ArrowDown', 'ArrowDown');
 
@@ -1361,7 +1383,7 @@ describe('CustomSelect', () => {
 
     const setScrollTop = mockPropertiesToScroll(40);
 
-    expect(setScrollTop).toBeCalledTimes(0);
+    expect(setScrollTop).toHaveBeenCalledTimes(0);
 
     await triggerKeydownEvent(inputRef.current!, 'ArrowUp', 'ArrowUp');
 
@@ -1414,7 +1436,7 @@ describe('CustomSelect', () => {
 
     await triggerKeydownEvent(inputRef.current!, ' ', 'Space');
 
-    expect(onChange).toBeCalledTimes(0);
+    expect(onChange).toHaveBeenCalledTimes(0);
   });
 
   it('check dev error when use different type of values', () => {
@@ -1436,5 +1458,66 @@ describe('CustomSelect', () => {
     );
 
     process.env.NODE_ENV = 'test';
+  });
+
+  it('checks CustomSelect placement class for borders when dropdown is opened and closed during  placement change', async () => {
+    const component = render(
+      <CustomSelect
+        data-testid="select"
+        options={[
+          { value: '0', label: 'Не выбрано' },
+          { value: '1', label: 'Категория 1' },
+          { value: '2', label: 'Категория 2' },
+          { value: '3', label: 'Категория 3' },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('select'));
+    await waitForFloatingPosition();
+
+    // dropdown по умолчанию открыт вниз и класс для границ выставлен верно
+    expect(document.querySelector(`.${styles['CustomSelect--pop-down']}`)).not.toBeNull();
+
+    // меняем позиционирование дропдауна вверх
+    placementStub = 'top';
+    component.rerender(
+      <CustomSelect
+        data-testid="select"
+        options={[
+          { value: '0', label: 'Не выбрано' },
+          { value: '1', label: 'Категория 1' },
+          { value: '2', label: 'Категория 2' },
+          { value: '3', label: 'Категория 3' },
+        ]}
+      />,
+    );
+
+    // dropdown открыт вверх и класс для границ выставлен верно
+    expect(document.querySelector(`.${styles['CustomSelect--pop-up']}`)).not.toBeNull();
+
+    // закрываем дропдаун и меняем позиционирование вниз
+    await userEvent.click(document.body);
+    placementStub = 'bottom';
+    component.rerender(
+      <CustomSelect
+        data-testid="select"
+        options={[
+          { value: '0', label: 'Не выбрано' },
+          { value: '1', label: 'Категория 1' },
+          { value: '2', label: 'Категория 2' },
+          { value: '3', label: 'Категория 3' },
+        ]}
+      />,
+    );
+
+    // снова открываем дропдаун
+    // в этот момент внутренне состояние placement CustomSelect указывает вверх
+    // но floating-ui возвращает "bottom", а значит и внутренне состояние и
+    // границы CustomSelect должны быть выставлены соответственно вниз
+    fireEvent.click(screen.getByTestId('select'));
+    await waitForFloatingPosition();
+
+    // дропдаун открыт вниз и класс для границ выставлен верно
+    expect(document.querySelector(`.${styles['CustomSelect--pop-down']}`)).not.toBeNull();
   });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -1496,7 +1496,7 @@ describe('CustomSelect', () => {
     expect(document.querySelector(`.${styles['CustomSelect--pop-up']}`)).not.toBeNull();
 
     // закрываем дропдаун и меняем позиционирование вниз
-    await userEvent.click(document.body);
+    fireEvent.blur(screen.getByTestId('select'));
     placementStub = 'bottom';
     component.rerender(
       <CustomSelect

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -3,7 +3,7 @@ import { classNames, debounce } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useDOM } from '../../lib/dom';
-import type { PlacementWithAuto } from '../../lib/floating';
+import type { Placement } from '../../lib/floating';
 import { defaultFilterFn, type FilterFn } from '../../lib/select';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { warnOnce } from '../../lib/warnOnce';
@@ -230,9 +230,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     calculateInputValueFromOptions(optionsProp, nativeSelectValue),
   );
 
-  const [popperPlacement, setPopperPlacement] = React.useState<PlacementWithAuto | undefined>(
-    popupDirection,
-  );
+  const [popperPlacement, setPopperPlacement] = React.useState<Placement>(popupDirection);
   const [options, setOptions] = React.useState(optionsProp);
   const [selectedOptionIndex, setSelectedOptionIndex] = React.useState<number | undefined>(
     findSelectedIndex(optionsProp, props.value ?? defaultValue, allowClearButton),
@@ -266,7 +264,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     () =>
       (opened &&
         dropdownOffsetDistance === 0 &&
-        (popperPlacement?.includes('top')
+        (popperPlacement.includes('top')
           ? styles['CustomSelect--pop-up']
           : styles['CustomSelect--pop-down'])) ||
       undefined,
@@ -851,7 +849,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
       {opened && (
         <CustomSelectDropdown
           targetRef={containerRef}
-          placement={popupDirection}
+          placement={popperPlacement}
           scrollBoxRef={setScrollBoxRef}
           onPlacementChange={setPopperPlacement}
           onMouseLeave={resetFocusedOption}

--- a/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
+++ b/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
@@ -39,7 +39,6 @@ export const CustomSelectDropdown = ({
   scrollBoxRef,
   placement = 'bottom',
   fetching,
-  onPlacementChange: parentOnPlacementChange,
   offsetDistance = 0,
   autoWidth = false,
   forcePortal = true,
@@ -51,21 +50,11 @@ export const CustomSelectDropdown = ({
   overscrollBehavior,
   ...restProps
 }: CustomSelectDropdownProps): React.ReactNode => {
-  const onPlacementChange = React.useCallback(
-    (placement: Placement) => {
-      if (parentOnPlacementChange) {
-        parentOnPlacementChange(placement);
-      }
-    },
-    [parentOnPlacementChange],
-  );
-
   return (
     <Popper
       targetRef={targetRef}
       offsetByMainAxis={offsetDistance}
       sameWidth={!autoWidth}
-      onPlacementChange={onPlacementChange}
       placement={placement}
       className={classNames(
         styles['CustomSelectDropdown'],

--- a/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
+++ b/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
@@ -33,8 +33,6 @@ export interface CustomSelectDropdownProps
   noMaxHeight?: boolean;
 }
 
-const calcIsTop = (placement: Placement) => placement.startsWith('top');
-
 export const CustomSelectDropdown = ({
   children,
   targetRef,
@@ -53,11 +51,8 @@ export const CustomSelectDropdown = ({
   overscrollBehavior,
   ...restProps
 }: CustomSelectDropdownProps): React.ReactNode => {
-  const [isTop, setIsTop] = React.useState(() => calcIsTop(placement));
-
   const onPlacementChange = React.useCallback(
     (placement: Placement) => {
-      setIsTop(calcIsTop(placement));
       if (parentOnPlacementChange) {
         parentOnPlacementChange(placement);
       }
@@ -76,7 +71,9 @@ export const CustomSelectDropdown = ({
         styles['CustomSelectDropdown'],
         'vkuiInternalCustomSelectDropdown',
         offsetDistance === 0 &&
-          (isTop ? styles['CustomSelectDropdown--top'] : styles['CustomSelectDropdown--bottom']),
+          (placement.includes('top')
+            ? styles['CustomSelectDropdown--top']
+            : styles['CustomSelectDropdown--bottom']),
         autoWidth &&
           classNames(
             styles['CustomSelectDropdown--wide'],


### PR DESCRIPTION
- close #7413

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи

## Описание
Мы не отправляли внутреннее значение `placement` из `CustomSelect` в `CustomSelectDropdown` потому и в некоторых ситуациях `onPlacementChange` `callback` не вызывался, потому что при длительном взаимодейтсвии с `CustomSelect`, внутренее значение могло быть `top`, при этом в `CustomSelectDropdown` передавался постоянно prop `placement="button"`, в итоге `usePlacementChangeCallback` не вызывал `onPlacementChange` callback.

## Изменение

Передаем внутренне состояние `placement` в `CustomSelectDropdown`, вместо `popupDirection`.

Тут есть эффект того, что изменение пропа `placement` после первого рендера не поменяет направление дропдауна.
Но это фича, которая не особо имеет смысл. 
Контролировать `placement` через проп в `CustomSelect` не очень получится, он принимает значения `'top' | 'bottom'` и по умолчанию уже `bottom`, то есть изменить его можно будет только на `top`, причём, только если дропдаун направлен вниз.
В то же время уже и сейчас, без этого фикса, если направление dropdown автоматически высчиталось как 'top', то сделать его `bottom` через prop `popupDirection` не получится.

Думаю, это нормально, что через свойство `placement` мы задаём значение для первого рендера, ведь дальше направлением дропдауна, если места под него нету снизу, управляет floatin-ui.