### PR TITLE
docs(SimpleCell): `expandable` description update

### DIFF
--- a/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
@@ -61,8 +61,10 @@ export interface SimpleCellOwnProps extends HasComponent {
    */
   disabled?: boolean;
   /**
-   * В режиме `auto` в iOS добавляет chevron справа.
-   * Передавать `always`, если предполагается переход при клике по ячейке.
+   * Управляет видимостью иконки шеврона `›`
+   *
+   * - `auto` - добавляет шеврон справа только для платформы `ios`;
+   * - `always` - всегда показывает шеврон.
    */
   expandable?: 'auto' | 'always';
   /**


### PR DESCRIPTION

## Описание

Описание свойство `expandable=always` может путать, так как кажется что его необходимо ставить если ячейка кликабельна

## Изменения

Обновляем описание на более ясное

## Release notes
-