### PR TITLE
fix(vkui-floating-ui): esm with .mjs

### DIFF
--- a/packages/vkui-floating-ui/package.json
+++ b/packages/vkui-floating-ui/package.json
@@ -51,8 +51,8 @@
     },
     "./utils/dom": {
       "import": {
-        "types": "./utils/dom/floating-ui.utils.dom.d.ts",
-        "default": "./utils/dom/floating-ui.utils.dom.esm.js"
+        "types": "./utils/dist/floating-ui.utils.dom.d.mts",
+        "default": "./utils/dist/floating-ui.utils.dom.mjs"
       },
       "types": "./utils/dom/floating-ui.utils.dom.d.ts",
       "module": "./utils/dom/floating-ui.utils.dom.esm.js",


### PR DESCRIPTION
К сожалению, текущими тестами это не отловить. Возможно, нужна тестовая сборка чисто под `mjs` на будущее.

## Описание
Пытался собрать Vite + TS + React + VKUI + SSR используя дефолтный [шаблон](https://github.com/bluwy/create-vite-extra/tree/master/template-ssr-react-ts), но наткнулся на ошибку:
```sh
/Users/andrey.medvedev/src/experiment/vkui-ssr-7529/node_modules/@vkontakte/vkui-floating-ui/utils/dom/floating-ui.utils.dom.esm.js:1
import { _ as _instanceof } from "@swc/helpers/_/_instanceof";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (node:internal/modules/cjs/loader:1378:20)
    at Module._compile (node:internal/modules/cjs/loader:1428:41)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at cjsLoader (node:internal/modules/esm/translators:346:17)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:286:7)
    at ModuleJob.run (node:internal/modules/esm/module_job:234:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
    at async nodeImport (file:///Users/andrey.medvedev/src/experiment/vkui-ssr-7529/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:52999:15)
    at async ssrImport (file:///Users/andrey.medvedev/src/experiment/vkui-ssr-7529/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:52857:16)
    at async eval (/Users/andrey.medvedev/src/experiment/vkui-ssr-7529/node_modules/@vkontakte/vkui/dist/cssm/lib/dom.js:7:31)
    at async instantiateModule (file:///Users/andrey.medvedev/src/experiment/vkui-ssr-7529/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:52915:5)
```

Оказывается, что мы не все файлы из модуля floating-ui/utils/dom/ берем по правильному пути при сборке.
[floating-ui.utils.dom.mjs](https://cdn.jsdelivr.net/npm/@floating-ui/utils@0.2.8/dist/floating-ui.utils.dom.mjs) файл лежит немного выше в [floatin-ui/utils/dist/](https://cdn.jsdelivr.net/npm/@floating-ui/utils@0.2.8/dist/), мы же берём `esm` файл вместо него и, видимо, его начинают воспринимать как `commonjs` из-за разницы в расширении, не смотря на то, что у файлов .mjs и .esm.js одинаковое содержание.

## Изменения
Поправил пути для .mjs файлов.

