### PR TITLE
fix(Alert): call onClose after item's action

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -90,6 +90,30 @@ describe('Alert', () => {
       });
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+
+    it('should call onClose last', async () => {
+      const callOrder: Array<'action' | 'onClose'> = [];
+      const action = jest.fn().mockImplementation(() => callOrder.push('action'));
+      const onClose = jest.fn().mockImplementation(() => callOrder.push('onClose'));
+      const result = render(
+        <Alert
+          onClose={onClose}
+          actions={[
+            {
+              action,
+              'title': 'Item',
+              'data-testid': '__action__',
+              'mode': 'default',
+            },
+          ]}
+        />,
+      );
+      await userEvent.click(result.getByTestId('__action__'));
+      await waitCSSKeyframesAnimation(result.getByRole('alertdialog'), {
+        runOnlyPendingTimers: true,
+      });
+      expect(callOrder).toEqual(['action', 'onClose']);
+    });
   });
 
   describe('calls action after close by default', () => {

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -100,9 +100,9 @@ export const Alert = ({
     closing ? 'exit' : 'enter',
     {
       onExited() {
-        onClose();
         itemActionCallbackRef.current();
         itemActionCallbackRef.current = noop;
+        onClose();
       },
     },
   );


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Release notes

## Описание

Цитата:

> Недавно столкнулся с проблемой, что в модалке основное действие не отрабатывало. В нашем компоненте мы используем компонент `Alert` и храним нужные данные в объекте, который сетим при открытии и уничтожаем при закрытии модалки, а в основном действии используем этот объект. Оказалось, что при выборе подтверждающего действия компонент `Alert` сначала вызывает `onClose`, а только потом само главное действие, из-за чего к моменту, когда нам нужен наш объект он оказывается уже удалённым. Решил проблему, отложив удаление нашего объекта в `onClose` на следующий цикл, но выглядит так, что лучше это иcправить на вашей стороне.

## Release notes

## Исправления

- Alert: `onClose` теперь вызывается после `action`