### PR TITLE
feat(PanelHeaderButton): add Badge support in label prop

### DIFF
--- a/packages/vkui/src/components/Badge/Badge.tsx
+++ b/packages/vkui/src/components/Badge/Badge.tsx
@@ -20,7 +20,7 @@ export interface BadgeProps extends RootComponentProps<HTMLSpanElement> {
 export const Badge = ({ mode = 'new', children, ...restProps }: BadgeProps): React.ReactNode => (
   <RootComponent
     Component="span"
-    baseClassName={classNames(styles['Badge'], stylesMode[mode])}
+    baseClassName={classNames(styles['Badge'], 'vkuiInternalBadge', stylesMode[mode])}
     {...restProps}
   >
     {children && <VisuallyHidden>{children}</VisuallyHidden>}

--- a/packages/vkui/src/components/Counter/Counter.module.css
+++ b/packages/vkui/src/components/Counter/Counter.module.css
@@ -49,18 +49,6 @@
 
 /**
  * CMP:
- * PanelHeaderButton
- */
-/* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-:global(.vkuiInternalPanelHeaderButton) .Counter {
-  position: absolute;
-  padding: 0;
-  inset-block-start: 8px;
-  inset-inline-end: 2px;
-}
-
-/**
- * CMP:
  * TabbarItem
  */
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.e2e-playground.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.e2e-playground.tsx
@@ -1,5 +1,7 @@
-import { Icon28AddOutline } from '@vkontakte/icons';
+import { Icon24AddOutline, Icon28AddOutline } from '@vkontakte/icons';
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
+import { Badge } from '../Badge/Badge';
+import { Counter } from '../Counter/Counter';
 import { PanelHeaderBack } from '../PanelHeaderBack/PanelHeaderBack';
 import { PanelHeaderClose } from '../PanelHeaderClose/PanelHeaderClose';
 import { PanelHeaderEdit, type PanelHeaderEditProps } from '../PanelHeaderEdit/PanelHeaderEdit';
@@ -15,6 +17,15 @@ export const PanelHeaderButtonPlayground = (props: ComponentPlaygroundProps) => 
           children: [<Icon28AddOutline key="icon" />],
           primary: [true, false],
           label: [undefined, 'label', <span key="label">label</span>],
+        },
+        {
+          children: [<Icon28AddOutline key="icon-28" />, <Icon24AddOutline key="icon-24" />],
+          label: [
+            <Counter size="s" mode="prominent" key="counter">
+              33
+            </Counter>,
+            <Badge mode="prominent" key="badge" />,
+          ],
         },
       ]}
     >

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.module.css
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.module.css
@@ -79,14 +79,16 @@
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-.PanelHeaderButton--vkcom > :not(:global(.vkuiInternalCounter)) {
+.PanelHeaderButton--vkcom > :not(:global(.vkuiInternalBadge)):not(:global(.vkuiInternalCounter)) {
   transition: opacity 0.3s;
   opacity: 0.7;
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-.PanelHeaderButton--vkcom.PanelHeaderButton--hover > :not(:global(.vkuiInternalCounter)),
-.PanelHeaderButton--vkcom.PanelHeaderButton--active > :not(:global(.vkuiInternalCounter)) {
+.PanelHeaderButton--vkcom.PanelHeaderButton--hover
+  > :not(:global(.vkuiInternalCounter)):not(:global(.vkuiInternalBadge)),
+.PanelHeaderButton--vkcom.PanelHeaderButton--active
+  > :not(:global(.vkuiInternalCounter)):not(:global(.vkuiInternalBadge)) {
   opacity: 1;
 }
 
@@ -118,4 +120,43 @@
   .PanelHeaderBack--sizeX-none.PanelHeaderBack--ios .PanelHeaderButton__label {
     display: none;
   }
+}
+
+/*
+ * CMP:
+ * Counter
+ */
+
+/* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
+.PanelHeaderButton :global(.vkuiInternalCounter) {
+  position: absolute;
+  padding: 0;
+  inset-block-start: 4px;
+  inset-inline-end: 4px;
+}
+
+/* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
+.PanelHeaderButton :global(.vkuiIcon--24) ~ :global(.vkuiInternalCounter),
+.PanelHeaderButton--ios :global(.vkuiInternalCounter) {
+  inset-block-start: 2px;
+  inset-inline-end: 2px;
+}
+
+/*
+ * CMP:
+ * Badge
+ */
+
+/* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
+.PanelHeaderButton :global(.vkuiInternalBadge) {
+  position: absolute;
+  inset-block-start: 8px;
+  inset-inline-end: 8px;
+}
+
+/* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
+.PanelHeaderButton :global(.vkuiIcon--24) ~ :global(.vkuiInternalBadge),
+.PanelHeaderButton--ios :global(.vkuiInternalBadge) {
+  inset-block-start: 6px;
+  inset-inline-end: 6px;
 }

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -16,6 +16,7 @@ const platformClassNames = {
 
 export interface PanelHeaderButtonProps extends Omit<TappableProps, 'label'> {
   primary?: boolean;
+  // TODO [>=7]: добавить св-во `indicator`, чтобы разграничить кейсы
   label?: React.ReactNode;
 }
 
@@ -90,7 +91,6 @@ export const PanelHeaderButton = ({
       activeEffectDelay={200}
       activeMode={activeMode}
       className={classNames(
-        'vkuiInternalPanelHeaderButton',
         styles['PanelHeaderButton'],
         platformClassNames.hasOwnProperty(platform)
           ? platformClassNames[platform]

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa66902c15086df4237fa3d487ad2618a1a45248f6f48c17aee6c658c028dab8
-size 21471
+oid sha256:cc72cf11e6391e17b8acae4a63ede92035793dd9a86ea0e961ed1cba37e6ddda
+size 32006

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:165feab0938ab40859bc7f5af10ccab40329022b58d4cc32832b7696f72b242e
-size 21549
+oid sha256:4cf2ee22a32292c313850e88d0724e9d2a1911cb5784f2e46582932e58326cee
+size 32097

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffd4a109e153aa1f2c0531b06c850b87ffd1eff20f9fb1c138682a409f0e594f
-size 21747
+oid sha256:81cb0dd2ed3f38f31f21a75a820d80603d6c8a11243aa978efb8af2d7a7bc9c2
+size 32259

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1484bb65b7cab54932f303901f3b36ac929e0ee00edaad7b765894e6fc7e5c30
-size 21684
+oid sha256:029db5c11f3c11fe288f84bae65e9c22ee3b2e5c0b0a71241f4bb661cd09b16f
+size 32151

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7462f637b83d446ca908b0fe723523d75aef96dbdbead2ca4311628368ac531
-size 20233
+oid sha256:579cb246af5be56dbaea33c6abb6d878ec4c46796fc3614c2581d2b06f34575e
+size 30735

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c26828c9addd1d47c4c5cdca513eeb6c38a4e8446e1157efefe20c949bd5e3b3
-size 20865
+oid sha256:22863ec51dde03d545e1068d111efcfca121dcbbde31d8a1c0fff78a41c0fbfd
+size 31467

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8731627ec87eb7c94be356e1f1db5efe426d263b8780ce68ecf937b6bebb6f2
-size 27928
+oid sha256:de3a8b166b7c1fd077dd6fc574f9612efddd1e3e03be4e925eab3e2e0a1cd8f8
+size 43741

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7a632ca16bdc917e94296f3a6c4b851081191db0f1ea321ab75098237cd2252
-size 28300
+oid sha256:cb15700a44756a564b5496aed2f162bf11c44df1caeacac4826527955109db2a
+size 44046

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90b6f07f968f1846134f561b52c65975dfededc98d5b05418a737030495c9aec
-size 20927
+oid sha256:8d098b0ab493fe6d2e72eb4b140d4889ec3ed2a1b9a829ecd5e1b9a73598e920
+size 31504

--- a/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/PanelHeaderButton/__image_snapshots__/panelheaderbutton-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a5e975f9b542182787c2652a745c3fad2236557fe11a355abde9bf7c155df62
-size 21356
+oid sha256:23b1d52cb963012d724b41c024ad86aade1d1e0cf81b6ddf77807f70d66c71e7
+size 31900


### PR DESCRIPTION
- close #6612

---

- [x] e2e-тесты
- [ ] Дизайн-ревью
- [x] Release notes

## Описание

Необходимо с соответствии с дизайном добавить поддержку `Badge` в `PanelHeaderButton`

**Целевое решение**: в версии `v7` (оставила коммент) необходимо будет разграничить `label` и добавить св-во `indicator`, которое позволит убрать немного лапшу в `css`

## Изменения

Получилась очень некрасивая портянка в `CSS`, пришлось добавить глобальный класс `vkuiInternalBadge`, потому что в дизайне сложные правила применения отступов. Попробовала попросить дизайн как-то покрутить, чтобы отступы были одинаковые, но ничего не получилось 😞 

## Release notes

## Улучшения
 - PanelHeaderButton: добавлена поддержка компонента `Badge` в `label`
 
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/14bb6d5e-2390-4766-8bdb-8e16d5166523">
  <img width="480" src="https://github.com/user-attachments/assets/404e2412-ed5d-4503-bf61-7c41d8784719"/>
  </picture>
