### PR TITLE
tech: rename vkui_version to current_vkui_version in inputs

### DIFF
--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -206,5 +206,5 @@ jobs:
         uses: VKCOM/gh-actions/VKUI/auto-update-release-notes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vkui_version: ${{ steps.get_version.outputs.vkui_version }}
+          current_vkui_version: ${{ steps.get_version.outputs.vkui_version }}
           pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
- caused by #7431 

---

## Описание

При вызове job-ы по обновлению release notes падает ошибка. Проблема в том, что в скрипте обновления нет инпута vkui_version, там используется current_vkui_version. Нужно переименовать vkui_version на current_vkui_version

