### PR TITLE
fix: remove spinner todo

### DIFF
--- a/packages/vkui/src/components/Button/Button.module.css
+++ b/packages/vkui/src/components/Button/Button.module.css
@@ -189,7 +189,6 @@
 }
 
 .spinner {
-  color: currentColor;
   position: absolute;
   inset: 0;
 }

--- a/packages/vkui/src/components/Button/Button.tsx
+++ b/packages/vkui/src/components/Button/Button.tsx
@@ -110,7 +110,12 @@ export const Button = ({
       getRootRef={getRootRef}
     >
       {loading && (
-        <Spinner size="s" className={styles.spinner} disableAnimation={disableSpinnerAnimation} />
+        <Spinner
+          size="s"
+          className={styles.spinner}
+          disableAnimation={disableSpinnerAnimation}
+          noColor
+        />
       )}
       <span className={styles.in}>
         {hasReactNode(before) && (

--- a/packages/vkui/src/components/Spinner/Spinner.module.css
+++ b/packages/vkui/src/components/Spinner/Spinner.module.css
@@ -10,13 +10,3 @@
 .noColor {
   color: currentColor;
 }
-
-/**
- * CMP:
- * PanelHeader
- * TODO [>=7]: удалить
- */
-/* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-:global(.vkuiInternalPanelHeader) .host {
-  color: currentColor;
-}


### PR DESCRIPTION
- [x] Release notes

## Описание

У `Spinner` есть проп `noColor`, вместо css-каскада рекомендуем использовать его.

## Release notes

## BREAKING CHANGE

- PanelHeader: теперь неявно не переопределяется цвет компонента `Spinner`, если вы использовали компонент `Spinner` внутри `PanelHeader` передавайте `<Spinner noColor />`

