### PR TITLE
fix(TabsItem): gaps use first-child

### DIFF
--- a/packages/vkui/src/components/TabsItem/TabsItem.module.css
+++ b/packages/vkui/src/components/TabsItem/TabsItem.module.css
@@ -17,7 +17,7 @@
   margin-block: 8px;
 }
 
-.TabsItem--withGaps:not(:first-of-type) {
+.TabsItem--withGaps:not(:first-child) {
   margin-inline-start: 6px;
 }
 


### PR DESCRIPTION
## Описание

TabsItem при использовании разных тегов(используя свойства `href` и `onClick`) могли не проставляться отступы между элементами

<img width="435" alt="image" src="https://github.com/user-attachments/assets/9816ab8d-076d-402b-8e6b-d060f6db5159">

## Изменения

Используем `first-child` вместо `first-of-type`

## Release notes

## Исправления

- [TabsItem](https://vkcom.github.io/VKUI/${version}/#/TabsItem): исправлен отступ между элементами при использовании `href` и `onClick` вместе