### PR TITLE
tech: fix clear command on codesandbox

### DIFF
--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -50,7 +50,7 @@
     "build": "yarn clear && yarn run -T concurrently 'yarn:build:*'",
     "build:types": "yarn run -T concurrently 'yarn:tsc:*'",
     "build:no-types": "yarn run -T concurrently 'yarn:swc:*' 'yarn:postcss'",
-    "clear": "yarn run -T shx rm -rf dist/*",
+    "clear": "yarn run -T shx rm -rf dist/* || yarn run -T shx true",
     "docker:clear-playwright-cache": "../../scripts/generate_env_docker.sh && docker compose --env-file=./.env.docker rm -f && docker volume rm vkui_package_vkui_playwright_cache",
     "postcss": "yarn run -T cross-env NODE_ENV=production concurrently 'yarn:postcss:*'",
     "postcss:bundle": "yarn run -T webpack --config webpack.styles.config.js",


### PR DESCRIPTION
related: #7627

## Описание
Сборка на [codesandbox](https://ci.codesandbox.io/status/VKCOM/VKUI/pr/7640/builds/544301) не проходит. 
Падает на шаге 

```shell
yarn run build:vkui (in /tmp/4789e560)
No matches found: "dist/*"
Error: Process rejected with status code 1
    at ChildProcess.<anonymous> (/app/dist/utils/exec.js:20:27)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12) {
  code: 1
}
```

Ошибка возникает из-за того, что мы вызываем `yarn clear` перед сборкой, то есть вызываем `rm -rf dist/*` когда папки `dist` нету, или она пуста. В таком случае `rm` кидает ошибку.

Из-за того, что мы используем `shx` для запуска `rm`, для поддержки кросплатформенной сборки, нет возможности проверить есть ли папка `dist` и есть ли в ней файлы, перед запуском `rm`, так как `shx` не поддерживает достаточно утилит для этого.
Если бы в shelljs выпустили новую версию с фиксом для [grеp](https://github.com/shelljs/shelljs/blob/8a960da8383666024bfdb2eff709a4fdf66333ee/src/grep.js#L78-L81), то мы могли бы решить это более элегантно и не игнорировать все возможные ошибки. Но на текущий момент в версии [v0.8.5](https://github.com/shelljs/shelljs/blob/70668a4555c7d49c4f67d53ea063b899be4d6d40/src/grep.js#L70-L71) этого нет.

Поэтому мы просто игнорируем ошибку. Думаю, что это вплоне безопасно для команды `rm -rf dist/*`