### PR TITLE
feat(Flex, SimpleGrid): extends from RootComponentProps

### DIFF
--- a/packages/vkui/src/components/Flex/Flex.tsx
+++ b/packages/vkui/src/components/Flex/Flex.tsx
@@ -7,8 +7,9 @@ import {
   type GapsProp,
   rowGapClassNames,
 } from '../../lib/layouts';
-import type { CSSCustomProperties, HTMLAttributesWithRootRef } from '../../types';
+import type { CSSCustomProperties } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
+import type { RootComponentProps } from '../RootComponent/RootComponent';
 import { FlexItem, type FlexItemProps } from './FlexItem/FlexItem';
 import styles from './Flex.module.css';
 
@@ -39,7 +40,7 @@ type FlexContentProps =
   | 'space-between'
   | 'space-evenly';
 
-export interface FlexProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
+export interface FlexProps extends Omit<RootComponentProps<HTMLElement>, 'baseClassName'> {
   /**
    * Направление осей, эквивалентно `flex-direction`.
    */

--- a/packages/vkui/src/components/Flex/FlexItem/FlexItem.tsx
+++ b/packages/vkui/src/components/Flex/FlexItem/FlexItem.tsx
@@ -1,6 +1,7 @@
 import { classNames } from '@vkontakte/vkjs';
-import type { HasChildren, HTMLAttributesWithRootRef } from '../../../types';
+import type { HasChildren } from '../../../types';
 import { RootComponent } from '../../RootComponent/RootComponent';
+import type { RootComponentProps } from '../../RootComponent/RootComponent';
 import styles from './FlexItem.module.css';
 
 const flexClassNames = {
@@ -18,7 +19,9 @@ const alignSelfClassNames = {
   stretch: styles.alignSelfStretch,
 };
 
-export interface FlexItemProps extends HTMLAttributesWithRootRef<HTMLDivElement>, HasChildren {
+export interface FlexItemProps
+  extends Omit<RootComponentProps<HTMLElement>, 'baseClassName'>,
+    HasChildren {
   /**
    * Для задания выравнивания, отлично от родительского, эквивалентно `align-self`
    */

--- a/packages/vkui/src/components/SimpleGrid/SimpleGrid.tsx
+++ b/packages/vkui/src/components/SimpleGrid/SimpleGrid.tsx
@@ -5,8 +5,9 @@ import {
   type GapsProp,
   rowGapClassNames,
 } from '../../lib/layouts';
-import type { CSSCustomProperties, HTMLAttributesWithRootRef } from '../../types';
+import type { CSSCustomProperties } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
+import type { RootComponentProps } from '../RootComponent/RootComponent';
 import styles from './SimpleGrid.module.css';
 
 const marginClassNames = {
@@ -23,7 +24,7 @@ const alignClassNames = {
   baseline: styles.alignBaseline,
 };
 
-export interface SimpleGridProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
+export interface SimpleGridProps extends Omit<RootComponentProps<HTMLElement>, 'baseClassName'> {
   /**
    * Количество колонок
    */


### PR DESCRIPTION
## Описание

По просьбе из чата расширяем `Flex`, `Flex.Item` и `SimpleGrid` пропами из `RootComponent`

## Release notes

## Улучшения
- Flex: свойства теперь наследуются из `RootComponentProps`
- SimpleGrid: свойства теперь наследуются из `RootComponentProps`

