### PR TITLE
chore(CODEOWNERS): exclude safe files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
-*        @VKCOM/vkui-core
-.github/ @VKCOM/vk-sec
+*                        @VKCOM/vkui-core
+.github/CODEOWNERS       @VKCOM/vk-sec
+.github/actions/         @VKCOM/vk-sec
+.github/workflows/       @VKCOM/vk-sec
+.github/dependabot.yml   @VKCOM/vk-sec
+.github/file-filters.yml @VKCOM/vk-sec


### PR DESCRIPTION
## Описание

Исключаем шаблоны `pull_request_template.md` и `ISSUE_TEMPLATE/*.md`, т.к. это не sensitive-файлы и не требуют внимания @VKCOM/vk-sec.

## Release notes
-
