### PR TITLE
fix(Select): disabled for options

### DIFF
--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -69,8 +69,8 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
           className={classNames(className, deviceType.mobile.className)}
           {...nativeProps}
         >
-          {options.map(({ label, value }) => (
-            <option value={value} key={`${value}`}>
+          {options.map(({ label, value, disabled }) => (
+            <option value={value} key={`${value}`} disabled={disabled}>
               {label}
             </option>
           ))}


### PR DESCRIPTION
## Описание

`disabled` не прокидывается в option

## Изменения

Прокидываем `disabled` в option

## Release notes

## Исправления

- [Select](https://vkcom.github.io/VKUI/${version}/#/Select): `disabled` для опций  не прокидывалось в NativeSelect
