### PR TITLE
tech: fix add-label action

### DIFF
--- a/.github/actions/add-label-to-pull-request/action.yml
+++ b/.github/actions/add-label-to-pull-request/action.yml
@@ -19,5 +19,5 @@ runs:
             issue_number: ${{ inputs.issue_number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: [${{ inputs.label }}]
+            labels: ["${{ inputs.label }}"]
           })


### PR DESCRIPTION
- caused by #7404

---

## Описание

При попытке добавить label при создании PR падает ошибка. Это из-за того, что в экшене переданный label не был обернут в кавычки. Добавил кавычки