### PR TITLE
fix: add package.json to "exports" field

### DIFF
--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -15,7 +15,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/cssm/index.js"
     },
-    "./dist/cssm/styles/themes.css": "./dist/cssm/styles/themes.css"
+    "./dist/cssm/styles/themes.css": "./dist/cssm/styles/themes.css",
+    "./package.json": "./package.json"
   },
   "files": [
     "./dist",


### PR DESCRIPTION
## Описание

В #7611 забыли про `package.json`, который можно импортировать.

## Release notes

## Исправления

- в поле `"exports"` добавлен `package.json`