### PR TITLE
feat(Tooltip): rename prop `text` to `description`, `header` to `title`

### DIFF
--- a/packages/codemods/src/transforms/v7/__testfixtures__/onboarding-tooltip/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/onboarding-tooltip/basic.input.tsx
@@ -1,0 +1,12 @@
+import { Button, OnboardingTooltip } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <React.Fragment>
+      <OnboardingTooltip placement="right" header="Header" text="Привет">
+        <Button style={{ margin: 20 }}>Наведи</Button>
+      </OnboardingTooltip>
+    </React.Fragment>
+  );
+};

--- a/packages/codemods/src/transforms/v7/__testfixtures__/tooltip/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/tooltip/basic.input.tsx
@@ -1,0 +1,12 @@
+import { Button, Tooltip } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <React.Fragment>
+      <Tooltip placement="right" header="Header" text="Привет">
+        <Button style={{ margin: 20 }}>Наведи</Button>
+      </Tooltip>
+    </React.Fragment>
+  );
+};

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/onboarding-tooltip.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/onboarding-tooltip.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`onboarding-tooltip transforms correctly 1`] = `
+"import { Button, OnboardingTooltip } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    (<React.Fragment>
+      <OnboardingTooltip placement="right" title="Header" description="Привет">
+        <Button style={{ margin: 20 }}>Наведи</Button>
+      </OnboardingTooltip>
+    </React.Fragment>)
+  );
+};"
+`;

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/tooltip.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/tooltip.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tooltip transforms correctly 1`] = `
+"import { Button, Tooltip } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    (<React.Fragment>
+      <Tooltip placement="right" title="Header" description="Привет">
+        <Button style={{ margin: 20 }}>Наведи</Button>
+      </Tooltip>
+    </React.Fragment>)
+  );
+};"
+`;

--- a/packages/codemods/src/transforms/v7/__tests__/onboarding-tooltip.ts
+++ b/packages/codemods/src/transforms/v7/__tests__/onboarding-tooltip.ts
@@ -1,0 +1,12 @@
+jest.autoMockOff();
+
+import { defineSnapshotTestFromFixture } from '../../../testHelpers/testHelper';
+
+const name = 'onboarding-tooltip';
+const fixtures = ['basic'] as const;
+
+describe(name, () => {
+  fixtures.forEach((test) =>
+    defineSnapshotTestFromFixture(__dirname, name, global.TRANSFORM_OPTIONS, `${name}/${test}`),
+  );
+});

--- a/packages/codemods/src/transforms/v7/__tests__/tooltip.ts
+++ b/packages/codemods/src/transforms/v7/__tests__/tooltip.ts
@@ -1,0 +1,12 @@
+jest.autoMockOff();
+
+import { defineSnapshotTestFromFixture } from '../../../testHelpers/testHelper';
+
+const name = 'tooltip';
+const fixtures = ['basic'] as const;
+
+describe(name, () => {
+  fixtures.forEach((test) =>
+    defineSnapshotTestFromFixture(__dirname, name, global.TRANSFORM_OPTIONS, `${name}/${test}`),
+  );
+});

--- a/packages/codemods/src/transforms/v7/onboarding-tooltip.ts
+++ b/packages/codemods/src/transforms/v7/onboarding-tooltip.ts
@@ -1,0 +1,18 @@
+import { API, FileInfo } from 'jscodeshift';
+import { getImportInfo, renameProp } from '../../codemod-helpers';
+import { JSCodeShiftOptions } from '../../types';
+
+export const parser = 'tsx';
+
+export default function transformer(file: FileInfo, api: API, options: JSCodeShiftOptions) {
+  const { alias } = options;
+  const j = api.jscodeshift;
+  const source = j(file.source);
+  const { localName } = getImportInfo(j, file, 'OnboardingTooltip', alias);
+
+  if (localName) {
+    renameProp(j, source, localName, { text: 'description', header: 'title' });
+  }
+
+  return source.toSource();
+}

--- a/packages/codemods/src/transforms/v7/tooltip.ts
+++ b/packages/codemods/src/transforms/v7/tooltip.ts
@@ -1,0 +1,18 @@
+import { API, FileInfo } from 'jscodeshift';
+import { getImportInfo, renameProp } from '../../codemod-helpers';
+import { JSCodeShiftOptions } from '../../types';
+
+export const parser = 'tsx';
+
+export default function transformer(file: FileInfo, api: API, options: JSCodeShiftOptions) {
+  const { alias } = options;
+  const j = api.jscodeshift;
+  const source = j(file.source);
+  const { localName } = getImportInfo(j, file, 'Tooltip', alias);
+
+  if (localName) {
+    renameProp(j, source, localName, { text: 'description', header: 'title' });
+  }
+
+  return source.toSource();
+}

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.e2e-playground.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.e2e-playground.tsx
@@ -12,7 +12,7 @@ export const OnboardingTooltipPlayground = (props: ComponentPlaygroundProps) => 
       {...props}
       propSets={[
         {
-          header: [undefined, 'header'],
+          title: [undefined, 'header'],
         },
         {
           placement: ['top-start', 'top-end', 'bottom-start', 'bottom-end'],
@@ -40,7 +40,7 @@ export const OnboardingTooltipPlayground = (props: ComponentPlaygroundProps) => 
             justifyContent: 'center',
           }}
         >
-          <OnboardingTooltip text="onboarding tooltip" {...props}>
+          <OnboardingTooltip description="onboarding tooltip" {...props}>
             <div className={TEST_CLASS_NAMES.CONTENT} style={{ display: 'flex' }}>
               Tooltip target
             </div>

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.stories.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.stories.tsx
@@ -41,7 +41,7 @@ export const Playground: Story = {
     </OnboardingTooltipContainer>
   ),
   args: {
-    text: 'OnboardingTooltip',
+    description: 'OnboardingTooltip',
   },
 };
 
@@ -68,7 +68,7 @@ export const ShowCase: Story = {
           </Group>
           <Group>
             <OnboardingTooltip
-              text="У нас тут brand new функционал подвезли. Зацените!"
+              description="У нас тут brand new функционал подвезли. Зацените!"
               shown={tooltip}
               onClose={() => setTooltip(false)}
               offsetByMainAxis={10}
@@ -87,8 +87,8 @@ export const ShowCase: Story = {
                   setTooltip2(false);
                   setTooltip3(true);
                 }}
-                text="Нажмите на кнопку, если хотите вернуться"
-                header="Назад"
+                description="Нажмите на кнопку, если хотите вернуться"
+                title="Назад"
               >
                 <PanelHeaderBack onClick={() => setActivePanel('tooltip')} />
               </OnboardingTooltip>
@@ -101,7 +101,7 @@ export const ShowCase: Story = {
               <SimpleCell
                 before={
                   <OnboardingTooltip
-                    text="Теперь у нас появились аватарки в списках. Правда круто?"
+                    description="Теперь у нас появились аватарки в списках. Правда круто?"
                     shown={tooltip3}
                     onClose={() => setTooltip3(false)}
                     arrowOffset={-6}
@@ -145,12 +145,12 @@ export const WithOnboardingTooltipContainer: Story = {
   render: () => (
     <>
       <OnboardingTooltipContainer style={{ minHeight: '120vh' }}>
-        <OnboardingTooltip text="Я скроллюсь">
+        <OnboardingTooltip description="Я скроллюсь">
           <div style={{ display: 'inline-block' }}>
             <Avatar />
           </div>
         </OnboardingTooltip>
-        <OnboardingTooltip text="Двигаем стрелочку" arrowOffset={20}>
+        <OnboardingTooltip description="Двигаем стрелочку" arrowOffset={20}>
           <div style={{ display: 'inline-block', marginLeft: 100 }}>
             <Avatar />
           </div>
@@ -167,7 +167,7 @@ export const WithOnboardingTooltipContainer: Story = {
           zIndex: 1,
         }}
       >
-        <OnboardingTooltip text="Я вылезаю (fixed)">
+        <OnboardingTooltip description="Я вылезаю (fixed)">
           <div style={{ display: 'inline-block' }}>
             <Avatar />
           </div>
@@ -183,17 +183,17 @@ export const WithOnboardingTooltipContainer: Story = {
           zIndex: 1,
         }}
       >
-        <OnboardingTooltip text="Я прилип слева">
+        <OnboardingTooltip description="Я прилип слева">
           <div style={{ display: 'inline-block', position: 'absolute', right: 0 }}>
             <Avatar />
           </div>
         </OnboardingTooltip>
-        <OnboardingTooltip text="Я прилип справа">
+        <OnboardingTooltip description="Я прилип справа">
           <div style={{ display: 'inline-block' }}>
             <Avatar />
           </div>
         </OnboardingTooltip>
-        <OnboardingTooltip text="Я прилип слева">
+        <OnboardingTooltip description="Я прилип слева">
           <div
             style={{
               display: 'inline-block',
@@ -205,7 +205,7 @@ export const WithOnboardingTooltipContainer: Story = {
             <Avatar />
           </div>
         </OnboardingTooltip>
-        <OnboardingTooltip text="Я прилип справа">
+        <OnboardingTooltip description="Я прилип справа">
           <div
             style={{
               display: 'inline-block',
@@ -217,7 +217,7 @@ export const WithOnboardingTooltipContainer: Story = {
             <Avatar />
           </div>
         </OnboardingTooltip>
-        <OnboardingTooltip text="Я по центру 😎">
+        <OnboardingTooltip description="Я по центру 😎">
           <div
             style={{
               display: 'inline-block',
@@ -233,7 +233,7 @@ export const WithOnboardingTooltipContainer: Story = {
       </OnboardingTooltipContainer>
       <div style={{ height: '100vh' }}></div>
       <OnboardingTooltipContainer fixed style={{ position: 'fixed', bottom: 0, width: '100%' }}>
-        <OnboardingTooltip text="Я прибит к низу">
+        <OnboardingTooltip description="Я прибит к низу">
           <div style={{ display: 'inline-block' }}>
             <Avatar />
           </div>
@@ -264,7 +264,7 @@ export const CustomArrowIcon: Story = {
     return (
       <OnboardingTooltipContainer>
         <OnboardingTooltip
-          text="У этого тултипа кастомная стрелка"
+          description="У этого тултипа кастомная стрелка"
           offsetByCrossAxis={ARROW_HEIGHT}
           arrowPadding={6}
           ArrowIcon={CustomIcon}

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.test.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.test.tsx
@@ -20,7 +20,7 @@ describe(OnboardingTooltip, () => {
   baselineComponent(
     (props) => (
       <OnboardingTooltipContainer>
-        <OnboardingTooltip shown text="text" {...props}>
+        <OnboardingTooltip shown description="text" {...props}>
           <div />
         </OnboardingTooltip>
       </OnboardingTooltipContainer>
@@ -30,7 +30,7 @@ describe(OnboardingTooltip, () => {
 
   it('renders tooltip when shown=true', async () => {
     await renderTooltip(
-      <OnboardingTooltip shown text="text">
+      <OnboardingTooltip shown description="text">
         <div />
       </OnboardingTooltip>,
     );
@@ -39,7 +39,7 @@ describe(OnboardingTooltip, () => {
 
   it('supports child with getRootRef', async () => {
     await renderTooltip(
-      <OnboardingTooltip shown text="text">
+      <OnboardingTooltip shown description="text">
         <RootRef />
       </OnboardingTooltip>,
     );
@@ -49,7 +49,7 @@ describe(OnboardingTooltip, () => {
   it('does not create extra markup when shown=false', () => {
     render(
       <OnboardingTooltipContainer data-testid="container">
-        <OnboardingTooltip shown={false} text="text">
+        <OnboardingTooltip shown={false} description="text">
           <div data-testid="xxx" />
         </OnboardingTooltip>
       </OnboardingTooltipContainer>,
@@ -108,7 +108,7 @@ describe(OnboardingTooltip, () => {
 
     const Fixture = (props: OnboardingTooltipProps) => (
       <OnboardingTooltipContainer data-testid="container">
-        <OnboardingTooltip shown text="text" {...props}>
+        <OnboardingTooltip shown description="text" {...props}>
           <div data-testid="xxx" />
         </OnboardingTooltip>
       </OnboardingTooltipContainer>

--- a/packages/vkui/src/components/OnboardingTooltip/Readme.md
+++ b/packages/vkui/src/components/OnboardingTooltip/Readme.md
@@ -23,7 +23,7 @@
 ```jsx static
 import { OnboardingTooltip, Button } from '@vkontakte/vkui';
 
-<OnboardingTooltip text="Обновлённый раздел поможет найти друзей">
+<OnboardingTooltip description="Обновлённый раздел поможет найти друзей">
   <Button>Друзья</Button>
 </OnboardingTooltip>;
 ```
@@ -53,7 +53,7 @@ const Example = () => {
         </Group>
         <Group>
           <OnboardingTooltip
-            text="У нас тут brand new функционал подвезли. Зацените!"
+            description="У нас тут brand new функционал подвезли. Зацените!"
             shown={tooltip}
             onClose={() => setTooltip(false)}
             offsetByMainAxis={8}
@@ -73,8 +73,8 @@ const Example = () => {
                 setTooltip2(false);
                 setTooltip3(true);
               }}
-              text="Нажмите на кнопку, если хотите вернуться"
-              header="Назад"
+              description="Нажмите на кнопку, если хотите вернуться"
+              title="Назад"
             >
               <PanelHeaderBack onClick={() => setActivePanel('tooltip')} />
             </OnboardingTooltip>
@@ -87,7 +87,7 @@ const Example = () => {
             <SimpleCell
               before={
                 <OnboardingTooltip
-                  text="Теперь у нас появились аватарки в списках. Правда круто?"
+                  description="Теперь у нас появились аватарки в списках. Правда круто?"
                   shown={tooltip3}
                   onClose={() => setTooltip3(false)}
                   arrowOffset={-6}
@@ -137,12 +137,12 @@ const Example = () => {
 ```jsx { "props": { "layout": false } }
 <>
   <OnboardingTooltipContainer style={{ minHeight: '120vh' }}>
-    <OnboardingTooltip text="Я скроллюсь">
+    <OnboardingTooltip description="Я скроллюсь">
       <div style={{ display: 'inline-block' }}>
         <Avatar />
       </div>
     </OnboardingTooltip>
-    <OnboardingTooltip text="Двигаем стрелочку" arrowOffset={20}>
+    <OnboardingTooltip description="Двигаем стрелочку" arrowOffset={20}>
       <div style={{ display: 'inline-block', marginLeft: 100 }}>
         <Avatar />
       </div>
@@ -159,7 +159,7 @@ const Example = () => {
       zIndex: 1,
     }}
   >
-    <OnboardingTooltip text="Я вылезаю (fixed)">
+    <OnboardingTooltip description="Я вылезаю (fixed)">
       <div style={{ display: 'inline-block' }}>
         <Avatar />
       </div>
@@ -175,17 +175,17 @@ const Example = () => {
       zIndex: 1,
     }}
   >
-    <OnboardingTooltip text="Я прилип слева">
+    <OnboardingTooltip description="Я прилип слева">
       <div style={{ display: 'inline-block', position: 'absolute', right: 0 }}>
         <Avatar />
       </div>
     </OnboardingTooltip>
-    <OnboardingTooltip text="Я прилип справа">
+    <OnboardingTooltip description="Я прилип справа">
       <div style={{ display: 'inline-block' }}>
         <Avatar />
       </div>
     </OnboardingTooltip>
-    <OnboardingTooltip text="Я прилип слева">
+    <OnboardingTooltip description="Я прилип слева">
       <div
         style={{
           display: 'inline-block',
@@ -197,7 +197,7 @@ const Example = () => {
         <Avatar />
       </div>
     </OnboardingTooltip>
-    <OnboardingTooltip text="Я прилип справа">
+    <OnboardingTooltip description="Я прилип справа">
       <div
         style={{
           display: 'inline-block',
@@ -209,7 +209,7 @@ const Example = () => {
         <Avatar />
       </div>
     </OnboardingTooltip>
-    <OnboardingTooltip text="Я по центру 😎">
+    <OnboardingTooltip description="Я по центру 😎">
       <div
         style={{
           display: 'inline-block',
@@ -225,7 +225,7 @@ const Example = () => {
   </OnboardingTooltipContainer>
   <div style={{ height: '100vh' }}></div>
   <OnboardingTooltipContainer fixed style={{ position: 'fixed', bottom: 0, width: '100%' }}>
-    <OnboardingTooltip text="Я прибит к низу">
+    <OnboardingTooltip description="Я прибит к низу">
       <div style={{ display: 'inline-block' }}>
         <Avatar />
       </div>
@@ -238,27 +238,31 @@ const Example = () => {
 
 ```jsx { "props": { "layout": false } }
 <OnboardingTooltipContainer>
-  <OnboardingTooltip placement="right" text={`appearance="accent"`} appearance="accent">
+  <OnboardingTooltip placement="right" description={`appearance="accent"`} appearance="accent">
     <div style={{ width: 50, margin: 10 }}>
       <Avatar />
     </div>
   </OnboardingTooltip>
-  <OnboardingTooltip placement="right" text={`appearance="neutral"`} appearance="neutral">
+  <OnboardingTooltip placement="right" description={`appearance="neutral"`} appearance="neutral">
     <div style={{ width: 50, margin: 10 }}>
       <Avatar />
     </div>
   </OnboardingTooltip>
-  <OnboardingTooltip placement="right" text={`appearance="white`} appearance="white">
+  <OnboardingTooltip placement="right" description={`appearance="white`} appearance="white">
     <div style={{ width: 50, margin: 10 }}>
       <Avatar />
     </div>
   </OnboardingTooltip>
-  <OnboardingTooltip placement="right" text={`appearance="black"`} appearance="black">
+  <OnboardingTooltip placement="right" description={`appearance="black"`} appearance="black">
     <div style={{ width: 50, margin: 10 }}>
       <Avatar />
     </div>
   </OnboardingTooltip>
-  <OnboardingTooltip placement="right" text={`appearance="inversion"`} appearance="inversion">
+  <OnboardingTooltip
+    placement="right"
+    description={`appearance="inversion"`}
+    appearance="inversion"
+  >
     <div style={{ width: 50, margin: 10 }}>
       <Avatar />
     </div>
@@ -294,7 +298,7 @@ const App = () => {
   return (
     <OnboardingTooltipContainer>
       <OnboardingTooltip
-        text="У этого тултипа кастомная стрелка"
+        description="У этого тултипа кастомная стрелка"
         arrowHeight={ARROW_HEIGHT}
         arrowPadding={6}
         ArrowIcon={CustomIcon}

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:130770859f6bbea273f471df58b0aac8ef7955e44e0a0668d066243f00c4da54
-size 104431
+oid sha256:72f335cb2972384587eacbb4a74453c3cdfca859f350a65ca05037e13fe2a917
+size 104358

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d693331c3ccb2c01b233381e1c860c1b08c8b4766f6224ff41d15a0176888ad4
-size 114544
+oid sha256:d681153115f510533d5012c1fc666e20c0e71f9b0e6b3abb9cec519ef21b2cfb
+size 114418

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0223d86db72ce0818d416630de40c08d71b1a13fcbfcb9bb10ad2d995fa87480
-size 106217
+oid sha256:800f3879b5d9aa9e67054d18913ed9ed8577a6f7765586f12d0d65c581fc55e8
+size 106116

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ed115ede301268dc6c94b4bb9881b6c9bf98de67ae276af0f31e213b4e6f491
-size 115756
+oid sha256:38357740e599a37ae69306d39249a25cb0a7972dcc23a8473951d87c8c41a5fb
+size 115667

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a05b58e0051e68e2fc5de00b0481b4bf5e2102f5ea335927aee62f4442d19d8
-size 100092
+oid sha256:37f8cf7277e97200c898cf429feadfbeb63bc2f727ec5029515aa57e4181a5c8
+size 100001

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fa04c0fb70fbfe36708436efd64925ab3a7da1438702d7ab00674eeaf78a08b
-size 109329
+oid sha256:3ac6aafdd2cfcd46f451160ad08d5484a7399ff7df55cab3425b72dacbfcfe07
+size 109244

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09ad861c4ec462c2677b7b8ce11acacb189d1989d59aaf099e8aa651f36725bd
-size 152611
+oid sha256:7cdf8fd19ae11b040d3835a225c225012251d5665f1da3627aa3c51b1e96f2ac
+size 152878

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c075848528ef472a0e9d6414c95cae5f522bf83bf3dbdc36d0ae8332e9f3a3c
-size 169702
+oid sha256:67434d0504374c07037b2175d3e1aa31e67bbd3487feaab369bbaf35577efcdb
+size 169054

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c95f6bc65fe4e3c7aa90c00329d00678a7185df797bdd0f01f3c415033f169c
-size 100684
+oid sha256:49f76519f3c30bc5d89a60ae8a3d621bf547933a1219a9f3546de426ce40e5fb
+size 100599

--- a/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/OnboardingTooltip/__image_snapshots__/onboardingtooltip-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf28370f48f308d2bca0b284e8a6fe1f2814adc0c535d946f602e8e54fcf1600
-size 109991
+oid sha256:cc3f3338a4d69fc5150b7472e01ec9c0d9a8e0b45f0fe44d898dbe2e28741689
+size 109781

--- a/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.tsx
+++ b/packages/vkui/src/components/Slider/SliderThumb/SliderThumb.tsx
@@ -128,7 +128,7 @@ export const SliderThumb = ({
             placement: resolvedPlacement,
             getRootRef: setArrowRef,
           }}
-          text={inputValue}
+          description={inputValue}
         />
       )}
     </React.Fragment>

--- a/packages/vkui/src/components/Textarea/Readme.md
+++ b/packages/vkui/src/components/Textarea/Readme.md
@@ -26,7 +26,7 @@ const App = () => {
               defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eget commodo lorem. Suspendisse convallis ligula vitae mi dictum ullamcorper. Fusce pulvinar quis sem vel tincidunt. Fusce lectus odio, dapibus at metus congue, mollis tempor lorem. Vivamus dictum iaculis turpis non tincidunt. Cras ornare venenatis mi, quis mollis mauris tempus at. Curabitur turpis metus, hendrerit a ligula quis, euismod fringilla neque. Cras pretium aliquet convallis. In et bibendum nulla. Maecenas iaculis commodo blandit. Phasellus semper nunc nec placerat dictum."
               getRef={textAreaRef}
               after={
-                <Tooltip text="Скопировать" placement="top" usePortal>
+                <Tooltip description="Скопировать" placement="top" usePortal>
                   <IconButton
                     label="Скопировать"
                     onClick={() => navigator.clipboard.writeText(textAreaRef.current.value)}

--- a/packages/vkui/src/components/Tooltip/Readme.md
+++ b/packages/vkui/src/components/Tooltip/Readme.md
@@ -1,7 +1,7 @@
 Тултип, открывающийся при наведении мыши на `children`. В качестве содержимого тултипа рекомендуется использовать только текст.
 
 ```jsx { "props": { "layout": false, "iframe": false } }
-<Tooltip placement="right" text="Привет">
+<Tooltip placement="right" description="Привет">
   <Button style={{ margin: 20 }}>Наведи</Button>
 </Tooltip>
 ```

--- a/packages/vkui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.stories.tsx
@@ -20,7 +20,7 @@ export const Playground: Story = {
     </Tooltip>
   ),
   args: {
-    text: 'Привет',
+    description: 'Привет',
   },
 };
 
@@ -31,7 +31,7 @@ export const InteractiveTooltipWithCloseAction: Story = {
     </Tooltip>
   ),
   args: {
-    text: 'Привет',
+    description: 'Привет',
     enableInteractive: true,
     closable: true,
   },

--- a/packages/vkui/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.test.tsx
@@ -4,7 +4,7 @@ import { Tooltip, type TooltipProps } from './Tooltip';
 
 describe(Tooltip, () => {
   baselineComponent((props) => (
-    <Tooltip shown text="test" {...props}>
+    <Tooltip shown description="test" {...props}>
       <div>Target</div>
     </Tooltip>
   ));

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.e2e-playground.tsx
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.e2e-playground.tsx
@@ -12,13 +12,13 @@ export const TooltipBasePlayground = (props: ComponentPlaygroundProps) => {
       {...props}
       propSets={[
         {
-          header: [undefined, 'Some header'],
+          title: [undefined, 'Some header'],
           onCloseIconClick: [undefined, noop],
         },
       ]}
     >
       {(props: TooltipBaseProps) => (
-        <TooltipBase text="Some text" {...props} className={TEST_CLASS_NAMES.CONTENT} />
+        <TooltipBase description="Some text" {...props} className={TEST_CLASS_NAMES.CONTENT} />
       )}
     </ComponentPlayground>
   );

--- a/packages/vkui/src/components/TooltipBase/TooltipBase.tsx
+++ b/packages/vkui/src/components/TooltipBase/TooltipBase.tsx
@@ -22,7 +22,7 @@ const stylesAppearance = {
 };
 
 export interface TooltipBaseProps
-  extends Omit<HTMLAttributesWithRootRef<HTMLDivElement>, 'children'> {
+  extends Omit<HTMLAttributesWithRootRef<HTMLDivElement>, 'children' | 'title'> {
   /**
    * Стиль отображения подсказки
    */
@@ -30,11 +30,11 @@ export interface TooltipBaseProps
   /**
    * Текст тултипа.
    */
-  text?: React.ReactNode;
+  description?: React.ReactNode;
   /**
    * Заголовок тултипа.
    */
-  header?: React.ReactNode;
+  title?: React.ReactNode;
   /**
    * Для показа указателя, требуется передать хотя бы `coords` и `placement`.
    */
@@ -83,8 +83,8 @@ export const TooltipBase = ({
   appearance = 'accent',
   arrowProps,
   ArrowIcon = DefaultIcon,
-  text,
-  header,
+  description,
+  title,
   maxWidth = TOOLTIP_MAX_WIDTH,
   closeIconLabel = 'Закрыть',
   onCloseIconClick,
@@ -110,8 +110,8 @@ export const TooltipBase = ({
       )}
       <div className={styles.content} style={maxWidth !== null ? { maxWidth } : undefined}>
         <div>
-          {hasReactNode(header) && <Subhead weight="2">{header}</Subhead>}
-          {hasReactNode(text) && <Subhead>{text}</Subhead>}
+          {hasReactNode(title) && <Subhead weight="2">{title}</Subhead>}
+          {hasReactNode(description) && <Subhead>{description}</Subhead>}
         </div>
         {typeof onCloseIconClick === 'function' && (
           <Tappable

--- a/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce3b4daff332d9d3310eb2a1231ed95e47656566a2d2e1e5ce0ffbd983e51619
-size 20698
+oid sha256:4dea5c5d5ceb8e82b302cd3766c859b26126eb2f6832d117772edf94f0b0bdf9
+size 20703

--- a/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/TooltipBase/__image_snapshots__/tooltipbase-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0935ccc385bbb4e6d7881451399a1205c0ce38a662bdcaa23d2529d2c8564928
-size 24717
+oid sha256:7b63aff8362f12aa792c40c74fdbac5327192717577af09cd8957e13f3e9eb39
+size 24546

--- a/packages/vkui/src/components/UsersStack/Readme.md
+++ b/packages/vkui/src/components/UsersStack/Readme.md
@@ -7,7 +7,7 @@ const AvatarWrapper = (props) => {
   const user = getRandomUser();
 
   return (
-    <Tooltip text={`${user.first_name} ${user.last_name}`}>
+    <Tooltip description={`${user.first_name} ${user.last_name}`}>
       <div
         style={{
           cursor: 'pointer',

--- a/packages/vkui/src/components/UsersStack/UsersStack.stories.tsx
+++ b/packages/vkui/src/components/UsersStack/UsersStack.stories.tsx
@@ -33,7 +33,7 @@ const AvatarWrapper = (props: UsersStackRenderWrapperProps) => {
   const user = getRandomUser();
 
   return (
-    <Tooltip text={`${user.first_name} ${user.last_name}`}>
+    <Tooltip description={`${user.first_name} ${user.last_name}`}>
       <div
         style={{
           cursor: 'pointer',

--- a/styleguide/Components/ComplexType/ComplexTypeRenderer.js
+++ b/styleguide/Components/ComplexType/ComplexTypeRenderer.js
@@ -14,7 +14,7 @@ export const ComplexTypeRenderer = ({ name, raw }) => {
         <Tooltip
           className={classNames('ComplexTypeDropdown', sizeX.regular.className)}
           placement="right"
-          text={raw}
+          description={raw}
         >
           <Text className="ComplexType">
             <span className="ComplexType__name">{name}</span>

--- a/styleguide/Components/Setting/Setting.js
+++ b/styleguide/Components/Setting/Setting.js
@@ -40,7 +40,7 @@ export const Setting = ({
       weight="3"
     >
       {hint && !disabled ? (
-        <Tooltip placement="top" enableInteractive text={hint} maxWidth={hintMaxWidth}>
+        <Tooltip placement="top" enableInteractive description={hint} maxWidth={hintMaxWidth}>
           <span className="Setting__label Setting__label--has-hint">
             {label} <Icon12InfoCircle className="Setting__labelHint" />
             :&nbsp;


### PR DESCRIPTION
- close #7758

---

- [x] Unit-тесты
- [x] e2e-тесты
- [x] Release notes
- [x] Codemod

## Описание

Переименовал в компоненте `Tooltip` и `OnboardingTooltip` свойство `text` на `description`, `header` на `title`

## Release notes
## BREAKING CHANGE
- Tooltip: переименованы свойства `text` на `description`, `header` на `title`
  ```diff
  <Tooltip
    placement="right"
  - header="Header"
  + title="Header"
  - text="Привет"
  + description="Привет"
  >
    <Button style={{ margin: 20 }}>Наведи</Button>
  </Tooltip>
  ```
- OnboardingTooltip: переименованы свойства `text` на `description`, `header` на `title`
  ```diff
  <OnboardingTooltip
    placement="right"
  - header="Header"
  + title="Header"
  - text="Привет"
  + description="Привет"
  >
    <Button style={{ margin: 20 }}>Наведи</Button>
  </OnboardingTooltip>
  ```