### PR TITLE
fix(cssm): CellButton import SimpleCell.module.css

### DIFF
--- a/packages/vkui/src/components/CellButton/CellButton.tsx
+++ b/packages/vkui/src/components/CellButton/CellButton.tsx
@@ -1,5 +1,6 @@
 import { classNames } from '@vkontakte/vkjs';
 import { SimpleCell, type SimpleCellProps } from '../SimpleCell/SimpleCell';
+import '../SimpleCell/SimpleCell.module.css';
 import styles from './CellButton.module.css';
 
 export const appearanceClassNames = {


### PR DESCRIPTION
## Описание

![image](https://github.com/user-attachments/assets/a0e2f74a-f0f9-4a75-bb32-427fded58d5c)

Стили SimpleCell перебивают стили CellButton в cssm сборке

## Изменения

Добавляем импорт SimpleCell выше чем CellButton 

## Release notes

## Исправления

- [SimpleCell ](https://vkcom.github.io/VKUI/${version}/#/SimpleCell ): Стили SimpleCell перебивают стили CellButton в cssm сборке