### PR TITLE
fix: fix generating screenshots names

### DIFF
--- a/packages/vkui/playwright-ct.config.ts
+++ b/packages/vkui/playwright-ct.config.ts
@@ -126,48 +126,48 @@ function generateProjects(): TestProject {
 
   const colorSchemes = [ColorScheme.LIGHT, ColorScheme.DARK];
   const projects = colorSchemes
-    .map((colorScheme) => [
+    .map((colorSchemeType) => [
       {
-        name: `android (chromium) • ${colorScheme}`,
+        name: `android (chromium) • ${colorSchemeType}`,
         use: {
           ...getDeviceDescriptorWithoutScaleFactor('Pixel 5'),
-          colorScheme,
+          colorSchemeType,
           platform: Platform.ANDROID,
         },
       },
 
       {
-        name: `ios (webkit) • ${colorScheme}`,
+        name: `ios (webkit) • ${colorSchemeType}`,
         use: {
           ...getDeviceDescriptorWithoutScaleFactor('iPhone XR'),
-          colorScheme,
+          colorSchemeType,
           platform: Platform.IOS,
         },
       },
 
       {
-        name: `vkcom (chromium) • ${colorScheme}`,
+        name: `vkcom (chromium) • ${colorSchemeType}`,
         use: {
           ...getDeviceDescriptorWithoutScaleFactor('Desktop Chrome'),
-          colorScheme,
+          colorSchemeType,
           platform: Platform.VKCOM,
         },
       },
 
       {
-        name: `vkcom (firefox) • ${colorScheme}`,
+        name: `vkcom (firefox) • ${colorSchemeType}`,
         use: {
           ...getDeviceDescriptorWithoutScaleFactor('Desktop Firefox'),
-          colorScheme,
+          colorSchemeType,
           platform: Platform.VKCOM,
         },
       },
 
       {
-        name: `vkcom (webkit) • ${colorScheme}`,
+        name: `vkcom (webkit) • ${colorSchemeType}`,
         use: {
           ...getDeviceDescriptorWithoutScaleFactor('Desktop Safari'),
-          colorScheme,
+          colorSchemeType,
           platform: Platform.VKCOM,
         },
       },

--- a/packages/vkui/src/testing/e2e/index.playwright.ts
+++ b/packages/vkui/src/testing/e2e/index.playwright.ts
@@ -79,7 +79,7 @@ export const test = testBase.extend<VKUITestOptions & InternalVKUITestOptions & 
     async (
       {
         platform,
-        colorScheme,
+        colorSchemeType,
         defaultBrowserType,
         onlyForBrowsers,
         onlyForPlatforms,
@@ -91,7 +91,7 @@ export const test = testBase.extend<VKUITestOptions & InternalVKUITestOptions & 
       const skipReasons = [
         { type: 'browser', matchList: onlyForBrowsers || [], value: defaultBrowserType },
         { type: 'platform', matchList: onlyForPlatforms || [], value: platform },
-        { type: 'colorScheme', matchList: onlyForColorSchemes || [], value: colorScheme },
+        { type: 'colorScheme', matchList: onlyForColorSchemes || [], value: colorSchemeType },
       ]
         .filter(
           ({ matchList, value }) => matchList.length > 0 && matchList.every((i) => i !== value),


### PR DESCRIPTION
- caused by #7728 

---

- [x] e2e-тесты

## Описание

После PR #7728 скриншоты генерируются и проверяются только для `light` `colorSheme`. Так происходит из-за неправильно прокинутого значения свойства.

## Изменения

Поправил именование свойства `colorScheme` на `colorSchemeType`. Использовано это имя так как `colorScheme` уже есть в playwright

## Release notes
-
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
