### PR TITLE
fix(DateInput): use zero values with keyboard input

### DIFF
--- a/packages/vkui/src/components/DateInput/DateInput.test.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.test.tsx
@@ -4,7 +4,7 @@ import { DateInput } from './DateInput';
 import styles from './DateInput.module.css';
 import inputLikeStyles from '../InputLike/InputLike.module.css';
 
-const date = new Date(2024, 6, 31, 11, 20);
+const date = new Date(2024, 6, 31, 11, 20, 0, 0);
 
 const getInputsLike = (container: HTMLElement) => {
   const dateInput = container.getElementsByClassName(styles.input)[0];
@@ -90,7 +90,24 @@ describe('DateInput', () => {
     const normalizedDate = convertInputsToNumbers(inputLikes);
     expect(normalizedDate).toEqual([30, 6, 2023, 15, 40]);
 
-    expect(onChange).toBeCalledTimes(5);
+    expect(onChange).toHaveBeenCalledTimes(5);
+    expect(onChange).toHaveBeenCalledWith(new Date(2023, 5, 30, 15, 40, 0, 0));
+  });
+
+  it('should call onChange with zero sec/ms', async () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    const { container } = render(<DateInput value={undefined} onChange={onChange} />);
+    const inputLikes = getInputsLike(container);
+
+    const [dates, months, years] = inputLikes;
+
+    await userEvent.type(dates, '30');
+    await userEvent.type(months, '06');
+    await userEvent.type(years, '2023');
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(new Date(2023, 5, 30, 0, 0, 0, 0));
   });
 
   it('should call onChange callback when change data by calendar', async () => {

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -175,7 +175,14 @@ export const DateInput = ({
       }
 
       if (isMatch(formattedValue, mask)) {
-        onChange?.(parse(formattedValue, mask, value ?? new Date()));
+        onChange?.(
+          parse(
+            formattedValue,
+            mask,
+            value ??
+              new Date(enableTime ? new Date().setSeconds(0, 0) : new Date().setHours(0, 0, 0, 0)),
+          ),
+        );
       }
     },
     [enableTime, maxElement, onChange, value],

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { Icon16Clear, Icon20CalendarOutline } from '@vkontakte/icons';
 import { classNames } from '@vkontakte/vkjs';
+import { startOfDay, startOfMinute } from 'date-fns';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useDateInput } from '../../hooks/useDateInput';
 import { useExternRef } from '../../hooks/useExternRef';
@@ -175,13 +176,9 @@ export const DateInput = ({
       }
 
       if (isMatch(formattedValue, mask)) {
+        const now = new Date();
         onChange?.(
-          parse(
-            formattedValue,
-            mask,
-            value ??
-              new Date(enableTime ? new Date().setSeconds(0, 0) : new Date().setHours(0, 0, 0, 0)),
-          ),
+          parse(formattedValue, mask, value ?? (enableTime ? startOfMinute(now) : startOfDay(now))),
         );
       }
     },


### PR DESCRIPTION
- [x] Unit-тесты
- [x] Release notes

## Описание

При ручном вводе даты (со временем и без), необходимо занулять секунды/миллисекунды (с часами и минутами, если дата без времени).

## Release notes

 ## Исправления
- DateInput: инициализируем секунды и миллисекунды (часы и минуты при вводе без времени) нулевыми значениями при ручном вводе даты



