### PR TITLE
fix: fix rerender component when slide controlled changes

### DIFF
--- a/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityHasPointer } from '../../../hooks/useAdaptivityHasPointer';
 import { useExternRef } from '../../../hooks/useExternRef';
 import { useGlobalEventListener } from '../../../hooks/useGlobalEventListener';
+import { useMutationObserver } from '../../../hooks/useMutationObserver';
 import { useDOM } from '../../../lib/dom';
 import { useIsomorphicLayoutEffect } from '../../../lib/useIsomorphicLayoutEffect';
 import { warnOnce } from '../../../lib/warnOnce';
@@ -248,9 +249,9 @@ export const CarouselBase = ({
     [slideIndex],
   );
 
-  useIsomorphicLayoutEffect(() => {
-    initializeSlides();
-  }, [children, align, slideWidth]);
+  useMutationObserver(layerRef, initializeSlides);
+
+  useIsomorphicLayoutEffect(initializeSlides, [align, slideWidth]);
 
   const slideLeft = (event: React.MouseEvent) => {
     onChange?.(

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
@@ -1,6 +1,7 @@
 import { type AllHTMLAttributes, useCallback, useRef, useState } from 'react';
 import { arraysEquals } from '../../helpers/array';
 import { useExternRef } from '../../hooks/useExternRef';
+import { useMutationObserver } from '../../hooks/useMutationObserver';
 import { FOCUSABLE_ELEMENTS_LIST, Keys, pressedKey } from '../../lib/accessibility';
 import {
   contains,
@@ -97,22 +98,11 @@ export const FocusTrap = <T extends HTMLElement = HTMLElement>({
     }
   };
 
-  useIsomorphicLayoutEffect(
-    function collectFocusableNodesRef() {
-      if (!ref.current) {
-        return;
-      }
-      const parentNode = ref.current;
-      const observer = new MutationObserver(() => onMutateParentHandler(parentNode));
-      observer.observe(ref.current, {
-        subtree: true,
-        childList: true,
-      });
-      recalculateFocusableNodesRef(parentNode);
-      return () => observer.disconnect();
-    },
-    [ref],
-  );
+  useMutationObserver(ref, () => ref.current && onMutateParentHandler(ref.current));
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current && recalculateFocusableNodesRef(ref.current);
+  }, [ref]);
 
   useIsomorphicLayoutEffect(
     function tryToAutoFocusToFirstNode() {

--- a/packages/vkui/src/hooks/useMutationObserver.test.tsx
+++ b/packages/vkui/src/hooks/useMutationObserver.test.tsx
@@ -1,0 +1,29 @@
+import { act, useRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { useMutationObserver } from './useMutationObserver';
+
+describe('test useMutationObserver', () => {
+  it('should call callback when add block', async () => {
+    const callback = jest.fn();
+    const Fixture = (props: { mockedBlocksIds: string[] }) => {
+      const ref = useRef(null);
+      useMutationObserver(ref, callback);
+      return (
+        <div ref={ref} style={{ position: 'static' }}>
+          {props.mockedBlocksIds.map((id) => (
+            <div key={id} data-testid={id} style={{ height: 50 }}></div>
+          ))}
+        </div>
+      );
+    };
+
+    const result = render(<Fixture mockedBlocksIds={['block-1']} />);
+
+    await act(async () => {
+      result.rerender(<Fixture mockedBlocksIds={['block-1', 'block-2']} />);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('block-2')).toBeInTheDocument();
+  });
+});

--- a/packages/vkui/src/hooks/useMutationObserver.ts
+++ b/packages/vkui/src/hooks/useMutationObserver.ts
@@ -1,0 +1,22 @@
+import type * as React from 'react';
+import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
+import { useStableCallback } from './useStableCallback';
+
+export const useMutationObserver = (
+  ref: React.MutableRefObject<HTMLElement | null> | React.RefObject<HTMLElement | null> | null,
+  callback: () => void,
+): void => {
+  const stableCallback = useStableCallback(callback);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!ref || !ref.current) {
+      return;
+    }
+    const observer = new MutationObserver(stableCallback);
+    observer.observe(ref.current, {
+      subtree: true,
+      childList: true,
+    });
+    return () => observer.disconnect();
+  }, [ref, stableCallback]);
+};


### PR DESCRIPTION
- close #7465 

---

- [x] Unit-тесты

## Описание

Сейчас есть проблема в компоненте `Gallery`. При контроллируемом переключении слайда происходит перерендер компонента и `children` меняется(поскольку это массив). Из-за этого в `CarouselBase` происходит срабатывание `useEffect`'а, у которого в `deps` есть `children`. В этом `useEffect`'е происходит вызов функции `initializeSlides`, где неправильно выставляется `transform` для слоя со слайдами(так как slideIndex изменился). Поэтому появляется на один фрейм баг описанный в задаче.

По идее при изменении ссылки на `children` не должна вызываться функция `initializeSlides`, так как содержимое не изменилось. И вообще содержимое галереи вряд ли будет меняться в рантайме(довольно редкий кейс). Но все равно надо учесть такой кейс. Как вариант - использование `MutationObserver` для отслеживания изменений в структуре компонента 

## Изменения

- Реализовал хук `useMutationObserver` для более удобного использования `MutationObserver` и потому что он уже используется в двух местах.
- Переиспользовал этот хук в `CarouselBase`, вместо `deps` в виде `children`
