### PR TITLE
feat: reexport useScroll as useRootScrollController

### DIFF
--- a/packages/vkui/src/components/AppRoot/ScrollContext.tsx
+++ b/packages/vkui/src/components/AppRoot/ScrollContext.tsx
@@ -49,6 +49,11 @@ export const ScrollContext: React.Context<ScrollContextInterface> =
     disableScrollLock: noop,
   });
 
+/**
+ * Хук предоставляет API для блокировки и разблокировки скролла основного элемента, который
+ * определяется параметром `scroll` в `AppRoot`. Используется при открытии модальных окон, чтобы
+ * исправить проблемы с двойным скроллом на мобильных устройствах.
+ */
 export const useScroll = (): ScrollContextInterface => React.useContext(ScrollContext);
 
 export interface ScrollControllerProps extends HasChildren {

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -415,7 +415,11 @@ export { useColorScheme } from './hooks/useColorScheme';
 export { usePagination } from './hooks/usePagination';
 export { useOrientationChange } from './hooks/useOrientationChange';
 export { useTodayDate } from './hooks/useTodayDate';
-export { useScrollLock } from './components/AppRoot/ScrollContext';
+export {
+  type ScrollContextInterface as UseRootScrollController,
+  useScroll as useRootScrollController,
+  useScrollLock,
+} from './components/AppRoot/ScrollContext';
 export { useNavTransition } from './components/NavTransitionContext/NavTransitionContext';
 export { useNavDirection } from './components/NavTransitionDirectionContext/NavTransitionDirectionContext';
 export { useNavId } from './components/NavIdContext/useNavId';


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- related to #7611

---

- [x] Release notes

## Описание

Есть случаи, когда тип экспортируют через `@vkontakte/vkui/dist/components/AppRoot/ScrollContext`. В целом полезно иметь доступ к интерфейсу `ScrollController`.

Также экспортируем тип `ScrollContextInterface` как `UseRootScrollController`.

## Изменения

<!--
Перечисли изменения и причины по которым они сделаны, если это по какой-то причине не очевидно.
В будущем это поможет ответить почему было сделано именно так.

Если всё прозрачно, то игнорируй этот заголовок.
-->

## Release notes
## Улучшения

- Добавлен экспорт `useRootScrollController()` – хук предоставляет API для блокировки и разблокировки скролла основного элемента, который определяется параметром `scroll` в `AppRoot`. Используется при открытии модальных окон, чтобы исправить проблемы с двойным скроллом на мобильных устройствах.