### PR TITLE
feat(Spacing): add css variables support

### DIFF
--- a/packages/vkui/src/components/Separator/Separator.e2e-playground.tsx
+++ b/packages/vkui/src/components/Separator/Separator.e2e-playground.tsx
@@ -1,8 +1,12 @@
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { type SpacingSize, spacingSizeClassNames } from '../../lib/spacings/sizes';
+import { type CSSCustomProperties } from '../../types';
 import { Separator, type SeparatorProps } from './Separator';
 
 const sizes = Object.keys(spacingSizeClassNames) as SpacingSize[];
+const divStyle: CSSCustomProperties = {
+  '--my-custom-var': '20px',
+};
 
 export const SeparatorPlayground = (props: ComponentPlaygroundProps) => {
   return (
@@ -33,10 +37,14 @@ export const SeparatorPlayground = (props: ComponentPlaygroundProps) => {
           align: ['start', 'center', 'end'],
           size: ['3xl'],
         },
+        {
+          direction: ['horizontal', 'vertical'],
+          size: ['--my-custom-var'],
+        },
       ]}
     >
       {(props: SeparatorProps) => (
-        <div style={props.direction === 'vertical' ? { display: 'flex' } : undefined}>
+        <div style={props.direction === 'vertical' ? { display: 'flex', ...divStyle } : divStyle}>
           First Item
           <Separator {...props} />
           Second Item

--- a/packages/vkui/src/components/Separator/Separator.tsx
+++ b/packages/vkui/src/components/Separator/Separator.tsx
@@ -1,5 +1,10 @@
 import { classNames } from '@vkontakte/vkjs';
-import { spacingSizeClassNames, type SpacingSizeProp } from '../../lib/spacings/sizes';
+import {
+  isSpacingSizeCustom,
+  isSpacingSizeMap,
+  spacingSizeClassNames,
+  type SpacingSizeProp,
+} from '../../lib/spacings/sizes';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Separator.module.css';
@@ -21,6 +26,8 @@ export interface SeparatorProps extends HTMLAttributesWithRootRef<HTMLDivElement
   direction?: 'horizontal' | 'vertical';
   /**
    * Размер контейнера, в который вложен разделитель
+   *
+   * Принимает значения дизайн-системы, числовые значения и css-переменные
    */
   size?: SpacingSizeProp;
   /**
@@ -62,13 +69,15 @@ export const Separator = ({
     baseClassName={classNames(
       padding && styles.padded,
       appearanceClassNames[appearance],
-      typeof size === 'string' && spacingSizeClassNames[size],
+      isSpacingSizeMap(size) && spacingSizeClassNames[size],
       directionClassNames[direction],
       size !== undefined && styles.sized,
       align !== 'center' && alignClassNames[align],
     )}
     style={{
-      ...(typeof size === 'number' && { [CUSTOM_CSS_TOKEN_FOR_USER_SIZE]: `${size}px` }),
+      ...(isSpacingSizeCustom(size) && {
+        [CUSTOM_CSS_TOKEN_FOR_USER_SIZE]: typeof size === 'number' ? `${size}px` : `var(${size})`,
+      }),
       ...style,
     }}
   >

--- a/packages/vkui/src/components/Separator/Separator.tsx
+++ b/packages/vkui/src/components/Separator/Separator.tsx
@@ -74,10 +74,14 @@ export const Separator = ({
         align !== 'center' && alignClassNames[align],
         spacingSizeClassName,
       )}
-      style={{
-        ...spacingSizeStyle,
-        ...style,
-      }}
+      style={
+        spacingSizeStyle
+          ? {
+              ...spacingSizeStyle,
+              ...style,
+            }
+          : style
+      }
     >
       <hr className={styles.in} />
     </RootComponent>

--- a/packages/vkui/src/components/Separator/Separator.tsx
+++ b/packages/vkui/src/components/Separator/Separator.tsx
@@ -1,10 +1,5 @@
 import { classNames } from '@vkontakte/vkjs';
-import {
-  isSpacingSizeCustom,
-  isSpacingSizeMap,
-  spacingSizeClassNames,
-  type SpacingSizeProp,
-} from '../../lib/spacings/sizes';
+import { resolveSpacingSize, type SpacingSizeProp } from '../../lib/spacings/sizes';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Separator.module.css';
@@ -63,24 +58,28 @@ export const Separator = ({
   style,
   size,
   ...restProps
-}: SeparatorProps): React.ReactNode => (
-  <RootComponent
-    {...restProps}
-    baseClassName={classNames(
-      padding && styles.padded,
-      appearanceClassNames[appearance],
-      isSpacingSizeMap(size) && spacingSizeClassNames[size],
-      directionClassNames[direction],
-      size !== undefined && styles.sized,
-      align !== 'center' && alignClassNames[align],
-    )}
-    style={{
-      ...(isSpacingSizeCustom(size) && {
-        [CUSTOM_CSS_TOKEN_FOR_USER_SIZE]: typeof size === 'number' ? `${size}px` : `var(${size})`,
-      }),
-      ...style,
-    }}
-  >
-    <hr className={styles.in} />
-  </RootComponent>
-);
+}: SeparatorProps): React.ReactNode => {
+  const [spacingSizeClassName, spacingSizeStyle] = resolveSpacingSize(
+    CUSTOM_CSS_TOKEN_FOR_USER_SIZE,
+    size,
+  );
+  return (
+    <RootComponent
+      {...restProps}
+      baseClassName={classNames(
+        padding && styles.padded,
+        appearanceClassNames[appearance],
+        directionClassNames[direction],
+        size !== undefined && styles.sized,
+        align !== 'center' && alignClassNames[align],
+        spacingSizeClassName,
+      )}
+      style={{
+        ...spacingSizeStyle,
+        ...style,
+      }}
+    >
+      <hr className={styles.in} />
+    </RootComponent>
+  );
+};

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27bbfe178f682235514d76a3bc4a7389af1239f7181f96fa4667e6de27e0e367
-size 103877
+oid sha256:ceff65a8a09f012a90be56d3bcc7e6a432bbe9efbb6cbcc3653f47fe78a1cbf1
+size 113903

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee3d1c279f70ab63f1d89a2a95a336fc9170852bac1225c564a00e32938f271c
-size 84486
+oid sha256:d74ae7ccc5a239fe78b07475b5d2b482ef6d7f6497ebd2b484795f3f5bd209ae
+size 91701

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e4eabb809406bc2f78149fceadcae6b7d11d6920c5bdf064c1c06a5b4bc0050
-size 107232
+oid sha256:b9fa985b3a3d16e7ea3c0f764d595bd50652f478d82f4f3f6897404352e6d4f9
+size 117395

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-ios-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e6a0f04edb9d7aade90eb197fc046920f993a2a01b89226ff73734ae0a30011
-size 87615
+oid sha256:39bc8833c5395602985532ecc0d79d48b502007020862e3aec992fc050e7ab90
+size 95367

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e158184fcdf496096ef4aecdba603df6a517d4f095b68de25dc13da9a5eaa660
-size 105792
+oid sha256:a534b9e80463e28cc657aaf11e4334a3376c240c7d0e345f1402f1eb8ce025b6
+size 115715

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c88d26cb512f326248cca0e82a2b02db9d4d72f0dfe7de742f0e4ce2feff724
-size 85695
+oid sha256:d03dcb9631175d2510471f3591993b9af7d7ca3b3e58ff4e365a7e2cdeaad31e
+size 92737

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e912b87086bcb5496ba65a5c9bffaec9452adca55817656f3450f9e8614d8c1b
-size 151541
+oid sha256:3831b7fd8b26988b81ee2bd2b42b3db3eb06e69c2685372b69e34582be7c7276
+size 166164

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:460d2defd50404360d8f5ef1124bbf8bd2cd5f0780bb91fcd2a089000cc55859
-size 121459
+oid sha256:ce7b142cc269cc6131c0445a7a6595d75cb473ac99e81f802ccee3e760e43262
+size 132150

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c25cd1d64d092997ced1f7468ac0cbb4b32c1c5a6f3dcbf776aa1e0b87cfe21
-size 108804
+oid sha256:edde7dc6acb598983c6dc7dde02c739222309b04421dcc652629660bc7036015
+size 118888

--- a/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Separator/__image_snapshots__/separator-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43d4a00b25a741287c3653f4e59cdadbe4f41187aac535a887c6bf5b2491ba5d
-size 89201
+oid sha256:3d2cd3fc7cb7bb8270a062c5a6b4975f55529125db9678ebacbc9858a49c5021
+size 96215

--- a/packages/vkui/src/components/Spacing/Spacing.e2e-playground.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.e2e-playground.tsx
@@ -1,10 +1,15 @@
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { type SpacingSize, spacingSizeClassNames } from '../../lib/spacings/sizes';
+import { type CSSCustomProperties } from '../../types';
 import { Div } from '../Div/Div';
 import { Separator } from '../Separator/Separator';
 import { Spacing, type SpacingProps } from './Spacing';
 
 const sizes = Object.keys(spacingSizeClassNames) as SpacingSize[];
+const divStyle: React.CSSProperties & CSSCustomProperties = {
+  'width': 100,
+  '--my-custom-var': '8px',
+};
 
 export const SpacingPlayground = (props: ComponentPlaygroundProps) => {
   return (
@@ -12,12 +17,12 @@ export const SpacingPlayground = (props: ComponentPlaygroundProps) => {
       {...props}
       propSets={[
         {
-          size: [undefined, ...sizes, 8, 16, 24],
+          size: [undefined, ...sizes, 8, 16, 24, '--my-custom-var'],
         },
       ]}
     >
       {({ size }: SpacingProps) => (
-        <Div style={{ width: 100 }}>
+        <Div style={divStyle}>
           <Separator padding />
           <Spacing size={size} />
           <Separator padding />

--- a/packages/vkui/src/components/Spacing/Spacing.test.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.test.tsx
@@ -31,6 +31,13 @@ describe('Spacing', () => {
     expect(h.container.firstElementChild).toHaveStyle(`${CUSTOM_CSS_TOKEN_FOR_USER_GAP}: 16px`);
   });
 
+  it('should use css variable size', () => {
+    const h = render(<Spacing size="--my-custom-var" />);
+    expect(h.container.firstElementChild).toHaveStyle(
+      `${CUSTOM_CSS_TOKEN_FOR_USER_GAP}: var(--my-custom-var)`,
+    );
+  });
+
   it('should preserve user style', () => {
     const h = render(<Spacing size={16} style={{ fontSize: 12 }} />);
     expect(h.container.firstElementChild).toHaveStyle(

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -32,10 +32,14 @@ export const Spacing = ({ size = 'm', style, ...restProps }: SpacingProps): Reac
   return (
     <RootComponent
       {...restProps}
-      style={{
-        ...spacingSizeStyle,
-        ...style,
-      }}
+      style={
+        spacingSizeStyle
+          ? {
+              ...spacingSizeStyle,
+              ...style,
+            }
+          : style
+      }
       baseClassName={classNames(styles.host, spacingSizeClassName)}
     />
   );

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { spacingSizeClassNames, type SpacingSizeProp } from '../../lib/spacings/sizes';
+import {
+  isSpacingSizeCustom,
+  isSpacingSizeMap,
+  spacingSizeClassNames,
+  type SpacingSizeProp,
+} from '../../lib/spacings/sizes';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Spacing.module.css';
@@ -10,6 +15,8 @@ export const CUSTOM_CSS_TOKEN_FOR_USER_GAP = '--vkui_internal--spacing_size';
 export interface SpacingProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
   /**
    * Высота спэйсинга
+   *
+   * Принимает значения дизайн-системы, числовые значения и css-переменные
    */
   size?: SpacingSizeProp;
   /**
@@ -27,13 +34,12 @@ export const Spacing = ({ size = 'm', style, ...restProps }: SpacingProps): Reac
     <RootComponent
       {...restProps}
       style={{
-        ...(typeof size === 'number' && { [CUSTOM_CSS_TOKEN_FOR_USER_GAP]: `${size}px` }),
+        ...(isSpacingSizeCustom(size) && {
+          [CUSTOM_CSS_TOKEN_FOR_USER_GAP]: typeof size === 'number' ? `${size}px` : `var(${size})`,
+        }),
         ...style,
       }}
-      baseClassName={classNames(
-        styles.host,
-        typeof size === 'string' && spacingSizeClassNames[size],
-      )}
+      baseClassName={classNames(styles.host, isSpacingSizeMap(size) && spacingSizeClassNames[size])}
     />
   );
 };

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import {
-  isSpacingSizeCustom,
-  isSpacingSizeMap,
-  spacingSizeClassNames,
-  type SpacingSizeProp,
-} from '../../lib/spacings/sizes';
+import { resolveSpacingSize, type SpacingSizeProp } from '../../lib/spacings/sizes';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Spacing.module.css';
@@ -30,16 +25,18 @@ export interface SpacingProps extends HTMLAttributesWithRootRef<HTMLDivElement> 
  * @see https://vkcom.github.io/VKUI/#/Spacing
  */
 export const Spacing = ({ size = 'm', style, ...restProps }: SpacingProps): React.ReactNode => {
+  const [spacingSizeClassName, spacingSizeStyle] = resolveSpacingSize(
+    CUSTOM_CSS_TOKEN_FOR_USER_GAP,
+    size,
+  );
   return (
     <RootComponent
       {...restProps}
       style={{
-        ...(isSpacingSizeCustom(size) && {
-          [CUSTOM_CSS_TOKEN_FOR_USER_GAP]: typeof size === 'number' ? `${size}px` : `var(${size})`,
-        }),
+        ...spacingSizeStyle,
         ...style,
       }}
-      baseClassName={classNames(styles.host, isSpacingSizeMap(size) && spacingSizeClassNames[size])}
+      baseClassName={classNames(styles.host, spacingSizeClassName)}
     />
   );
 };

--- a/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bb59dff8393cfd3bd1d8199d8e5b427b80452b30efc0e664d3cf4204d86bcd6
-size 12338
+oid sha256:da14c44b7e278e49f04727f94569945ae0bce08731b490dbebdb4a6230e147d8
+size 18339

--- a/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b19dbea2aed9aa53a2c4b3a0b7572cb38fbbd0c81c58817a3ef0f15140c44837
-size 21074
+oid sha256:69e82d9a3109137fb66432180578c1a20721dcbf4e0bbb5124f30e22461e0dfc
+size 26729

--- a/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/Spacing/__image_snapshots__/spacing-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:819917bd9c05ee51fd05b6cdce8aac03ca4d4e2b370fde5645fc66187628dbed
-size 12315
+oid sha256:c29480a3780edc3d46b3621c59e4114b749b33e8c308ebb9de677ec6badc733d
+size 18548

--- a/packages/vkui/src/lib/spacings/sizes.ts
+++ b/packages/vkui/src/lib/spacings/sizes.ts
@@ -1,4 +1,4 @@
-import type { LiteralUnion } from '../../types';
+import type { CSSCustomProperties, LiteralUnion } from '../../types';
 import styles from '../../styles/spacings.module.css';
 
 export type SpacingSize = '2xs' | 'xs' | 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl';
@@ -17,10 +17,17 @@ export const spacingSizeClassNames: Record<SpacingSize, string> = {
 
 export type SpacingSizeProp = LiteralUnion<SpacingSize | `--${string}`, number>;
 
-export function isSpacingSizeMap(size?: SpacingSizeProp): size is SpacingSize {
-  return typeof size === 'string' && !size.startsWith('--');
-}
+export function resolveSpacingSize(
+  cssVariable: string,
+  size?: SpacingSizeProp,
+): [string | undefined, CSSCustomProperties | undefined] {
+  if (typeof size === 'string') {
+    if (size.startsWith('--')) {
+      return [undefined, { [cssVariable]: `var(${size})` }];
+    } else {
+      return [spacingSizeClassNames[size as SpacingSize], undefined];
+    }
+  }
 
-export function isSpacingSizeCustom(size?: SpacingSizeProp): size is number | `--${string}` {
-  return typeof size === 'number' || (typeof size === 'string' && size.startsWith('--'));
+  return [undefined, typeof size === 'number' ? { [cssVariable]: `${size}px` } : undefined];
 }

--- a/packages/vkui/src/lib/spacings/sizes.ts
+++ b/packages/vkui/src/lib/spacings/sizes.ts
@@ -15,4 +15,12 @@ export const spacingSizeClassNames: Record<SpacingSize, string> = {
   '4xl': styles['-spacing--4xl'],
 };
 
-export type SpacingSizeProp = LiteralUnion<SpacingSize, number>;
+export type SpacingSizeProp = LiteralUnion<SpacingSize | `--${string}`, number>;
+
+export function isSpacingSizeMap(size?: SpacingSizeProp): size is SpacingSize {
+  return typeof size === 'string' && !size.startsWith('--');
+}
+
+export function isSpacingSizeCustom(size?: SpacingSizeProp): size is number | `--${string}` {
+  return typeof size === 'number' || (typeof size === 'string' && size.startsWith('--'));
+}


### PR DESCRIPTION
- [x] Unit-тесты
- [x] e2e-тесты
- [x] Документация фичи
- [x] Release notes

## Описание

Иногда необходима возможность передать в кач-ве `size` просто `css`-переменную - для это даем возможность пробросить строку, которая начинается с `--`

## Release notes

 ## Улучшения
 - Spacing: добавлена возможность передать `css`-переменную в `size` 
 - Separator: добавлена возможность передать `css`-переменную в `size` 

