### PR TITLE
ci(codecov): use_oidc

### DIFF
--- a/.github/workflows/branch_test_coverage.yml
+++ b/.github/workflows/branch_test_coverage.yml
@@ -43,6 +43,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     name: Deploy test coverage
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +57,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           flags: unittests
           files: .nyc_output/coverage-final.json
           fail_ci_if_error: true

--- a/.github/workflows/pull_request_packages_deploy.yml
+++ b/.github/workflows/pull_request_packages_deploy.yml
@@ -26,6 +26,8 @@ jobs:
     if: ${{ needs.pr_workflow_payload.outputs.status == 'success' }}
     runs-on: ubuntu-latest
     name: Deploy test coverage
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +46,7 @@ jobs:
         if: ${{ steps.artifact.outputs.found_artifact == 'true' }}
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           flags: unittests
           files: .nyc_output/coverage-final.json
           override_branch: ${{ env.PR_HEAD_BRANCH }}


### PR DESCRIPTION
## Описание

Используем [OIDC](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) подпись вместо токена для Codecov

## Release notes
-