### PR TITLE
feat: enhance codemods

### DIFF
--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -2,11 +2,11 @@
 
 Чтобы упростить переход на новую мажорную версию, можно воспользоваться инструментом по автоматической миграции ваших компонентов.
 
-> Для начала обновите ваше приложение до необходимой мажорной версии (например, **v7**) в соответствии с требованиями вашего пакетного менеджера и среды
+> Для начала обновите ваше приложение до необходимой мажорной версии (например, **v7**) в соответствии с требованиями вашего пакетного менеджера и среды.
 
-> Обратите внимание, минимальная поддерживаемая версия **React** `v18.2.0`
+> Обратите внимание, минимальная поддерживаемая версия **React** `v18.2.0`.
 
-> Пока для перевода доступны только `Typescript`-файлы (_.ts/_.tsx)
+> Пока для перевода доступны только `Typescript`-файлы (_.ts/_.tsx).
 
 > Из-за особенностей работы `jscodeshift` после применения миграции у вас могут появиться лишние скобки вокруг `JSX`-элементов, пожалуйста, запустите `prettier`, чтобы отформатировать код в соответствии с вашими настройками.
 
@@ -25,34 +25,39 @@ npx @vkontakte/vkui-codemods
 ```console
 $ npx @vkontakte/vkui-codemods --help
 
-Usage: @vkontakte/vkui-codemod [codemod-name]
+Usage: @vkontakte/vkui-codemod [codemod-names...]
 
 Arguments:
- codemod-name              which codemod should be applied
+  codemod-names                                 which codemods should be applied
 
 Options:
- -V, --version             output the version number
- -l --list                 list available codemods
- --all                     apply all available codemods
- -tv --transforms-version <transformsVersion>  vkui major version transforms (available versions: "6", "7")
- -p --path <paths>         path to files in which to apply the codemods (default: current directory)
- --dry-run                 no changes are made to files
- --ignore-config <config>  ignore files if they match patterns sourced from a configuration file (e.g. a .gitignore)
- --debug                   all logs are shown
- --alias <alias>           in case you have adapter over original library (default: "@vkontakte/vkui")
- -h, --help                display help for command
+  -V, --version                                 output the version number
+  -l --list                                     list available codemods
+  --all                                         apply all available codemods
+  -tv --transforms-version <transformsVersion>  vkui major version transforms (available versions: "6", "7")
+  -p --path [paths...]                          file paths where codemods need to apply (space separated list), default:
+                                                current directory
+  --input-file <file>                           apply codemods only to file/directory listed in the file
+  --dry-run                                     no changes are made to files
+  --ignore-config <config>                      ignore files if they match patterns sourced from a configuration file (e.g. a
+                                                .gitignore)
+  --debug                                       all logs are shown
+  --alias <alias>                               in case you have adapter over original library (default: "@vkontakte/vkui")
+  -h, --help                                    display help for command
 ```
 
-При запуске приложения без аргументов будет предложено выбрать один из имеющихся codemod (их название отражает название компонента, к которому будет применено изменение). Если вам необходимо применить все имеющиеся codemods, запустите команду с опцией `--all`:
+Если приложение запустить без опции `-tv (--transforms-version)`, скрипт попытается автоматически определить версию, на которую необходимо мигрировать. Если этого сделать не удалось - нужно будет выбрать версию из предложенного списка.
+
+При запуске приложения без аргументов будет предложено выбрать одну или несколько имеющихся миграций (их название отражает название компонента, к которому будет применено изменение). Если вам необходимо применить все имеющиеся миграции, запустите команду с опцией `--all`:
 
 ```shell
 npx @vkontakte/vkui-codemods --all
 ```
 
-Если вы хотите исключить некоторые файлы или директории из обработки, то временно создайте файл (по примеру .gitignore) с перечисленными исключениями:
+Если вы хотите исключить некоторые файлы или директории из обработки, то временно создайте файл (по примеру .gitignore) с перечисленными исключениями в папке:
 
 ```shell
-npx @vkontakte/vkui-codemods --all --path "./examples" --ignore-config "./.codemodignore"
+npx @vkontakte/vkui-codemods --all --path src --ignore-config "./.codemodignore"
 ```
 
 ```
@@ -61,10 +66,32 @@ MyBeautifulComponentToIgnore.tsx
 directoryToIgnore/
 ```
 
-Приведенная выше команда применит все codemods в директории `examples` (находится в корне текущей директории), игонорируя файл `MyBeautifulComponentToIgnore.tsx` и директорию `directoryToIgnore`, указанные в `.codemodignore` (находится в корне текущей директории)
+Приведенная выше команда применит все codemods в директории `src` (находится в корне текущей директории), игонорируя файл `MyBeautifulComponentToIgnore.tsx` и директорию `directoryToIgnore`, указанные в `.codemodignore` (находится в корне текущей директории).
+
+Если вы хотите перечислить файлы и директории, которые нужно включить в обработку, в отдельном конфигурационном файле, это можно сделать, указав опцию `--input-file <file>`:
+
+```
+// .input-file
+MyBeautifulComponent.tsx
+src/components
+```
 
 > Обратите внимание, если вы используете собственный адаптер над библиотекой `VKUI` и делаете ре-экспорт существующих компонентов, то можете воспользоваться опцией `--alias` для указания правильного пути.
 
 ```shell
 npx @vkontakte/vkui-codemods --all --alias "@myscope/VKUIFake"
+```
+
+## Примеры
+
+Представленный ниже скрипт позволит запустить все имеющиеся миграции в файлах `App.tsx` и `Main.tsx` в папке `src`:
+
+```shell
+npx @vkontakte/vkui-codemods --path src/App.tsx src/Main.tsx --all
+```
+
+Следующий скрипт запустит миграции компонентов `Flex` и `Separator` при обновлении на версию VKUI v7 в текущей директории:
+
+```shell
+npx @vkontakte/vkui-codemods flex separator -tv 7
 ```

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -35,9 +35,11 @@ Options:
   -l --list                                     list available codemods
   --all                                         apply all available codemods
   -tv --transforms-version <transformsVersion>  vkui major version transforms (available versions: "6", "7")
-  -p --path [paths...]                          file paths where codemods need to apply (space separated list), default:
-                                                current directory
+  -p --path [paths...]                          file paths where codemods need to apply (space separated list), default: current
+                                                directory
   --input-file <file>                           apply codemods only to file/directory listed in the file
+  --log-file <file>                             log migration instructions with required manual changes to the file instead of
+                                                the console
   --dry-run                                     no changes are made to files
   --ignore-config <config>                      ignore files if they match patterns sourced from a configuration file (e.g. a
                                                 .gitignore)
@@ -46,13 +48,19 @@ Options:
   -h, --help                                    display help for command
 ```
 
+### `-tv (--transforms-version)`
+
 Если приложение запустить без опции `-tv (--transforms-version)`, скрипт попытается автоматически определить версию, на которую необходимо мигрировать. Если этого сделать не удалось - нужно будет выбрать версию из предложенного списка.
+
+### `--all`
 
 При запуске приложения без аргументов будет предложено выбрать одну или несколько имеющихся миграций (их название отражает название компонента, к которому будет применено изменение). Если вам необходимо применить все имеющиеся миграции, запустите команду с опцией `--all`:
 
 ```shell
 npx @vkontakte/vkui-codemods --all
 ```
+
+### `--ignore-config <file>`
 
 Если вы хотите исключить некоторые файлы или директории из обработки, то временно создайте файл (по примеру .gitignore) с перечисленными исключениями в папке:
 
@@ -68,6 +76,12 @@ directoryToIgnore/
 
 Приведенная выше команда применит все codemods в директории `src` (находится в корне текущей директории), игонорируя файл `MyBeautifulComponentToIgnore.tsx` и директорию `directoryToIgnore`, указанные в `.codemodignore` (находится в корне текущей директории).
 
+### `--log-file <file>`
+
+Есть вероятность, что применить автоматические миграции не представляется возможным. В таком случае приложение выведет в консоль подсказку, какие изменения необходимо внести вручную. Этих изменений может быть большое количество, для удобства можно воспользоваться опцией `--log-file <file>`, тогда все инструкции будут записаны в указанный файл (если его не существует, то он будет создан автоматически).
+
+### `--input-file <file>`
+
 Если вы хотите перечислить файлы и директории, которые нужно включить в обработку, в отдельном конфигурационном файле, это можно сделать, указав опцию `--input-file <file>`:
 
 ```
@@ -75,6 +89,8 @@ directoryToIgnore/
 MyBeautifulComponent.tsx
 src/components
 ```
+
+### `--alias`
 
 > Обратите внимание, если вы используете собственный адаптер над библиотекой `VKUI` и делаете ре-экспорт существующих компонентов, то можете воспользоваться опцией `--alias` для указания правильного пути.
 

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import prompts from 'prompts';
@@ -8,7 +9,8 @@ import logger from './helpers/logger.js';
 
 export interface CliOptions {
   list: boolean;
-  path: string;
+  path: string[];
+  inputFile: string;
   dryRun: boolean;
   ignoreConfig: string;
   debug: boolean;
@@ -19,20 +21,16 @@ export interface CliOptions {
 
 export interface Cli {
   flags: CliOptions;
-  codemodName: string;
+  codemods: string[];
   transformsVersion: string;
 }
 
-const trimStringValue = (value: string | undefined) =>
-  typeof value === 'string' ? value.trim() : value;
-
-const promptAvailableCodemods = async (codemods: string[]): Promise<string> => {
-  const { codemod } = await prompts(
+const promptAvailableCodemods = async (codemods: string[]): Promise<string[]> => {
+  const { value } = await prompts(
     {
-      type: 'select',
-      name: 'codemod',
-      message: 'Pick a codemod',
-      initial: 0,
+      type: 'multiselect',
+      name: 'value',
+      message: 'Pick codemods',
       choices: codemods.map((name) => ({ title: name, value: name })),
     },
     {
@@ -41,22 +39,51 @@ const promptAvailableCodemods = async (codemods: string[]): Promise<string> => {
       },
     },
   );
+  if (value.length === 0) {
+    logger.error('No codemods picked.');
+    process.exit(1);
+  }
 
-  return codemod;
+  return value;
+};
+
+const promptTransformVersions = async (): Promise<string> => {
+  const { value } = await prompts(
+    {
+      type: 'select',
+      name: 'value',
+      message: 'Pick version',
+      choices: [
+        { title: 'v6', value: '6' },
+        { title: 'v7', value: '7' },
+      ],
+    },
+    {
+      onCancel: () => {
+        process.exit(1);
+      },
+    },
+  );
+
+  return value;
 };
 
 export const runCli = async (): Promise<Cli> => {
   const program = new Command('@vkontakte/vkui-codemod')
     .version(pkg.version || 'unknown')
-    .argument('[codemod-name]', 'which codemod should be applied', trimStringValue)
-    .usage(`${chalk.green('[codemod-name]')}`)
+    .argument('[codemod-names...]', 'which codemods should be applied')
+    .usage(`${chalk.green('[codemod-names...]')}`)
     .option('-l --list', 'list available codemods')
     .option('--all', 'apply all available codemods')
     .option(
       '-tv --transforms-version <transformsVersion>',
       'vkui major version transforms (available versions: "6", "7")',
     )
-    .option('-p --path <paths>', 'path to files in which to apply the codemods')
+    .option(
+      '-p --path [paths...]',
+      'file paths where codemods need to apply (space separated list), default: current directory',
+    )
+    .option('--input-file <file>', 'apply codemods only to file/directory listed in the file')
     .option('--dry-run', 'no changes are made to files')
     .option(
       '--ignore-config <config>',
@@ -70,31 +97,47 @@ export const runCli = async (): Promise<Cli> => {
     .parse(process.argv);
 
   const options = program.opts() as CliOptions;
-
-  let codemodName = program.args[0];
-  const transformsVersion = options.transformsVersion || autoDetectVKUIVersion();
+  let codemods = program.processedArgs[0] as string[];
+  let transformsVersion = options.transformsVersion || autoDetectVKUIVersion();
 
   if (!transformsVersion) {
-    logger.error(
-      'Problem determining the major version of vkui, try specifying it using the --transforms-version',
-    );
-    process.exit(1);
+    transformsVersion = await promptTransformVersions();
   }
 
+  const availableCodemods = getAvailableCodemods(transformsVersion);
+
   if (options.list) {
-    const codemods = getAvailableCodemods(transformsVersion);
-    logger.info(codemods);
+    logger.info(availableCodemods);
     process.exit(0);
   }
 
-  if (!codemodName && !options.all) {
-    const codemods = getAvailableCodemods(transformsVersion);
-    codemodName = await promptAvailableCodemods(codemods);
+  if (options.inputFile && !fs.existsSync(options.inputFile)) {
+    logger.error(`Input file ${options.inputFile} does not exist.`);
+    process.exit(1);
+  }
+
+  if (codemods.length > 0) {
+    const wrongCodemods = [];
+    for (let codemodName of codemods) {
+      if (!availableCodemods.includes(codemodName)) {
+        wrongCodemods.push(codemodName);
+      }
+    }
+    if (wrongCodemods.length > 0) {
+      logger.error(
+        `The following codemods doesn't exist: ${wrongCodemods}. Please check the available codemods by running with --list option`,
+      );
+      process.exit(1);
+    }
+  }
+
+  if (codemods.length === 0 && !options.all) {
+    codemods = await promptAvailableCodemods(availableCodemods);
   }
 
   return {
     flags: options,
-    codemodName,
+    codemods,
     transformsVersion,
   };
 };

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -11,6 +11,7 @@ export interface CliOptions {
   list: boolean;
   path: string[];
   inputFile: string;
+  logFile: string;
   dryRun: boolean;
   ignoreConfig: string;
   debug: boolean;
@@ -84,6 +85,10 @@ export const runCli = async (): Promise<Cli> => {
       'file paths where codemods need to apply (space separated list), default: current directory',
     )
     .option('--input-file <file>', 'apply codemods only to file/directory listed in the file')
+    .option(
+      '--log-file <file>',
+      'log migration instructions with required manual changes to the file instead of the console',
+    )
     .option('--dry-run', 'no changes are made to files')
     .option(
       '--ignore-config <config>',
@@ -133,6 +138,10 @@ export const runCli = async (): Promise<Cli> => {
 
   if (codemods.length === 0 && !options.all) {
     codemods = await promptAvailableCodemods(availableCodemods);
+  }
+
+  if (options.all) {
+    codemods = availableCodemods;
   }
 
   return {

--- a/packages/codemods/src/index.ts
+++ b/packages/codemods/src/index.ts
@@ -133,18 +133,20 @@ const run = async () => {
 
   logger.info("\n 🚀 Let's go!");
 
-  let logStream = undefined;
-  if (flags.logFile) {
-    logStream = fs.createWriteStream(flags.logFile, { flags: 'a' });
-    await once(logStream, 'open');
+  function applyCodemods(logStream?: WriteStream) {
+    codemods.forEach((codemodName) => {
+      logger.info(`Codemod ${codemodName} in process...`);
+      runJSCodeShift({ codemodName, transformsVersion, paths, flags, logStream });
+    });
   }
-  codemods.forEach((codemodName) => {
-    logger.info(`Codemod ${codemodName} in process...`);
-    runJSCodeShift({ codemodName, transformsVersion, paths, flags, logStream });
-  });
 
-  if (logStream) {
+  if (flags.logFile) {
+    const logStream = fs.createWriteStream(flags.logFile, { flags: 'a' });
+    await once(logStream, 'open');
+    applyCodemods(logStream);
     logStream.end();
+  } else {
+    applyCodemods();
   }
 
   logger.info(

--- a/packages/codemods/src/transforms/v7/__testfixtures__/spacing/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/spacing/basic.input.tsx
@@ -11,6 +11,8 @@ const App = () => {
       <Spacing size="3xs" />
 
       <Spacing size={"3xs"} />
+
+      <Spacing size={8} />
     </React.Fragment>
   );
 };

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spacing.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spacing.ts.snap
@@ -12,6 +12,7 @@ const App = () => {
       </Spacing>
       <Spacing size="2xs" />
       <Spacing size={"2xs"} />
+      <Spacing size={8} />
     </React.Fragment>)
   );
 };"

--- a/packages/codemods/src/transforms/v7/cell-button.ts
+++ b/packages/codemods/src/transforms/v7/cell-button.ts
@@ -45,7 +45,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       if (!value || !modeToAppearance[value]) {
         report(
           api,
-          `: ${localName} has been changed. Manual changes required: need to change 'mode' prop to 'appearance'`,
+          `: ${localName} has been changed. Manual changes required: need to change 'mode' prop to 'appearance'.`,
         );
         return;
       }

--- a/packages/codemods/src/transforms/v7/common/remapSizePropValue.ts
+++ b/packages/codemods/src/transforms/v7/common/remapSizePropValue.ts
@@ -26,11 +26,19 @@ export const remapSizePropValue = ({
     })
     .forEach((attribute) => {
       let nodeToReplaceValue;
+      if (
+        attribute.node.value?.type !== 'JSXExpressionContainer' &&
+        attribute.node.value?.type !== 'StringLiteral'
+      ) {
+        return;
+      }
       if (attribute.node.value?.type === 'JSXExpressionContainer') {
         const expression = attribute.node.value.expression;
-        if (expression.type === 'StringLiteral') {
-          nodeToReplaceValue = expression;
+        if (expression.type !== 'StringLiteral') {
+          return;
         }
+
+        nodeToReplaceValue = expression;
       }
       if (attribute.node.value?.type === 'StringLiteral') {
         nodeToReplaceValue = attribute.node.value;

--- a/packages/codemods/src/transforms/v7/config-provider.ts
+++ b/packages/codemods/src/transforms/v7/config-provider.ts
@@ -75,7 +75,7 @@ function handleConfigProviderProps(
   const showReport = () => {
     report(
       api,
-      `: "${localName}" has been changed. Manual changes required: need to rename "appearance" field to "colorScheme" in object if it need`,
+      `: "${localName}" has been changed. Manual changes required: perhaps need to rename "appearance" field to "colorScheme" in object.`,
     );
   };
   const types = source.find(j.TSTypeReference, {
@@ -90,7 +90,7 @@ function handleUseConfigProvider(j: JSCodeshift, api: API, source: Collection, l
   const showReport = () => {
     report(
       api,
-      `: "${localName}" has been changed. Manual changes required: need to rename "appearance" field to "colorScheme" in result of hook if it need`,
+      `: "${localName}" has been changed. Manual changes required: perhaps need to rename "appearance" field to "colorScheme" in result of hook.`,
     );
   };
   const identifiers = source.find(j.Identifier, {
@@ -105,7 +105,7 @@ function handleConfigProvider(j: JSCodeshift, api: API, source: Collection, loca
   const showReport = () => {
     report(
       api,
-      `: "${localName}" has been changed. Manual changes required: need to rename "appearance" field to "colorScheme" if it need`,
+      `: "${localName}" has been changed. Manual changes required: perhaps need to rename "appearance" field to "colorScheme".`,
     );
   };
   source
@@ -145,7 +145,7 @@ function handleConfigProviderContext(
   const showReport = () => {
     report(
       api,
-      `: "${localName}" has been changed. Manual changes required: need to rename "appearance" field to "colorScheme" if it need`,
+      `: "${localName}" has been changed. Manual changes required: perhaps need to rename "appearance" field to "colorScheme".`,
     );
   };
 

--- a/packages/codemods/src/transforms/v7/image-overlay.ts
+++ b/packages/codemods/src/transforms/v7/image-overlay.ts
@@ -86,7 +86,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
         );
 
         // Кейс, когда disableInteractive не был задан, значит overlay interactive.
-        // Сейчас у него обязательно должен быть onClick, чтобы не ломать обратную совместимость
+        // Сейчас у него обязательно должен быть onClick, чтобы не лоймать обратную совместимость
 
         if (!disableInteractiveAttribute) {
           // Проверяем наличие onClick, и если его нет, то пользователь должен добавить onClick
@@ -101,8 +101,8 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
         // Рассчитываем значение disableInteractive в boolean
         const disableInteractiveValue = calcDisableInteractiveValue(disableInteractiveAttribute);
         if (disableInteractiveValue === null) {
-          // Если у disableInteractive используется сложное выражение
-          // То пользователь сам должен удалить этот проп, как ему нужно
+          // Если у disableInteractive используется сложное выражение,
+          // то пользователь сам должен удалить этот проп, как ему нужно
           showDisableInteractivePropReport(localName);
         }
 
@@ -110,7 +110,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
         removeAttribute(overlayItemAttributes, disableInteractiveAttribute);
 
         if (disableInteractiveValue) {
-          // Если disableInteractive = true, то все, что нам нужно это удалить атрибут onClick
+          // Если disableInteractive = true, то все, что нам нужно, это удалить атрибут onClick
           // Важно: мы можем его спокойно удалить, так как в этом кейсе он может быть только undefined
           if (onClickAttribute) {
             removeAttribute(overlayItemAttributes, onClickAttribute);
@@ -122,10 +122,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
           showDisableInteractivePropReport(localName);
           return;
         }
-        // Если disableInteractive = false и onClick не пустой надо обработать следующие кейс:
+        // Если disableInteractive = false и onClick не пустой, надо обработать следующие кейсы:
         // onClick=undefined: надо добавить колбэк
-        // onClick=identifier: все хорошо,оставляем как есть
-        // В остальных случаях, надо чтобы пользователь убедился, что onClick устанавливается корректно
+        // onClick=identifier: все хорошо, оставляем как есть
+        // В остальных случаях надо, чтобы пользователь убедился, что onClick устанавливается корректно
         if (onClickAttribute.value?.type === 'JSXExpressionContainer') {
           const expression = onClickAttribute.value.expression;
           if (expression.type === 'Identifier') {

--- a/packages/codemods/src/transforms/v7/image-overlay.ts
+++ b/packages/codemods/src/transforms/v7/image-overlay.ts
@@ -38,7 +38,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
   const showDisableInteractivePropReport = (localName: string) => {
     showReport(
       localName,
-      `"disableInteractive" has been removed, please use "onClick" if you want to make ${localName}.Overlay interactive`,
+      `"disableInteractive" has been removed, please use "onClick" if you want to make ${localName}.Overlay interactive.`,
     );
   };
 
@@ -93,7 +93,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
           if (!onClickAttribute) {
             showReport(
               localName,
-              `If you want to make ${localName}.Overlay interactive please add "onClick" prop`,
+              `If you want to make ${localName}.Overlay interactive, please add "onClick" prop.`,
             );
           }
           return;
@@ -140,7 +140,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
         }
         showReport(
           localName,
-          `"disableInteractive" has been removed, please validate that "onClick" prop value not falsy`,
+          `"disableInteractive" has been removed, please validate that "onClick" prop value not falsy.`,
         );
       });
   };

--- a/packages/codemods/src/transforms/v7/users-stack.ts
+++ b/packages/codemods/src/transforms/v7/users-stack.ts
@@ -46,7 +46,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       if (!value || !directionToAvatarsPosition[value]) {
         report(
           api,
-          `: ${localName} has been changed. Manual changes required: need to change direction prop to avatarsPosition`,
+          `: ${localName} has been changed. Manual changes required: need to change direction prop to avatarsPosition.`,
         );
         return;
       }


### PR DESCRIPTION
## Изменения

- отредактировано README.md
- исправлены информационные сообщения
- добавлена возможность вывода информации о ручных миграциях в файл (`--log-file <file>`)
- добавлена возможность применить несколько миграций одновременно (а не только все или одну) (`[codemod-names...]`)
- добавлена возможность задать несколько путей, в которых необходимо применить миграции (`--path [paths...]`)
- добавлена возможность вместо путей указать конкретные файлы или директории через файл (`--input-file <file>`)
- в миграции по `Spacing` ограничена обработка  не-строковых нод

## Release notes
-

