### PR TITLE
fix(Search): mv type="text" to type="search"

### DIFF
--- a/packages/vkui/src/components/Search/Readme.md
+++ b/packages/vkui/src/components/Search/Readme.md
@@ -1,4 +1,4 @@
-Надстройка над `<input type="text" />`. Компонент принимает все валидные для этого элемента свойства.
+Надстройка над `<input type="search" />`. Компонент принимает все валидные для этого элемента свойства.
 
 ```jsx { "props": { "layout": false, "adaptivity": true, "showCustomPanelHeaderAfterProps": true } }
 const thematics = [


### PR DESCRIPTION
@shevchux заметил, что в документации указан неверный `type`