### PR TITLE
fix(AppRoot): Use memo for AppRootContext value

### DIFF
--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -198,20 +198,23 @@ export const AppRoot = ({
     [scroll],
   );
 
+  const contextValue = React.useMemo(
+    () => ({
+      appRoot: appRootRef,
+      portalRoot: portalRootRef,
+      embedded: mode === 'embedded',
+      mode,
+      disablePortal,
+      layout,
+      get keyboardInput() {
+        return isKeyboardInputActiveRef.current;
+      },
+    }),
+    [disablePortal, isKeyboardInputActiveRef, layout, mode],
+  );
+
   const content = (
-    <AppRootContext.Provider
-      value={{
-        appRoot: appRootRef,
-        portalRoot: portalRootRef,
-        embedded: mode === 'embedded',
-        mode,
-        disablePortal,
-        layout,
-        get keyboardInput() {
-          return isKeyboardInputActiveRef.current;
-        },
-      }}
-    >
+    <AppRootContext.Provider value={contextValue}>
       <ScrollController elRef={appRootRef}>{children}</ScrollController>
     </AppRootContext.Provider>
   );


### PR DESCRIPTION
- [x] Release notes

## Описание
Выяснилось, что если `AppRoot` по какой-то причине ререндерится, то это вызывает ререндер компонентов, основанных на `Tappable`/`Clickable` компонентах, даже если они обернуты в `React.memo`. 
Виной тому пересоздающийся объект контекста.

Когда может ререндерится `AppRoot`?
Например, когда он обернут в компонент, который слушает изменения стора, бывает нужно для того, чтобы менять тему самого `AppRoot`. Тогда получается, что каждое обновление стора вызывает ререндер `AppRoot` и компонентов `VKUI`.

Пример с вспроизведением: https://7zmxhp.csb.app/

<details>
<summary>
Нужно посмотреть что происходит в react profiler при каждом ререндере AppRoot.
</summary>

| До | После |
|---|----|
| <img width="967" alt="Screenshot 2024-09-26 at 16 17 16" src="https://github.com/user-attachments/assets/acab3dd3-bbb5-4797-a96a-0599c625aad0"> | <img width="967" alt="Screenshot 2024-09-26 at 16 46 16" src="https://github.com/user-attachments/assets/a799a434-a8dd-4b8b-bb34-784ca7490a36"> |


</details>

<details>

<summary>Код:</summary>

```tsx


import React, { FunctionComponent, memo, useEffect, useState } from 'react'
import { createRoot } from 'react-dom/client'
import { AppRoot, Button } from '@vkontakte/vkui'

const rootContainer = document.getElementById('root')

if (rootContainer === null) {
  throw new Error('React #root element does not exist')
}

const root = createRoot(rootContainer, { identifierPrefix: 'vkm' })

root.render(<App />)

function App() {
  const [_, setState] = useState(0)

  useEffect(() => {
    setInterval(() => {
      setState((state) => ++state)
    }, 1000)
  }, [])

  return (
    <AppRoot>
      <MyButtons isVKUI />
      <MyButtons />
    </AppRoot>
  )
}

const MyButtons: FunctionComponent<{ isVKUI?: boolean }> = memo(
  function MyButtons({ isVKUI }) {
    return isVKUI ? (
      <div>
        <Button>VKUI button 1</Button>
        <br />
        <Button>VKUI button 2</Button>
        <br />
      </div>
    ) : (
      <div>
        <button>not VKUI button 1</button>
        <br />
        <button>not VKUI button 2</button>
        <br />
      </div>
    )
  },
)
```

</details>

## Изменения
Используем `React.useMemo` для объекта, который мы передаем как значение контекста `AppRootContext`.

## Release notes
## Исправления
- AppRoot: мемоизируем контекст `AppRootContext`, чтобы компоненты, зависящие от него, лишний раз не ререндерелись при ререндере `AppRoot`.

<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
