### PR TITLE
feat(CardScroll): rename prop `noSpaces` to `padding`

### DIFF
--- a/packages/codemods/src/transforms/v7/__testfixtures__/card-scroll/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/card-scroll/basic.input.tsx
@@ -1,0 +1,59 @@
+import { Card, CardScroll } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    <React.Fragment>
+      {/* noSpaces by default -> padding=true */}
+      <CardScroll
+        size="s"
+      >
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+
+      {/* noSpaces="false" -> padding="true" */}
+      <CardScroll
+        size="s"
+        noSpaces={false}
+      >
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+
+      {/* noSpaces="true" -> padding="false" */}
+      <CardScroll
+        size="s"
+        noSpaces={true}
+      >
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+
+      {/* noSpaces="true" -> padding="false" */}
+      <CardScroll
+        size="s"
+        noSpaces
+      >
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+    </React.Fragment>
+  );
+};

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/card-scroll.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/card-scroll.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`card-scroll transforms correctly 1`] = `
+"import { Card, CardScroll } from '@vkontakte/vkui';
+import React from 'react';
+
+const App = () => {
+  return (
+    (<React.Fragment>
+      {/* noSpaces by default -> padding=true */}
+      <CardScroll size="s" padding>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+      {/* noSpaces="false" -> padding="true" */}
+      <CardScroll
+        size="s"
+        padding
+      >
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+      {/* noSpaces="true" -> padding="false" */}
+      <CardScroll size="s">
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+      {/* noSpaces="true" -> padding="false" */}
+      <CardScroll size="s">
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+        <Card>
+          <div style={{ paddingBottom: '66%' }} />
+        </Card>
+      </CardScroll>
+    </React.Fragment>)
+  );
+};"
+`;

--- a/packages/codemods/src/transforms/v7/__tests__/card-scroll.ts
+++ b/packages/codemods/src/transforms/v7/__tests__/card-scroll.ts
@@ -1,0 +1,12 @@
+jest.autoMockOff();
+
+import { defineSnapshotTestFromFixture } from '../../../testHelpers/testHelper';
+
+const name = 'card-scroll';
+const fixtures = ['basic'] as const;
+
+describe(name, () => {
+  fixtures.forEach((test) =>
+    defineSnapshotTestFromFixture(__dirname, name, global.TRANSFORM_OPTIONS, `${name}/${test}`),
+  );
+});

--- a/packages/codemods/src/transforms/v7/card-scroll.ts
+++ b/packages/codemods/src/transforms/v7/card-scroll.ts
@@ -1,0 +1,70 @@
+import { API, FileInfo, JSXAttribute, JSXSpreadAttribute } from 'jscodeshift';
+import { getImportInfo, removeAttribute } from '../../codemod-helpers';
+import { report } from '../../report';
+import { JSCodeShiftOptions } from '../../types';
+
+export const parser = 'tsx';
+
+export default function transformer(file: FileInfo, api: API, options: JSCodeShiftOptions) {
+  const { alias } = options;
+  const j = api.jscodeshift;
+  const source = j(file.source);
+  const { localName } = getImportInfo(j, file, 'CardScroll', alias);
+
+  if (!localName) {
+    return source.toSource();
+  }
+
+  const getValueFromAttribute = (attribute: JSXAttribute): boolean | null => {
+    if (attribute.value?.type === 'BooleanLiteral') {
+      return attribute.value.value;
+    }
+    if (attribute.value?.type === 'JSXExpressionContainer') {
+      const expression = attribute.value.expression;
+      if (expression.type === 'BooleanLiteral') {
+        return expression.value;
+      }
+      return null;
+    }
+    return true;
+  };
+
+  const addPropPadding = (attributes: Array<JSXAttribute | JSXSpreadAttribute> | undefined) => {
+    attributes?.push(j.jsxAttribute(j.jsxIdentifier('padding')));
+  };
+
+  source
+    .find(j.JSXElement, {
+      openingElement: {
+        name: {
+          name: localName,
+        },
+      },
+    })
+    .forEach((path) => {
+      const attributes = path.node.openingElement.attributes;
+      const noSpacesAttr: JSXAttribute | undefined = attributes?.find(
+        (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'noSpaces',
+      ) as JSXAttribute | undefined;
+
+      if (!noSpacesAttr) {
+        addPropPadding(attributes);
+        return;
+      }
+      const attrValue = getValueFromAttribute(noSpacesAttr);
+      if (attrValue === null) {
+        report(
+          api,
+          `Manual changes required for ${localName}'s "noSpaces" prop. Need to change it to "padding" prop`,
+        );
+        return;
+      }
+      removeAttribute(attributes, noSpacesAttr);
+
+      if (!attrValue) {
+        addPropPadding(attributes);
+      }
+    });
+
+  return source.toSource();
+}

--- a/packages/vkui/src/components/CardScroll/CardScroll.e2e-playground.tsx
+++ b/packages/vkui/src/components/CardScroll/CardScroll.e2e-playground.tsx
@@ -14,13 +14,15 @@ export const CardScrollPlayground = (props: ComponentPlaygroundProps) => {
       {...props}
       propSets={[
         {
+          padding: [true],
           size: ['s', 'm', 'l', false],
         },
         {
+          padding: [true],
           showArrows: [true, false, 'always'],
         },
         {
-          noSpaces: [false, true],
+          padding: [false],
         },
       ]}
     >

--- a/packages/vkui/src/components/CardScroll/CardScroll.module.css
+++ b/packages/vkui/src/components/CardScroll/CardScroll.module.css
@@ -19,7 +19,7 @@
   margin-block-start: 16px;
 }
 
-.withSpaces .gap {
+.withPaddings .gap {
   inline-size: var(--vkui--size_base_padding_horizontal--regular);
 }
 
@@ -29,7 +29,7 @@
  */
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
 :global(.vkuiInternalSplitCol--viewWidth-tabletPlus):global(.vkuiInternalSplitCol--spaced-auto)
-  .withSpaces
+  .withPaddings
   .gap {
   inline-size: 16px;
 }
@@ -37,7 +37,7 @@
 @media (--viewWidth-smallTabletPlus) {
   /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
   :global(.vkuiInternalSplitCol--viewWidth-none):global(.vkuiInternalSplitCol--spaced-auto)
-    .withSpaces
+    .withPaddings
     .gap {
     inline-size: 16px;
   }
@@ -48,33 +48,33 @@
  * Group
  */
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-:global(.vkuiInternalGroup--mode-card) .withSpaces {
+:global(.vkuiInternalGroup--mode-card) .withPaddings {
   margin-inline: -8px;
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-:global(.vkuiInternalGroup--mode-card) .withSpaces:first-child {
+:global(.vkuiInternalGroup--mode-card) .withPaddings:first-child {
   padding-block-start: var(--vkui--size_cardgrid_padding_vertical--regular);
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-:global(.vkuiInternalGroup--mode-card) .withSpaces:last-child {
+:global(.vkuiInternalGroup--mode-card) .withPaddings:last-child {
   padding-block-end: var(--vkui--size_cardgrid_padding_vertical--regular);
 }
 
 @media (--sizeX-regular) {
   /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-  :global(.vkuiInternalGroup--mode-none) .withSpaces {
+  :global(.vkuiInternalGroup--mode-none) .withPaddings {
     margin-inline: -8px;
   }
 
   /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-  :global(.vkuiInternalGroup--mode-none) .withSpaces:first-child {
+  :global(.vkuiInternalGroup--mode-none) .withPaddings:first-child {
     padding-block-start: var(--vkui--size_cardgrid_padding_vertical--regular);
   }
 
   /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-  :global(.vkuiInternalGroup--mode-none) .withSpaces:last-child {
+  :global(.vkuiInternalGroup--mode-none) .withPaddings:last-child {
     padding-block-end: var(--vkui--size_cardgrid_padding_vertical--regular);
   }
 }

--- a/packages/vkui/src/components/CardScroll/CardScroll.tsx
+++ b/packages/vkui/src/components/CardScroll/CardScroll.tsx
@@ -20,7 +20,10 @@ export interface CardScrollProps extends HTMLAttributesWithRootRef<HTMLDivElemen
    */
   size?: 's' | 'm' | 'l' | false;
   showArrows?: HorizontalScrollProps['showArrows'];
-  noSpaces?: boolean;
+  /**
+   * Добавляет отступы по краям слева и справа
+   */
+  padding?: boolean;
 }
 
 /**
@@ -30,7 +33,7 @@ export const CardScroll = ({
   children,
   size = 's',
   showArrows = true,
-  noSpaces = false,
+  padding = false,
   Component = 'ul',
   ...restProps
 }: CardScrollProps): React.ReactNode => {
@@ -99,7 +102,7 @@ export const CardScroll = ({
         styles.host,
         'vkuiInternalCardScroll',
         size !== false && stylesSize[size],
-        !noSpaces && styles.withSpaces,
+        padding && styles.withPaddings,
       )}
     >
       <HorizontalScroll

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:404fa07f4d8191bbd40b83e1e0ac8a765ffdff15f73a77149be0eef64e9c0455
-size 20459
+oid sha256:2e2a768acf01ebd6f417ca6b2ec315c1983a2f219404bb3453a5e62f322bd236
+size 19786

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b96a63cbe24036b8cd52b0eaee3378c7a26dc55e5f5ab0ee05d429b8cc887c5b
-size 19491
+oid sha256:a7c5b3a8d1edfe854c1954ed366a02925ccefd90a77f8f2a6ba403e19ef80798
+size 19416

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88337868a1772bf8243779dbf77abe8a1147f265f5b5edaefc0cb8f439cf967e
-size 20210
+oid sha256:e7213f2993215d9c810613424bf92c841a693bb9f4193e53bd7e75fc4b6a8f69
+size 22019

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d85a4acf1c58a39baf85cabc0021dd1e3619c03f0439ad8fd3131fd45d421c25
-size 18922
+oid sha256:b22703102f65763e5cf8d3a1f553f5802d0d27585cc6b82a628ef6ad2a7d8803
+size 21016

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28619d6a39d6e8ac36ff6ed3a775f8af9bedb847f9ea6d5e2aca74985519a398
-size 18778
+oid sha256:c46b5ecba181af3758c7de12281e1d7f1bb2986bebaa4b1081b7958fbf827738
+size 20382

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6094ce95a9317d022b47d58b6b19001e173b1fb96746880b060e9c47f5e010af
-size 21173
+oid sha256:cef61dd18c9ee86f6538c590815c0a94f2fac90199307338af84f4f7dc6054c3
+size 20876

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:056a043ee80984f4997a7ef7a76b5d3f7d2434212b8327ebec27267736ed50b6
-size 28858
+oid sha256:3ac21d8200cde3ae7f673fd88df330883ea54f5c943be8b66fb98ce96433b899
+size 30055

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40d90b1db097015fe81f782d6bd66ade4abce37bfc6747742ebb8434ece16655
-size 29074
+oid sha256:c01476cb75a3aebfdf2540bcb59ae1e368624718382627c545ea8d4f84e7f836
+size 30525

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:547833fdd6e9ac3f66909bc0b87a13a46e9e71990c2ecaf224e71ff226ede5d8
-size 19442
+oid sha256:2c10285dfd259362b8a0e1d6209befa3c5668b05b2b0c52d3ff78aa248af1ad1
+size 21352

--- a/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/CardScroll/__image_snapshots__/cardscroll-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81a3771427b4e97fef7d86278e8df3643394a9192fce5972ae75b95ec7495bdb
-size 19589
+oid sha256:715b7930e3c0ab0f865f6b8d9ff5e3c210f982f2aa01147154502e4d553cea67
+size 21842


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7756 

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] e2e-тесты
- [x] Release notes
- [x] Codemod

## Описание

В компоненте `CardScroll` заменил свойство `noSpaces` на `padding` с противоположным значением. При этом по умолчанию `padding` = false. Поэтому кодмоды были реализованы с учетом этого.

## Release notes
## BREAKING CHANGE
- CardScroll: свойство `noSpaces` заменено на `padding`
  ```diff
  <CardScroll
    size="s"
  - noSpaces
  + padding={false}
  >
    <Card>
      <div style={{ paddingBottom: '66%' }} />
    </Card>
  </CardScroll>
  ```