### PR TITLE
feat(Spacing): remove 3xs size type

### DIFF
--- a/packages/codemods/src/transforms/v7/__testfixtures__/spacing/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/spacing/basic.input.tsx
@@ -1,0 +1,16 @@
+import { Separator, Spacing } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <React.Fragment>
+      <Spacing size="3xs">
+        <Separator/>
+      </Spacing>
+
+      <Spacing size="3xs" />
+
+      <Spacing size={"3xs"} />
+    </React.Fragment>
+  );
+};

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spacing.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spacing.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`spacing transforms correctly 1`] = `
+"import { Separator, Spacing } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    (<React.Fragment>
+      <Spacing size="2xs">
+        <Separator/>
+      </Spacing>
+      <Spacing size="2xs" />
+      <Spacing size={"2xs"} />
+    </React.Fragment>)
+  );
+};"
+`;

--- a/packages/codemods/src/transforms/v7/__tests__/spacing.ts
+++ b/packages/codemods/src/transforms/v7/__tests__/spacing.ts
@@ -1,0 +1,11 @@
+jest.autoMockOff();
+import { defineSnapshotTestFromFixture } from '../../../testHelpers/testHelper';
+
+const name = 'spacing';
+const fixtures = ['basic'] as const;
+
+describe(name, () => {
+  fixtures.forEach((test) =>
+    defineSnapshotTestFromFixture(__dirname, name, global.TRANSFORM_OPTIONS, `${name}/${test}`),
+  );
+});

--- a/packages/codemods/src/transforms/v7/header.ts
+++ b/packages/codemods/src/transforms/v7/header.ts
@@ -16,6 +16,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
 
   remapSizePropValue({
     j,
+    api,
     source,
     componentName: localName,
     sizesMap: {

--- a/packages/codemods/src/transforms/v7/spacing.ts
+++ b/packages/codemods/src/transforms/v7/spacing.ts
@@ -9,7 +9,8 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const { alias } = options;
   const j = api.jscodeshift;
   const source = j(file.source);
-  const { localName } = getImportInfo(j, file, 'Spinner', alias);
+  const { localName } = getImportInfo(j, file, 'Spacing', alias);
+
   if (!localName) {
     return source.toSource();
   }
@@ -20,10 +21,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
     source,
     componentName: localName,
     sizesMap: {
-      large: 'xl',
-      medium: 'l',
-      regular: 'm',
-      small: 's',
+      '3xs': '2xs',
     },
   });
 

--- a/packages/vkui/src/components/Header/Header.module.css
+++ b/packages/vkui/src/components/Header/Header.module.css
@@ -18,7 +18,7 @@
 .Header__before {
   align-self: center;
   margin-inline-end: var(--vkui--spacing_size_m);
-  margin-block-start: var(--vkui--spacing_size_3xs);
+  margin-block-start: var(--vkui--spacing_size_2xs);
 }
 
 .Header__before--withSubtitle {

--- a/packages/vkui/src/components/Spacing/Spacing.module.css
+++ b/packages/vkui/src/components/Spacing/Spacing.module.css
@@ -7,11 +7,6 @@
   box-sizing: border-box;
 }
 
-.Spacing--3xs {
-  /* TODO [>=7]: удалить deprecated токен */
-  --vkui_internal--Spacing_gap: var(--vkui--spacing_size_3xs);
-}
-
 .Spacing--2xs {
   --vkui_internal--Spacing_gap: var(--vkui--spacing_size_2xs);
 }

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -7,7 +7,6 @@ import styles from './Spacing.module.css';
 export const CUSTOM_CSS_TOKEN_FOR_USER_GAP = '--vkui_internal--Spacing_gap';
 
 export const sizesClassNames: Record<SpacingSize, string> = {
-  '3xs': styles['Spacing--3xs'],
   '2xs': styles['Spacing--2xs'],
   'xs': styles['Spacing--xs'],
   's': styles['Spacing--s'],
@@ -19,7 +18,7 @@ export const sizesClassNames: Record<SpacingSize, string> = {
   '4xl': styles['Spacing--4xl'],
 };
 
-export type SpacingSize = 's' | 'm' | 'l' | '3xs' | '2xs' | 'xs' | 'xl' | '2xl' | '3xl' | '4xl';
+export type SpacingSize = 's' | 'm' | 'l' | '2xs' | 'xs' | 'xl' | '2xl' | '3xl' | '4xl';
 
 export interface SpacingProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
   /**

--- a/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddb07ab72b7d0430d923693b509fe32aa97516c731ed94ed90f6b4cbd917695d
-size 7831
+oid sha256:426da6e137c369af0f35cb25f60e5e6eb69ee18ba51603bb277db5e794d2599e
+size 7385

--- a/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e9a80df8bff4f6fe0496e8020bbb104b6e2709effc6412661a1061bee608a96
-size 14260
+oid sha256:b4a7e8873839134b451b70489cf1ef828c24a7c3ab61f4608a121d579f496e42
+size 13642

--- a/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8b3b25315ba825ae5c1a708ce8f19cab1a06876267d07cf19ef70c0ce9d2de5
-size 7431
+oid sha256:612fc15808c0b85e6a44348aa7bc19ce43b995de90955f8e42f24520f02f4b83
+size 6896


### PR DESCRIPTION
- [x] Unit-тесты
- [x] e2e-тесты
- [x] Release notes

## Описание

Сейчас в некоторых местах в css используется токен `--vkui--spacing_size_3xs`, но этот токен устарел и равен токену `--vkui--spacing_size_2xs`. Нужно избавиться от использования этого токена в css

## Изменения

- Выпилил использование этого токена в компоненте Spacing, соответственно удалил один из вариантов пропа size
- Реализовал кодмод, чтобы size: 3xs преобразовывался в 2xs в Spacing.
- Заменил использование токена `--vkui--spacing_size_3xs` на `--vkui--spacing_size_2xs` в css компонента Header

## Release notes

## BREAKING CHANGE
- Spacing: удален вариант значения пропа size `3xs` вместо него можно использовать `2xs`, он такой же по значению
  ```diff
  - <Spacing size="3xs" />
  + <Spacing size="2xs" />
  ```
