### PR TITLE
feat(RichCell): rename props header, text, caption

### DIFF
--- a/packages/codemods/src/transforms/v7/__testfixtures__/rich-cell/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/rich-cell/basic.input.tsx
@@ -1,0 +1,31 @@
+import { Avatar, RichCell } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  const text = "Text"
+  return (
+    <React.Fragment>
+      <RichCell
+        before={<Avatar size={72} src="" />}
+        subhead="Subhead"
+        text="Text"
+        caption="Caption"
+        after="After"
+        afterCaption="After Caption"
+      >
+        Children
+      </RichCell>
+
+      <RichCell
+        before={<Avatar size={72} src="" />}
+        subhead={"Subhead"}
+        text={text}
+        caption={"Caption"}
+        after="After"
+        afterCaption="After Caption"
+      >
+        Children
+      </RichCell>
+    </React.Fragment>
+  );
+};

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/rich-cell.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/rich-cell.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rich-cell transforms correctly 1`] = `
+"import { Avatar, RichCell } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  const text = "Text"
+  return (
+    (<React.Fragment>
+      <RichCell
+        before={<Avatar size={72} src="" />}
+        overTitle="Subhead"
+        subtitle="Text"
+        extraSubtitle="Caption"
+        after="After"
+        afterCaption="After Caption"
+      >
+        Children
+      </RichCell>
+      <RichCell
+        before={<Avatar size={72} src="" />}
+        overTitle={"Subhead"}
+        subtitle={text}
+        extraSubtitle={"Caption"}
+        after="After"
+        afterCaption="After Caption"
+      >
+        Children
+      </RichCell>
+    </React.Fragment>)
+  );
+};"
+`;

--- a/packages/codemods/src/transforms/v7/__tests__/rich-cell.ts
+++ b/packages/codemods/src/transforms/v7/__tests__/rich-cell.ts
@@ -1,0 +1,12 @@
+jest.autoMockOff();
+
+import { defineSnapshotTestFromFixture } from '../../../testHelpers/testHelper';
+
+const name = 'rich-cell';
+const fixtures = ['basic'] as const;
+
+describe(name, () => {
+  fixtures.forEach((test) =>
+    defineSnapshotTestFromFixture(__dirname, name, global.TRANSFORM_OPTIONS, `${name}/${test}`),
+  );
+});

--- a/packages/codemods/src/transforms/v7/rich-cell.ts
+++ b/packages/codemods/src/transforms/v7/rich-cell.ts
@@ -1,0 +1,22 @@
+import { API, FileInfo } from 'jscodeshift';
+import { getImportInfo, renameProp } from '../../codemod-helpers';
+import { JSCodeShiftOptions } from '../../types';
+
+export const parser = 'tsx';
+
+export default function transformer(file: FileInfo, api: API, options: JSCodeShiftOptions) {
+  const { alias } = options;
+  const j = api.jscodeshift;
+  const source = j(file.source);
+  const { localName } = getImportInfo(j, file, 'RichCell', alias);
+
+  if (localName) {
+    renameProp(j, source, localName, {
+      subhead: 'overTitle',
+      text: 'subtitle',
+      caption: 'extraSubtitle',
+    });
+  }
+
+  return source.toSource();
+}

--- a/packages/vkui/src/components/RichCell/Readme.md
+++ b/packages/vkui/src/components/RichCell/Readme.md
@@ -7,9 +7,9 @@
     <Group>
       <RichCell
         before={<Avatar size={72} src={getAvatarUrl('')} />}
-        subhead="Subhead"
-        text="Text"
-        caption="Caption"
+        overTitle="Over Title"
+        subtitle="Subtitle"
+        extraSubtitle="Extra Subtitle"
         after="After"
         afterCaption="After Caption"
         bottom={
@@ -34,7 +34,7 @@
     <Group header={<Header>Рекомендации друзей</Header>}>
       <RichCell
         before={<Avatar size={72} src={getAvatarUrl('user_ilyagrshn')} />}
-        caption="Команда ВКонтакте, Санкт-Петербург"
+        extraSubtitle="Команда ВКонтакте, Санкт-Петербург"
         bottom={
           <UsersStack
             photos={[
@@ -94,8 +94,8 @@
     <Group header={<Header>История переводов</Header>}>
       <RichCell
         before={<Avatar size={48} src={getAvatarUrl('user_ti')} />}
-        text="Держи за обед в EZO"
-        caption="сегодня в 18:00"
+        subtitle="Держи за обед в EZO"
+        extraSubtitle="сегодня в 18:00"
         after="+ 1 232 ₽"
         afterCaption="Комиссия 1%"
         actions={
@@ -121,7 +121,7 @@
       </RichCell>
       <RichCell
         before={<Avatar size={48} src={getAvatarUrl('user_lihachyov')} />}
-        caption="Вчера в 20:30"
+        extraSubtitle="Вчера в 20:30"
         after="- 1 800 ₽"
       >
         Михаил Лихачев

--- a/packages/vkui/src/components/RichCell/RichCell.e2e-playground.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.e2e-playground.tsx
@@ -13,10 +13,10 @@ export const RichCellPlayground = (props: ComponentPlaygroundProps) => {
       propSets={[
         {
           before: [<Avatar size={72} key="72" />],
-          subhead: ['Subhead subhead subhead subhead'],
+          overTitle: ['Subhead subhead subhead subhead'],
           children: ['Children children children children'],
-          text: ['Text text text text text text'],
-          caption: ['Caption caption caption caption'],
+          subtitle: ['Text text text text text text'],
+          extraSubtitle: ['Caption caption caption caption'],
           after: ['After'],
           afterAlign: ['start', 'center', 'end'],
           afterCaption: ['After Caption'],
@@ -35,10 +35,10 @@ export const RichCellPlayground = (props: ComponentPlaygroundProps) => {
         },
         {
           before: [<Avatar size={72} key="72" />],
-          subhead: ['Subhead subhead subhead subhead'],
+          overTitle: ['Subhead subhead subhead subhead'],
           children: ['Children children children children'],
-          text: ['Text text text text text text'],
-          caption: ['Caption caption caption caption'],
+          subtitle: ['Text text text text text text'],
+          extraSubtitle: ['Caption caption caption caption'],
           after: ['After'],
           afterCaption: ['After Caption'],
           bottom: [
@@ -57,7 +57,7 @@ export const RichCellPlayground = (props: ComponentPlaygroundProps) => {
         {
           before: [<Avatar size={48} key="48" />],
           children: ['Михаил Лихачев'],
-          caption: ['Команда ВКонтакте, Санкт-Петербург'],
+          overTitle: ['Команда ВКонтакте, Санкт-Петербург'],
           after: [
             <RichCell.Icon key="icon">
               <Icon24UserAddOutline />

--- a/packages/vkui/src/components/RichCell/RichCell.module.css
+++ b/packages/vkui/src/components/RichCell/RichCell.module.css
@@ -86,11 +86,11 @@
   }
 }
 
-.subhead {
+.overTitle {
   color: var(--vkui--color_text_secondary);
 }
 
-.caption {
+.extraSubtitle {
   margin-block-start: 1px;
   color: var(--vkui--color_text_secondary);
 }
@@ -99,10 +99,10 @@
   font-weight: var(--vkui--font_weight_accent2);
 }
 
-.textEllipsis .subhead,
+.textEllipsis .overTitle,
 .textEllipsis .children,
-.textEllipsis .text,
-.textEllipsis .caption {
+.textEllipsis .subtitle,
+.textEllipsis .extraSubtitle {
   white-space: nowrap;
   text-overflow: ellipsis;
   max-inline-size: 100%;
@@ -118,14 +118,14 @@
 }
 
 .children,
-.text,
+.subtitle,
 .afterChildren {
   font-size: var(--vkui--font_paragraph--font_size--regular);
   line-height: var(--vkui--font_paragraph--line_height--regular);
 }
 
 .sizeYCompact .children,
-.sizeYCompact .text,
+.sizeYCompact .subtitle,
 .sizeYCompact .afterChildren {
   font-size: var(--vkui--font_subhead--font_size--regular);
   line-height: var(--vkui--font_subhead--line_height--regular);
@@ -133,7 +133,7 @@
 
 @media (--sizeY-compact) {
   .sizeYNone .children,
-  .sizeYNone .text,
+  .sizeYNone .subtitle,
   .sizeYNone .afterChildren {
     font-size: var(--vkui--font_subhead--font_size--regular);
     line-height: var(--vkui--font_subhead--line_height--regular);

--- a/packages/vkui/src/components/RichCell/RichCell.stories.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.stories.tsx
@@ -66,9 +66,9 @@ type Story = StoryObj<RichCellProps>;
 export const Playground: Story = {
   args: {
     before: 'Avatar72',
-    subhead: 'Subhead',
-    text: 'Text',
-    caption: 'Caption',
+    overTitle: 'Over Title',
+    subtitle: 'Subtitle',
+    extraSubtitle: 'Extra Subtitle',
     after: 'After',
     afterCaption: 'After Caption',
     children: 'Example',

--- a/packages/vkui/src/components/RichCell/RichCell.test.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.test.tsx
@@ -15,9 +15,9 @@ describe('RichCell', () => {
     (afterAlign, expectedContainerStyle, alignClassName) => {
       const { container } = render(
         <RichCell
-          subhead="Subhead"
-          text="Text"
-          caption="Caption"
+          overTitle="Subhead"
+          subtitle="Text"
+          extraSubtitle="Caption"
           afterAlign={afterAlign}
           after={<div data-testid="after" />}
           afterCaption="After Caption"

--- a/packages/vkui/src/components/RichCell/RichCell.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.tsx
@@ -23,15 +23,15 @@ export interface RichCellProps extends TappableProps {
   /**
    * Контейнер для текста над `children`.
    */
-  subhead?: React.ReactNode;
+  overTitle?: React.ReactNode;
   /**
    * Контейнер для текста под `children`.
    */
-  text?: React.ReactNode;
+  subtitle?: React.ReactNode;
   /**
    * Контейнер для текста под `text`.
    */
-  caption?: React.ReactNode;
+  extraSubtitle?: React.ReactNode;
   /**
    * Контейнер для контента под `caption`. Например `<UsersStack size="m" />`.
    */
@@ -79,10 +79,10 @@ export interface RichCellProps extends TappableProps {
 export const RichCell: React.FC<RichCellProps> & {
   Icon: typeof RichCellIcon;
 } = ({
-  subhead,
+  overTitle,
   children,
-  text,
-  caption,
+  subtitle,
+  extraSubtitle,
   before,
   after,
   afterCaption,
@@ -121,16 +121,16 @@ export const RichCell: React.FC<RichCellProps> & {
       <div className={styles.in}>
         <div className={styles.content}>
           <div className={styles.contentBefore}>
-            {subhead && (
-              <Subhead Component="div" className={styles.subhead}>
-                {subhead}
+            {overTitle && (
+              <Subhead Component="div" className={styles.overTitle}>
+                {overTitle}
               </Subhead>
             )}
             <div className={styles.children}>{children}</div>
-            {text && <div className={styles.text}>{text}</div>}
-            {caption && (
-              <Subhead Component="div" className={styles.caption}>
-                {caption}
+            {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
+            {extraSubtitle && (
+              <Subhead Component="div" className={styles.extraSubtitle}>
+                {extraSubtitle}
               </Subhead>
             )}
           </div>

--- a/packages/vkui/src/components/RichCell/RichCell.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.tsx
@@ -29,7 +29,7 @@ export interface RichCellProps extends TappableProps {
    */
   subtitle?: React.ReactNode;
   /**
-   * Контейнер для текста под `text`.
+   * Контейнер для текста под `subtitle`.
    */
   extraSubtitle?: React.ReactNode;
   /**

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7433e54c54f9d5d4e4ff882142e7da5f28381cb46782fb1807c4c422e5140cc2
-size 169221
+oid sha256:dfec7dfb9f4c1dc708b2b17be1249c2983fd7fa7cf51370bbb43910e1e10530f
+size 176372

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c25918fedb793383d2581998d148c8aed75049f1fd9e179a97d6ac5e9fe8529
-size 170365
+oid sha256:64282d341950a8f321df3e5d02de348726d67f1250979ba59b0a8c01c29bfdb4
+size 178476

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d899b2b1d53836a1587c15ab863abc6dd328ad023a7fbdc622be9c448873c17
-size 178621
+oid sha256:fcc8680ba0d5e6a3f41e7535e275b84c7c5bac7a78e1e944f6f82de0d9542d3d
+size 183889

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad0e6fe429a29a741edbd49573fe1edbc210313e797cc56142425328fb85dbb0
-size 178556
+oid sha256:6850fc4ed23ef0e07ac8d1e16dcd02cf41206e3d244f7e582b428f9e29729f7c
+size 184100

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1df45bcf6aacfeca6cce0744a7a263b85e6b349f3680ede3e68ad759deb6d119
-size 102679
+oid sha256:d6d7ae46e47e76fef71e686bc0301f7e16b7551b34abe48f2fbe6f41c2a16b44
+size 104466

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:727445016d4594c24636581eca59feef2befe13f63c7a58cb0d9c85e23deccdb
-size 104076
+oid sha256:ff4082bfbfe2ee2e6d7eef441844af68473cec7a303df214b2debc64b3ee3faa
+size 105900

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb410e7bada8b4ff3dc26b894bf25ee934075099e859f5ad2d70c899185a82b5
-size 175730
+oid sha256:109f654c4d62ab4517725de5f22d18e920e9566a85665a4e918d12f73643e5a7
+size 179250

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5941ac14b5194accd785ebc2312aea7e76598c8ada1db2e495b204c1bb5b2935
-size 179807
+oid sha256:4ffe014799436cc64a92c29a0c9952cbbd8c430b3446a457578a0ff20b5e4aa3
+size 183272

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ae82e7c446630bea80b22f3c27bd2fc040658e462c3d9eb8cbab3c683c7af24
-size 106012
+oid sha256:d237cfde74327e5ee1f3f149e5c36461b3bdbd12fa7d7cfc04add54a21364f96
+size 107641

--- a/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/RichCell/__image_snapshots__/richcell-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84ae9486cdc6502ea1b76fca261f563503827566432825bd468428f0407f21ff
-size 106648
+oid sha256:e5b202b6738e9c6d2e2db3e1a42771187686da2a792a1aaf8e9a566b6e8a0fa8
+size 108370


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7716 

---

- [x] Unit-тесты
- [x] e2e-тесты
- [x] Release notes
- [x] codemod

## Описание

Необходимо переименовать свойство `text` в `subtitle`, `caption` в `extraSubtitle`, `subhead` в `overTitle` компонента RichCell

## Release notes
## BREAKING CHANGE
- RichCell:
  - Переименовано свойство `text` на `subtitle`
  - Переименовано свойство `caption` на `extraSubtitle`
  - Переименовано свойство `subhead` на `overTitle`