### PR TITLE
tech: add check package name before run script

### DIFF
--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Check if PR updates relevant dependencies
         id: check_deps
+        if: {{ steps.metadata.outputs.package-name == "@vkontakte/vkui" }}
         run: |
 
           # ```sh


### PR DESCRIPTION
- caused by #7385

## Описание

Сейчас job check-dependabot-pr работает и проверяет измененные зависимости даже, если они сделаны не в пакете `vkui` . Так быть не должно

## Изменения

Добавил проверку на то, что изменения касаются пакета `vkui`
