### PR TITLE
fix(useLayoutEffectCall): rm useRef

### DIFF
--- a/packages/vkui/src/components/View/useLayoutEffectCall.tsx
+++ b/packages/vkui/src/components/View/useLayoutEffectCall.tsx
@@ -1,42 +1,20 @@
 import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 
-class LayoutEffectCall {
-  #fns: Array<() => void> = [];
-
-  /**
-   * Выполняет переданные функции
-   */
-  run() {
-    for (const fn of this.#fns) {
-      fn();
-    }
-
-    this.#fns = [];
-  }
-
-  /**
-   * Вызовет функцию после изменения DOM, но до того как пользователь увидит
-   * изменения
-   */
-  add = (fn: () => void) => {
-    this.#fns.push(fn);
-  };
-}
-
 /**
  * Возвращает функцию которая вызывает callback после изменения DOM, но до того
  * как пользователь увидит изменения
  */
 export function useLayoutEffectCall() {
-  const ref = React.useRef<LayoutEffectCall | null>(null);
-  if (!ref.current) {
-    ref.current = new LayoutEffectCall();
-  }
+  const [fns] = React.useState<Array<() => void>>(() => []);
 
   useIsomorphicLayoutEffect(() => {
-    ref.current!.run();
+    while (fns.length > 0) {
+      fns.pop()!();
+    }
   });
 
-  return ref.current.add;
+  const add = React.useCallback((fn: () => void) => fns.push(fn), [fns]);
+
+  return add;
 }


### PR DESCRIPTION
- see #6919

---

- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] ~Release notes~

## Описание

Хук `useRef` [нельзя](https://react.dev/reference/react/useRef) использовать для чтения или записи во время рендеринга

> Do not write or read ref.current during rendering.
> ...
> If you have to read [or write](https://react.dev/reference/react/useState#storing-information-from-previous-renders) something during rendering, [use state](https://react.dev/reference/react/useState) instead.
>
> When you break these rules, your component might still work, but most of the newer features we’re adding to React will rely on these expectations. Read more about [keeping your components pure.](https://react.dev/learn/keeping-components-pure#where-you-_can_-cause-side-effects)

## Изменения

Заменяем useRef  на useState в хуке `useLayoutEffectCall`

## Release notes
-