### PR TITLE
fix(Avatar): keepAspectRation=true by default

### DIFF
--- a/packages/vkui/src/components/Avatar/Avatar.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.tsx
@@ -87,6 +87,7 @@ export const Avatar: React.FC<AvatarProps> & {
   initials,
   fallbackIcon: fallbackIconProp,
   children,
+  keepAspectRatio = true,
   ...restProps
 }: AvatarProps) => {
   const gradientName =
@@ -109,6 +110,7 @@ export const Avatar: React.FC<AvatarProps> & {
   return (
     <ImageBase
       {...restProps}
+      keepAspectRatio={keepAspectRatio}
       size={size}
       fallbackIcon={fallbackIcon}
       className={classNames(

--- a/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
@@ -187,7 +187,7 @@ describe(ImageBase, () => {
   });
 
   it('should have className with keepRatio', () => {
-    render(<ImageBaseTest src="#" keepAspectRatio={true} />);
+    render(<ImageBaseTest src="#" keepAspectRatio={true} widthSize="100%" />);
 
     expect(getImageBaseImgEl()).toHaveClass(styles.imgKeepRatio);
   });

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -86,7 +86,7 @@ export interface ImageBaseProps
   objectFit?: React.CSSProperties['objectFit'];
   /**
    * Флаг для сохранения пропорций картинки.
-   * Для корректной работы необходимо задать размеры хотя бы одной стороны картинки
+   * Для корректной работы необходимо задать размеры одной стороны картинки
    */
   keepAspectRatio?: boolean;
 }
@@ -153,10 +153,14 @@ export const ImageBase: React.FC<ImageBaseProps> & {
   keepAspectRatio = false,
   ...restProps
 }: ImageBaseProps) => {
+  const oneOfTwoDimensionsDefined =
+    (widthSize !== undefined && heightSize === undefined) ||
+    (widthSize === undefined && heightSize !== undefined);
+  const needToKeepAspectRatio = keepAspectRatio && oneOfTwoDimensionsDefined;
   const size = sizeProp ?? minOr([sizeToNumber(widthSize), sizeToNumber(heightSize)], defaultSize);
 
-  const width = widthSize ?? (keepAspectRatio ? undefined : size);
-  const height = heightSize ?? (keepAspectRatio ? undefined : size);
+  const width = widthSize ?? (needToKeepAspectRatio ? undefined : size);
+  const height = heightSize ?? (needToKeepAspectRatio ? undefined : size);
 
   const [loaded, setLoaded] = React.useState(false);
   const [failed, setFailed] = React.useState(false);
@@ -224,14 +228,14 @@ export const ImageBase: React.FC<ImageBaseProps> & {
             className={classNames(
               styles.img,
               getObjectFitClassName(objectFit),
-              keepAspectRatio && styles.imgKeepRatio,
+              needToKeepAspectRatio && styles.imgKeepRatio,
             )}
             crossOrigin={crossOrigin}
             decoding={decoding}
             loading={loading}
             referrerPolicy={referrerPolicy}
             style={
-              keepAspectRatio
+              needToKeepAspectRatio
                 ? {
                     width: widthImg || width,
                     height: heightImg || height,


### PR DESCRIPTION
- [x] Release notes

## Описание

Нужно для компонента Avatar сделать keepAspectRation=true  по дефолту

## Изменения

Сделал keepAspectRation=true  для Avatar по дефолту.
Заметил, что keepAspectRatio работает неправильно в Avatar, когда не задан widthSize и heightSize и доработал этот момент
Codmod как мне кажется не нужен, так как аватары итак обычно одинаковые по ширине и высоте

## Release notes
## Улучшения
- Avatar: cвойство `keepAspectRation` теперь `true` by default