### PR TITLE
fix(Link): rm margin from icon

### DIFF
--- a/packages/vkui/src/components/Link/Link.e2e-playground.tsx
+++ b/packages/vkui/src/components/Link/Link.e2e-playground.tsx
@@ -5,7 +5,7 @@ export const LinkFocusVisiblePlayground = (props: ComponentPlaygroundProps) => (
   <ComponentPlayground {...props}>
     {(props: LinkProps) => (
       <div style={{ width: 300, padding: 10 }}>
-        Нажимая «Продолжить», вы принимаете{' '}
+        Нажимая «Продолжить», вы принимаете&nbsp;
         <Link href="#" {...props}>
           пользовательское соглашение
         </Link>

--- a/packages/vkui/src/components/Link/Link.e2e-playground.tsx
+++ b/packages/vkui/src/components/Link/Link.e2e-playground.tsx
@@ -1,3 +1,4 @@
+import { Icon24ExternalLinkOutline } from '@vkontakte/icons';
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { Link, type LinkProps } from './Link';
 
@@ -5,9 +6,10 @@ export const LinkFocusVisiblePlayground = (props: ComponentPlaygroundProps) => (
   <ComponentPlayground {...props}>
     {(props: LinkProps) => (
       <div style={{ width: 300, padding: 10 }}>
-        Нажимая «Продолжить», вы принимаете&nbsp;
+        Нажимая «Продолжить», вы принимаете{' '}
         <Link href="#" {...props}>
-          пользовательское соглашение
+          пользовательское соглашение&nbsp;
+          <Icon24ExternalLinkOutline width={16} height={16} />
         </Link>
         ...
       </div>

--- a/packages/vkui/src/components/Link/Link.module.css
+++ b/packages/vkui/src/components/Link/Link.module.css
@@ -25,7 +25,6 @@
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
 .Link :global(.vkuiIcon) {
-  margin-inline-start: 4px;
   display: inline-block;
   vertical-align: middle;
 }

--- a/packages/vkui/src/components/Link/Link.stories.tsx
+++ b/packages/vkui/src/components/Link/Link.stories.tsx
@@ -27,7 +27,8 @@ export const WithIcon: Story = {
     target: '_blank',
     children: (
       <>
-        https://google.com <Icon24ExternalLinkOutline width={16} height={16} />
+        https://google.com&nbsp;
+        <Icon24ExternalLinkOutline width={16} height={16} />
       </>
     ),
   },

--- a/packages/vkui/src/components/Link/Readme.md
+++ b/packages/vkui/src/components/Link/Readme.md
@@ -19,13 +19,14 @@
   <Spacing size={24} />
 
   <Link href="https://google.com" target="_blank">
-    https://google.com <Icon24ExternalLinkOutline width={16} height={16} />
+    https://google.com&nbsp;
+    <Icon24ExternalLinkOutline width={16} height={16} />
   </Link>
 
   <Spacing size={24} />
 
   <div style={{ width: 304 }}>
-    Нажимая «Продолжить», вы принимаете <Link href="#">пользовательское соглашение</Link> и{' '}
+    Нажимая «Продолжить», вы принимаете&nbsp;<Link href="#">пользовательское соглашение</Link> и{' '}
     <Link href="#">политику конфиденциальности</Link>.
   </div>
 

--- a/packages/vkui/src/components/Link/__image_snapshots__/link-state-focus-visible-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Link/__image_snapshots__/link-state-focus-visible-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1d605231604aa87f70d78fe3c3f7bf775d308572d0bea8be9198ad2d04f0450
-size 6436
+oid sha256:44de1380a1fe701cc970d60d6b2817a5e0f0397dbd22b6b538852e24d4d2d7df
+size 6755


### PR DESCRIPTION
- close #6855
- related to #6895 

---

## Описание

Удаляем `margin`, т.к.:
- сейчас расчёт такой, что иконка всегда после текста, а она может быть перед текстом;
- обычный пробел сам по себе и так компенсирует отступ, чтобы текст и иконка не слипались;
- по прошедшим e2e тестам видно, что `margin` не нужен.

## Изменения

Заменил в доках обычный пробел на `&npsp;`, т.к. логичнее использовать его, чтобы иконка не переносилась без текста.

## Скриншот

<img width="707" alt="image" src="https://github.com/VKCOM/VKUI/assets/5850354/e904297a-cc8b-4c86-a826-85fd5df699f7">


## Release notes

## Исправления

- Link: из CSS удалён зашитый отступ справа в `4px`, который выставлялся иконке. Был расчёт, что иконка всегда справа, но она может быть и слева, в этом раскладе появлялся ненужный отступ слева. Было решено отдать пользователю управлять отступами. Поэтому, если вам требуется отступ, используйте неразрывный пробел:
  либо через HTML-код `&nbsp;`,
  ```diff
  <Link href="https://google.com" target="_blank">
  -  https://google.com <Icon24ExternalLinkOutline width={16} height={16} />
  +  https://google.com&nbsp;<Icon24ExternalLinkOutline width={16} height={16} />
  </Link>
  ```
  либо через сочетания клавиш _⌥ + ␣_ (на **MacOS**).