### PR TITLE
fix(Placeholder): cleanup stretched styling

### DIFF
--- a/packages/vkui/src/components/Placeholder/Placeholder.module.css
+++ b/packages/vkui/src/components/Placeholder/Placeholder.module.css
@@ -14,7 +14,6 @@
 
 .Placeholder--stretched {
   flex: 1 0;
-  padding-block: inherit;
   block-size: 100%;
 }
 


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7530

---

- [x] Release notes

## Описание

Удаляем не обоснованный `padding-block: inherit` у `stretched` режима.

см. https://github.com/VKCOM/VKUI/issues/7530#issuecomment-2340337039

## Release notes

## Исправления

- Placeholder:  при `stretched` режиме больше не выставляется `padding-block: inherit`.


