### PR TITLE
fix(UseFloatingWithInteractions): fix bug with disableAfterClickClose in Tooltip

### DIFF
--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -122,7 +122,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   const handleFocusOnReference = useStableCallback(() => {
     // Повторный вызов события фокуса - следствие клика на reference-элемент
     if (shownLocalState.shown) {
-      if (!closeAfterClick) {
+      if (!closeAfterClick && shownLocalState.reason === 'hover') {
         return;
       }
       commitShownLocalState(false, 'focus');

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -122,6 +122,9 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
   const handleFocusOnReference = useStableCallback(() => {
     // Повторный вызов события фокуса - следствие клика на reference-элемент
     if (shownLocalState.shown) {
+      if (!closeAfterClick) {
+        return;
+      }
       commitShownLocalState(false, 'focus');
       return;
     }


### PR DESCRIPTION
- close #7635

---

- [x] Unit-тесты
- [x] Release notes

## Описание

Есть проп `disableCloseAfterClick` у компонента Tooltip, который блокирует закрытие тултипа при клике на якорный элемент

## Изменения

При исследовании бага выяснил, что проблема связана с тем, что по умолчанию у тултипа trigger'ы это `['hover', 'focus']` и именно из-за наличия фокуса, при нажатии на элемент, срабатывает событие фокуса у элемент, и затем срабатывает соответствующий обработчик в котором тултип закрывается.

Чтобы поправить баг, в обработчике фокуса добавил проверку на флаг `closeAfterClick`, а также на причину текущего открытия поповера, а именно то, что поповер был открыт по ховеру. Таким образом баг не воспроизводится и старое поведение работает корректно

## Release notes
- Tooltip: поправлен баг с закрытием тултипа при клике на якорный элемент при прокидывании `disableCloseAfterClick=true`