### PR TITLE
docs(HorizontalScroll): rm TODO from description

### DIFF
--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -53,8 +53,6 @@ export interface HorizontalScrollProps
   scrollOnAnyWheel?: boolean;
   /**
    * Задает потомкам инлайновое положение (горизонально)
-   *
-   * TODO [>=7]: Сделать по умолчанию `true` (или удалить, применяя стили всегда)
    */
   inline?: boolean;
 }


### PR DESCRIPTION
## Описание

В описании свойства залезло TODO. В мастере его уже нет, но есть в v6 

## Изменения

Удаляем TODO из описания

## Release notes
-
