### PR TITLE
feat(ScreenSpinner): rename prop caption to label

### DIFF
--- a/packages/codemods/src/transforms/v7/__testfixtures__/screen-spinner/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/screen-spinner/basic.input.tsx
@@ -4,12 +4,23 @@ import React from 'react';
 const App = () => {
   return (
     <React.Fragment>
+      {/* Проверяем удаление size */}
       <ScreenSpinner
         state="loading"
         size="regular"
       />
       <ScreenSpinner.Container>
         <ScreenSpinner.Loader size="small" />
+        <ScreenSpinner.SwapIcon />
+      </ScreenSpinner.Container>
+
+      {/* Проверяем переименование caption на label */}
+      <ScreenSpinner
+        state="loading"
+        caption="Caption"
+      />
+      <ScreenSpinner.Container caption="Caption">
+        <ScreenSpinner.Loader />
         <ScreenSpinner.SwapIcon />
       </ScreenSpinner.Container>
     </React.Fragment>

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/screen-spinner.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/screen-spinner.ts.snap
@@ -7,8 +7,18 @@ import React from 'react';
 const App = () => {
   return (
     (<React.Fragment>
+      {/* Проверяем удаление size */}
       <ScreenSpinner state="loading" />
       <ScreenSpinner.Container>
+        <ScreenSpinner.Loader />
+        <ScreenSpinner.SwapIcon />
+      </ScreenSpinner.Container>
+      {/* Проверяем переименование caption на label */}
+      <ScreenSpinner
+        state="loading"
+        label="Caption"
+      />
+      <ScreenSpinner.Container label="Caption">
         <ScreenSpinner.Loader />
         <ScreenSpinner.SwapIcon />
       </ScreenSpinner.Container>

--- a/packages/vkui/src/components/ScreenSpinner/Readme.md
+++ b/packages/vkui/src/components/ScreenSpinner/Readme.md
@@ -7,7 +7,7 @@
 
 Чтобы уведомить о выполнении асинхронного процесса пользователей скринридеров, проставьте на [`SplitLayout`](#/SplitLayout), в котором выполняется процесс, метки [`aria-busy`](https://doka.guide/a11y/aria-busy/) и [`aria-live`](https://doka.guide/a11y/aria-live/).
 
-Чтобы заменить текст, который прочитает скринридер, передайте его в `children`. Он будет скрыт визуально, но останется доступным для ассистивных технологий. Если вы используете свойство `caption`, то передавать `children` не нужно, будет зачитан текст, переданный в `caption`.
+Чтобы заменить текст, который прочитает скринридер, передайте его в `children`. Он будет скрыт визуально, но останется доступным для ассистивных технологий. Если вы используете свойство `label`, то передавать `children` не нужно, будет зачитан текст, переданный в `label`.
 
 ```jsx { "props": { "layout": false, "adaptivity": true } }
 const [popout, setPopout] = useState(null);
@@ -20,7 +20,7 @@ const setLoadingScreenSpinner = () => {
 };
 
 const setDoneScreenSpinner = () => {
-  setPopout(<ScreenSpinner state="done" caption="Вы подписались на сообщество" />);
+  setPopout(<ScreenSpinner state="done" label="Вы подписались на сообщество" />);
   setTimeout(clearPopout, 3000);
 };
 
@@ -29,7 +29,7 @@ const setErrorScreenSpinner = () => {
 
   setTimeout(() => {
     setPopout(
-      <ScreenSpinner state="error" caption="Очень большая ошибка">
+      <ScreenSpinner state="error" label="Очень большая ошибка">
         Произошла ошибка
       </ScreenSpinner>,
     );
@@ -45,7 +45,7 @@ const setCancelableScreenSpinner = () => {
 const setScreenSpinnerWithCustomIcon = () => {
   setPopout(<ScreenSpinner state="custom" customIcon={<Icon56KeyOutline />} />);
 
-  setTimeout(clearPopout, 20000);
+  setTimeout(clearPopout, 2000);
 };
 
 <SplitLayout popout={popout} aria-live="polite" aria-busy={!!popout}>

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.e2e-playground.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.e2e-playground.tsx
@@ -12,7 +12,7 @@ export const ScreenSpinnerLoadingPlayground = (props: ComponentPlaygroundProps) 
         },
         {
           state: ['loading', 'cancelable', 'error'],
-          caption: ['Text for screenspinner to test layout'],
+          label: ['Text for screenspinner to test layout'],
         },
       ]}
     >

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.module.css
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.module.css
@@ -9,7 +9,7 @@
   animation: screen-spinner-intro 0.3s ease;
 }
 
-.hasCaption {
+.hasLabel {
   inline-size: fit-content;
   block-size: fit-content;
   max-inline-size: 150px;
@@ -30,13 +30,13 @@
   color: var(--vkui--color_icon_contrast);
 }
 
-.caption {
+.label {
   color: var(--vkui--color_text_secondary);
   margin-block-start: var(--vkui--spacing_size_xs);
   text-align: center;
 }
 
-.modeOverlay .caption {
+.modeOverlay .label {
   color: var(--vkui--color_text_contrast);
 }
 

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
@@ -24,7 +24,7 @@ export const ScreenSpinner: React.FC<ScreenSpinnerProps> & {
   onClick,
   cancelLabel,
   mode,
-  caption,
+  label,
   customIcon,
   ...restProps
 }: ScreenSpinnerProps): React.ReactNode => {
@@ -32,7 +32,7 @@ export const ScreenSpinner: React.FC<ScreenSpinnerProps> & {
 
   return (
     <PopoutWrapper className={className} style={style} noBackground>
-      <ScreenSpinnerContainer state={state} mode={mode} caption={caption} customIcon={customIcon}>
+      <ScreenSpinnerContainer state={state} mode={mode} label={label} customIcon={customIcon}>
         <ScreenSpinnerLoader {...restProps} />
         <ScreenSpinnerSwapIcon onClick={onClick} cancelLabel={cancelLabel} />
       </ScreenSpinnerContainer>

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
@@ -20,31 +20,31 @@ const modeClassNames = {
 };
 
 type ScreenSpinnerContainerProps = HTMLAttributesWithRootRef<HTMLSpanElement> &
-  Pick<ScreenSpinnerProps, 'state' | 'mode' | 'caption' | 'customIcon'>;
+  Pick<ScreenSpinnerProps, 'state' | 'mode' | 'label' | 'customIcon'>;
 
 export const ScreenSpinnerContainer: React.FC<ScreenSpinnerContainerProps> = ({
   state = 'loading',
   mode = 'shadow',
   customIcon,
-  caption,
+  label,
   children,
   ...restProps
 }: ScreenSpinnerContainerProps) => {
   return (
-    <ScreenSpinnerContext.Provider value={{ state, caption, customIcon }}>
+    <ScreenSpinnerContext.Provider value={{ state, label, customIcon }}>
       <RootComponent
         baseClassName={classNames(
           styles.host,
           modeClassNames[mode],
           state !== 'loading' && stateClassNames[state],
-          hasReactNode(caption) && styles.hasCaption,
+          hasReactNode(label) && styles.hasLabel,
         )}
         {...restProps}
       >
         <div className={styles.iconSlot}>{children}</div>
-        {hasReactNode(caption) && (
-          <Footnote className={styles.caption} aria-hidden>
-            {caption}
+        {hasReactNode(label) && (
+          <Footnote className={styles.label} aria-hidden>
+            {label}
           </Footnote>
         )}
       </RootComponent>

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
@@ -11,12 +11,12 @@ export const ScreenSpinnerLoader: React.FC<Omit<SpinnerProps, 'size'>> = ({
   children,
   ...restProps
 }) => {
-  const { caption } = React.useContext(ScreenSpinnerContext);
+  const { label } = React.useContext(ScreenSpinnerContext);
   // TODO [>=7]: см. https://github.com/VKCOM/VKUI/pull/7505#discussion_r1754153438
-  const a11yText = children ? children : caption ?? 'Пожалуйста, подождите...';
+  const a11yText = children ? children : label ?? 'Пожалуйста, подождите...';
   return (
     <Spinner
-      className={classNames(styles.spinner, !caption && styles.spinnerTransition)}
+      className={classNames(styles.spinner, !label && styles.spinnerTransition)}
       size="xl"
       noColor
       {...restProps}

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:08aff6c3f88a097eda180df4f6dcacf56b829fc825a123bf590e2ac9a33c505f
-size 59609
+oid sha256:2079731d6ea12306a13a5085c8bc3db14f5e57c4335a25e385e684ab697332be
+size 59358

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:158b5965bb16a15bd6dd0d75bc13a910f430f2fb4ca9f771806e186682903e4d
-size 58463
+oid sha256:aeafa9e2e4cd161ea94ebfef48bdd71ec887ddc78535c56f2a2dcb955279021e
+size 58249

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9244efc67ca5d849149835505e3dd1d906379a43af11c2029f12ca33bb5597b
-size 58715
+oid sha256:e6d6d81e52fe02b76cbc15d82254cf1da11405dd8db4dc2b23573b38d6c8e88b
+size 58602

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88ec37d68d60acb1ab33765d710c125019a83858ab1fabf625ff9b36d0ad8010
-size 59203
+oid sha256:c5e51162eee668a369d6c62f96852b64b3ff22bcf32896b73d27d700eeb504e1
+size 58886

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd0d37edb8873baefeef8f24f8cbd250c44d69b5ec829deb4580004c98408e98
-size 58354
+oid sha256:7f0bb2fccbf898a4a8e78b19dce75cba47cc8e8f7734488f8f1606d2b062e488
+size 57740

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b65cd8147e0d9d2b921372db08f7001de0ed73ae74d198ce64d00aa161d53c80
-size 59119
+oid sha256:734979a39a9781ea459d286c3a96b02f751653770e979c7caf09a8b45d01cfb2
+size 58691

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39033eab04d6f5370fcbb21f0c1f5338e68b213f4cbde0a7fc8b854267f041b6
-size 79932
+oid sha256:c6f4c521a1659b8965ccd83af6abfcc4fb17a3bb08230eeb2f49d581c13ed8af
+size 78837

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89f091d188f7b007ea03af94db0b6f7aef4a06b57967ba3872ebecaa7f873d2a
-size 85715
+oid sha256:9fbebc5a56ca0d82719dd0beab7acc1906911921978f4b95ae01cd231bae438e
+size 84048

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:459f3bce60946da4754cfd8f13ac1d62bbc33aeee668266abce300e4a8374a78
-size 57613
+oid sha256:3b782eab2124874999cb7bf381cadaafec3ae918b21673c66738b8e0e320ed77
+size 57148

--- a/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ScreenSpinner/__image_snapshots__/screenspinner-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b85e72003abed0600d74e57648a58fd05cde8a079c5a7088c355bb877da72b1
-size 59052
+oid sha256:3299e8673c737eb80c52e1f1dcb48631ea03247a698784f281b4dff8fec0ddef
+size 58706

--- a/packages/vkui/src/components/ScreenSpinner/context.ts
+++ b/packages/vkui/src/components/ScreenSpinner/context.ts
@@ -3,13 +3,13 @@ import { type ScreenSpinnerProps } from './types';
 
 export interface ScreenSpinnerContextProps {
   state: NonNullable<ScreenSpinnerProps['state']>;
-  caption?: ScreenSpinnerProps['caption'];
+  label?: ScreenSpinnerProps['label'];
   customIcon?: ScreenSpinnerProps['customIcon'];
 }
 
 export const ScreenSpinnerContext: React.Context<ScreenSpinnerContextProps> =
   React.createContext<ScreenSpinnerContextProps>({
     state: 'loading',
-    caption: undefined,
+    label: undefined,
     customIcon: undefined,
   });

--- a/packages/vkui/src/components/ScreenSpinner/types.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/types.tsx
@@ -11,6 +11,6 @@ export type ScreenSpinnerProps = Omit<SpinnerProps, 'size'> & {
   /**
    * Текст под иконкой
    */
-  caption?: React.ReactNode;
+  label?: React.ReactNode;
   cancelLabel?: string;
 };


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7789

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] e2e-тесты
- [x] Release notes
- [x] Codemod

## Описание

В компоненте `ScreenSpinner` и в его подкомпоненте `ScreenSpinner.Container` переименовал свойство `caption` на `label`

## Release notes
## BREAKING CHANGE
- ScreenSpinner: свойство `caption` переименовано на `label`
  ```diff
  <ScreenSpinner
    state="loading"
  - caption="Caption"
  + label="Caption"
  />


  <ScreenSpinner.Container
  - caption="Caption"
  + label="Caption"
  >
    <ScreenSpinner.Loader />
    <ScreenSpinner.SwapIcon />
  </ScreenSpinner.Container>
  ```