### PR TITLE
feat: add use client directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-compiler": "0.0.0-experimental-56229e1-20240813",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-server-components": "^1.2.0",
     "eslint-plugin-unicorn": "^55.0.0",
     "husky": "^9.1.6",
     "jest": "^29.7.0",

--- a/packages/vkui/.eslintrc.js
+++ b/packages/vkui/.eslintrc.js
@@ -16,7 +16,7 @@ if (!E2E_TEST || !E2E_PLAYGROUND_HELPERS) {
 
 module.exports = {
   root: false,
-  extends: ['plugin:react-hooks/recommended'],
+  extends: ['plugin:react-hooks/recommended', 'plugin:react-server-components/recommended'],
   plugins: ['import', '@project-tools/vkui', 'unicorn'],
   parserOptions: {
     project: './tsconfig.eslint.json',
@@ -177,6 +177,7 @@ module.exports = {
             ],
           },
         ],
+        'react-server-components/use-client': 'off',
       },
     },
 
@@ -186,6 +187,7 @@ module.exports = {
         'no-restricted-properties': 'off',
         'no-restricted-globals': 'off',
         'react/display-name': 'off',
+        'react-server-components/use-client': 'off',
       },
     },
 
@@ -215,6 +217,7 @@ module.exports = {
             ],
           },
         ],
+        'react-server-components/use-client': 'off',
       },
     },
 
@@ -244,6 +247,7 @@ module.exports = {
             ],
           },
         ],
+        'react-server-components/use-client': 'off',
       },
     },
 
@@ -252,6 +256,7 @@ module.exports = {
       rules: {
         'import/no-default-export': 'off',
         '@typescript-eslint/consistent-type-assertions': 'off',
+        'react-server-components/use-client': 'off',
       },
     },
   ],

--- a/packages/vkui/src/components/Accordion/Accordion.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useCustomEnsuredControl } from '../../hooks/useEnsuredControl';
 import { useObjectMemo } from '../../hooks/useObjectMemo';

--- a/packages/vkui/src/components/Accordion/AccordionContent.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionContent.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';

--- a/packages/vkui/src/components/Accordion/AccordionSummary.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionSummary.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon24ChevronDown, Icon24ChevronUp } from '@vkontakte/icons';
 import { callMultiple } from '../../lib/callMultiple';

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { noop } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ActionSheet/ActionSheetDropdownMenu.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetDropdownMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ActionSheet/ActionSheetDropdownSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetDropdownSheet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/AdaptiveIconRenderer/AdaptiveIconRenderer.tsx
+++ b/packages/vkui/src/components/AdaptiveIconRenderer/AdaptiveIconRenderer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditionalRender';
 

--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { getSizeX, isCompactByViewHeight, isCompactByViewWidth } from '../../lib/adaptivity';
 import type { HasChildren } from '../../types';

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon20Cancel } from '@vkontakte/icons';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/Alert/AlertAction.tsx
+++ b/packages/vkui/src/components/Alert/AlertAction.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/Alert/AlertActions.tsx
+++ b/packages/vkui/src/components/Alert/AlertActions.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/Alert/AlertTypography.tsx
+++ b/packages/vkui/src/components/Alert/AlertTypography.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { usePlatform } from '../../hooks/usePlatform';
 import type { HasChildren } from '../../types';

--- a/packages/vkui/src/components/AppRoot/AppRoot.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRoot.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
+++ b/packages/vkui/src/components/AppRoot/AppRootPortal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useAppearance } from '../../hooks/useAppearance';
 import { useIsClient } from '../../hooks/useIsClient';

--- a/packages/vkui/src/components/AppRoot/ScrollContext.tsx
+++ b/packages/vkui/src/components/AppRoot/ScrollContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { noop } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { ImageBase, type ImageBaseBadgeProps, ImageBaseContext } from '../../ImageBase/ImageBase';

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import {

--- a/packages/vkui/src/components/Banner/Banner.tsx
+++ b/packages/vkui/src/components/Banner/Banner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon24Cancel, Icon24Chevron, Icon24Dismiss, Icon24DismissDark } from '@vkontakte/icons';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/BaseGallery/BaseGallery.tsx
+++ b/packages/vkui/src/components/BaseGallery/BaseGallery.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityHasPointer } from '../../hooks/useAdaptivityHasPointer';

--- a/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/BaseGallery/CarouselBase/CarouselBase.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityHasPointer } from '../../../hooks/useAdaptivityHasPointer';

--- a/packages/vkui/src/components/Button/Button.tsx
+++ b/packages/vkui/src/components/Button/Button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Calendar/Calendar.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { isSameDay, isSameMonth } from 'date-fns';

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { ENABLE_KEYBOARD_INPUT_EVENT_NAME } from '../../hooks/useKeyboardInputTracker';

--- a/packages/vkui/src/components/CalendarDays/CalendarDays.tsx
+++ b/packages/vkui/src/components/CalendarDays/CalendarDays.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { isSameDay, isSameMonth } from 'date-fns';

--- a/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   Icon12Dropdown,

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   addMonths,

--- a/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { setHours, setMinutes } from 'date-fns';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';

--- a/packages/vkui/src/components/CardGrid/CardGrid.tsx
+++ b/packages/vkui/src/components/CardGrid/CardGrid.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import type { HasComponent, HTMLAttributesWithRootRef } from '../../types';

--- a/packages/vkui/src/components/CardScroll/CardScroll.tsx
+++ b/packages/vkui/src/components/CardScroll/CardScroll.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useDOM } from '../../lib/dom';

--- a/packages/vkui/src/components/Cell/Cell.tsx
+++ b/packages/vkui/src/components/Cell/Cell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { SwappedItemRange } from '../../hooks/useDraggableWithDomApi';

--- a/packages/vkui/src/components/Cell/CellCheckbox/CellCheckbox.tsx
+++ b/packages/vkui/src/components/Cell/CellCheckbox/CellCheckbox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   Icon20CheckBoxOff,

--- a/packages/vkui/src/components/Cell/CellDragger/CellDragger.tsx
+++ b/packages/vkui/src/components/Cell/CellDragger/CellDragger.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icon24Reorder, Icon24ReorderIos } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
 import {

--- a/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   Icon20CheckBoxIndetermanate,

--- a/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { Tappable } from '../../Tappable/Tappable';

--- a/packages/vkui/src/components/ChipsInput/ChipsInput.tsx
+++ b/packages/vkui/src/components/ChipsInput/ChipsInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useExternRef } from '../../hooks/useExternRef';
 import { ChipsInputBase } from '../ChipsInputBase/ChipsInputBase';
 import type { ChipOption, ChipsInputBaseProps } from '../ChipsInputBase/types';

--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Cancel } from '@vkontakte/icons';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { isHTMLElement } from '@vkontakte/vkui-floating-ui/utils/dom';

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MouseEventHandler } from 'react';
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/Clickable/Clickable.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { useFocusVisible } from '../../hooks/useFocusVisible';

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { IconAppearanceProvider } from '@vkontakte/icons';
 import { useAutoDetectAppearance } from '../../hooks/useAutoDetectAppearance';

--- a/packages/vkui/src/components/ConfigProvider/ConfigProviderOverride.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProviderOverride.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
 import {

--- a/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HTMLAttributesWithRootRef } from '../../types';

--- a/packages/vkui/src/components/CustomScrollView/CustomScrollView.tsx
+++ b/packages/vkui/src/components/CustomScrollView/CustomScrollView.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/CustomScrollView/ScrollX.tsx
+++ b/packages/vkui/src/components/CustomScrollView/ScrollX.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { stopPropagation } from '../../lib/utils';

--- a/packages/vkui/src/components/CustomScrollView/ScrollY.tsx
+++ b/packages/vkui/src/components/CustomScrollView/ScrollY.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { stopPropagation } from '../../lib/utils';

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, debounce } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/CustomSelect/CustomSelectClearButton.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelectClearButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Cancel } from '@vkontakte/icons';
 import { stopPropagation } from '../../lib/utils';

--- a/packages/vkui/src/components/CustomSelect/CustomSelectInput.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelectInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Done } from '@vkontakte/icons';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Clear, Icon20CalendarOutline } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/vkui/src/components/DatePicker/DatePicker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { leadingZero } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Clear, Icon20CalendarOutline } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/DropZone/DropZone.tsx
+++ b/packages/vkui/src/components/DropZone/DropZone.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { callMultiple } from '../../lib/callMultiple';

--- a/packages/vkui/src/components/DropdownIcon/DropdownIcon.tsx
+++ b/packages/vkui/src/components/DropdownIcon/DropdownIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   Icon20ChevronUp,

--- a/packages/vkui/src/components/Epic/Epic.tsx
+++ b/packages/vkui/src/components/Epic/Epic.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { getNavId } from '../../lib/getNavId';

--- a/packages/vkui/src/components/Epic/ScrollSaver.tsx
+++ b/packages/vkui/src/components/Epic/ScrollSaver.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import type { HasChildren } from '../../types';

--- a/packages/vkui/src/components/FixedLayout/FixedLayout.tsx
+++ b/packages/vkui/src/components/FixedLayout/FixedLayout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback } from 'react';
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
+++ b/packages/vkui/src/components/FocusTrap/FocusTrap.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type AllHTMLAttributes, useCallback, useRef, useState } from 'react';
 import { arraysEquals } from '../../helpers/array';
 import { useExternRef } from '../../hooks/useExternRef';

--- a/packages/vkui/src/components/FormField/FormField.tsx
+++ b/packages/vkui/src/components/FormField/FormField.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/FormFieldClearButton/FormFieldClearButton.tsx
+++ b/packages/vkui/src/components/FormFieldClearButton/FormFieldClearButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Cancel } from '@vkontakte/icons';
 import { stopPropagation } from '../../lib/utils';

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HasComponent, HasRootRef } from '../../../types';

--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.tsx
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Gallery/Gallery.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { clamp } from '../../helpers/math';
 import { useIsClient } from '../../hooks/useIsClient';

--- a/packages/vkui/src/components/GridAvatar/GridAvatarBadge/GridAvatarBadge.tsx
+++ b/packages/vkui/src/components/GridAvatar/GridAvatarBadge/GridAvatarBadge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { ImageBase, type ImageBaseBadgeProps, ImageBaseContext } from '../../ImageBase/ImageBase';

--- a/packages/vkui/src/components/Group/GroupContainer.tsx
+++ b/packages/vkui/src/components/Group/GroupContainer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Header/Header.tsx
+++ b/packages/vkui/src/components/Header/Header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode, isPrimitiveReactNode } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { useAdaptivityHasPointer } from '../../hooks/useAdaptivityHasPointer';

--- a/packages/vkui/src/components/IconButton/IconButton.tsx
+++ b/packages/vkui/src/components/IconButton/IconButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/Image/Image.tsx
+++ b/packages/vkui/src/components/Image/Image.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { ImageBase, type ImageBaseOverlayProps, type ImageBaseProps } from '../ImageBase/ImageBase';

--- a/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
+++ b/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { ImageBase, type ImageBaseBadgeProps, ImageBaseContext } from '../../ImageBase/ImageBase';

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';

--- a/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HTMLAttributesWithRootRef } from '../../../types';

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityHasPointer } from '../../../hooks/useAdaptivityHasPointer';

--- a/packages/vkui/src/components/Input/Input.tsx
+++ b/packages/vkui/src/components/Input/Input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/InputLike/InputLike.tsx
+++ b/packages/vkui/src/components/InputLike/InputLike.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { callMultiple } from '../../lib/callMultiple';
 import { stopPropagation } from '../../lib/utils';

--- a/packages/vkui/src/components/ModalCard/ModalCard.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
+++ b/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ModalCardBase/ModalCardBaseCloseButton.tsx
+++ b/packages/vkui/src/components/ModalCardBase/ModalCardBaseCloseButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon20Cancel, Icon24Dismiss } from '@vkontakte/icons';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
+++ b/packages/vkui/src/components/ModalPageHeader/ModalPageHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';

--- a/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRoot.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';

--- a/packages/vkui/src/components/ModalRoot/ModalRootAdaptive.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootAdaptive.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { useScrollLock } from '../AppRoot/ScrollContext';

--- a/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';

--- a/packages/vkui/src/components/ModalRoot/useModalManager.tsx
+++ b/packages/vkui/src/components/ModalRoot/useModalManager.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { isFunction, noop } from '@vkontakte/vkjs';
 import { getNavId } from '../../lib/getNavId';

--- a/packages/vkui/src/components/ModalRoot/withModalRootContext.tsx
+++ b/packages/vkui/src/components/ModalRoot/withModalRootContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import type { ModalRootContextInterface } from './ModalRootContext';
 import { useModalRootContext } from './useModalRootContext';

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/NavTransitionContext/NavTransitionContext.tsx
+++ b/packages/vkui/src/components/NavTransitionContext/NavTransitionContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useObjectMemo } from '../../hooks/useObjectMemo';
 

--- a/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.tsx
+++ b/packages/vkui/src/components/NavTransitionDirectionContext/NavTransitionDirectionContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 type DirectionContextType = boolean | undefined;

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { hasReactNode } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';

--- a/packages/vkui/src/components/Pagination/Pagination.tsx
+++ b/packages/vkui/src/components/Pagination/Pagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon24ChevronCompactLeft, Icon24ChevronCompactRight } from '@vkontakte/icons';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Pagination/PaginationPage/PaginationPageEllipsis.tsx
+++ b/packages/vkui/src/components/Pagination/PaginationPage/PaginationPageEllipsis.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HasRootRef } from '../../../types';

--- a/packages/vkui/src/components/Panel/Panel.tsx
+++ b/packages/vkui/src/components/Panel/Panel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
+++ b/packages/vkui/src/components/PanelHeader/PanelHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/PanelHeaderBack/PanelHeaderBack.tsx
+++ b/packages/vkui/src/components/PanelHeaderBack/PanelHeaderBack.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   Icon20ChevronLeftOutline,

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, isPrimitiveReactNode } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/PanelHeaderClose/PanelHeaderClose.tsx
+++ b/packages/vkui/src/components/PanelHeaderClose/PanelHeaderClose.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icon24CancelOutline, Icon28CancelOutline } from '@vkontakte/icons';
 import { usePlatform } from '../../hooks/usePlatform';
 import { AdaptiveIconRenderer } from '../AdaptiveIconRenderer/AdaptiveIconRenderer';

--- a/packages/vkui/src/components/PanelHeaderContent/PanelHeaderContent.tsx
+++ b/packages/vkui/src/components/PanelHeaderContent/PanelHeaderContent.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.tsx
+++ b/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/PanelHeaderEdit/PanelHeaderEdit.tsx
+++ b/packages/vkui/src/components/PanelHeaderEdit/PanelHeaderEdit.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   Icon24DoneOutline,

--- a/packages/vkui/src/components/PanelHeaderSubmit/PanelHeaderSubmit.tsx
+++ b/packages/vkui/src/components/PanelHeaderSubmit/PanelHeaderSubmit.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icon24DoneOutline, Icon28DoneOutline } from '@vkontakte/icons';
 import { usePlatform } from '../../hooks/usePlatform';
 import { AdaptiveIconRenderer } from '../AdaptiveIconRenderer/AdaptiveIconRenderer';

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HTMLAttributesWithRootRef } from '../../types';

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { usePatchChildren } from '../../hooks/usePatchChildren';

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useExternRef } from '../../hooks/useExternRef';
 import {

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';

--- a/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
+++ b/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import type { HasRef, HasRootRef } from '../../../types';
 import { AdaptiveIconRenderer } from '../../AdaptiveIconRenderer/AdaptiveIconRenderer';

--- a/packages/vkui/src/components/Removable/Removable.tsx
+++ b/packages/vkui/src/components/Removable/Removable.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon24Cancel } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/RichCell/RichCell.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Root/Root.tsx
+++ b/packages/vkui/src/components/Root/Root.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useScrollLock } from '../AppRoot/ScrollContext';
 import { PopoutWrapper } from '../PopoutWrapper/PopoutWrapper';

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { Spinner } from '../Spinner/Spinner';

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon24Cancel } from '@vkontakte/icons';
 import { mergeCalls } from '../../lib/mergeCalls';

--- a/packages/vkui/src/components/Search/Search.tsx
+++ b/packages/vkui/src/components/Search/Search.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Clear, Icon16SearchOutline, Icon24Cancel } from '@vkontakte/icons';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/vkui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityConditionalRender } from '../../hooks/useAdaptivityConditionalRender';

--- a/packages/vkui/src/components/SelectMimicry/SelectMimicry.tsx
+++ b/packages/vkui/src/components/SelectMimicry/SelectMimicry.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/SelectionControl/SelectionControl.tsx
+++ b/packages/vkui/src/components/SelectionControl/SelectionControl.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/SelectionControl/SelectionControlLabel/SelectionControlLabel.tsx
+++ b/packages/vkui/src/components/SelectionControl/SelectionControlLabel/SelectionControlLabel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { RootComponent } from '../../RootComponent/RootComponent';

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/vkui/src/components/Skeleton/Skeleton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { millisecondsInSecond } from 'date-fns/constants';

--- a/packages/vkui/src/components/Slider/Slider.tsx
+++ b/packages/vkui/src/components/Slider/Slider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';

--- a/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.tsx
+++ b/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useBooleanState } from '../../../hooks/useBooleanState';

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';

--- a/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.tsx
+++ b/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Spinner/Spinner.tsx
+++ b/packages/vkui/src/components/Spinner/Spinner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Spinner, Icon24Spinner, Icon32Spinner, Icon44Spinner } from '@vkontakte/icons';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/SplitCol/SplitCol.tsx
+++ b/packages/vkui/src/components/SplitCol/SplitCol.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/SplitLayout/SplitLayout.tsx
+++ b/packages/vkui/src/components/SplitLayout/SplitLayout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
+++ b/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Dropdown } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Tabbar/Tabbar.tsx
+++ b/packages/vkui/src/components/Tabbar/Tabbar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/Tabs/Tabs.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';

--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/Tappable/Tappable.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { SizeType } from '../../lib/adaptivity';

--- a/packages/vkui/src/components/Textarea/Textarea.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';

--- a/packages/vkui/src/components/ToolButton/ToolButton.tsx
+++ b/packages/vkui/src/components/ToolButton/ToolButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import {

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.tsx
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Icon16Cancel } from '@vkontakte/icons';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';

--- a/packages/vkui/src/components/Touch/Touch.tsx
+++ b/packages/vkui/src/components/Touch/Touch.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { getWindow, isHTMLElement } from '../../lib/dom';

--- a/packages/vkui/src/components/Typography/Caption/Caption.tsx
+++ b/packages/vkui/src/components/Typography/Caption/Caption.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { type HasCaps, Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/Typography/DisplayTitle/DisplayTitle.tsx
+++ b/packages/vkui/src/components/Typography/DisplayTitle/DisplayTitle.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.tsx
+++ b/packages/vkui/src/components/Typography/EllipsisText/EllipsisText.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRef } from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { getTextFromChildren } from '../../../lib/children';

--- a/packages/vkui/src/components/Typography/Footnote/Footnote.tsx
+++ b/packages/vkui/src/components/Typography/Footnote/Footnote.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { type HasCaps, Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/Typography/Headline/Headline.tsx
+++ b/packages/vkui/src/components/Typography/Headline/Headline.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/vkui/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
+++ b/packages/vkui/src/components/Typography/Subhead/Subhead.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/Typography/Text/Text.tsx
+++ b/packages/vkui/src/components/Typography/Text/Text.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/Typography/Title/Title.tsx
+++ b/packages/vkui/src/components/Typography/Title/Title.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
 import { Typography, type TypographyProps } from '../Typography';

--- a/packages/vkui/src/components/View/View.tsx
+++ b/packages/vkui/src/components/View/View.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { usePlatform } from '../../hooks/usePlatform';

--- a/packages/vkui/src/components/View/ViewInfinite.tsx
+++ b/packages/vkui/src/components/View/ViewInfinite.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { withContext } from '../../hoc/withContext';

--- a/packages/vkui/src/components/WriteBar/WriteBar.tsx
+++ b/packages/vkui/src/components/WriteBar/WriteBar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   Icon24Attach,

--- a/packages/vkui/src/hoc/withContext.tsx
+++ b/packages/vkui/src/hoc/withContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 export function withContext<T, X>(

--- a/packages/vkui/src/hoc/withPlatform.tsx
+++ b/packages/vkui/src/hoc/withPlatform.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useConfigProvider } from '../components/ConfigProvider/ConfigProviderContext';
 import type { HasPlatform } from '../types';

--- a/packages/vkui/src/lib/SSR.tsx
+++ b/packages/vkui/src/lib/SSR.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { ConfigProviderOverride } from '../components/ConfigProvider/ConfigProviderOverride';
 import { useObjectMemo } from '../hooks/useObjectMemo';

--- a/packages/vkui/src/lib/dom.tsx
+++ b/packages/vkui/src/lib/dom.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { canUseDOM } from '@vkontakte/vkjs';
 import { rectToClientRect } from '@vkontakte/vkui-floating-ui/core';

--- a/packages/vkui/src/storybook/ModalWrapper.tsx
+++ b/packages/vkui/src/storybook/ModalWrapper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Button } from '../components/Button/Button';
 import { ModalRoot } from '../components/ModalRoot/ModalRootAdaptive';

--- a/packages/vkui/src/storybook/VKUIDecorators.tsx
+++ b/packages/vkui/src/storybook/VKUIDecorators.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import type { Decorator } from '@storybook/react';
 import { AdaptivityProvider } from '../components/AdaptivityProvider/AdaptivityProvider';

--- a/packages/vkui/src/testing/presets/getFormFieldIconsPresets.tsx
+++ b/packages/vkui/src/testing/presets/getFormFieldIconsPresets.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icon16Clear, Icon28MessageOutline } from '@vkontakte/icons';
 import { noop } from '@vkontakte/vkjs';
 import { IconButton } from '../../components/IconButton/IconButton';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3797,6 +3797,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.33.2"
     eslint-plugin-react-compiler: "npm:0.0.0-experimental-56229e1-20240813"
     eslint-plugin-react-hooks: "npm:^4.6.2"
+    eslint-plugin-react-server-components: "npm:^1.2.0"
     eslint-plugin-unicorn: "npm:^55.0.0"
     husky: "npm:^9.1.6"
     jest: "npm:^29.7.0"
@@ -4522,18 +4523,6 @@ __metadata:
     es-abstract: "npm:^1.22.1"
     es-shim-unscopables: "npm:^1.0.0"
   checksum: 10/33f20006686e0cbe844fde7fd290971e8366c6c5e3380681c2df15738b1df766dd02c7784034aeeb3b037f65c496ee54de665388288edb323a2008bb550f77ea
-  languageName: node
-  linkType: hard
-
-"array.prototype.toreversed@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "array.prototype.toreversed@npm:1.1.2"
-  dependencies:
-    call-bind: "npm:^1.0.2"
-    define-properties: "npm:^1.2.0"
-    es-abstract: "npm:^1.22.1"
-    es-shim-unscopables: "npm:^1.0.0"
-  checksum: 10/b4076d687ddc22c191863ce105d320cc4b0e1435bfda9ffeeff681682fe88fa6fe30e0d2ae94fa4b2d7fad901e1954ea4f75c1cab217db4848da84a2b5889192
   languageName: node
   linkType: hard
 
@@ -6284,7 +6273,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
+"define-properties@npm:^1.1.3, define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
   dependencies:
@@ -6720,7 +6709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.22.1, es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0, es-abstract@npm:^1.23.1, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3":
+"es-abstract@npm:^1.17.5, es-abstract@npm:^1.22.1, es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0, es-abstract@npm:^1.23.1, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3":
   version: 1.23.3
   resolution: "es-abstract@npm:1.23.3"
   dependencies:
@@ -7287,31 +7276,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:^7.33.2":
-  version: 7.34.3
-  resolution: "eslint-plugin-react@npm:7.34.3"
+"eslint-plugin-react-server-components@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "eslint-plugin-react-server-components@npm:1.2.0"
+  dependencies:
+    eslint-plugin-react: "npm:^7.32.2"
+    globals: "npm:^13.20.0"
+  checksum: 10/0158c3fe19af01ea3dccda918ae5275f66732b7824ce59d3969f0f01916dfca94e23549e15dd2d9f965c29dc8401080d7e06dae63881b53569719a4cea3d1b09
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-react@npm:^7.32.2, eslint-plugin-react@npm:^7.33.2":
+  version: 7.37.1
+  resolution: "eslint-plugin-react@npm:7.37.1"
   dependencies:
     array-includes: "npm:^3.1.8"
     array.prototype.findlast: "npm:^1.2.5"
     array.prototype.flatmap: "npm:^1.3.2"
-    array.prototype.toreversed: "npm:^1.1.2"
     array.prototype.tosorted: "npm:^1.1.4"
     doctrine: "npm:^2.1.0"
     es-iterator-helpers: "npm:^1.0.19"
     estraverse: "npm:^5.3.0"
+    hasown: "npm:^2.0.2"
     jsx-ast-utils: "npm:^2.4.1 || ^3.0.0"
     minimatch: "npm:^3.1.2"
     object.entries: "npm:^1.1.8"
     object.fromentries: "npm:^2.0.8"
-    object.hasown: "npm:^1.1.4"
     object.values: "npm:^1.2.0"
     prop-types: "npm:^15.8.1"
     resolve: "npm:^2.0.0-next.5"
     semver: "npm:^6.3.1"
     string.prototype.matchall: "npm:^4.0.11"
+    string.prototype.repeat: "npm:^1.0.0"
   peerDependencies:
-    eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: 10/f160a5b0a376e520b0cd5e2b6111e91966533708842270e460e2f93a45c80f42dc79232a38a6ccb1a397b1d9deba06f6dc819333d9e1af55d392bf52b20d6c9b
+    eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+  checksum: 10/a7b9cf2c43255844ad0c9d4e3758a8c2b687a2ce9a09f4161ab245581d5d2d91b37742e541c88aa9ce368ec6c860e23dc78c15117f3fc1cdc433847038e8346b
   languageName: node
   linkType: hard
 
@@ -8456,7 +8455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^13.19.0":
+"globals@npm:^13.19.0, globals@npm:^13.20.0":
   version: 13.24.0
   resolution: "globals@npm:13.24.0"
   dependencies:
@@ -11799,17 +11798,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.hasown@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "object.hasown@npm:1.1.4"
-  dependencies:
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.2"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10/797385577b3ef3c0d19333e03ed34bc7987978ae1ee1245069c9922e17d1128265187f729dc610260d03f8d418af26fcd7919b423793bf0af9099d9f08367d69
-  languageName: node
-  linkType: hard
-
 "object.values@npm:^1.1.6, object.values@npm:^1.2.0":
   version: 1.2.0
   resolution: "object.values@npm:1.2.0"
@@ -14955,6 +14943,16 @@ __metadata:
     set-function-name: "npm:^2.0.2"
     side-channel: "npm:^1.0.6"
   checksum: 10/a902ff4500f909f2a08e55cc5ab1ffbbc905f603b36837674370ee3921058edd0392147e15891910db62a2f31ace2adaf065eaa3bc6e9810bdbc8ca48e05a7b5
+  languageName: node
+  linkType: hard
+
+"string.prototype.repeat@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "string.prototype.repeat@npm:1.0.0"
+  dependencies:
+    define-properties: "npm:^1.1.3"
+    es-abstract: "npm:^1.17.5"
+  checksum: 10/4b1bd91b75fa8fdf0541625184ebe80e445a465ce4253c19c3bccd633898005dadae0f74b85ae72662a53aafb8035bf48f8f5c0755aec09bc106a7f13959d05e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- resolve #6288

## Описание

В react для разделения компонентов на клиентские и серверные требуется использовать директива `use client`

https://react.dev/reference/rsc/use-client

## Изменения

- Добавлен линтер на `use client`
- Автоматом проставлены директивы

## Release notes

## Улучшения
- Были добавлены [use client](https://react.dev/reference/rsc/use-client) директивы
