### PR TITLE
ci(lfs): install zstd

### DIFF
--- a/.github/actions/lfs/action.yml
+++ b/.github/actions/lfs/action.yml
@@ -20,6 +20,16 @@ runs:
           apt-get install -y git-lfs
         fi
 
+    # см. https://github.com/actions/cache/issues/1455
+    - name: Install zstd
+      shell: bash
+      run: |
+        if zstd > /dev/null ; then
+            echo "zstd installed"
+        else
+          apt-get install -y zstd
+        fi
+
     - name: Create LFS file list
       shell: bash
       run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
@@ -29,6 +39,7 @@ runs:
       with:
         path: .git/lfs
         key: lfs-${{ hashFiles('.lfs-assets-id') }}
+        enableCrossOsArchive: 'true'
 
     - name: Checkout LFS objects
       shell: bash


### PR DESCRIPTION
## Описание

`actions/cache` для сжатия кэша использует zstd,  eсли его нет то использует gzip. Из-за этого в контейнерах кэш не может восстановиться.

## Изменения

Устанавливаем zstd если его нет.
