### PR TITLE
build(dev-deps): Update markdown-to-jsx to 7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
     "webpack-merge": "^6.0.1",
     "yargs": "^17.7.2"
   },
+  "resolutions": {
+    "markdown-to-jsx@npm:^6.11.4": "^7.5.0"
+  },
   "scripts": {
     "docs:styleguide": "yarn workspace @project-docs/styleguide run start",
     "docs:styleguide:props": "yarn workspace @project-docs/styleguide run start:props",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11541,24 +11541,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-to-jsx@npm:^6.11.4":
-  version: 6.11.4
-  resolution: "markdown-to-jsx@npm:6.11.4"
-  dependencies:
-    prop-types: "npm:^15.6.2"
-    unquote: "npm:^1.1.0"
+"markdown-to-jsx@npm:^7.4.5, markdown-to-jsx@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "markdown-to-jsx@npm:7.5.0"
   peerDependencies:
     react: ">= 0.14.0"
-  checksum: 10/1dc3c245e1677770c38fc5be9a22d015e944b6d93126fae4f0abecba148bdbb6e926e05aea0bfbf9d6b0cb36309d213b5185bf32887fc276b8c826537c111473
-  languageName: node
-  linkType: hard
-
-"markdown-to-jsx@npm:^7.4.5":
-  version: 7.4.7
-  resolution: "markdown-to-jsx@npm:7.4.7"
-  peerDependencies:
-    react: ">= 0.14.0"
-  checksum: 10/d421f561a57256164564f4b4ac1c3439493f7b88d46ca8d1ed429e481a199a8756591e180d401654c0826ccabe9e76ce4fb97286a0b3c43a7a6346c735778b2b
+  checksum: 10/b1fbe4429b968aefe02d4549eebb8d7456ccd7a8417805bb7f4bde1b466bdd0c81df3b14c5a1d9dcc49c6451ae50cf23cd04228fb6a0e1f8579ad0b76adae044
   languageName: node
   linkType: hard
 
@@ -13574,7 +13562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -16594,13 +16582,6 @@ __metadata:
     webpack-sources: "npm:^3.2.3"
     webpack-virtual-modules: "npm:^0.6.1"
   checksum: 10/d9819fad8a177c080f7f2b80744d633101935a8a6cc26b42e6a46648cccc1c5de83b7763233d56e11af53f34e6c5074816262897c9048a31e5d697bef5bb57e7
-  languageName: node
-  linkType: hard
-
-"unquote@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "unquote@npm:1.1.1"
-  checksum: 10/71745867d09cba44ba2d26cb71d6dda7045a98b14f7405df4faaf2b0c90d24703ad027a9d90ba9a6e0d096de2c8d56f864fd03f1c0498c0b7a3990f73b4c8f5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- see GHSA-4wx3-54gh-9fr9
- https://redirect.github.com/styleguidist/react-styleguidist/issues/2167

---

## Описание

Запихнул в resolutions, так как styleguidist скорее всего не обновится

## Release notes
-
