### PR TITLE
refactor(SSR): rm DOMContext

### DIFF
--- a/packages/vkui/src/lib/SSR.tsx
+++ b/packages/vkui/src/lib/SSR.tsx
@@ -2,9 +2,7 @@
 
 import * as React from 'react';
 import { ConfigProviderOverride } from '../components/ConfigProvider/ConfigProviderOverride';
-import { useObjectMemo } from '../hooks/useObjectMemo';
 import { type BrowserInfo, computeBrowserInfo } from './browser';
-import { DOMContext, getDOM } from './dom';
 import { platform as getPlatform } from './platform';
 
 export interface SSRWrapperProps {
@@ -21,11 +19,7 @@ export const SSRWrapper: React.FC<SSRWrapperProps> = ({ userAgent, browserInfo, 
     browserInfo = computeBrowserInfo(userAgent);
   }
 
-  const dom = useObjectMemo(getDOM());
-
   return (
-    <ConfigProviderOverride platform={getPlatform(browserInfo)}>
-      <DOMContext.Provider value={dom}>{children}</DOMContext.Provider>
-    </ConfigProviderOverride>
+    <ConfigProviderOverride platform={getPlatform(browserInfo)}>{children}</ConfigProviderOverride>
   );
 };

--- a/packages/vkui/src/lib/dom.tsx
+++ b/packages/vkui/src/lib/dom.tsx
@@ -32,7 +32,7 @@ export interface DOMContextInterface {
 export type DOMProps = DOMContextInterface;
 
 /* eslint-disable no-restricted-globals */
-export const getDOM = (): DOMContextInterface => ({
+const getDOM = (): DOMContextInterface => ({
   window: canUseDOM ? window : undefined,
   document: canUseDOM ? document : undefined,
 });


### PR DESCRIPTION

- [x] ~Unit-тесты~ (не требуется)
- [x] ~e2e-тесты~ (не требуется)
- [x] ~Дизайн-ревью~ (не требуется)
- [x] ~Документация фичи~ (не требуется)
- [x] ~Release notes~ (не требуется)

## Описание

В компоненте SSRWrapper есть провайдер DOMContext который записывает в контекст те же данные, что и у контекста по умолчанию

## Изменения

Удалил DOMContext.Provider из SSRWrapper
 
## Release notes
-
