### PR TITLE
fix(useStableCallback): rm useRef

### DIFF
--- a/packages/vkui/src/hooks/useStableCallback.ts
+++ b/packages/vkui/src/hooks/useStableCallback.ts
@@ -17,5 +17,5 @@ export function useStableCallback<Args extends unknown[], Return>(
   useIsomorphicLayoutEffect(() => {
     ref.current = fn;
   });
-  return React.useRef((...args: Args) => (0, ref.current)(...args)).current;
+  return React.useCallback((...args: Args) => (0, ref.current)(...args), []);
 }


### PR DESCRIPTION
- see #6919

---

- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] ~Release notes~

## Описание

Хук `useRef` [нельзя](https://react.dev/reference/react/useRef) использовать для чтения или записи во время рендеринга

> Do not write or read ref.current during rendering.
> ...
> If you have to read [or write](https://react.dev/reference/react/useState#storing-information-from-previous-renders) something during rendering, [use state](https://react.dev/reference/react/useState) instead.
>
> When you break these rules, your component might still work, but most of the newer features we’re adding to React will rely on these expectations. Read more about [keeping your components pure.](https://react.dev/learn/keeping-components-pure#where-you-_can_-cause-side-effects)

## Изменения

Заменяем useRef  на useCallback в хуке `useStableCallback`

## Release notes
-