### PR TITLE
fix(Search): clear button not disabled

### DIFF
--- a/packages/vkui/src/components/Search/Search.tsx
+++ b/packages/vkui/src/components/Search/Search.tsx
@@ -206,6 +206,7 @@ export const Search = ({
             onClick={onCancel}
             className={styles['Search__icon']}
             tabIndex={hasValue ? undefined : -1}
+            disabled={inputProps.disabled}
           >
             <VisuallyHidden>{clearLabel}</VisuallyHidden>
             {platform === 'ios' ? <Icon16Clear /> : <Icon24Cancel />}


### PR DESCRIPTION
## Описание

Кнопка очистки была доступна не смотря на то, что поиск был задисайблен

<img width="614" alt="image" src="https://github.com/user-attachments/assets/5a2bdec4-9be2-4ed6-a992-f587cb901369">


## Изменения

Отключаем кнопку очистки при передаче `disabled` в компонент поиска
