### PR TITLE
feat(Tooltip): add `closable` prop

### DIFF
--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -36,7 +36,10 @@ type AllowedFloatingComponentProps = Pick<
   | 'disableFlipMiddleware'
 >;
 
-type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
+type AllowedTooltipBaseProps = Omit<
+  TooltipBaseProps,
+  'arrowProps' | 'closeIconLabel' | 'onCloseIconClick'
+>;
 
 type AllowedFloatingArrowProps = {
   /**

--- a/packages/vkui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.stories.tsx
@@ -23,3 +23,16 @@ export const Playground: Story = {
     text: 'Привет',
   },
 };
+
+export const InteractiveTooltipWithCloseAction: Story = {
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button style={{ margin: 20 }}>Наведи</Button>
+    </Tooltip>
+  ),
+  args: {
+    text: 'Привет',
+    enableInteractive: true,
+    closable: true,
+  },
+};

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNames, hasReactNode } from '@vkontakte/vkjs';
+import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useGlobalEscKeyDown } from '../../hooks/useGlobalEscKeyDown';
 import { usePatchChildren } from '../../hooks/usePatchChildren';
@@ -7,13 +7,14 @@ import { animationFadeClassNames } from '../../lib/animation';
 import {
   type FloatingComponentProps,
   getArrowCoordsByMiddlewareData,
+  type OnShownChange,
   useFloatingMiddlewaresBootstrap,
   useFloatingWithInteractions,
   usePlacementChangeCallback,
 } from '../../lib/floating';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
+import { type FloatingArrowProps as FloatingArrowPropsPrivate } from '../FloatingArrow/FloatingArrow';
 import { TooltipBase, type TooltipBaseProps } from '../TooltipBase/TooltipBase';
-import { Subhead } from '../Typography/Subhead/Subhead';
 
 type AllowedFloatingComponentProps = Pick<
   FloatingComponentProps,
@@ -33,7 +34,22 @@ type AllowedFloatingComponentProps = Pick<
   | 'disableFlipMiddleware'
 >;
 
-type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps'>;
+type AllowedTooltipBaseProps = Omit<TooltipBaseProps, 'arrowProps' | 'onCloseIconClick'>;
+
+/**
+ * @alias
+ * @public
+ */
+export type TooltipArrowProps = Omit<
+  FloatingArrowPropsPrivate,
+  'getRootRef' | 'coords' | 'placement' | 'Icon'
+>;
+
+/**
+ * @alias
+ * @public
+ */
+export type TooltipOnShownChange = OnShownChange;
 
 export interface TooltipProps extends AllowedFloatingComponentProps, AllowedTooltipBaseProps {
   /**
@@ -47,6 +63,12 @@ export interface TooltipProps extends AllowedFloatingComponentProps, AllowedTool
    * Добавляет возможность наводить на тултип.
    */
   enableInteractive?: boolean;
+  /**
+   * Добавляет возможность закрыть тултип через иконку-крестик.
+   *
+   * > Работает в сочетании с `enableInteractive` или при использовании `shown` и `onShownChange`.
+   */
+  closable?: boolean;
   /**
    * Скрывает стрелку, указывающую на якорный элемент.
    */
@@ -95,12 +117,11 @@ export const Tooltip = ({
   // TooltipBaseProps
   id: idProp,
   getRootRef,
-  text,
-  header,
   appearance = 'neutral',
   style: styleProp,
   className,
   zIndex = 'var(--vkui--z_index_popout)',
+  closable,
   onPlacementChange,
   ...popperProps
 }: TooltipProps): React.ReactNode => {
@@ -130,6 +151,7 @@ export const Tooltip = ({
     referenceProps,
     floatingProps,
     middlewareData,
+    onClose,
     onEscapeKeyDown,
   } = useFloatingWithInteractions({
     defaultShown,
@@ -170,16 +192,11 @@ export const Tooltip = ({
                   getRootRef: setArrowRef,
                 }
           }
-          text={
-            <React.Fragment>
-              {hasReactNode(header) && <Subhead weight="2">{header}</Subhead>}
-              {hasReactNode(text) && <Subhead>{text}</Subhead>}
-            </React.Fragment>
-          }
           className={classNames(
             willBeHide ? animationFadeClassNames.out : animationFadeClassNames.in,
             className,
           )}
+          onCloseIconClick={closable ? onClose : undefined}
         />
       </AppRootPortal>
     );

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.e2e-playground.tsx
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.e2e-playground.tsx
@@ -1,0 +1,25 @@
+import { noop } from '@vkontakte/vkjs';
+import {
+  ComponentPlayground,
+  type ComponentPlaygroundProps,
+  TEST_CLASS_NAMES,
+} from '@vkui-e2e/playground-helpers';
+import { TooltipBase, type TooltipBaseProps } from './TooltipBase';
+
+export const TooltipBasePlayground = (props: ComponentPlaygroundProps) => {
+  return (
+    <ComponentPlayground
+      {...props}
+      propSets={[
+        {
+          header: [undefined, 'Some header'],
+          onCloseIconClick: [undefined, noop],
+        },
+      ]}
+    >
+      {(props: TooltipBaseProps) => (
+        <TooltipBase text="Some text" {...props} className={TEST_CLASS_NAMES.CONTENT} />
+      )}
+    </ComponentPlayground>
+  );
+};

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.e2e.tsx
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.e2e.tsx
@@ -1,0 +1,13 @@
+import { test } from '@vkui-e2e/test';
+import { TooltipBasePlayground } from './TooltipBase.e2e-playground';
+
+test.use({ onlyForPlatforms: ['android'] });
+
+test('TooltipBase', async ({
+  mount,
+  expectScreenshotClippedToContent,
+  componentPlaygroundProps,
+}) => {
+  await mount(<TooltipBasePlayground {...componentPlaygroundProps} />);
+  await expectScreenshotClippedToContent();
+});

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.module.css
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.module.css
@@ -20,7 +20,7 @@
   align-self: flex-start;
   margin-inline-start: 10px;
   color: inherit;
-  padding: 4px;
+  padding: 0;
   border: 0;
   background: none;
 }

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.module.css
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.module.css
@@ -3,12 +3,26 @@
 }
 
 .TooltipBase__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   background-color: var(--vkui--color_background_contrast_themed);
   box-shadow: var(--vkui--elevation3);
   padding-block: 9px 10px;
   padding-inline: 12px;
   border-radius: var(--vkui--size_border_radius--regular);
   color: var(--vkui--color_text_primary);
+}
+
+.TooltipBase__closeButton {
+  flex-grow: 0;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-inline-start: 10px;
+  color: inherit;
+  padding: 4px;
+  border: 0;
+  background: none;
 }
 
 .TooltipBase__arrow {

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.tsx
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
-import { classNames } from '@vkontakte/vkjs';
+import { Icon16Cancel } from '@vkontakte/icons';
+import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { DefaultIcon } from '../FloatingArrow/DefaultIcon';
 import { FloatingArrow, type FloatingArrowProps } from '../FloatingArrow/FloatingArrow';
 import { RootComponent } from '../RootComponent/RootComponent';
+import { Tappable } from '../Tappable/Tappable';
 import { Subhead } from '../Typography/Subhead/Subhead';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './TooltipBase.module.css';
 
 export const TOOLTIP_MAX_WIDTH = 220;
@@ -58,6 +61,14 @@ export interface TooltipBaseProps
    * Передача `null` полностью сбрасывает установку `max-width` на элемент.
    */
   maxWidth?: number | string | null;
+  /**
+   * Скрытый текст для кнопки закрытия.
+   */
+  closeIconLabel?: string;
+  /**
+   * Обработчик нажатия на кнопку закрытия. При передаче, показывается иконка.
+   */
+  onCloseIconClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 /**
@@ -73,6 +84,8 @@ export const TooltipBase = ({
   text,
   header,
   maxWidth = TOOLTIP_MAX_WIDTH,
+  closeIconLabel = 'Закрыть',
+  onCloseIconClick,
   className,
   ...restProps
 }: TooltipBaseProps): React.ReactNode => {
@@ -97,8 +110,22 @@ export const TooltipBase = ({
         className={styles['TooltipBase__content']}
         style={maxWidth !== null ? { maxWidth } : undefined}
       >
-        {header && <Subhead weight="2">{header}</Subhead>}
-        {text && <Subhead>{text}</Subhead>}
+        <div>
+          {hasReactNode(header) && <Subhead weight="2">{header}</Subhead>}
+          {hasReactNode(text) && <Subhead>{text}</Subhead>}
+        </div>
+        {typeof onCloseIconClick === 'function' && (
+          <Tappable
+            Component="button"
+            className={styles['TooltipBase__closeButton']}
+            hoverMode="opacity"
+            activeMode="opacity"
+            onClick={onCloseIconClick}
+          >
+            <VisuallyHidden>{closeIconLabel}</VisuallyHidden>
+            <Icon16Cancel display="block" />
+          </Tappable>
+        )}
       </div>
     </RootComponent>
   );

--- a/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fc7c44556ad422c28cb32277677f746d73929adc31f68dc890e1ba3a0386b68
-size 20718
+oid sha256:ce3b4daff332d9d3310eb2a1231ed95e47656566a2d2e1e5ce0ffbd983e51619
+size 20698

--- a/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fc7c44556ad422c28cb32277677f746d73929adc31f68dc890e1ba3a0386b68
+size 20718

--- a/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:537d097ef5cf398e869e8c5c21419c44f8fe2a172c36765d00f25977edd3c422
-size 24755
+oid sha256:0935ccc385bbb4e6d7881451399a1205c0ce38a662bdcaa23d2529d2c8564928
+size 24717

--- a/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:537d097ef5cf398e869e8c5c21419c44f8fe2a172c36765d00f25977edd3c422
+size 24755

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -132,7 +132,11 @@ export type {
 export { Snackbar } from './components/Snackbar/Snackbar';
 export type { SnackbarProps } from './components/Snackbar/Snackbar';
 export { Tooltip } from './components/Tooltip/Tooltip';
-export type { TooltipProps } from './components/Tooltip/Tooltip';
+export type {
+  TooltipProps,
+  TooltipOnShownChange,
+  TooltipArrowProps,
+} from './components/Tooltip/Tooltip';
 
 /**
  * Modals


### PR DESCRIPTION


<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6258

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~ – сейчас их в целом пока нет, не стал покрывать в этом PR
- [x] e2e-тесты
- [ ] Дизайн-ревью
- [x] Документация фичи

## Описание

- related to #6892

## Изменения

- для `TooltipBase` добавил параметры `closeIconLabel` и `onCloseIconClick`
  - в `OnboardingTooltip` игнорируем их, т.к. там логика закрытия завязана на нажатие на оверлей;
  - добавил пару скриншотов.
- в `Tooltip`:
  - удалил дублирующий `TooltipBase` код;
  - по аналогии с `Popover`, добавил типы и их ре-экспорт  `TooltipArrowProps` и `TooltipOnShownChange`;
  - в Story файл добавит пример с `closable`.
