### PR TITLE
fix(CustomResizeObserver): remove set src to iframe

### DIFF
--- a/packages/vkui/src/lib/floating/customResizeObserver.ts
+++ b/packages/vkui/src/lib/floating/customResizeObserver.ts
@@ -68,7 +68,6 @@ export class CustomResizeObserver {
 
   observeUsingIframe(element: HTMLElement): void {
     const iframe = element.ownerDocument.createElement('iframe');
-    iframe.src = 'javascript:void(0)';
     iframe.ariaHidden = 'true';
     iframe.tabIndex = -1;
     Object.assign(iframe.style, defaultIframeStyles);


### PR DESCRIPTION
- [x] Release notes

## Описание

Сейчас `CustomResizeObserver` в своей реализации использует создание iframe-ов для отслеживания их размеров. При создании он устанавливает `src="javascript:void(0)"`, что может вызывать проблемы с `Content Security Policy (CSP)` при следующих заголовках:
- `script-src` - ограничивает источники выполняемых скриптов
- `frame-src` - ограничивает источники для iframe-ов

Для решения этой проблемы предлагается не устанавливать атрибут `src` явно, так как браузер по умолчанию использует `about:blank`.

Плюсы такого подхода:
1. Совместимость с CSP - отсутствие явного `javascript: URL` не нарушает политику безопасности
2. Меньше кода - нет необходимости явно указывать src
3. Стандартное поведение - использование браузерного дефолта `about:blank`
4. Более безопасное решение - `about:blank` является доверенным источником

## Изменения

- Убрал установку атрибута `src` для создаваемого iframe'а, позволяя браузеру использовать стандартное значение `about:blank`

## Release notes
## Исправления
- Исправлены ошибки в консоли связанная с тем, что в CustomResizeObserver создавался iframe с `src="javascript:void(0)"` теперь создается с `src="about:blank"`