### PR TITLE
[v6]fix(FormItem): rm TODO from topNode description

### DIFF
--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -44,8 +44,6 @@ export interface FormItemProps
    * Позволяет полностью заменить шапку поля пользовательским компонентом.
    *
    * @since 6.1.0
-   *
-   * TODO [>=7]: удалить и использовать top - оно будет принимать либо строку, либо подкомпонент
    */
   topNode?: React.ReactNode;
   bottom?: React.ReactNode;


### PR DESCRIPTION
@andres-kovalev заметил, что в доках просвечивается TODO параметра `topNode`. Удалил под **v6**.

## Release notes
## Документация

- FormItem: удалён **TODO** текст у параметра `topNode`