### PR TITLE
fix(Tappable): bring back vkuiInternalTappable

### DIFF
--- a/packages/vkui/src/components/Tappable/Tappable.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.tsx
@@ -60,6 +60,7 @@ export const Tappable = ({
   return (
     <Clickable
       baseClassName={classNames(
+        'vkuiInternalTappable',
         baseClassName,
         styles.host,
         sizeX !== SizeType.REGULAR && sizeXClassNames[sizeX],


### PR DESCRIPTION
- caused by #6132

---

## Описание

В ходе рефакторинга потерялся глобальный класс `vkuiInternalTappable`

## Изменения

<!--
Перечисли изменения и причины по которым они сделаны, если это по какой-то причине не очевидно.
В будущем это поможет ответить почему было сделано именно так.

Если всё прозрачно, то игнорируй этот заголовок.
-->

## Release notes

 ## Исправления
 - Tappable: возвращена компенсация отступа при оборачивании `Header`

