### PR TITLE
feat(usePatchChildren): add reexport

### DIFF
--- a/packages/vkui/src/hooks/usePatchChildren.ts
+++ b/packages/vkui/src/hooks/usePatchChildren.ts
@@ -5,12 +5,8 @@ import {
   isForwardRefElement,
   isValidNotReactFragmentElement,
 } from '../lib/utils';
-import { warnOnce } from '../lib/warnOnce';
 import type { HasRootRef } from '../types';
-import { useEffectDev } from './useEffectDev';
 import { useExternRef } from './useExternRef';
-
-const warn = warnOnce('usePatchChildrenRef');
 
 type InjectProps<T> = Omit<React.HTMLAttributes<T>, keyof React.DOMAttributes<T>> &
   React.Attributes & {
@@ -29,8 +25,8 @@ type ChildrenElement<T> =
   | undefined;
 
 /**
- * Функция пытается прокинуть в переданный React-элемент хук для получения его ссылки на DOM этого
- * элемента.
+ * Хук позволяет пропатчить переданный компонент так, чтобы можно было получить ссылку на его
+ * DOM-элемент. Также есть возможность прокинуть дополнительные параметры.
  *
  * @param children
  * @param injectProps
@@ -39,7 +35,7 @@ type ChildrenElement<T> =
  * 👎 Без параметра `externRef`
  * ```ts
  * const { ref } = useSomeHook();
- * const [childRef, child] = usePatchChildrenRef(children);
+ * const [childRef, child] = usePatchChildren(children);
  * React.useLayoutEffect(() => {
  *   ref.current = childRef.current; // или ref.current(childRef.current)
  * }, [childRef]);
@@ -48,10 +44,8 @@ type ChildrenElement<T> =
  * 👍 С параметром `externRef`
  * ```ts
  * const { ref } = useSomeHook();
- * const [childRef, child] = usePatchChildrenRef(children, undefined, ref);
+ * const [childRef, child] = usePatchChildren(children, undefined, ref);
  * ```
- *
- * @private
  */
 export const usePatchChildren = <ElementType extends HTMLElement = HTMLElement>(
   children?: ChildrenElement<ElementType>,
@@ -84,15 +78,6 @@ export const usePatchChildren = <ElementType extends HTMLElement = HTMLElement>(
     : isValidElementResult
       ? { getRootRef: childRef, ...injectProps, ...mergedEventsByInjectProps }
       : undefined;
-
-  useEffectDev(() => {
-    if (!childRef.current) {
-      warn(
-        'Кажется, в children передан компонент, который не поддерживает свойство getRootRef. Мы не можем получить ссылку на корневой dom-элемент этого компонента',
-        'error',
-      );
-    }
-  }, [isValidElementResult ? children.type : null, childRef]);
 
   return [childRef, isValidElementResult ? React.cloneElement(children, props) : children];
 };

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -414,6 +414,7 @@ export {
 export { useColorScheme } from './hooks/useColorScheme';
 export { usePagination } from './hooks/usePagination';
 export { type Orientation, useOrientationChange } from './hooks/useOrientationChange';
+export { usePatchChildren } from './hooks/usePatchChildren';
 export { useTodayDate } from './hooks/useTodayDate';
 export { useScrollLock } from './components/AppRoot/ScrollContext';
 export { useNavTransition } from './components/NavTransitionContext/NavTransitionContext';


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- related to #7611

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Release notes

## Описание

Добавил тестов для покрытия `100%`.

## Release notes
## Улучшения

- Добавлен экспорт `usePatchChildren()` – хук позволяет пропатчить переданный компонент так, чтобы можно было получить ссылку на его DOM-элемент. Также есть возможность прокинуть в компонент дополнительные параметры.
