### PR TITLE
fix(Search): add global class

### DIFF
--- a/packages/vkui/src/components/Search/Search.module.css
+++ b/packages/vkui/src/components/Search/Search.module.css
@@ -201,7 +201,6 @@
   inline-size: initial;
 }
 
-/* FIXME поменять на `:global(.vkuiInternalGroup--mode-plain)` */
-.modePlain .host {
+:global(.vkuiInternalGroup--mode-plain) .host {
   padding-block-start: 4px;
 }


### PR DESCRIPTION
- caused by #6979

---


## Описание

Забыли поменять глобальный класс

## Release notes

 ## Исправления
 - Search: исправлен отступ при `Group` в режиме `mode="plain"`

