### PR TITLE
tech: move check dependabot to job is-updated-vkui-floating-ui

### DIFF
--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -59,6 +59,9 @@ jobs:
 
   is-updated-vkui-floating-ui:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.base.ref == 'master' }}
     outputs:
       result: ${{ steps.check_floating_ui_updated.outputs.floating_ui_updated }}
       prev_floating_ui_version: ${{ steps.check_floating_ui_updated.outputs.prev_version }}
@@ -93,10 +96,7 @@ jobs:
   autopublish-vkui-floating-ui:
     runs-on: ubuntu-latest
     needs: is-updated-vkui-floating-ui
-    if: ${{ github.event.pull_request.merged == true
-      && github.event.pull_request.user.login == 'dependabot[bot]'
-      && github.event.pull_request.base.ref == 'master'
-      && needs.is-updated-vkui-floating-ui.outputs.result == 'true' }}
+    if: ${{ needs.is-updated-vkui-floating-ui.outputs.result == 'true' }}
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Add labels
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Patch
         if: ${{ startsWith(github.event.pull_request.title, 'fix') }}
         uses: ./.github/actions/add-label-to-pull-request


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- caused by #7404

---

## Описание

Не было проверки на то, что PR был создан dependabot, поэтому падал шаг dependabot/fetch-metadata. Добавил проверку перед джобой

Также поправил проблему с вызовом экшена в pull_request_common.yml/labels