### PR TITLE
feat(Separator): rename separator direction values

### DIFF
--- a/packages/vkui/src/components/Separator/Readme.md
+++ b/packages/vkui/src/components/Separator/Readme.md
@@ -12,7 +12,7 @@
   <Panel id="separator">
     <PanelHeader>Separator</PanelHeader>
 
-    <Group header={<Header mode="secondary">direction="inline"</Header>}>
+    <Group header={<Header mode="secondary">direction="horizontal"</Header>}>
       <Cell before={<Icon28Notifications />}>Уведомления</Cell>
       <Cell before={<Icon28BlockOutline />}>Не беспокоить</Cell>
 
@@ -21,12 +21,12 @@
       <Cell before={<Icon28UserOutline />}>Учётная запись</Cell>
       <Cell before={<Icon28SlidersOutline />}>Основные</Cell>
     </Group>
-    <Group header={<Header mode="secondary">direction="block"</Header>}>
+    <Group header={<Header mode="secondary">direction="vertical"</Header>}>
       <Flex margin="auto">
         <Link>Новости</Link>
-        <Separator direction="block" size="xl" />
+        <Separator direction="vertical" size="xl" />
         <Link>Звонки</Link>
-        <Separator direction="block" size="xl" />
+        <Separator direction="vertical" size="xl" />
         <Link>Друзья</Link>
       </Flex>
     </Group>

--- a/packages/vkui/src/components/Separator/Separator.e2e-playground.tsx
+++ b/packages/vkui/src/components/Separator/Separator.e2e-playground.tsx
@@ -16,12 +16,12 @@ export const SeparatorPlayground = (props: ComponentPlaygroundProps) => {
           appearance: ['primary', 'primary-alpha', 'secondary'],
         },
         {
-          direction: ['inline'],
+          direction: ['horizontal'],
           size: [undefined, 'xl'],
           padding: [true, false],
         },
         {
-          direction: ['block'],
+          direction: ['vertical'],
           size: ['xl'],
         },
         {
@@ -29,14 +29,14 @@ export const SeparatorPlayground = (props: ComponentPlaygroundProps) => {
           size: ['3xl'],
         },
         {
-          direction: ['block'],
+          direction: ['vertical'],
           align: ['start', 'center', 'end'],
           size: ['3xl'],
         },
       ]}
     >
       {(props: SeparatorProps) => (
-        <div style={props.direction === 'block' ? { display: 'flex' } : undefined}>
+        <div style={props.direction === 'vertical' ? { display: 'flex' } : undefined}>
           First Item
           <Separator {...props} />
           Second Item

--- a/packages/vkui/src/components/Separator/Separator.module.css
+++ b/packages/vkui/src/components/Separator/Separator.module.css
@@ -18,18 +18,18 @@
   --vkui_internal--separator_align: end;
 }
 
-.directionBlock {
+.directionVertical {
   display: inline-flex;
   align-self: stretch;
 }
 
-.sized.directionInline {
+.sized.directionHorizontal {
   display: flex;
   block-size: var(--vkui_internal--spacing_size);
   align-items: var(--vkui_internal--separator_align, center);
 }
 
-.sized.directionBlock {
+.sized.directionVertical {
   inline-size: var(--vkui_internal--spacing_size);
   justify-content: var(--vkui_internal--separator_align, center);
 }
@@ -41,23 +41,23 @@
   border: 0;
 }
 
-.directionInline .in {
+.directionHorizontal .in {
   block-size: var(--vkui--size_border--regular);
 }
 
-.directionBlock .in {
+.directionVertical .in {
   inline-size: var(--vkui--size_border--regular);
 }
 
-.sized.directionInline .in {
+.sized.directionHorizontal .in {
   flex: 1 0 auto;
 }
 
-.directionInline.padded .in {
+.directionHorizontal.padded .in {
   margin-inline: var(--vkui--size_base_padding_horizontal--regular);
 }
 
-.directionBlock.padded .in {
+.directionVertical.padded .in {
   margin-block: var(--vkui--size_base_padding_horizontal--regular);
 }
 

--- a/packages/vkui/src/components/Separator/Separator.stories.tsx
+++ b/packages/vkui/src/components/Separator/Separator.stories.tsx
@@ -25,7 +25,7 @@ export const Playground: Story = {
     (Component, props) => (
       <div
         style={
-          props.args.direction === 'block'
+          props.args.direction === 'vertical'
             ? { display: 'flex', alignItems: 'center', height: 50 }
             : undefined
         }
@@ -54,7 +54,7 @@ export const DefaultDirectionExample: Story = {
 export const BlockDirectionExample: Story = {
   ...Playground,
   args: {
-    direction: 'block',
+    direction: 'vertical',
     size: '2xl',
   },
   decorators: [

--- a/packages/vkui/src/components/Separator/Separator.tsx
+++ b/packages/vkui/src/components/Separator/Separator.tsx
@@ -18,7 +18,7 @@ export interface SeparatorProps extends HTMLAttributesWithRootRef<HTMLDivElement
   /**
    * Направление отображения разделителя
    */
-  direction?: 'inline' | 'block';
+  direction?: 'horizontal' | 'vertical';
   /**
    * Размер контейнера, в который вложен разделитель
    */
@@ -36,8 +36,8 @@ const appearanceClassNames = {
 };
 
 const directionClassNames = {
-  block: styles.directionBlock,
-  inline: styles.directionInline,
+  horizontal: styles.directionHorizontal,
+  vertical: styles.directionVertical,
 };
 
 const alignClassNames = {
@@ -51,7 +51,7 @@ const alignClassNames = {
 export const Separator = ({
   padding = false,
   appearance = 'primary',
-  direction = 'inline',
+  direction = 'horizontal',
   align = 'center',
   style,
   size,

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd2526610b72e0dca3d9b31e76f1417e74fca714a1f2272bb844fce7a4e42925
-size 103022
+oid sha256:27bbfe178f682235514d76a3bc4a7389af1239f7181f96fa4667e6de27e0e367
+size 103877

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ddf7512c10472b895091ed89628065b3dbd2bec20a35f413d12a0c1fd287445
-size 83611
+oid sha256:ee3d1c279f70ab63f1d89a2a95a336fc9170852bac1225c564a00e32938f271c
+size 84486

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42b4b83caf0e7b39c5e4fbaf12c350735a49f840cc65cb5eed4334631f9f74fd
-size 106447
+oid sha256:5e4eabb809406bc2f78149fceadcae6b7d11d6920c5bdf064c1c06a5b4bc0050
+size 107232

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1e44413707838ab1c7522287d29b8403be5ecee30e22ba00604e5058dcb2a8a
-size 86573
+oid sha256:1e6a0f04edb9d7aade90eb197fc046920f993a2a01b89226ff73734ae0a30011
+size 87615

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:668d8fcbc426460044c62c8919ef1af807271eb4091b4ef8061caea916080161
-size 104572
+oid sha256:e158184fcdf496096ef4aecdba603df6a517d4f095b68de25dc13da9a5eaa660
+size 105792

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7bf6fa7ad453e786fd9d7876e2f3e792abc4873335ac16f6307edfbe326ae8a8
-size 84482
+oid sha256:5c88d26cb512f326248cca0e82a2b02db9d4d72f0dfe7de742f0e4ce2feff724
+size 85695

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eaea5d1933322acb24be3341e7842617f67c12b9879d7f9378a60b24ae2c5ae8
-size 147057
+oid sha256:e912b87086bcb5496ba65a5c9bffaec9452adca55817656f3450f9e8614d8c1b
+size 151541

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd5e80d4e4f7ace4c95bd5d7ea84c29627f58265c9c08904e04d4cbd1a2b28c3
-size 115950
+oid sha256:460d2defd50404360d8f5ef1124bbf8bd2cd5f0780bb91fcd2a089000cc55859
+size 121459

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6467d5904278c4c19c6e3441d46d6108e0c321a27d32ff9a1fc757038dbc4e25
-size 107789
+oid sha256:6c25cd1d64d092997ced1f7468ac0cbb4b32c1c5a6f3dcbf776aa1e0b87cfe21
+size 108804

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:289975ab9d56064eee419fe05dd57daac6d4f6a26e479967c0eb94db345cc4e2
-size 87702
+oid sha256:43d4a00b25a741287c3653f4e59cdadbe4f41187aac535a887c6bf5b2491ba5d
+size 89201


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7760

---

- [x] Unit-тесты
- [x] e2e-тесты

## Описание

Значения Separator свойства direction переименованы с 'block'|'inline' на 'vertical'|'horizontal'

> **Release notes** см. #7720

## Release notes
-