### PR TITLE
feat(Typography): Support fontWeightBase tokens

### DIFF
--- a/packages/vkui/src/components/Typography/Typography.module.css
+++ b/packages/vkui/src/components/Typography/Typography.module.css
@@ -10,18 +10,35 @@
 
 /* Мы утяжеляем селектор, чтобы перебить другие селекторы */
 .Typography--weight-1.Typography--weight-1.Typography--weight-1 {
+  font-weight: var(--vkui--font_weight_base1);
+}
+
+.Typography--accent.Typography--weight-1.Typography--weight-1.Typography--weight-1 {
   font-weight: var(--vkui--font_weight_accent1);
 }
 
 .Typography--weight-2.Typography--weight-2.Typography--weight-2 {
+  font-weight: var(--vkui--font_weight_base2);
+}
+
+.Typography--accent.Typography--weight-2.Typography--weight-2.Typography--weight-2 {
   font-weight: var(--vkui--font_weight_accent2);
 }
 
 .Typography--weight-3.Typography--weight-3.Typography--weight-3 {
+  font-weight: var(--vkui--font_weight_base3);
+}
+
+.Typography--accent.Typography--weight-3.Typography--weight-3.Typography--weight-3 {
   font-weight: var(--vkui--font_weight_accent3);
 }
 
 /* stylelint-disable-next-line selector-max-type */
 .Typography b {
+  font-weight: var(--vkui--font_weight_base1);
+}
+
+/* stylelint-disable-next-line selector-max-type */
+.Typography--accent.Typography b {
   font-weight: var(--vkui--font_weight_accent1);
 }

--- a/packages/vkui/src/components/Typography/Typography.stories.tsx
+++ b/packages/vkui/src/components/Typography/Typography.stories.tsx
@@ -19,6 +19,7 @@ import { Playground as TitleStory } from './Title/Title.stories';
 
 interface TypographyOverview {
   weight: '1' | '2' | '3';
+  accent: true;
 }
 
 const story: Meta<TypographyOverview> = {
@@ -29,6 +30,7 @@ const story: Meta<TypographyOverview> = {
       control: 'inline-radio',
       options: ['1', '2', '3'],
     },
+    accent: { control: 'boolean' },
   },
   decorators: [withCartesian],
 };

--- a/packages/vkui/src/components/Typography/Typography.test.tsx
+++ b/packages/vkui/src/components/Typography/Typography.test.tsx
@@ -1,6 +1,68 @@
+import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
-import { Typography } from './Typography';
+import { Typography, type TypographyProps } from './Typography';
+import styles from './Typography.module.css';
+import rootComponentStyles from '../RootComponent/RootComponent.module.css';
 
 describe('Typography', () => {
   baselineComponent(Typography);
+
+  it.each<{
+    props: Partial<TypographyProps>;
+    hasClassName: string;
+  }>([
+    {
+      props: {},
+      hasClassName: '', // по умолчанию Typography
+    },
+    {
+      props: { weight: '1' },
+      hasClassName: `${styles['Typography--weight-1']} ${styles['Typography--accent']}`,
+    },
+    {
+      props: { weight: '2' },
+      hasClassName: `${styles['Typography--weight-2']} ${styles['Typography--accent']}`,
+    },
+    {
+      props: { weight: '3' },
+      hasClassName: `${styles['Typography--weight-3']} ${styles['Typography--accent']}`,
+    },
+    {
+      props: { weight: '1', useAccentWeight: true },
+      hasClassName: `${styles['Typography--weight-1']} ${styles['Typography--accent']}`,
+    },
+    {
+      props: { weight: '2', useAccentWeight: true },
+      hasClassName: `${styles['Typography--weight-2']} ${styles['Typography--accent']}`,
+    },
+    {
+      props: { weight: '3', useAccentWeight: true },
+      hasClassName: `${styles['Typography--weight-3']} ${styles['Typography--accent']}`,
+    },
+    {
+      props: { weight: '1', useAccentWeight: false },
+      hasClassName: `${styles['Typography--weight-1']}`,
+    },
+    {
+      props: { weight: '2', useAccentWeight: false },
+      hasClassName: `${styles['Typography--weight-2']}`,
+    },
+    {
+      props: { weight: '3', useAccentWeight: false },
+      hasClassName: `${styles['Typography--weight-3']}`,
+    },
+    {
+      props: { normalize: true, inline: true },
+      hasClassName: `${styles['Typography--normalize']} ${styles['Typography--inline']}`,
+    },
+  ])('it should have className $hasClassName with props $props', ({ props, hasClassName }) => {
+    render(<Typography {...props}>Test</Typography>);
+
+    expect(screen.getByText('Test')).toHaveClass(
+      `${styles['Typography']} ${hasClassName} ${rootComponentStyles['RootComponent']}`,
+      {
+        exact: true,
+      },
+    );
+  });
 });

--- a/packages/vkui/src/components/Typography/Typography.tsx
+++ b/packages/vkui/src/components/Typography/Typography.tsx
@@ -27,7 +27,7 @@ export interface TypographyProps
    * Используются токены fontWeightAccent[1, 2, 3]
    * Используется только вместе с `weight`
    */
-  useAccent?: boolean;
+  useAccentWeight?: boolean;
   /**
    * Убирает внешние отступы
    */
@@ -42,7 +42,7 @@ export const Typography = ({
   weight,
 
   // TODO [>=7]: сделать по умолчанию false (нужен будет кодмод)
-  useAccent = true,
+  useAccentWeight = true,
   Component = 'span',
   normalize,
   inline,
@@ -55,7 +55,7 @@ export const Typography = ({
       normalize && styles['Typography--normalize'],
       inline && styles['Typography--inline'],
       weight && stylesWeight[weight],
-      weight && useAccent && styles['Typography--accent'],
+      weight && useAccentWeight && styles['Typography--accent'],
     )}
     {...restProps}
   />

--- a/packages/vkui/src/components/Typography/Typography.tsx
+++ b/packages/vkui/src/components/Typography/Typography.tsx
@@ -23,6 +23,11 @@ export interface TypographyProps
    */
   weight?: '1' | '2' | '3';
   /**
+   * Включает акцентный тип начертания шрифта.
+   * Используется только вместе с `weight`
+   */
+  accent?: boolean;
+  /**
    * Убирает внешние отступы
    */
   normalize?: boolean;
@@ -34,6 +39,7 @@ export interface TypographyProps
 
 export const Typography = ({
   weight,
+  accent = true,
   Component = 'span',
   normalize,
   inline,
@@ -46,6 +52,7 @@ export const Typography = ({
       normalize && styles['Typography--normalize'],
       inline && styles['Typography--inline'],
       weight && stylesWeight[weight],
+      weight && accent && styles['Typography--accent'],
     )}
     {...restProps}
   />

--- a/packages/vkui/src/components/Typography/Typography.tsx
+++ b/packages/vkui/src/components/Typography/Typography.tsx
@@ -24,9 +24,10 @@ export interface TypographyProps
   weight?: '1' | '2' | '3';
   /**
    * Включает акцентный тип начертания шрифта.
+   * Используются токены fontWeightAccent[1, 2, 3]
    * Используется только вместе с `weight`
    */
-  accent?: boolean;
+  useAccent?: boolean;
   /**
    * Убирает внешние отступы
    */
@@ -39,7 +40,9 @@ export interface TypographyProps
 
 export const Typography = ({
   weight,
-  accent = true,
+
+  // TODO [>=7]: сделать по умолчанию false (нужен будет кодмод)
+  useAccent = true,
   Component = 'span',
   normalize,
   inline,
@@ -52,7 +55,7 @@ export const Typography = ({
       normalize && styles['Typography--normalize'],
       inline && styles['Typography--inline'],
       weight && stylesWeight[weight],
-      weight && accent && styles['Typography--accent'],
+      weight && useAccent && styles['Typography--accent'],
     )}
     {...restProps}
   />


### PR DESCRIPTION
- related #7283 (раздел с проблемой font-weight)

---


- [x] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [x] Документация фичи
- [x] Release notes

## Описание

`font-weight` в дизайн системе может выглядеть как отдельны режим.
Мы позволяем менять `font-weight `с помощью свойства `weight` компонента `Typography`, который под капотом у всех других типографических элементов.
https://github.com/VKCOM/VKUI/blob/716657bed3a0498ac2458ec0b53f9e3bfa46da0d/packages/vkui/src/components/Typography/Typography.tsx#L21-L24

Но Typography поддерживает не все токены, которые могут быть использованы в дизайн-системе.
Вот все токены `fontWeight` пока что существующие в vkui-tokens. [Ссылка](https://github.com/VKCOM/vkui-tokens/blob/ecdad88decf36df7ad14f5df493ba5adbddae6a5/src/themeDescriptions/base/paradigm.ts#L14-L19) на токены темы `paradigm`
```js
https://github.com/VKCOM/VKUI/blob/716657bed3a0498ac2458ec0b53f9e3bfa46da0d/packages/vkui/src/components/Typography/Typography.module.css#L12-L27
```

Сейчас VKUI поддерживает только разные уровни `fontWeightAccent`
https://github.com/VKCOM/VKUI/blob/716657bed3a0498ac2458ec0b53f9e3bfa46da0d/packages/vkui/src/components/Typography/Typography.module.css#L12-L27

Стоит также поддержать и уровни `fontWeightBase`, я видел использование таких токенов в дизайн системе, независимо от regular/compact. Например жирность была fontWeightBase равная 700 и в режиме compact и в режиме regular, что нельзя сейчас поддержать в VKUI.
Надо придумать как эти токены добавить.

## Изменения
 Добавлено свойство `useAccentWeight`, которое по умолчанию `true`, так как в VKUI по умолчанию используются токены `fontWeightAccent`. Сейчас, чтобы использовались токены `fontWeightBase` надо явно задать `useAccentWeight={false}`.
 
Явно указывать `accent` по умолчанию как `false` выглядит как breaking change, так как могут быть пользователи `Text` компонента, которые ожидают уже, что там будет `accent` токены по умолчанию.
Добавил TODO поменять `accent` на `false` в V7.

Добавлять `useBaseWeight`, вместо `useAccentWeight` не стал, выглядит не плохо с одной стороны, но `base`, это как бы база, а `accent` уже как бы отличный вариант от `base`, надстройка, хочется её такой и оставить.
В общем, я больше склоняюсь к `useAccentWeight`.

## Release notes

## Улучшения
- Typography: добавлено свойство `useAccentWeight` для использования `fontWeightAccent` токенов, если  требуется поменять начертание текста с помощью свойства `weight`. По умолчанию в VKUI `useAccentWeight={true}`, то есть при исползовании свойства `weight` применяются токены `fontWeightAccent`. Если нужно, чтобы использовались токены `fontWeightBase` необходимо явно указать `useAccentWeight={false}`. В v7 `useAccentWeight` по умолчанию будет `false`.