### PR TITLE
fix(CarouselBase): fix two slides transition

### DIFF
--- a/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
@@ -11,7 +11,12 @@ import { RootComponent } from '../../RootComponent/RootComponent';
 import { ScrollArrow } from '../../ScrollArrow/ScrollArrow';
 import { type CustomTouchEvent, Touch } from '../../Touch/Touch';
 import { type BaseGalleryProps, type GallerySlidesState } from '../types';
-import { ANIMATION_DURATION, CONTROL_ELEMENTS_STATE, SLIDES_MANAGER_STATE } from './constants';
+import {
+  ANIMATION_DURATION,
+  CONTROL_ELEMENTS_STATE,
+  SLIDE_THRESHOLD,
+  SLIDES_MANAGER_STATE,
+} from './constants';
 import { calculateIndent, getLoopPoints, getTargetIndex } from './helpers';
 import { useSlideAnimation } from './hooks';
 import type { ControlElementsState, SlidesManagerState } from './types';
@@ -253,7 +258,14 @@ export const CarouselBase = ({
 
   useIsomorphicLayoutEffect(initializeSlides, [align, slideWidth]);
 
+  const calculateMinDeltaXToSlide = () => {
+    return slidesManager.current.slides[slideIndex].width * SLIDE_THRESHOLD;
+  };
+
   const slideLeft = (event: React.MouseEvent) => {
+    if (slideIndex > 0) {
+      shiftXCurrentRef.current += calculateMinDeltaXToSlide();
+    }
     onChange?.(
       (slideIndex - 1 + slidesManager.current.slides.length) % slidesManager.current.slides.length,
     );
@@ -261,6 +273,9 @@ export const CarouselBase = ({
   };
 
   const slideRight = (event: React.MouseEvent) => {
+    if (slideIndex < slidesManager.current.slides.length - 1) {
+      shiftXCurrentRef.current -= calculateMinDeltaXToSlide();
+    }
     onChange?.((slideIndex + 1) % slidesManager.current.slides.length);
     onNextClick?.(event);
   };


### PR DESCRIPTION
- close #7610

---

- [x] Unit-тесты
- [x] Release notes

## Описание

Сейчас в компоненте `Gallery` со значением `looped` некорректно происходит переход между слайдами, когда всего два слайда

## Изменения

В функции `performSlideChange` происходит обработка трех кейсов:
1. Переход с последнего слайда на первый
2. Переход с первого слайда на последний
3. Обычный переход с любого слайда на следующий или предыдущий

Когда всего два слайда и мы пытаемся перейти с первого на второй, срабатывает проверка на переход с первого на последний(что в целом логично). Из-за чего и происходит неправильная "обратная" анимация.

Чтобы проверка проходила правильно, добавил при обработке нажатия на стрелочки добавление или убавления `shiftXCurrentRef.current `на минимальное для перехода к следующему/предыдущему слайду значение

## Release notes
## Исправления

- Gallery: Поправлен баг с переходом между двумя слайдами стрелками 
