### PR TITLE
fix(vkui): return module

### DIFF
--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -2,6 +2,7 @@
   "version": "6.7.0",
   "name": "@vkontakte/vkui",
   "description": "VKUI library",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
- cause #7611

## Описание

webpack 4 не поддерживает `exports`, поэтому возвращаем поле `module`

## Изменения

Возвращаем поле module

## Release notes
-