### PR TITLE
fix(useModalRegistry): use useRef

### DIFF
--- a/packages/vkui/src/components/ModalCard/ModalCard.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.tsx
@@ -47,7 +47,7 @@ export const ModalCard = ({
   const platform = usePlatform();
 
   const modalContext = React.useContext(ModalRootContext);
-  const { refs } = useModalRegistry(getNavId({ nav, id }, warn), 'card');
+  const refs = useModalRegistry(getNavId({ nav, id }, warn), 'card');
   const rootRef = useExternRef(getRootRef, refs.modalElement);
 
   const contextValue = React.useMemo(() => ({ labelId: `${id}-label` }), [id]);

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -124,7 +124,7 @@ export const ModalPage = ({
   const size = isDesktop ? sizeProp : 's';
 
   const modalContext = React.useContext(ModalRootContext);
-  const { refs } = useModalRegistry(getNavId({ nav, id }, warn), 'page');
+  const refs = useModalRegistry(getNavId({ nav, id }, warn), 'page');
   const rootRef = useExternRef(getRootRef, refs.modalElement);
 
   const contextValue = React.useMemo(() => ({ labelId: `${id}-label` }), [id]);

--- a/packages/vkui/src/components/ModalRoot/ModalRootContext.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootContext.tsx
@@ -3,7 +3,7 @@ import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import type { ModalElements, ModalsStateEntry, ModalType } from './types';
 
 export type ModalRegistryEntry = ModalElements & Required<Pick<ModalsStateEntry, 'type' | 'id'>>;
-type ModalRefs = { [k in keyof ModalElements]: (e: ModalElements[k]) => void };
+type ModalRefs = { [k in keyof ModalElements]: React.Ref<NonNullable<ModalElements[k]>> };
 
 export interface ModalRootContextInterface {
   updateModalHeight: VoidFunction;
@@ -22,16 +22,25 @@ export const ModalRootContext: React.Context<ModalRootContextInterface> =
 /**
  * All referenced elements must be static
  */
-export function useModalRegistry(
-  id: string | undefined,
-  type: ModalType,
-): {
-  refs: Required<ModalRefs>;
-} {
+export function useModalRegistry(id: string | undefined, type: ModalType): Required<ModalRefs> {
   const modalContext = React.useContext(ModalRootContext);
-  const elements = React.useRef<ModalElements>({}).current;
+
+  const modalElement = React.useRef<HTMLDivElement>(null);
+  const innerElement = React.useRef<HTMLDivElement>(null);
+  const headerElement = React.useRef<HTMLDivElement>(null);
+  const contentElement = React.useRef<HTMLDivElement>(null);
+  const bottomInset = React.useRef<HTMLDivElement>(null);
+
   useIsomorphicLayoutEffect(() => {
     if (id !== undefined) {
+      const elements = {
+        modalElement: modalElement.current,
+        innerElement: innerElement.current,
+        headerElement: headerElement.current,
+        contentElement: contentElement.current,
+        bottomInset: bottomInset.current,
+      };
+
       modalContext.registerModal({ ...elements, type, id });
       // unset refs on  unmount to prevent leak
       const reset = Object.keys(elements).reduce<ModalRegistryEntry>(
@@ -43,12 +52,11 @@ export function useModalRegistry(
     return undefined;
   }, []);
 
-  const refs = React.useRef<Required<ModalRefs>>({
-    modalElement: (e) => (elements.modalElement = e),
-    innerElement: (e) => (elements.innerElement = e),
-    headerElement: (e) => (elements.headerElement = e),
-    contentElement: (e) => (elements.contentElement = e),
-    bottomInset: (e) => (elements.bottomInset = e),
-  }).current;
-  return { refs };
+  return {
+    modalElement,
+    innerElement,
+    headerElement,
+    contentElement,
+    bottomInset,
+  };
 }

--- a/packages/vkui/src/components/ModalRoot/types.ts
+++ b/packages/vkui/src/components/ModalRoot/types.ts
@@ -9,11 +9,11 @@ export type TranslateRange = [number, number];
 export type ModalsState = { [index: string]: ModalsStateEntry };
 
 export interface ModalElements {
-  modalElement?: HTMLElement | null;
-  innerElement?: HTMLElement | null;
-  headerElement?: HTMLElement | null;
-  contentElement?: HTMLElement | null;
-  bottomInset?: HTMLElement | null;
+  modalElement?: HTMLDivElement | null;
+  innerElement?: HTMLDivElement | null;
+  headerElement?: HTMLDivElement | null;
+  contentElement?: HTMLDivElement | null;
+  bottomInset?: HTMLDivElement | null;
 }
 
 export interface ModalsStateEntry extends ModalElements {


### PR DESCRIPTION
- see #6919

---

- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] ~Release notes~

## Описание

Хук `useRef` [нельзя](https://react.dev/reference/react/useRef) использовать для чтения или записи во время рендеринга

> Do not write or read ref.current during rendering.
> ...
> If you have to read [or write](https://react.dev/reference/react/useState#storing-information-from-previous-renders) something during rendering, [use state](https://react.dev/reference/react/useState) instead.
>
> When you break these rules, your component might still work, but most of the newer features we’re adding to React will rely on these expectations. Read more about [keeping your components pure.](https://react.dev/learn/keeping-components-pure#where-you-_can_-cause-side-effects)

## Изменения

Используем useRef по назначению

## Release notes
-