### PR TITLE
fix(ModalRoot): call onClosed only once

### DIFF
--- a/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -144,7 +144,19 @@ export const ModalRootDesktop = ({
     // Анимация закрытия модального окна
     if (!activeModal) {
       requestAnimationFrame(() => {
-        waitTransitionFinish(prevModalState?.innerElement, () => onExited(id), timeout);
+        waitTransitionFinish(
+          prevModalState?.innerElement,
+          (event) => {
+            // Исключаем дочерние элементы
+            if (event && event.target === prevModalState?.innerElement) {
+              onExited(id);
+            } else if (!event) {
+              // Вызвался по тайм-ауту
+              onExited(id);
+            }
+          },
+          timeout,
+        );
         animateModalOpacity(prevModalState, false);
         setMaskOpacity(prevModalState, 0);
       });

--- a/packages/vkui/src/hooks/useWaitTransitionFinish.ts
+++ b/packages/vkui/src/hooks/useWaitTransitionFinish.ts
@@ -4,7 +4,7 @@ import { useDOM } from '../lib/dom';
 
 export const useWaitTransitionFinish = (): ((
   element: HTMLElement | undefined | null,
-  eventHandler: VoidFunction,
+  eventHandler: (e?: TransitionEvent) => void,
   durationFallback: number,
 ) => void) => {
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -19,7 +19,7 @@ export const useWaitTransitionFinish = (): ((
   const waitTransitionFinish = React.useCallback(
     (
       element: HTMLElement | undefined | null,
-      eventHandler: VoidFunction,
+      eventHandler: (e?: TransitionEvent) => void,
       durationFallback: number,
     ) => {
       if (element) {


### PR DESCRIPTION
- close #7525

---

- [x] Release notes

## Описание

За счет бабблинга событий `transitionend` на родительском элементе может вызываться несколько раз

## Изменения

- проверяем на целевой элемент, для которого нам интересно завершение анимации
- немного изменяем типы

## Release notes

## Исправления
 - [ModalRoot](https://vkcom.github.io/VKUI/6.7.0/#/ModalRoot): исправлены повторные вызовы `onClosed` при определенных условиях 
