### PR TITLE
fix(CustomSelect): Fix input focus on arrow click on touch device

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -707,19 +707,6 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   }, [emptyText, options, renderDropdown, renderOption]);
 
   const selectInputRef = useExternRef(getSelectInputRef);
-  const focusOnInputTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
-  const focusOnInput = React.useCallback(() => {
-    clearTimeout(focusOnInputTimerRef.current);
-
-    focusOnInputTimerRef.current = setTimeout(() => {
-      selectInputRef.current && selectInputRef.current.focus();
-    }, 0);
-  }, [selectInputRef]);
-  useIsomorphicLayoutEffect(function clearFocusOnInputTimer() {
-    return () => {
-      clearTimeout(focusOnInputTimerRef.current);
-    };
-  }, []);
 
   const controlledValueSet = isControlledOutside && props.value !== '';
   const uncontrolledValueSet = !isControlledOutside && nativeSelectValue !== '';
@@ -737,7 +724,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         onClick={function clearSelectState() {
           setNativeSelectValue('');
           setInputValue('');
-          focusOnInput();
+          selectInputRef.current && selectInputRef.current.focus();
         }}
         disabled={restProps.disabled}
         data-testid={clearButtonTestId}
@@ -749,7 +736,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     iconProp,
     restProps.disabled,
     clearButtonTestId,
-    focusOnInput,
+    selectInputRef,
   ]);
 
   const icon = React.useMemo(() => {
@@ -794,11 +781,11 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
         const inputIsNotFocused = document.activeElement !== selectInputRef.current;
         if (inputIsNotFocused) {
-          focusOnInput();
+          selectInputRef.current.focus();
         }
       }
     },
-    [document, focusOnInput, selectInputRef],
+    [document, selectInputRef],
   );
 
   const preventInputBlurWhenClickInsideFocusedSelectArea = (


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->

- [x] Release notes

## Описание
На touch устройстве не работает фокус на input при клике в зоне инпута ближе к стрелочке. Фокус есть на обертке, но сам инпут фокуса не имеет и клавиатура не появляется, как при клике на сам инпут, ближе к левому краю.
Воспроизводится в симуляторе Iphone и на реальном устройстве.

Дело в том, что не во всей видимой области инпута событие клика принимает input, и чтобы это победить мы программно вызываем фокус на инпуте.

Изначально, в https://github.com/VKCOM/VKUI/pull/6087, а конкретно в https://github.com/VKCOM/VKUI/commit/0f45bb9d02406a7db9bf918b27ccecc1f46f5621 это было реализовано с помощью отложенного вызова фокуса для кнопки очистки, а потом функция с отложенным фокусом перекочевала и на остальной новый код.

Объяснялось это тем, что без таймаута фокус просто не работал при клике на clear button.
Финальный код был сложнее, чем тот, когда этот отложенный фокус был добавлен, и он уже мог работать без отложенного вызова фокуса.

Протестировал в браузере и в симуляторе Iphone.
## Изменения
Убран отложенный вызов фокуса на инпуте с помощью setTimeout.
Это исправляет фокус как при клике на стрелочку, так и при клике на clearButton.

## Release notes
## Исправления
- CustomSelect: для touch устройств исправлен фокус на инпуте при клике на CustomSelect ближе к правому краю, в районе стрелки.
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
