### PR TITLE
fix(Flex): add margin auto offset

### DIFF
--- a/packages/vkui/src/components/Flex/Flex.e2e-playground.tsx
+++ b/packages/vkui/src/components/Flex/Flex.e2e-playground.tsx
@@ -10,7 +10,7 @@ export const FlexPlayground = (props: ComponentPlaygroundProps) => {
       propSets={[
         {
           children: [[<ChildNode key="1" />, <ChildNode key="2" />]],
-          gap: ['m'],
+          gap: ['m', undefined],
           margin: ['auto'],
         },
         {

--- a/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1a1fcb3e0023c8bad0487a9f92c0a82acab1de74a4eeb1597e774fd6450e3d8
-size 15670
+oid sha256:557bc49d99694b39e8d0e1eeb102d28dbc94ba779b3d297e6a1dd33d23eed859
+size 19413

--- a/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:277e34a552db906ae0a9e56e31b2181d6070dc4286ffda25e624e5bfbfdfb729
-size 15873
+oid sha256:1c7ba7696ab1023f88d29d8798fac7fecdee548e004799da5f707423d8995798
+size 19734

--- a/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:856826766e5b9d2a17fe81a1461a04242ccf344b1e8c891df705ccde90f5ac71
-size 15455
+oid sha256:29a8907dbb351288b473bcdd38e534c7ecdb4a8f8cf61d6d41e9f62f0a6e877c
+size 18932

--- a/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8eeca1594f011091bfba2c72e6ae1d2fcb1449023545e700a74bed7938b16b70
-size 20744
+oid sha256:7a0d99891b8eaec8aa8b4f2d32823a76991381fb7d7f5c112a2c036bb9f07c62
+size 25765

--- a/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Flex/__image_snapshots__/flex-rendering-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8569d2fafdc6f5e92f5d1c792cc204480b6f2cb0499c5a5f9828f7a1dc6e1d13
-size 15630
+oid sha256:cee4feb92d0ee6f97866bdb0c3af981fbebc89ff88e595beaaf539c15493fa44
+size 19172

--- a/packages/vkui/src/styles/constants.css
+++ b/packages/vkui/src/styles/constants.css
@@ -80,8 +80,8 @@
   --vkui_internal--z_index_horizontal_scroll_arrow: 1;
 
   /* Layout Gaps */
-  --vkui_internal--row_gap: 0;
-  --vkui_internal--column_gap: 0;
+  --vkui_internal--row_gap: 0px;
+  --vkui_internal--column_gap: 0px;
 }
 
 @supports (padding-top: constant(safe-area-inset-top)) {


### PR DESCRIPTION
- [x] e2e-тесты

## Описание

Из-за того, что по умолчанию `--vkui_internal--row_gap` и `--vkui_internal--column_gap` устанавливались в `0`, то при их участии в расчете через `calc` свойство `margin` рассчитывалось неверно (отсутствовали отступы сверху-слева)

## Изменения

Инициализируем значения как `0px`
