### PR TITLE
fix: deprecate useObjectMemo

### DIFF
--- a/packages/vkui/src/components/Accordion/Accordion.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import { useCustomEnsuredControl } from '../../hooks/useEnsuredControl';
-import { useObjectMemo } from '../../hooks/useObjectMemo';
 import type { HasChildren } from '../../types';
 import { AccordionContent } from './AccordionContent';
 import { AccordionContext } from './AccordionContext';
@@ -53,12 +52,15 @@ export const Accordion: React.FC<AccordionProps> & {
     disabled: restProps.disabled,
   });
 
-  const context = useObjectMemo({
-    labelId,
-    contentId,
-    expanded: expanded || false,
-    onChange,
-  });
+  const context = React.useMemo(
+    () => ({
+      labelId,
+      contentId,
+      expanded: expanded || false,
+      onChange,
+    }),
+    [contentId, expanded, labelId, onChange],
+  );
 
   return <AccordionContext.Provider value={context}>{children}</AccordionContext.Provider>;
 };

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { noop } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
-import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useCSSKeyframesAnimationController } from '../../lib/animation';
 import { useScrollLock } from '../AppRoot/ScrollContext';
@@ -58,7 +57,7 @@ export const ActionSheet = ({
 }: ActionSheetProps): React.ReactNode => {
   const platform = usePlatform();
   const [closingBy, setClosingBy] = React.useState<undefined | CloseInitiators>(undefined);
-  const onCloseWithOther = () => setClosingBy('other');
+  const onCloseWithOther = React.useCallback(() => setClosingBy('other'), []);
   const actionCallbackRef = React.useRef(noop);
 
   const [animationState, animationHandlers] = useCSSKeyframesAnimationController(
@@ -93,7 +92,10 @@ export const ActionSheet = ({
       },
     [],
   );
-  const contextValue = useObjectMemo({ onItemClick, mode, onClose: onCloseWithOther });
+  const contextValue = React.useMemo(
+    () => ({ onItemClick, mode, onClose: onCloseWithOther }),
+    [mode, onCloseWithOther, onItemClick],
+  );
 
   const DropdownComponent = mode === 'menu' ? ActionSheetDropdownMenu : ActionSheetDropdownSheet;
 

--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { IconAppearanceProvider } from '@vkontakte/icons';
 import { useAutoDetectColorScheme } from '../../hooks/useAutoDetectColorScheme';
-import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { TokensClassProvider } from '../../lib/tokens';
 import { excludeKeysWithUndefined } from '../../lib/utils';
 import {
@@ -40,16 +39,28 @@ export const ConfigProvider = (propsRaw: ConfigProviderProps): React.ReactNode =
 
   const colorScheme = useAutoDetectColorScheme(colorSchemeProp);
 
-  const configContext = useObjectMemo({
-    hasCustomPanelHeaderAfter,
-    customPanelHeaderAfterMinWidth,
-    isWebView,
-    transitionMotionEnabled,
-    platform,
-    locale,
-    tokensClassNames,
-    colorScheme,
-  });
+  const configContext = React.useMemo(
+    () => ({
+      hasCustomPanelHeaderAfter,
+      customPanelHeaderAfterMinWidth,
+      isWebView,
+      transitionMotionEnabled,
+      platform,
+      locale,
+      tokensClassNames,
+      colorScheme,
+    }),
+    [
+      colorScheme,
+      customPanelHeaderAfterMinWidth,
+      hasCustomPanelHeaderAfter,
+      isWebView,
+      locale,
+      platform,
+      tokensClassNames,
+      transitionMotionEnabled,
+    ],
+  );
 
   return (
     <ConfigProviderContext.Provider value={configContext}>

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { classNames, hasReactNode, isPrimitiveReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
-import { useObjectMemo } from '../../hooks/useObjectMemo';
 import type { HasComponent, HasRootRef } from '../../types';
 import { Removable, type RemovableProps } from '../Removable/Removable';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -119,7 +118,7 @@ export const FormItem: React.FC<FormItemProps> & {
     </React.Fragment>
   );
 
-  const context = useObjectMemo({ required, topMultiline });
+  const context = React.useMemo(() => ({ required, topMultiline }), [required, topMultiline]);
 
   return (
     <RootComponent

--- a/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootDesktop.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';
-import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { usePrevious } from '../../hooks/usePrevious';
 import { useWaitTransitionFinish } from '../../hooks/useWaitTransitionFinish';
 import { useDOM } from '../../lib/dom';
@@ -53,12 +52,15 @@ export const ModalRootDesktop = ({
     enteringModal,
     activeModal,
   });
-  const modalRootContext: ModalRootContextInterface = useObjectMemo({
-    updateModalHeight: () => undefined,
-    registerModal: ({ id, ...data }) => Object.assign(getModalState(id) ?? {}, data),
-    onClose: onExit,
-    isInsideModal: true,
-  });
+  const modalRootContext: ModalRootContextInterface = React.useMemo(
+    () => ({
+      updateModalHeight: () => undefined,
+      registerModal: ({ id, ...data }) => Object.assign(getModalState(id) ?? {}, data),
+      onClose: onExit,
+      isInsideModal: true,
+    }),
+    [getModalState, onExit],
+  );
 
   const timeout = platform === 'ios' ? 400 : 320;
   const modals = React.Children.toArray(children) as React.ReactElement[];

--- a/packages/vkui/src/components/NavTransitionContext/NavTransitionContext.tsx
+++ b/packages/vkui/src/components/NavTransitionContext/NavTransitionContext.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { useObjectMemo } from '../../hooks/useObjectMemo';
 
 export interface TransitionContextProps {
   entering: boolean;
@@ -16,8 +15,12 @@ export const NavTransitionProvider = ({
   entering,
 }: React.PropsWithChildren<TransitionContextProps>): React.ReactNode => {
   const parentContext = useNavTransition();
-  const contextValue = useObjectMemo({
-    entering: parentContext.entering || entering,
-  });
+  const contextValue = React.useMemo(
+    () => ({
+      entering: parentContext.entering || entering,
+    }),
+    [entering, parentContext.entering],
+  );
+
   return <TransitionContext.Provider value={contextValue}>{children}</TransitionContext.Provider>;
 };

--- a/packages/vkui/src/components/SplitCol/SplitCol.tsx
+++ b/packages/vkui/src/components/SplitCol/SplitCol.tsx
@@ -5,7 +5,6 @@ import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useMediaQueries } from '../../hooks/useMediaQueries';
-import { useObjectMemo } from '../../hooks/useObjectMemo';
 import { ViewWidth, viewWidthToClassName } from '../../lib/adaptivity';
 import { matchMediaListAddListener, matchMediaListRemoveListener } from '../../lib/matchMedia';
 import type { HTMLAttributesWithRootRef } from '../../types';
@@ -89,10 +88,13 @@ export const SplitCol = (props: SplitColProps): React.ReactNode => {
   const { viewWidth } = useAdaptivity();
   const animate = useTransitionAnimate(animateProp);
 
-  const contextValue = useObjectMemo({
-    colRef: baseRef,
-    animate,
-  });
+  const contextValue = React.useMemo(
+    () => ({
+      colRef: baseRef,
+      animate,
+    }),
+    [animate, baseRef],
+  );
 
   return (
     <RootComponent

--- a/packages/vkui/src/hooks/useObjectMemo.ts
+++ b/packages/vkui/src/hooks/useObjectMemo.ts
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { isEqual } from '@vkontakte/vkjs';
 
+/**
+ * @deprecated используйте React.useMemo
+ */
 export function useObjectMemo<T>(object: T): T {
+  /**
+   * Запись и чтение во время рендеринга в useRef запрещена
+   */
   const cache = React.useRef(object);
   if (!isEqual(cache.current, object)) {
     cache.current = object;


### PR DESCRIPTION
- see #6919

---

- [x] ~Unit-тесты~ (не требуются)
- [x] ~e2e-тесты~ (не требуются)
- [x] ~Дизайн-ревью~ (не требуются)
- [x] Документация фичи 
- [x] ~Release notes~

## Описание

Хук `useRef` [нельзя](https://react.dev/reference/react/useRef) использовать для чтения или записи во время рендеринга

> Do not write or read ref.current during rendering.
> ...
> If you have to read [or write](https://react.dev/reference/react/useState#storing-information-from-previous-renders) something during rendering, [use state](https://react.dev/reference/react/useState) instead.
>
> When you break these rules, your component might still work, but most of the newer features we’re adding to React will rely on these expectations. Read more about [keeping your components pure.](https://react.dev/learn/keeping-components-pure#where-you-_can_-cause-side-effects)

## Изменения

Депрекейтим `useObjectMemo`, меняем в некоторых местах на `React.useObjectMemo`

## Release notes
-