### PR TITLE
fix(Group): separator size

### DIFF
--- a/packages/vkui/src/components/Group/Group.module.css
+++ b/packages/vkui/src/components/Group/Group.module.css
@@ -176,6 +176,7 @@
   content: '';
   block-size: var(--vkui--size_border--regular);
   background: var(--vkui--color_separator_primary);
+  margin-block-end: calc(-1 * var(--vkui--size_border--regular));
 }
 
 /* разделитель при mode="plain" */


### PR DESCRIPTION
- Fixes #6977

---

- [x] ~Unit-тесты~ (не требуется)
- [x] ~e2e-тесты~ (у нас нет тестов на dpi)
- [x] ~Дизайн-ревью~ (не требуется)
- [x] ~Документация фичи~ (не требуется)
- [x] Release notes

## Описание

Сепаратор в группе неверно отрисовывается на iPhone 15. Также размер отступа между группами не совпадает с дизайном

## Изменения

Исправил размер блока с сепаратором за счет отрицательного margin-block-end

## Release notes

## Исправления
- [Group](https://vkcom.github.io/VKUI/${version}/#/Group): исправлено отображение сепаратора на iPhone 15 
