### PR TITLE
feat: add useStateWithPrev

### DIFF
--- a/packages/vkui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/vkui/src/components/Skeleton/Skeleton.tsx
@@ -5,7 +5,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { millisecondsInSecond } from 'date-fns/constants';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
-import { usePrevious } from '../../hooks/usePrevious';
+import { useStateWithPrev } from '../../hooks/useStateWithPrev';
 import { useDOM } from '../../lib/dom';
 import type { CSSCustomProperties, HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -64,8 +64,8 @@ function useSkeletonSyncAnimation(disableAnimation: boolean, duration = 1.5) {
  */
 function useSkeletonPosition(rootRef: React.MutableRefObject<HTMLElement | null>) {
   const { document, window } = useDOM();
-  const [skeletonGradientLeft, setSkeletonGradientLeft] = React.useState('0');
-  const prevSkeletonGradientLeft = usePrevious(skeletonGradientLeft);
+  const [[skeletonGradientLeft, prevSkeletonGradientLeft], setSkeletonGradientLeft] =
+    useStateWithPrev('0');
 
   const updatePosition = React.useCallback(() => {
     const el = rootRef.current;
@@ -78,7 +78,7 @@ function useSkeletonPosition(rootRef: React.MutableRefObject<HTMLElement | null>
     if (prevSkeletonGradientLeft !== gradientValue) {
       setSkeletonGradientLeft(gradientValue);
     }
-  }, [document, prevSkeletonGradientLeft, rootRef]);
+  }, [document, prevSkeletonGradientLeft, rootRef, setSkeletonGradientLeft]);
 
   React.useEffect(updatePosition, [updatePosition]);
   useGlobalEventListener(window, 'resize', updatePosition);

--- a/packages/vkui/src/hooks/usePrevious.ts
+++ b/packages/vkui/src/hooks/usePrevious.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+/**
+ * @deprecated постарайтесь избавится от этого хука или используйте `useStateWithPrev`
+ */
 export function usePrevious<T>(value: T): T | undefined {
   const ref = React.useRef<T | undefined>();
 
@@ -7,5 +10,11 @@ export function usePrevious<T>(value: T): T | undefined {
     ref.current = value;
   });
 
+  /**
+   * ref.current нельзя читать во время рендеринга
+   *
+   * - see https://react.dev/reference/react/useRef
+   * - also https://react.dev/reference/react/useState#storing-information-from-previous-renders
+   */
   return ref.current;
 }

--- a/packages/vkui/src/hooks/useStateWithPrev.test.ts
+++ b/packages/vkui/src/hooks/useStateWithPrev.test.ts
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react';
+import { useStateWithPrev } from './useStateWithPrev';
+
+describe(useStateWithPrev, () => {
+  it('get previous value', () => {
+    const renderCounter = jest.fn();
+
+    const { result } = renderHook(() => {
+      const [[state, prevState], setState] = useStateWithPrev(3);
+
+      renderCounter();
+
+      return {
+        state,
+        prevState,
+        setState,
+      };
+    });
+
+    expect(result.current.prevState).toEqual(undefined);
+    expect(result.current.state).toEqual(3);
+
+    let prevRenderSetState = result.current.setState;
+
+    React.act(() => {
+      result.current.setState(6);
+    });
+    expect(result.current.prevState).toEqual(3);
+    expect(result.current.state).toEqual(6);
+    expect(result.current.setState).toStrictEqual(prevRenderSetState);
+
+    React.act(() => {
+      result.current.setState((value) => value + 3);
+    });
+    expect(result.current.prevState).toEqual(6);
+    expect(result.current.state).toEqual(9);
+    expect(result.current.setState).toStrictEqual(prevRenderSetState);
+
+    expect(renderCounter).toHaveBeenCalledTimes(3);
+  });
+  it('initialState is function', () => {
+    const renderCounter = jest.fn();
+
+    const { result } = renderHook(() => {
+      const [[state, prevState], setState] = useStateWithPrev(() => 3);
+
+      renderCounter();
+
+      return {
+        state,
+        prevState,
+        setState,
+      };
+    });
+
+    expect(result.current.prevState).toEqual(undefined);
+    expect(result.current.state).toEqual(3);
+  });
+});

--- a/packages/vkui/src/hooks/useStateWithPrev.ts
+++ b/packages/vkui/src/hooks/useStateWithPrev.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+function basicStateInitializer<S>(initialArg: S | (() => S)): S {
+  return initialArg instanceof Function ? initialArg() : initialArg;
+}
+
+function initializer<T>(initialArg: T | (() => T)): [T, T | undefined] {
+  const initialState = basicStateInitializer(initialArg);
+
+  return [initialState, undefined];
+}
+
+function basicStateReducer<S>(state: S, action: React.SetStateAction<S>): S {
+  return action instanceof Function ? action(state) : action;
+}
+
+function reducer<T>(
+  [prevState]: [T, T | undefined],
+  action: React.SetStateAction<T>,
+): [T, T | undefined] {
+  const newState = basicStateReducer(prevState, action);
+
+  return [newState, prevState];
+}
+
+/**
+ * Возвращает значение с текущим и предыдущим состоянием
+ *
+ * # Пример
+ *
+ * ```ts
+ * const [[count, prevCount], setCount] = useStateWithPrev(initialState);
+ * ```
+ */
+export function useStateWithPrev<T>(
+  initialState: T | (() => T),
+): [[T, T | undefined], React.Dispatch<React.SetStateAction<T>>] {
+  return React.useReducer<React.Reducer<[T, T | undefined], React.SetStateAction<T>>, undefined>(
+    reducer,
+    undefined,
+    () => initializer(initialState),
+  );
+}

--- a/packages/vkui/src/lib/animation/useCSSKeyframesAnimationController.ts
+++ b/packages/vkui/src/lib/animation/useCSSKeyframesAnimationController.ts
@@ -1,6 +1,5 @@
-import { useState } from 'react';
+import * as React from 'react';
 import { noop } from '@vkontakte/vkjs';
-import { usePrevious } from '../../hooks/usePrevious';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
 
@@ -29,10 +28,14 @@ export const useCSSKeyframesAnimationController = (
   }: UseCSSAnimationControllerCallback = {},
   disableInitAnimation = false,
 ): [AnimationState, AnimationHandlers] => {
-  const [state, setState] = useState<AnimationState>(() =>
+  const [state, setState] = React.useState<AnimationState>(() =>
     disableInitAnimation ? (stateProp === 'enter' ? 'entered' : 'exited') : stateProp,
   );
-  const prevState = usePrevious(stateProp);
+
+  const prevStateRef = React.useRef<'enter' | 'exit' | undefined>(undefined);
+  React.useEffect(() => {
+    prevStateRef.current = stateProp;
+  });
 
   const onAnimationStart = () => {
     if (state === 'enter') {
@@ -67,6 +70,8 @@ export const useCSSKeyframesAnimationController = (
 
   useIsomorphicLayoutEffect(
     function updateState() {
+      const prevState = prevStateRef.current;
+
       if (prevState === stateProp) {
         return;
       }
@@ -89,7 +94,7 @@ export const useCSSKeyframesAnimationController = (
           break;
       }
     },
-    [state, prevState, stateProp, onEnter, onExit],
+    [state, stateProp, onEnter, onExit],
   );
 
   return [state, { onAnimationStart, onAnimationEnd }];

--- a/packages/vkui/src/lib/animation/useCSSTransition.ts
+++ b/packages/vkui/src/lib/animation/useCSSTransition.ts
@@ -1,13 +1,7 @@
-import {
-  type TransitionEvent,
-  type TransitionEventHandler,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { type TransitionEvent, type TransitionEventHandler, useEffect, useRef } from 'react';
 import { noop } from '@vkontakte/vkjs';
-import { usePrevious } from '../../hooks/usePrevious';
 import { useStableCallback } from '../../hooks/useStableCallback';
+import { useStateWithPrev } from '../../hooks/useStateWithPrev';
 
 /* istanbul ignore next: особенность рендера в браузере когда меняется className, в Jest не воспроизвести */
 const forceReflowForFixNewMountedElement = (node: Element | null) => void node?.scrollTop;
@@ -72,7 +66,7 @@ export const useCSSTransition = <Ref extends Element = Element>(
   const onExited = useStableCallback(onExitedProp || noop);
 
   const ref = useRef<Ref | null>(null);
-  const [state, setState] = useState<UseCSSTransitionState>(() => {
+  const [[state, prevState], setState] = useStateWithPrev<UseCSSTransitionState>(() => {
     if (!inProp) {
       return 'exited';
     }
@@ -84,7 +78,6 @@ export const useCSSTransition = <Ref extends Element = Element>(
 
     return 'entered';
   });
-  const prevState = usePrevious(state);
 
   useEffect(
     function updateState() {
@@ -158,6 +151,7 @@ export const useCSSTransition = <Ref extends Element = Element>(
 
       state,
       prevState,
+      setState,
 
       enableAppear,
       enableEnter,

--- a/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
+++ b/packages/vkui/src/lib/floating/usePlacementChangeCallback.ts
@@ -1,4 +1,4 @@
-import { usePrevious } from '../../hooks/usePrevious';
+import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
 import type { OnPlacementChange, Placement, PlacementWithAuto } from './types/common';
 
@@ -7,12 +7,18 @@ export function usePlacementChangeCallback(
   resolvedPlacement: Placement,
   onPlacementChange: OnPlacementChange | undefined,
 ): void {
-  const prevPlacement = usePrevious(resolvedPlacement);
+  const prevPlacementRef = React.useRef<Placement | undefined>(undefined);
+  React.useEffect(() => {
+    prevPlacementRef.current = resolvedPlacement;
+  });
 
   useIsomorphicLayoutEffect(() => {
     if (!onPlacementChange) {
       return;
     }
+
+    const prevPlacement = prevPlacementRef.current;
+
     const isInitialPlacementChanged =
       prevPlacement === undefined && initialPlacement !== resolvedPlacement;
     const isResolvedPlacementChanged =
@@ -20,5 +26,5 @@ export function usePlacementChangeCallback(
     if (isInitialPlacementChanged || isResolvedPlacementChanged) {
       onPlacementChange(resolvedPlacement);
     }
-  }, [prevPlacement, initialPlacement, resolvedPlacement, onPlacementChange]);
+  }, [initialPlacement, resolvedPlacement, onPlacementChange]);
 }


### PR DESCRIPTION
- see #6919

---

- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] Документация фичи
- [x] ~Release notes~

## Описание

Хук `useRef` [нельзя](https://react.dev/reference/react/useRef) использовать для чтения или записи во время рендеринга

> Do not write or read ref.current during rendering.
> ...
> If you have to read [or write](https://react.dev/reference/react/useState#storing-information-from-previous-renders) something during rendering, [use state](https://react.dev/reference/react/useState) instead.
>
> When you break these rules, your component might still work, but most of the newer features we’re adding to React will rely on these expectations. Read more about [keeping your components pure.](https://react.dev/learn/keeping-components-pure#where-you-_can_-cause-side-effects)

## Изменения

- Добавляем хук `useStateWithPrev`
- Депрекейтим `usePrevious`

## Release notes
-