### PR TITLE
feat(Tappable): allow parent to hover with children by props

### DIFF
--- a/packages/vkui/src/components/Clickable/Clickable.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.tsx
@@ -53,7 +53,7 @@ const RealClickable = <T,>({
   hasActive = true,
   hovered,
   activated,
-  hasHoverWithChild,
+  hasHoverWithChildren,
   unlockParentHover,
   onPointerEnter,
   onPointerLeave,
@@ -102,10 +102,10 @@ const RealClickable = <T,>({
 
   const lockStateContextValue = React.useMemo(
     () => ({
-      lockHoverStateBubbling: hasHoverWithChild ? noop : setLockHoverBubblingImmediate,
+      lockHoverStateBubbling: hasHoverWithChildren ? noop : setLockHoverBubblingImmediate,
       lockActiveStateBubbling: setLockActiveBubblingImmediate,
     }),
-    [setLockHoverBubblingImmediate, setLockActiveBubblingImmediate, hasHoverWithChild],
+    [setLockHoverBubblingImmediate, setLockActiveBubblingImmediate, hasHoverWithChildren],
   );
 
   return (

--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -131,7 +131,6 @@ function useHover({ hovered, hasHover = true, lockState, setParentStateLock }: U
 
   return {
     isHovered,
-    hoveredState: hoveredStateLocal,
     onPointerEnter: hasHover ? onPointerEnter : noop,
     onPointerLeave: hasHover ? onPointerLeave : noop,
   };
@@ -204,7 +203,6 @@ function useActive({
 
   return {
     isActivated,
-    activatedState,
     onPointerLeave: hasActive ? onPointerCancel : noop,
     onPointerDown: hasActive ? onPointerDown : noop,
     onPointerCancel: hasActive ? onPointerCancel : noop,
@@ -280,14 +278,14 @@ export function useState({
   const [lockActiveStateRef, setParentStateLockActiveBubbling, setLockActiveBubblingImmediate] =
     useLockRef(lockActiveStateBubbling);
 
-  const { isHovered, hoveredState, ...hoverEvent } = useHover({
+  const { isHovered, ...hoverEvent } = useHover({
     hasHover,
     hovered,
     lockState: lockHoverState,
     setParentStateLock: setParentStateLockHoverBubbling,
   });
 
-  const { isActivated, activatedState, ...activeEvent } = useActive({
+  const { isActivated, ...activeEvent } = useActive({
     ...restProps,
     lockStateRef: lockActiveStateRef,
     setParentStateLock: setParentStateLockActiveBubbling,

--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -30,13 +30,13 @@ export interface StateProps {
    * Присваивается родителькому компоненту.
    *
    * @example
-   * <Tappable hasHoverWithChild>
+   * <Tappable hasHoverWithChildren>
    *   <IconButton />
    *   <IconButton />
    *   <IconButton />
    * </Tappable>
    */
-  hasHoverWithChild?: boolean;
+  hasHoverWithChildren?: boolean;
 
   /**
    * Позволяет родительскому компоненту показывать hovered-состояние при наведении

--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -229,7 +229,7 @@ function useLockState(
 ): readonly [boolean, (v: boolean) => void, (...args: any[]) => void] {
   const [lockState, setLockState] = React.useState(false);
 
-  const setParentStateLockBubblingImmediate = React.useCallback(
+  const setStateLockBubblingImmediate = React.useCallback(
     (isLock: boolean) => {
       setLockState(isLock);
       setParentStateLockBubbling(isLock);
@@ -237,7 +237,7 @@ function useLockState(
     [setParentStateLockBubbling],
   );
 
-  return [lockState, setParentStateLockBubbling, setParentStateLockBubblingImmediate] as const;
+  return [lockState, setParentStateLockBubbling, setStateLockBubblingImmediate] as const;
 }
 
 function useLockRef(
@@ -245,7 +245,7 @@ function useLockRef(
 ): readonly [React.MutableRefObject<boolean>, (v: boolean) => void, (...args: any[]) => void] {
   const lockStateRef = React.useRef(false);
 
-  const setParentStateLockBubblingImmediate = React.useCallback(
+  const setStateLockBubblingImmediate = React.useCallback(
     (isLock: boolean) => {
       lockStateRef.current = isLock;
       setParentStateLockBubbling(isLock);
@@ -253,7 +253,7 @@ function useLockRef(
     [setParentStateLockBubbling],
   );
 
-  return [lockStateRef, setParentStateLockBubbling, setParentStateLockBubblingImmediate] as const;
+  return [lockStateRef, setParentStateLockBubbling, setStateLockBubblingImmediate] as const;
 }
 
 /**

--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
-import { callMultiple } from '../../lib/callMultiple';
 import { mergeCalls } from '../../lib/mergeCalls';
 import { useStateWithDelay } from './useStateWithDelay';
 
@@ -23,6 +22,38 @@ export interface StateProps {
   hasActive?: boolean;
 
   /**
+   * Позволяет родительскому компоненту
+   * иметь hovered-cостояние при наведении
+   * на любой дочерний элемент.
+   * По умолчанию состояние hovered у родителя сбрасывается.
+   *
+   * Присваивается родителькому компоненту.
+   *
+   * @example
+   * <Tappable hasHoverWithChild>
+   *   <IconButton />
+   *   <IconButton />
+   *   <IconButton />
+   * </Tappable>
+   */
+  hasHoverWithChild?: boolean;
+
+  /**
+   * Позволяет родительскому компоненту показывать hovered-состояние при наведении
+   * на текущий дочерний компонент.
+   *
+   * Присваивается дочернему компоненту.
+   *
+   * @example
+   * <Tappable>
+   *   <IconButton unlockParentHover />
+   *   <IconButton unlockParentHover />
+   *   <IconButton />
+   * </Tappable>
+   */
+  unlockParentHover?: boolean;
+
+  /**
    * Длительность показа `activated`-состояния
    */
   activeEffectDelay?: number;
@@ -38,42 +69,105 @@ export interface StateProps {
   hoverClassName?: string;
 }
 
-interface StateHookProps extends StateProps {
-  /**
-   * Блокирование активации состояний
-   */
-  lockState: boolean;
-}
-
 export const DEFAULT_ACTIVE_EFFECT_DELAY = 600;
 
 const ACTIVE_DELAY = 70;
 
+function calculateIsHovered({
+  hasHover,
+  lockState,
+  hoveredStateControlled,
+  hoveredStateLocal,
+}: {
+  hasHover: boolean;
+  lockState: boolean;
+  hoveredStateControlled: boolean;
+  hoveredStateLocal: boolean;
+}): boolean {
+  return hasHover && !lockState && (hoveredStateControlled || hoveredStateLocal);
+}
+
+interface UseHoverProps extends Pick<StateProps, 'hovered' | 'hasHover'> {
+  /**
+   * Блокирование активации состояний
+   */
+  lockState: boolean;
+  setParentStateLock: (v: boolean) => void;
+}
+
 /**
  * Управляет наведением на компонент, игнорирует тач события
  */
-function useHover({ hovered, hoverClassName, hasHover = true, lockState }: StateHookProps) {
-  const [hoveredState, setHover] = React.useState(false);
+function useHover({ hovered, hasHover = true, lockState, setParentStateLock }: UseHoverProps) {
+  const [hoveredStateLocal, setHoveredStateLocal] = React.useState(false);
 
-  const hover = hasHover && !lockState && (hovered || hoveredState) ? hoverClassName : undefined;
+  const prevHoverRef = React.useRef<boolean | undefined>(undefined);
+
+  const handleHover = React.useCallback(
+    (isHover: boolean) => {
+      setHoveredStateLocal(isHover);
+
+      const isHovered = calculateIsHovered({
+        hasHover,
+        lockState,
+        hoveredStateControlled: Boolean(hovered),
+        hoveredStateLocal: isHover,
+      });
+      if (prevHoverRef.current === undefined || isHovered !== prevHoverRef.current) {
+        prevHoverRef.current = isHovered;
+        setParentStateLock(isHovered);
+      }
+    },
+    [setParentStateLock, hasHover, hovered, lockState],
+  );
 
   const onPointerEnter: React.PointerEventHandler<any> = (e) => {
     if (e.pointerType === 'touch') {
       return;
     }
 
-    setHover(true);
+    handleHover(true);
   };
 
   const onPointerLeave = () => {
-    setHover(false);
+    handleHover(false);
   };
 
+  const isHovered = calculateIsHovered({
+    hasHover,
+    lockState,
+    hoveredStateControlled: Boolean(hovered),
+    hoveredStateLocal,
+  });
+
   return {
-    hover,
+    isHovered,
+    hoveredState: hoveredStateLocal,
     onPointerEnter: hasHover ? onPointerEnter : noop,
     onPointerLeave: hasHover ? onPointerLeave : noop,
   };
+}
+
+function calculateIsActive({
+  hasActive,
+  lockState,
+  activeStateControlled,
+  activeStateLocal,
+}: {
+  hasActive: boolean;
+  lockState: boolean;
+  activeStateControlled: boolean;
+  activeStateLocal: boolean;
+}): boolean {
+  return hasActive && !lockState && (activeStateControlled || activeStateLocal);
+}
+
+interface UseActiveProps extends Pick<StateProps, 'activated' | 'activeEffectDelay' | 'hasActive'> {
+  /**
+   * Блокирование активации состояний
+   */
+  lockStateRef: React.MutableRefObject<boolean>;
+  setParentStateLock: (v: boolean) => void;
 }
 
 /**
@@ -81,20 +175,31 @@ function useHover({ hovered, hoverClassName, hasHover = true, lockState }: State
  */
 function useActive({
   activated,
-  activeClassName,
   activeEffectDelay,
   hasActive = true,
-  lockState,
-}: StateHookProps) {
-  const [activatedState, setActivated] = useStateWithDelay(false);
+  lockStateRef,
+  setParentStateLock,
+}: UseActiveProps) {
+  // передаём setParentStateLock, чтобы функция вызывалась вместе с установкой стейта,
+  // если установка отложена c помощью delay, то и вызов будет отложен
+  const [activatedState, setActivated] = useStateWithDelay<boolean>(false, 0, setParentStateLock);
 
   // Список нажатий которые не требуется отменять
   const pointersUp = React.useMemo(() => new Set<number>(), []);
 
-  const active =
-    hasActive && !lockState && (activated || activatedState) ? activeClassName : undefined;
+  const onPointerDown = () => {
+    if (lockStateRef.current) {
+      return;
+    }
 
-  const onPointerDown = () => setActivated(true, ACTIVE_DELAY);
+    setActivated(true, ACTIVE_DELAY);
+    // намеренно выставляем lock, так как setActivated вызов отложен
+    // а у отложенного setActivated setParentStateLock тоже вызовится отложенно
+    // родитель сейчас тоже обработает это же событие PointerDown
+    // если мы не залочим activatedState у родителя сейчас, то родитель выставит active состояние
+    setParentStateLock(true);
+  };
+
   const onPointerCancel: React.PointerEventHandler = (e) => {
     if (pointersUp.has(e.pointerId)) {
       pointersUp.delete(e.pointerId);
@@ -106,12 +211,25 @@ function useActive({
 
   const onPointerUp: React.PointerEventHandler = (e) => {
     pointersUp.add(e.pointerId);
+
+    if (lockStateRef.current) {
+      return;
+    }
+
     setActivated(true);
     setActivated(false, activeEffectDelay);
   };
 
+  const isActivated = calculateIsActive({
+    hasActive,
+    lockState: lockStateRef.current,
+    activeStateControlled: Boolean(activated),
+    activeStateLocal: activatedState,
+  });
+
   return {
-    active,
+    isActivated,
+    activatedState,
     onPointerLeave: hasActive ? onPointerCancel : noop,
     onPointerDown: hasActive ? onPointerDown : noop,
     onPointerCancel: hasActive ? onPointerCancel : noop,
@@ -119,50 +237,97 @@ function useActive({
   };
 }
 
-export const ClickableLockStateContext: React.Context<((v: boolean) => void) | undefined> =
-  React.createContext<undefined | ((v: boolean) => void)>(undefined);
+interface ClickableLockStateContextInterface {
+  lockHoverStateBubbling?: (v: boolean) => void;
+  lockActiveStateBubbling?: (v: boolean) => void;
+}
+
+export const ClickableLockStateContext: React.Context<ClickableLockStateContextInterface> =
+  React.createContext<ClickableLockStateContextInterface>({
+    lockHoverStateBubbling: undefined,
+    lockActiveStateBubbling: undefined,
+  });
 
 /**
  * Блокирует стейт на всплытие
  */
-function useLockState(): readonly [boolean, (v: boolean) => void, (...args: any[]) => void] {
-  const setLockBubbling = React.useContext(ClickableLockStateContext) || noop;
+function useLockState(
+  setParentStateLockBubbling: (v: boolean) => void,
+): readonly [boolean, (v: boolean) => void, (...args: any[]) => void] {
   const [lockState, setLockState] = React.useState(false);
 
-  const setLockBubblingImmediate = callMultiple(setLockState, setLockBubbling);
+  const setParentStateLockBubblingImmediate = React.useCallback(
+    (isLock: boolean) => {
+      setLockState(isLock);
+      setParentStateLockBubbling(isLock);
+    },
+    [setParentStateLockBubbling],
+  );
 
-  return [lockState, setLockBubbling, setLockBubblingImmediate] as const;
+  return [lockState, setParentStateLockBubbling, setParentStateLockBubblingImmediate] as const;
+}
+
+function useLockRef(
+  setParentStateLockBubbling: (v: boolean) => void,
+): readonly [React.MutableRefObject<boolean>, (v: boolean) => void, (...args: any[]) => void] {
+  const lockStateRef = React.useRef(false);
+
+  const setParentStateLockBubblingImmediate = React.useCallback(
+    (isLock: boolean) => {
+      lockStateRef.current = isLock;
+      setParentStateLockBubbling(isLock);
+    },
+    [setParentStateLockBubbling],
+  );
+
+  return [lockStateRef, setParentStateLockBubbling, setParentStateLockBubblingImmediate] as const;
 }
 
 /**
  * Управляет состоянием компонента
  */
-export function useState({ hasHover, hasActive, ...restProps }: StateProps): {
+export function useState({
+  hovered,
+  hasHover,
+  hasActive,
+  unlockParentHover,
+  ...restProps
+}: StateProps): {
   stateClassName: string;
-  setLockBubblingImmediate: (...args: any[]) => void;
+  setLockHoverBubblingImmediate: (...args: any[]) => void;
+  setLockActiveBubblingImmediate: (...args: any[]) => void;
 } {
-  const [lockState, setLockBubbling, setLockBubblingImmediate] = useLockState();
+  const { lockHoverStateBubbling = noop, lockActiveStateBubbling = noop } =
+    React.useContext(ClickableLockStateContext);
 
-  const props = {
+  const [lockHoverState, setParentStateLockHoverBubbling, setLockHoverBubblingImmediate] =
+    useLockState(unlockParentHover ? noop : lockHoverStateBubbling);
+  const [lockActiveStateRef, setParentStateLockActiveBubbling, setLockActiveBubblingImmediate] =
+    useLockRef(lockActiveStateBubbling);
+
+  const { isHovered, hoveredState, ...hoverEvent } = useHover({
     hasHover,
-    hasActive,
-    lockState,
+    hovered,
+    lockState: lockHoverState,
+    setParentStateLock: setParentStateLockHoverBubbling,
+  });
+
+  const { isActivated, activatedState, ...activeEvent } = useActive({
     ...restProps,
-  };
+    lockStateRef: lockActiveStateRef,
+    setParentStateLock: setParentStateLockActiveBubbling,
+  });
 
-  const { hover, ...hoverEvent } = useHover({ ...props });
-  const { active, ...activeEvent } = useActive(props);
-
-  const stateClassName = classNames(hover, active);
+  const stateClassName = classNames(
+    isHovered && restProps.hoverClassName,
+    isActivated && restProps.activeClassName,
+  );
   const handlers = mergeCalls(hoverEvent, activeEvent);
-
-  React.useEffect(() => {
-    setLockBubbling(!!stateClassName);
-  }, [setLockBubbling, stateClassName]);
 
   return {
     stateClassName,
-    setLockBubblingImmediate,
+    setLockHoverBubblingImmediate,
+    setLockActiveBubblingImmediate,
     ...handlers,
   };
 }

--- a/packages/vkui/src/components/Clickable/useStateWithDelay.test.tsx
+++ b/packages/vkui/src/components/Clickable/useStateWithDelay.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { useStateWithDelay } from './useStateWithDelay';
+
+describe(useStateWithDelay, () => {
+  it('updates state after delay', () => {
+    jest.useFakeTimers();
+    const handle = renderHook(() => useStateWithDelay(5));
+
+    expect(handle.result.current[0]).toBe(5);
+
+    act(() => handle.result.current[1](10));
+
+    handle.rerender();
+    expect(handle.result.current[0]).toBe(10);
+
+    // setState с задержкой в 500мс
+    act(() => handle.result.current[1](20, 500));
+
+    handle.rerender();
+    // время ещё не вышло, состояние не обновилось
+    expect(handle.result.current[0]).not.toBe(20);
+
+    act(() => jest.runAllTimers());
+
+    handle.rerender();
+    // состояние обновилось после таймера
+    expect(handle.result.current[0]).toBe(20);
+  });
+
+  it('calls callback on state update', () => {
+    jest.useFakeTimers();
+
+    const onStateChangeStub = jest.fn();
+    const handle = renderHook(() => useStateWithDelay<number>(5, 0, onStateChangeStub));
+
+    expect(handle.result.current[0]).toBe(5);
+    expect(onStateChangeStub).not.toHaveBeenCalled();
+
+    act(() => handle.result.current[1](10));
+
+    handle.rerender();
+    expect(handle.result.current[0]).toBe(10);
+    expect(onStateChangeStub).toHaveBeenCalledWith(10);
+
+    onStateChangeStub.mockClear();
+    // setState с задержкой в 500мс
+    act(() => handle.result.current[1](20, 500));
+
+    handle.rerender();
+    // время ещё не вышло, состояние не обновилось
+    expect(handle.result.current[0]).not.toBe(20);
+    expect(onStateChangeStub).not.toHaveBeenCalled();
+
+    act(() => jest.runAllTimers());
+
+    handle.rerender();
+    // состояние обновилось после таймера
+    expect(handle.result.current[0]).toBe(20);
+    expect(onStateChangeStub).toHaveBeenCalledWith(20);
+
+    onStateChangeStub.mockClear();
+
+    // setState с аргументом-функцией с задержкой в 500мс
+    act(() => handle.result.current[1]((prevValue) => prevValue + 30, 500));
+
+    act(() => jest.runAllTimers());
+    handle.rerender();
+
+    // состояние после таймера обновилось
+    expect(handle.result.current[0]).toBe(50);
+    // коллбэк был вызван с верным значением
+    expect(onStateChangeStub).toHaveBeenCalledWith(50);
+  });
+});

--- a/packages/vkui/src/components/Clickable/useStateWithDelay.tsx
+++ b/packages/vkui/src/components/Clickable/useStateWithDelay.tsx
@@ -16,6 +16,24 @@ type DispatchWithDelay<S> = (value: S, delay?: number) => void;
  *   setCount(count + 1, 500)
  * }
  * ```
+ *
+ * Есть возможность передать функцию-коллбэк, которая будет
+ * вызвана сразу после вызова setState с новым значением стейта
+ * в качестве аргумента.
+ *
+ * ```ts
+ * const onCountChange = React.useCallback((count) => {
+ *   // обработчик нового значения count
+ *   // будет вызван через 500мс
+ * }, []);
+ *
+ *
+ * const [count, setCount] = useStateWithDelay(initialState, 0, onCountChange);
+ *
+ * const click = () => {
+ *   setCount(count + 1, 500)
+ * }
+ * ```
  */
 export function useStateWithDelay<S>(
   initialState: S | (() => S),

--- a/packages/vkui/src/components/Clickable/useStateWithDelay.tsx
+++ b/packages/vkui/src/components/Clickable/useStateWithDelay.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isFunction, noop } from '@vkontakte/vkjs';
 
 type DispatchWithDelay<S> = (value: S, delay?: number) => void;
 
@@ -19,21 +20,39 @@ type DispatchWithDelay<S> = (value: S, delay?: number) => void;
 export function useStateWithDelay<S>(
   initialState: S | (() => S),
   defaultDelay = 0,
+  onStateChange: (v: S) => void = noop,
 ): [S, DispatchWithDelay<React.SetStateAction<S>>] {
   const [value, setValue] = React.useState(initialState);
   const timeout = React.useRef<ReturnType<typeof setTimeout>>();
+
+  const handleSetValue = React.useCallback(
+    (nextValue: React.SetStateAction<S>) => {
+      if (isFunction(nextValue)) {
+        setValue((prevValue) => {
+          const value = nextValue(prevValue);
+          onStateChange(value);
+
+          return value;
+        });
+      } else {
+        setValue(nextValue);
+        onStateChange(nextValue);
+      }
+    },
+    [onStateChange],
+  );
 
   const setValueWithDelay = React.useCallback(
     (newValue: React.SetStateAction<S>, delay: number = defaultDelay) => {
       clearTimeout(timeout.current);
       if (delay === 0) {
-        setValue(newValue);
+        handleSetValue(newValue);
         return;
       }
 
-      timeout.current = setTimeout(() => setValue(newValue), delay);
+      timeout.current = setTimeout(() => handleSetValue(newValue), delay);
     },
-    [defaultDelay],
+    [defaultDelay, handleSetValue],
   );
 
   return [value, setValueWithDelay];


### PR DESCRIPTION
- close #7228

-------

- [x] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [x] Release notes

## Описание
Необходимо дать возможность `Tappable` компонентам или компонентам основанным на `Tappable` иметь hover-состояние при наведении на дочерние компоненты.
По умолчанию мы намеренно отключаем это поведение.
Включение необходимо реализовать через свойство.

В процессе изучения проблемы пришел к выводу, что нам мало только разрешить `hover` у родителя при наведении на дочерний элемент. Нам также нужно продолжать запрещать распространение `active` состояния с дочернего компонента на родительский.
Но тут возникли проблемы. Дело в том, что запрещение `active` работало только вместе с `hover`. Всё потому, что активное состояние включается с задержкой по `setTimeout`, что также влечёт за собой отложенное включение флага запрета для родительского компонента, и за это время родительский компонент уже успевает взвести таймер на включение своего отложенного активного состояния. 

Раньше, когда `active` и `hover` состояния запрещались вместе, то `active` состояние блокировалось сразу при наведении на дочерний элемент (`hover`).

Сейчас же логика требует запрещать `active` при клике (`onPointerDown`).
Из-за этой особенности (отложенная установка состояния) не удалось реализовать запрет распространения `active` состояния по аналогии с запретом `hover` состояния, через локальный стейт. Для `active` состояния пришлось использовать `ref` а не стейт, чтобы всегда можно было к нему обратиться из любого обработчика событий, и понять, что запрет есть.
Из-за этого накладываются ограничения работы с ref, нельзя менять стейт и вызвать ререндер при изменении значения. Для активного состояния вызывать ререндер не требуется.
 С hover использование ref для запрета не сработало бы, потому что нельзя было бы прекратить/включить hover, при снятии запрета через ref, потому что не было бы ререндера. 

Вообще все эти запреты можно было бы реализовать шаря через всплывающие события какое-нибудь кастомное свойство, но запись в event не очень приветствуется.

## Изменения
Добавлено два новых свойства для `Tappable` компонента: 
- `hasHoverWithChildren` для родительского `Tappable`, чтобы `hover` состояние родительского `Tappable` не блокировалось при наведении на любой из дочерних `Tappable`.
- `unlockParentHover` для дочернего `Tappable`, чтобы при наведении на конкретный `Tappable` у родительского тоже появлялось `hover` состояние.

Разница между ними в том, что с `hasHoverWithChildren` можно разом разрешить родителю реагировать на hover состояние всех дочерних элементов, а с `unlockParentHover` это можно сделать выборочно.



Глобально логика осталась прежней. Каждый `Tappable` хранит блокировку своих состояний у себя в стейте или в `ref` и передаёт фукнции, включающие/отключающие блокировку, дочерним компонентам через контекст. Дочерние компоненты по умолчанию вызывают эти функции блокировки во время `active/hover` состояний, за счёт этого родительские компоненты `active/hover` состояния не обрабатывают, если блокировка включена.

Так как мы хотим разрешить только `hover` состояние, то `active` состояние нужно продолжать блокировать.
Для этого пришлось разбить блокировку на два вида, два состояния, `lockHover` и `lockActive`.

блокировка `hover` состояния реализована через `useState`. 
блокировка `active` состояния реализована через `useRef`, из-за особенностей реализации `active` состояния (`useStateWithDelay`)

Чтобы разрешать обработку `hover/active` состояний по свойству из пропсов мы, либо не передаём дочерним компонентам в контекст фукнцию для отключения блокироки (по свойству `hasHoverWithChildren`), либо в дочернем компоненте не используем переданную функцию блокировки (по свойству `unlockParentHover`)

Расширены возможности хука `useStateWithDelay`, теперь в него можно передать функцию-коллбэк, которая вызовится в момент изменения стейта с новым значением стейта в качестве аргумента.
Понадобилось, чтобы управлять блокировкой `active` состояния, которое выключается с задержкой после клика.
https://github.com/VKCOM/VKUI/blob/b42476972b5ae09a3e7f6eb48552c7463bb8bec2/packages/vkui/src/components/Clickable/useState.tsx#L212-L221

## Release notes
## Улучшения
- Tappable: 
  - добавлено новое свойство `unlockParentHover`, которое можно использовать в ситуации когда один `Tappable` вложен в другой и при на ведении на дочерний нужно, чтобы hover состояние также появлялось на родительском `Tappable`. Выставляется на дочернем. По умолчанию hover состояние дочернего элемента родительскому не передаётся.
  - добавлено новое свойство `hasHoverWithChildren`, которое можно использовать в ситуации когда множество `Tappable` вложены в другой `Tappable` и нужно, чтобы при на ведении на каждый из дочерних `Tappable` hover состояние передавалось родительскому `Tappable`. Выставляется на родительском `Tappable`. В такой ситуации `unlockParentHover` на дочерних компонентах можно опустить.
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
