### PR TITLE
fix(Tappable): force activated/hovered state

### DIFF
--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -93,12 +93,13 @@ function useHover({ hovered, hasHover = true, lockState, setParentStateLock }: U
     (isHover: boolean) => {
       setHoveredStateLocal(isHover);
 
-      const isHovered = calculateStateValue({
-        hasState: hasHover,
-        isLocked: lockState,
-        stateValueControlled: Boolean(hovered),
-        stateValueLocal: isHover,
-      });
+      const isHovered =
+        hovered ??
+        calculateStateValue({
+          hasState: hasHover,
+          isLocked: lockState,
+          stateValueLocal: isHover,
+        });
 
       // проверка сделана чтобы реже вызывать обновление состояния
       // контекста родителя
@@ -122,12 +123,13 @@ function useHover({ hovered, hasHover = true, lockState, setParentStateLock }: U
     handleHover(false);
   };
 
-  const isHovered = calculateStateValue({
-    hasState: hasHover,
-    isLocked: lockState,
-    stateValueControlled: Boolean(hovered),
-    stateValueLocal: hoveredStateLocal,
-  });
+  const isHovered =
+    hovered ??
+    calculateStateValue({
+      hasState: hasHover,
+      isLocked: lockState,
+      stateValueLocal: hoveredStateLocal,
+    });
 
   return {
     isHovered,
@@ -194,12 +196,13 @@ function useActive({
     setActivated(false, activeEffectDelay);
   };
 
-  const isActivated = calculateStateValue({
-    hasState: hasActive,
-    isLocked: lockStateRef.current,
-    stateValueControlled: Boolean(activated),
-    stateValueLocal: activatedState,
-  });
+  const isActivated =
+    activated ??
+    calculateStateValue({
+      hasState: hasActive,
+      isLocked: lockStateRef.current,
+      stateValueLocal: activatedState,
+    });
 
   return {
     isActivated,
@@ -287,6 +290,7 @@ export function useState({
 
   const { isActivated, ...activeEvent } = useActive({
     ...restProps,
+    hasActive,
     lockStateRef: lockActiveStateRef,
     setParentStateLock: setParentStateLockActiveBubbling,
   });
@@ -309,13 +313,11 @@ export function useState({
 function calculateStateValue({
   hasState,
   isLocked,
-  stateValueControlled,
   stateValueLocal,
 }: {
   hasState: boolean;
   isLocked: boolean;
-  stateValueControlled: boolean;
   stateValueLocal: boolean;
 }): boolean {
-  return hasState && !isLocked && (stateValueControlled || stateValueLocal);
+  return hasState && !isLocked && stateValueLocal;
 }

--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -265,9 +265,12 @@ function useLockRef(
 export function useState({
   hovered,
   hasHover,
+  activated,
   hasActive,
+  activeEffectDelay,
   unlockParentHover,
-  ...restProps
+  hoverClassName,
+  activeClassName,
 }: StateProps): {
   stateClassName: string;
   setLockHoverBubblingImmediate: (...args: any[]) => void;
@@ -289,16 +292,14 @@ export function useState({
   });
 
   const { isActivated, ...activeEvent } = useActive({
-    ...restProps,
+    activated,
     hasActive,
+    activeEffectDelay,
     lockStateRef: lockActiveStateRef,
     setParentStateLock: setParentStateLockActiveBubbling,
   });
 
-  const stateClassName = classNames(
-    isHovered && restProps.hoverClassName,
-    isActivated && restProps.activeClassName,
-  );
+  const stateClassName = classNames(isHovered && hoverClassName, isActivated && activeClassName);
   const handlers = mergeCalls(hoverEvent, activeEvent);
 
   return {

--- a/packages/vkui/src/components/Tappable/Tappable.test.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.test.tsx
@@ -210,11 +210,12 @@ describe(Tappable, () => {
     it('activates during longtap', async () => {
       render(<TappableTest onClick={noop} />);
       fireEvent.pointerDown(tappable());
-      expect(tappable()).not.toHaveClass(styles.activatedBackground);
-      await waitFor(() => expect(tappable()).toHaveClass(styles.activatedBackground));
+      act(jest.runOnlyPendingTimers);
+      expect(tappable()).toHaveClass(styles.activatedBackground);
 
       fireEvent.pointerUp(tappable());
-      expect(tappable()).toHaveClass(styles.activatedBackground);
+      act(jest.runOnlyPendingTimers);
+      expect(tappable()).not.toHaveClass(styles.activatedBackground);
     });
 
     it('does not activate on child Tappable click', async () => {
@@ -262,12 +263,16 @@ describe(Tappable, () => {
         expect(tappable()).not.toHaveClass(styles.activatedBackground);
       });
 
-      it('on hasActive=false', () => {
-        const h = render(<TappableTest />);
-        fireEvent.mouseDown(tappable());
-        act(jest.runAllTimers);
-        h.rerender(<TappableTest hasActive={false} />);
-        expect(tappable()).not.toHaveClass(styles.activatedBackground);
+      it('on hasActive=false', async () => {
+        render(<TappableTest hasActive={false} onClick={noop} />);
+        await userEvent.click(tappable());
+        let errored = false;
+        await waitFor(() => expect(tappable()).toHaveClass(styles.activatedBackground)).catch(
+          () => {
+            errored = true;
+          },
+        );
+        expect(errored).toBeTruthy();
       });
 
       it('on child hover', async () => {


### PR DESCRIPTION
## Описание

- related #7519

Условия: есть два вложенных в друг друга `Tappable`-компонента. Если мы управляем `active`-состоянием "сверху", то у нас всплывают вот такие артефакты, когда мы кликаем на родительский компонент (и при клике сетаем проп `activated=true`) и достаточно быстро на дочерний:

https://github.com/user-attachments/assets/c71d1687-2ce2-44aa-b4e4-b97c642be1e9

Из-за того, что в #7519 обновление `active`-состояния завязано на `ref`, то обновления родительского компонента мы не увидим до следующего ререндера.

## Изменения

- при вычисление `active/hover`-состояния при условии наличия `activated/hovered` пропов мы должны всегда полагаться на эти значения, вне зависимости от состояния `isLocked`.
- ещё заметила, что потерялось свойство `hasActive` - оно не прокидывалось и не участвовало в вычислении наличия `active`-состояния. Тестами это не отловили, потому что сам тест содержал ошибку 🙃 

**NOTE**: "неприятный" сайд-эффект, который можно словить от исправленного поведения - при передаче не-undefined состояния `activated/hovered` - нужно их обновлять самостоятельно, завязываясь на соответствующие события. Существовавшая проверка:

`hasState && !isLocked && (stateValueControlled || stateValueLocal)`

При `activated/hovered=false` мы полагались на локальное состояние, это было удобно, но, кажется, что не особо правильно. Если хочется управлять этими состояниями самостоятельно, то и обновлять их нужно тоже самостоятельно, без каких-то полумер х) 

### **_Возможный BREAKING CHANGE_**:

Кажется, что можно отказаться от пропов `hasActive/hasHover` - их функции на себя возьмет undefined значение `activated/hovered`. Т.е. по умолчанию если не прокидывать `activated/hovered` - поведение будет как `hasActive/hasHover=true`, а при указании значений `activated/hovered` - будет полагаться исключительно на переданные значения. Можно данный PR вмерджить в `v6`, а breaking change сделать в `v7`

## Release notes

## Исправления
- Tappable: вернули работу `hasActive` свойства, исправили отсутствие `activated`-состояния при некоторых условиях
