### PR TITLE
ci(update_screens): add contents write permission

### DIFF
--- a/.github/workflows/update_screens.yml
+++ b/.github/workflows/update_screens.yml
@@ -99,6 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
     needs: [update_screens]
     name: 'Collect updated screenshots and push changes'
     steps:


### PR DESCRIPTION
- related #7427

Падает уже с другой ошибкой:
![image](https://github.com/user-attachments/assets/1a04ace6-724c-46b4-8d74-2377a674c7cd)

По [рекомендации](https://github.com/peter-evans/create-pull-request#:~:text=GITHUB_TOKEN%20(permissions%20contents%3A%20write%20and%20pull%2Drequests%3A%20write)) добавляем ещё `contents: write`
