### PR TITLE
fix(CustomSelect): fix custom select cursor updating

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -772,9 +772,8 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     // Чтобы в такой ситуации отключить blur инпута мы превентим mousedown событие обёртки
     const isInputFocused = document && document.activeElement === selectInputRef.current;
     const clickTarget = e.target as HTMLElement;
-    const wrapperClicked = containerRef.current?.contains(clickTarget);
     const inputClicked = selectInputRef.current?.contains(clickTarget);
-    if (isInputFocused && wrapperClicked && !inputClicked) {
+    if (isInputFocused && !inputClicked) {
       e.preventDefault();
     }
   };

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -219,6 +219,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const scrollBoxRef = React.useRef<HTMLDivElement | null>(null);
   const selectElRef = useExternRef(getRef);
   const optionsWrapperRef = React.useRef<HTMLDivElement>(null);
+  const selectInputRef = useExternRef(getSelectInputRef);
 
   const [focusedOptionIndex, setFocusedOptionIndex] = React.useState<number | undefined>(-1);
   const [isControlledOutside, setIsControlledOutside] = React.useState(props.value !== undefined);
@@ -422,7 +423,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     const event = new Event('focusin', { bubbles: true });
     selectElRef.current?.dispatchEvent(event);
     selectInputRef.current?.select();
-  }, [selectElRef]);
+  }, [selectElRef, selectInputRef]);
 
   const onClick = React.useCallback(() => {
     if (opened) {
@@ -669,7 +670,6 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     }
   }, [emptyText, options, renderDropdown, renderOption]);
 
-  const selectInputRef = useExternRef(getSelectInputRef);
   const focusOnInputTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
   const focusOnInput = React.useCallback(() => {
     clearTimeout(focusOnInputTimerRef.current);

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -421,6 +421,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const onFocus = React.useCallback(() => {
     const event = new Event('focusin', { bubbles: true });
     selectElRef.current?.dispatchEvent(event);
+    selectInputRef.current?.select();
   }, [selectElRef]);
 
   const onClick = React.useCallback(() => {
@@ -770,7 +771,10 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     // но вне инпута (например по иконке дропдауна), будет убирать фокус с инпута.
     // Чтобы в такой ситуации отключить blur инпута мы превентим mousedown событие обёртки
     const isInputFocused = document && document.activeElement === selectInputRef.current;
-    if (isInputFocused) {
+    const clickTarget = e.target as HTMLElement;
+    const wrapperClicked = containerRef.current?.contains(clickTarget);
+    const inputClicked = selectInputRef.current?.contains(clickTarget);
+    if (isInputFocused && wrapperClicked && !inputClicked) {
       e.preventDefault();
     }
   };


### PR DESCRIPTION
- close #7504

---

- [x] Release notes

## Описание

Сейчас нельзя изменять положение курсора с помощью мыши в searchable CustomSelect-е. Проблема в том, что при обработке mousedown происходит preventDefault всегда когда input  в фокусе. Нужно доработать проверку так, что при наличии фокуса и клике в input не происходил preventDefault

## Изменения

Доработал проверку в обработчике mouseDown, чтобы можно было менять положение курсора мышью
Обработал кейс, чтобы при фокуса в поле просходило выделение всего текста

## Release notes

## Исправления
- CustomSelect: поправлена проблема с изменением позиции курсора с помощью мыши
