### PR TITLE
feat(EllipsisText): add prop tooltipEnabled, that show tooltip with full text

### DIFF
--- a/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.module.css
+++ b/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.module.css
@@ -15,7 +15,7 @@
 }
 
 /* Хак для того, чтобы убрать системный тултип в Safari */
-.EllipsisText__content:after {
+.EllipsisText__content::after {
   content: '';
   display: block;
 }

--- a/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.module.css
+++ b/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.module.css
@@ -11,6 +11,13 @@
   white-space: nowrap;
   flex: 0 0 auto;
   max-inline-size: inherit;
+  position: relative;
+}
+
+/* Хак для того, чтобы убрать системный тултип в Safari */
+.EllipsisText__content:after {
+  content: "";
+  display: block;
 }
 
 .EllipsisText__content--multiline {

--- a/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.module.css
+++ b/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.module.css
@@ -16,7 +16,7 @@
 
 /* Хак для того, чтобы убрать системный тултип в Safari */
 .EllipsisText__content:after {
-  content: "";
+  content: '';
   display: block;
 }
 

--- a/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.test.tsx
+++ b/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.test.tsx
@@ -1,7 +1,88 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { baselineComponent } from '../../../testing/utils';
 import { EllipsisText } from './EllipsisText';
 import styles from './EllipsisText.module.css';
+
+const setupEllipsisOverflow = ({
+  initialOffsetHeight = 0,
+  initialScrollHeight = 0,
+  initialOffsetWidth = 0,
+  initialScrollWidth = 0,
+  maxLines,
+}: {
+  initialOffsetHeight?: number;
+  initialScrollHeight?: number;
+  initialOffsetWidth?: number;
+  initialScrollWidth?: number;
+  maxLines?: number;
+}) => {
+  let content: HTMLElement;
+  let offsetHeight = initialOffsetHeight;
+  let scrollHeight = initialScrollHeight;
+  let offsetWidth = initialOffsetWidth;
+  let scrollWidth = initialScrollWidth;
+
+  const Fixture = () => {
+    return (
+      <EllipsisText
+        tooltipEnabled
+        maxLines={maxLines}
+        getRootRef={(element) => {
+          if (!element) {
+            return;
+          }
+          content = element.firstElementChild as HTMLElement;
+          jest.spyOn(content, 'offsetHeight', 'get').mockImplementation(() => offsetHeight);
+          jest.spyOn(content, 'scrollHeight', 'get').mockImplementation(() => scrollHeight);
+          jest.spyOn(content, 'offsetWidth', 'get').mockImplementation(() => offsetWidth);
+          jest.spyOn(content, 'scrollWidth', 'get').mockImplementation(() => scrollWidth);
+        }}
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+      </EllipsisText>
+    );
+  };
+
+  const result = render(<Fixture />);
+
+  const rerender = () => {
+    result.rerender(<Fixture />);
+  };
+
+  return {
+    get container() {
+      return result.container;
+    },
+    get content() {
+      return content;
+    },
+    set offsetHeight(newValue: number) {
+      offsetHeight = newValue;
+    },
+    set scrollHeight(newValue: number) {
+      scrollHeight = newValue;
+    },
+    set offsetWidth(newValue: number) {
+      offsetWidth = newValue;
+    },
+    set scrollWidth(newValue: number) {
+      scrollWidth = newValue;
+    },
+    rerender,
+  };
+};
+
+const checkShowTooltipByMouseOver = async (content: HTMLElement, needShow: boolean) => {
+  fireEvent.mouseOver(content);
+  await waitFor(() => {
+    if (needShow) {
+      expect(screen.queryByRole('tooltip')).toBeTruthy();
+    } else {
+      expect(screen.queryByRole('tooltip')).toBeFalsy();
+    }
+  });
+};
 
 describe('EllipsisText', () => {
   baselineComponent((props) => <EllipsisText {...props}>EllipsisText</EllipsisText>);
@@ -20,5 +101,36 @@ describe('EllipsisText', () => {
     const text = screen.getByTestId('text-wrapper').firstElementChild as HTMLElement;
     expect(text).not.toBeNull();
     expect(text).toHaveClass(styles['EllipsisText__content--multiline']);
+  });
+
+  it('should show tooltip when horizontal overflow', async () => {
+    const setupData = setupEllipsisOverflow({
+      initialScrollWidth: 80,
+      initialOffsetWidth: 60,
+    });
+    await checkShowTooltipByMouseOver(setupData.content, true);
+  });
+
+  it('should show tooltip when vertical overflow', async () => {
+    const setupData = setupEllipsisOverflow({
+      initialScrollHeight: 80,
+      initialOffsetHeight: 60,
+    });
+    await checkShowTooltipByMouseOver(setupData.content, true);
+  });
+
+  it('check recalculate show tooltip when resize element', async () => {
+    const setupData = setupEllipsisOverflow({
+      initialScrollWidth: 60,
+      initialOffsetWidth: 60,
+    });
+    // тултип не покажется, так как контент не будет обрезан
+    await checkShowTooltipByMouseOver(setupData.content, false);
+    setupData.scrollWidth = 80;
+    // Когда CustomResizeObserver заменят на ResizeObserver тест упадет
+    // Нужно будет по-другому тригерить событие ресайза или просто замокать ResizeObserver
+    const iframe = setupData.container.getElementsByTagName('IFRAME')[0] as HTMLIFrameElement;
+    fireEvent(iframe.contentWindow!, new Event('resize'));
+    await checkShowTooltipByMouseOver(setupData.content, true);
   });
 });

--- a/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.tsx
+++ b/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.tsx
@@ -1,8 +1,10 @@
-import { useRef } from 'react';
+import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useIsomorphicLayoutEffect } from '../../../lib/useIsomorphicLayoutEffect';
 import type { HasRootRef } from '../../../types';
 import type { RootComponentProps } from '../../RootComponent/RootComponent';
+import { Tooltip, type TooltipProps } from '../../Tooltip/Tooltip';
+import { useOverflowDetector } from './useOverflowDetector';
 import styles from './EllipsisText.module.css';
 
 export interface EllipsisTextProps
@@ -22,7 +24,43 @@ export interface EllipsisTextProps
    * > @see [line-clamp](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp)
    */
   maxLines?: number;
+  /**
+   * Отвечает за то, нужно ли показывать тултип с полным текстом.
+   * Будет показывать тултип, только в случае, когда текст не помещается и обрезается.
+   */
+  tooltipEnabled?: boolean;
+  /**
+   * Позиция тултипа, который показывает полный текст. Работает совместно с `tooltipEnabled=true`
+   */
+  tooltipPlacement?: TooltipProps['placement'];
 }
+
+const TextWithTooltip = ({
+  children,
+  contentRef,
+  tooltipChildren,
+  placement,
+}: {
+  children: React.ReactNode;
+  contentRef: React.RefObject<HTMLElement>;
+  tooltipChildren: React.ReactNode;
+  placement: EllipsisTextProps['tooltipPlacement'];
+}) => {
+  const needToShowTooltip = useOverflowDetector({
+    ref: contentRef,
+  });
+
+  return (
+    <Tooltip
+      text={tooltipChildren}
+      placement={placement}
+      usePortal
+      shown={needToShowTooltip ? undefined : false}
+    >
+      <div>{children}</div>
+    </Tooltip>
+  );
+};
 
 /** Компонент ограничивает текстовый контент убирая его в многоточие.
  *
@@ -35,9 +73,11 @@ const EllipsisText = ({
   children,
   maxWidth,
   maxLines = 1,
+  tooltipEnabled,
+  tooltipPlacement = 'top',
   ...restProps
 }: EllipsisTextProps): React.ReactNode => {
-  const contentRef = useRef<HTMLSpanElement | null>(null);
+  const contentRef = React.useRef<HTMLSpanElement | null>(null);
 
   useIsomorphicLayoutEffect(() => {
     if (contentRef && contentRef.current) {
@@ -45,19 +85,39 @@ const EllipsisText = ({
     }
   }, [contentRef, maxLines]);
 
-  return (
-    <span ref={getRootRef} className={classNames(styles['EllipsisText'], className)} {...restProps}>
+  const content = React.useMemo(() => {
+    return (
       <span
-        style={{ maxWidth }}
-        ref={contentRef}
-        className={classNames(
-          styles['EllipsisText__content'],
-          maxLines > 1 && styles['EllipsisText__content--multiline'],
-        )}
+        ref={getRootRef}
+        className={classNames(styles['EllipsisText'], className)}
+        {...restProps}
       >
-        {children}
+        <span
+          style={{ maxWidth }}
+          ref={contentRef}
+          className={classNames(
+            styles['EllipsisText__content'],
+            maxLines > 1 && styles['EllipsisText__content--multiline'],
+          )}
+        >
+          {children}
+        </span>
       </span>
-    </span>
+    );
+  }, [children, className, getRootRef, maxLines, maxWidth, restProps]);
+
+  if (!tooltipEnabled) {
+    return content;
+  }
+
+  return (
+    <TextWithTooltip
+      contentRef={contentRef}
+      tooltipChildren={children}
+      placement={tooltipPlacement}
+    >
+      {content}
+    </TextWithTooltip>
   );
 };
 

--- a/packages/vkui/src/components/Typography/EllipsisText/Readme.md
+++ b/packages/vkui/src/components/Typography/EllipsisText/Readme.md
@@ -20,7 +20,7 @@
 <HorizontalCell
   size="l"
   header={
-    <EllipsisText maxWidth={100} maxLines={2}>
+    <EllipsisText maxWidth={100} maxLines={2} tooltipEnabled>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit
     </EllipsisText>
   }

--- a/packages/vkui/src/components/Typography/EllipsisText/useOverflowDetector.ts
+++ b/packages/vkui/src/components/Typography/EllipsisText/useOverflowDetector.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { useResizeObserver } from '../../../hooks/useResizeObserver';
+
+export const useOverflowDetector = ({ ref }: { ref: React.RefObject<HTMLElement> }): boolean => {
+  const [overflow, setOverflow] = React.useState(false);
+
+  const recalculateOverflow = React.useCallback(() => {
+    if (!ref || !ref.current) {
+      return;
+    }
+    setOverflow(
+      ref.current.offsetWidth < ref.current.scrollWidth ||
+        ref.current.offsetHeight < ref.current.scrollHeight,
+    );
+  }, [ref]);
+
+  useResizeObserver(ref, recalculateOverflow, {
+    forceUseIframe: true,
+  });
+
+  React.useEffect(recalculateOverflow, [recalculateOverflow]);
+
+  return overflow;
+};

--- a/packages/vkui/src/hooks/useResizeObserver.ts
+++ b/packages/vkui/src/hooks/useResizeObserver.ts
@@ -9,6 +9,11 @@ import { useStableCallback } from './useStableCallback';
 export function useResizeObserver(
   ref: React.MutableRefObject<HTMLElement | null> | React.RefObject<HTMLElement | null> | null,
   callback: (element: HTMLElement) => void,
+  options: {
+    forceUseIframe: boolean;
+  } = {
+    forceUseIframe: false,
+  },
 ): void {
   const stableCallback = useStableCallback(callback);
 
@@ -20,11 +25,11 @@ export function useResizeObserver(
       }
       const element = ref.current;
       const observer = new CustomResizeObserver(() => stableCallback(element));
-      observer.observe(element);
+      observer.observe(element, options.forceUseIframe);
       observer.appendToTheDOM();
 
       return () => observer.disconnect();
     },
-    [ref, stableCallback],
+    [options.forceUseIframe, ref, stableCallback],
   );
 }

--- a/packages/vkui/src/lib/floating/customResizeObserver.ts
+++ b/packages/vkui/src/lib/floating/customResizeObserver.ts
@@ -47,8 +47,8 @@ export class CustomResizeObserver {
     this.updateFunction = updateFunction;
   }
 
-  observe(element: HTMLElement): void {
-    if (isPositioned(element)) {
+  observe(element: HTMLElement, forceUseIframe = false): void {
+    if (forceUseIframe || isPositioned(element)) {
       return this.observeUsingIframe(element);
     }
     return this.observeUsingMutationObserver(element);


### PR DESCRIPTION
- close #7636

---

- [x] Unit-тесты
- [x] e2e-тесты
- [x] Документация фичи
- [x] Release notes

## Описание

Для компонента `EllipsisText` нужно реализовать отображение тултипа с полным не обрезанным текстом. Важно, чтобы этот тултип отображался только, когда текст действительно не помещается и обрезается 

## Изменения

- Добавил проп `tooltipEnabled` для включения отображения тултипа с полным текстом
- Добавил хук `useOverflowDetector`, который определяет есть ли переполнение текстом, чтобы показывать тултип только при переполнении
- Добавил проп `tooltipPlacement`, чтобы управлять положением тултипа
- Доработал CustomResizeObserver, добавил опцию форсированного использования iframe для отслеживания размеров объекта
- Добавил тесты для нового функционала

## Release notes
## Улучшения
- EllipsisText: Добавлен проп `tooltipEnabled` для включения отображения тултипа с полным текстом
