### PR TITLE
feat(RootComponent): add baseStyle

### DIFF
--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -73,7 +73,6 @@ export const ActionSheetItem = ({
   onImmediateClick,
   multiline = false,
   iconChecked,
-  className,
   isCancelItem,
   ...restProps
 }: ActionSheetItemProps): React.ReactNode => {
@@ -130,7 +129,7 @@ export const ActionSheetItem = ({
       {...restProps}
       onClick={onItemClickImpl}
       activeMode={platform === 'ios' ? styles.active : undefined}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         platform === 'ios' && styles.ios,
         mode === 'cancel' && styles.modeCancel,
@@ -138,7 +137,6 @@ export const ActionSheetItem = ({
         sizeY === 'compact' && styles.sizeYCompact,
         isRich && styles.rich,
         actionSheetMode === 'menu' && styles.menu,
-        className,
       )}
       onKeyDown={onKeyDown}
     >

--- a/packages/vkui/src/components/Alert/AlertAction.tsx
+++ b/packages/vkui/src/components/Alert/AlertAction.tsx
@@ -20,7 +20,7 @@ const AlertActionIos = ({ mode, ...restProps }: AlertActionProps) => {
   return (
     <Tappable
       Component={restProps.href ? 'a' : 'button'}
-      className={classNames(
+      baseClassName={classNames(
         styles.action,
         mode === 'destructive' && styles.actionModeDestructive,
         mode === 'cancel' && styles.actionModeCancel,

--- a/packages/vkui/src/components/AspectRatio/AspectRatio.tsx
+++ b/packages/vkui/src/components/AspectRatio/AspectRatio.tsx
@@ -23,21 +23,15 @@ export interface AspectRatioProps extends Omit<RootComponentProps<HTMLElement>, 
  * @since 5.5.0
  * @see https://vkcom.github.io/VKUI/#/AspectRatio
  */
-export function AspectRatio({
-  ratio,
-  mode = 'stretch',
-  style: styleProp,
-  ...props
-}: AspectRatioProps): JSX.Element {
+export function AspectRatio({ ratio, mode = 'stretch', ...props }: AspectRatioProps): JSX.Element {
   const style: React.CSSProperties & CSSCustomProperties = {
     '--vkui_internal--aspect_ratio': String(ratio),
-    ...styleProp,
   };
 
   return (
     <RootComponent
       baseClassName={classNames(styles.host, mode === 'stretch' && styles.modeStretch)}
-      style={style}
+      baseStyle={style}
       {...props}
     />
   );

--- a/packages/vkui/src/components/Banner/Banner.tsx
+++ b/packages/vkui/src/components/Banner/Banner.tsx
@@ -96,7 +96,6 @@ export const Banner = ({
   actions,
   onDismiss,
   dismissLabel = 'Скрыть',
-  className,
   Component,
   ...restProps
 }: BannerProps): React.ReactNode => {
@@ -173,7 +172,6 @@ export const Banner = ({
         mode === 'image' && styles.modeImage,
         size === 'm' && styles.sizeM,
         mode === 'image' && imageTheme === 'dark' && styles.inverted,
-        className,
       )}
       {...restProps}
     >

--- a/packages/vkui/src/components/Button/Button.tsx
+++ b/packages/vkui/src/components/Button/Button.tsx
@@ -73,7 +73,6 @@ export const Button = ({
   getRootRef,
   loading,
   onClick,
-  className,
   disableSpinnerAnimation,
   rounded,
   disabled,
@@ -92,8 +91,7 @@ export const Button = ({
       disabled={loading || disabled}
       {...restProps}
       onClick={loading ? undefined : onClick}
-      className={classNames(
-        className,
+      baseClassName={classNames(
         styles.host,
         stylesSize[size],
         stylesMode[mode],

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
@@ -58,7 +58,6 @@ export const CalendarDay: React.FC<CalendarDayProps> = React.memo(
     hintedSelectionEnd,
     sameMonth,
     size,
-    className,
     children,
     renderDayContent,
     testId,
@@ -102,7 +101,7 @@ export const CalendarDay: React.FC<CalendarDayProps> = React.memo(
 
     return (
       <Tappable
-        className={classNames(styles.host, size === 's' && styles.sizeS, className)}
+        baseClassName={classNames(styles.host, size === 's' && styles.sizeS)}
         hoverMode={styles.hostHovered}
         activeMode={styles.hostActivated}
         hasActive={false}

--- a/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
@@ -156,7 +156,7 @@ export const CalendarHeader = ({
       {!prevMonthHidden && (
         <AdaptivityProvider sizeX="regular">
           <Tappable
-            className={classNames(styles.navIcon, styles.navIconPrev, prevMonthClassName)}
+            baseClassName={classNames(styles.navIcon, styles.navIconPrev, prevMonthClassName)}
             onClick={onPrevMonth}
             data-testid={prevMonthButtonTestId}
             {...restPrevMonthProps}
@@ -222,7 +222,7 @@ export const CalendarHeader = ({
       {!nextMonthHidden && (
         <AdaptivityProvider sizeX="regular">
           <Tappable
-            className={classNames(styles.navIcon, styles.navIconNext, nextMonthClassName)}
+            baseClassName={classNames(styles.navIcon, styles.navIconNext, nextMonthClassName)}
             onClick={onNextMonth}
             data-testid={nextMonthButtonTestId}
             {...restNextMonthProps}

--- a/packages/vkui/src/components/Counter/Counter.tsx
+++ b/packages/vkui/src/components/Counter/Counter.tsx
@@ -2,7 +2,8 @@
 
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { type HTMLAttributesWithRootRef } from '../../types';
+import { mergeStyle } from '../../helpers/mergeStyle';
+import { type CSSCustomProperties, type HTMLAttributesWithRootRef } from '../../types';
 import { Caption } from '../Typography/Caption/Caption';
 import { Headline } from '../Typography/Headline/Headline';
 import styles from './Counter.module.css';
@@ -73,25 +74,23 @@ export const Counter = ({
     return 'accent';
   }, [appearanceProp, mode]);
 
-  const style = React.useMemo(() => {
-    if (mode === 'inherit' || appearance !== 'custom' || !color) {
-      return styleProp;
-    }
-    switch (mode) {
-      case 'primary':
-        return {
-          ...styleProp,
-          '--vkui_internal--counter_background': color,
-        };
-      case 'contrast':
-      case 'tertiary':
-        return {
-          ...styleProp,
-          '--vkui_internal--counter_foreground': color,
-        };
-    }
-    return styleProp;
-  }, [appearance, color, mode, styleProp]);
+  const style: (React.CSSProperties & CSSCustomProperties<string | undefined>) | undefined =
+    React.useMemo(() => {
+      if (mode === 'inherit' || appearance !== 'custom' || !color) {
+        return undefined;
+      }
+      switch (mode) {
+        case 'primary':
+          return {
+            '--vkui_internal--counter_background': color,
+          };
+        case 'contrast':
+        case 'tertiary':
+          return {
+            '--vkui_internal--counter_foreground': color,
+          };
+      }
+    }, [appearance, color, mode]);
 
   if (React.Children.count(children) === 0) {
     return null;
@@ -103,7 +102,7 @@ export const Counter = ({
   return (
     <CounterTypography
       {...restProps}
-      style={style}
+      style={mergeStyle(style, styleProp)}
       Component="span"
       className={classNames(
         'vkuiInternalCounter',

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -3,8 +3,9 @@
 import * as React from 'react';
 import { Icon16Done } from '@vkontakte/icons';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
+import { mergeStyle } from '../../helpers/mergeStyle';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
-import type { HTMLAttributesWithRootRef } from '../../types';
+import type { CSSCustomProperties, HTMLAttributesWithRootRef } from '../../types';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { Paragraph } from '../Typography/Paragraph/Paragraph';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
@@ -74,15 +75,14 @@ export const CustomSelectOption = ({
   ...restProps
 }: CustomSelectOptionProps): React.ReactNode => {
   const { sizeY = 'none' } = useAdaptivity();
-  const style = React.useMemo(
+  const style: (React.CSSProperties & CSSCustomProperties<number>) | undefined = React.useMemo(
     () =>
       hierarchy > 0
         ? {
             '--vkui_internal--custom_select_option_hierarchy_level': hierarchy,
-            ...styleProp,
           }
-        : styleProp,
-    [hierarchy, styleProp],
+        : undefined,
+    [hierarchy],
   );
   const hovered = hoveredProp && !disabled ? true : false;
 
@@ -103,7 +103,7 @@ export const CustomSelectOption = ({
         hierarchy > 0 && styles.hierarchy,
         className,
       )}
-      style={style}
+      style={mergeStyle(style, styleProp)}
     >
       {hasReactNode(before) && <div className={styles.before}>{before}</div>}
       <div className={styles.main}>

--- a/packages/vkui/src/components/Flex/Flex.tsx
+++ b/packages/vkui/src/components/Flex/Flex.tsx
@@ -1,6 +1,5 @@
 import { Children } from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { mergeStyle } from '../../helpers/mergeStyle';
 import {
   calculateGap,
   columnGapClassNames,
@@ -83,7 +82,6 @@ export const Flex: React.FC<FlexProps> & {
   margin = 'none',
   noWrap = false,
   direction = 'row',
-  style: styleProp,
   reverse = false,
   children,
   ...props
@@ -105,7 +103,7 @@ export const Flex: React.FC<FlexProps> & {
         withGaps && styles.withGaps,
         withGaps && getGapsPresets(rowGap, columnGap),
       )}
-      style={mergeStyle(getGapsByUser(rowGap, columnGap), styleProp)}
+      baseStyle={getGapsByUser(rowGap, columnGap)}
     >
       {children}
     </RootComponent>

--- a/packages/vkui/src/components/Flex/FlexItem/FlexItem.tsx
+++ b/packages/vkui/src/components/Flex/FlexItem/FlexItem.tsx
@@ -46,13 +46,12 @@ export const FlexItem = ({
   alignSelf,
   flex,
   flexBasis,
-  style,
   ...rest
 }: FlexItemProps): React.ReactNode => {
   return (
     <RootComponent
       {...rest}
-      style={{ flexBasis, ...style }}
+      baseStyle={{ flexBasis }}
       baseClassName={classNames(
         alignSelf && alignSelfClassNames[alignSelf],
         flex && flexClassNames[flex],

--- a/packages/vkui/src/components/IconButton/IconButton.tsx
+++ b/packages/vkui/src/components/IconButton/IconButton.tsx
@@ -26,12 +26,7 @@ const warn = warnOnce('IconButton');
 /**
  * @see https://vkcom.github.io/VKUI/#/IconButton
  */
-export const IconButton = ({
-  label,
-  children,
-  className,
-  ...restProps
-}: IconButtonProps): React.ReactNode => {
+export const IconButton = ({ label, children, ...restProps }: IconButtonProps): React.ReactNode => {
   const platform = usePlatform();
   const { sizeY = 'none' } = useAdaptivity();
 
@@ -53,11 +48,10 @@ export const IconButton = ({
       activeMode="background"
       Component={restProps.href ? 'a' : 'button'}
       {...restProps}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         sizeY !== 'regular' && sizeYClassNames[sizeY],
         platform === 'ios' && styles.ios,
-        className,
       )}
     >
       {label && <VisuallyHidden>{label}</VisuallyHidden>}

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -142,7 +142,6 @@ export const ImageBase: React.FC<ImageBaseProps> & {
   height: heightImg,
   widthSize,
   heightSize,
-  style,
   noBorder = false,
   fallbackIcon: fallbackIconProp,
   children,
@@ -209,7 +208,7 @@ export const ImageBase: React.FC<ImageBaseProps> & {
   return (
     <ImageBaseContext.Provider value={{ size }}>
       <Clickable
-        style={{ width, height, ...style }}
+        baseStyle={{ width, height }}
         baseClassName={classNames(
           styles.host,
           loaded && styles.loaded,

--- a/packages/vkui/src/components/Link/Link.tsx
+++ b/packages/vkui/src/components/Link/Link.tsx
@@ -31,7 +31,6 @@ export const Link = ({
   noUnderline,
   hasVisited,
   children,
-  className,
   ...restProps
 }: LinkProps): React.ReactNode => {
   const before = beforeProp ? <span className={styles.before}>{beforeProp}</span> : null;
@@ -41,11 +40,10 @@ export const Link = ({
     <Tappable
       Component={restProps.href ? 'a' : 'button'}
       {...restProps}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         hasVisited && styles.hasVisited,
         noUnderline ? undefined : styles.withUnderline,
-        className,
       )}
       hasHover={false}
       activeMode="opacity"

--- a/packages/vkui/src/components/List/List.tsx
+++ b/packages/vkui/src/components/List/List.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { classNames } from '@vkontakte/vkjs';
 import { DATA_DRAGGABLE_PLACEHOLDER_REACT_PROP } from '../../hooks/useDraggableWithDomApi';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -15,20 +14,13 @@ export type ListProps = HTMLAttributesWithRootRef<HTMLDivElement> & {
 /**
  * @see https://vkcom.github.io/VKUI/#/List
  */
-export const List = ({
-  children,
-  gap = 0,
-  className,
-  style,
-  ...restProps
-}: ListProps): React.ReactNode => {
+export const List = ({ children, gap = 0, ...restProps }: ListProps): React.ReactNode => {
   return (
     <RootComponent
       role="list"
-      className={classNames(styles.host, className)}
-      style={{
+      baseClassName={styles.host}
+      baseStyle={{
         gridGap: gap,
-        ...style,
       }}
       {...restProps}
     >

--- a/packages/vkui/src/components/MiniInfoCell/MiniInfoCell.tsx
+++ b/packages/vkui/src/components/MiniInfoCell/MiniInfoCell.tsx
@@ -67,14 +67,12 @@ export const MiniInfoCell = ({
   mode = 'base',
   textWrap = 'nowrap',
   chevron = false,
-  className,
   ...restProps
 }: MiniInfoCellProps): React.ReactNode => {
   const cellClasses = classNames(
     styles.host,
     stylesTextWrap[textWrap],
     mode !== 'base' && stylesMode[mode],
-    className,
   );
 
   const cellContent = (
@@ -91,7 +89,7 @@ export const MiniInfoCell = ({
   );
 
   return restProps.onClick ? (
-    <Tappable Component="div" role="button" {...restProps} className={cellClasses}>
+    <Tappable Component="div" role="button" {...restProps} baseClassName={cellClasses}>
       {cellContent}
     </Tappable>
   ) : (

--- a/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
+++ b/packages/vkui/src/components/ModalCardBase/ModalCardBase.tsx
@@ -97,7 +97,6 @@ export const ModalCardBase = ({
   actions,
   onClose,
   dismissLabel = 'Скрыть',
-  style,
   size: sizeProp,
   modalDismissButtonTestId,
   dismissButtonMode = 'outside',
@@ -125,9 +124,8 @@ export const ModalCardBase = ({
         isDesktop && styles.desktop,
         withSafeZone && styles.withSafeZone,
       )}
-      style={{
+      baseStyle={{
         maxWidth: size,
-        ...style,
       }}
     >
       <div

--- a/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.tsx
+++ b/packages/vkui/src/components/ModalDismissButton/ModalDismissButton.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Icon20Cancel } from '@vkontakte/icons';
-import { classNames } from '@vkontakte/vkjs';
 import { Tappable, type TappableProps } from '../Tappable/Tappable';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './ModalDismissButton.module.css';
@@ -12,12 +11,11 @@ export type ModalDismissButtonProps = Omit<TappableProps, 'mode' | 'onClose'>;
  */
 export const ModalDismissButton = ({
   children = 'Закрыть',
-  className,
   ...restProps
 }: ModalDismissButtonProps): React.ReactNode => {
   return (
     <Tappable
-      className={classNames(styles.host, className)}
+      baseClassName={styles.host}
       {...restProps}
       activeMode={styles.active}
       hoverMode={styles.hover}

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { hasReactNode } from '@vkontakte/vkjs';
+import { mergeStyle } from '../../helpers/mergeStyle';
 import { useExternRef } from '../../hooks/useExternRef';
 import { usePatchChildren } from '../../hooks/usePatchChildren';
 import { createPortal } from '../../lib/createPortal';
@@ -137,17 +138,13 @@ export const OnboardingTooltip = ({
       floatingDataY,
     );
 
-    if (styleProp) {
-      Object.assign(floatingStyle, styleProp);
-    }
-
     tooltip = createPortal(
       <>
         <TooltipBase
           {...restProps}
           id={tooltipId}
           getRootRef={tooltipRef}
-          style={floatingStyle}
+          style={mergeStyle(floatingStyle, styleProp)}
           maxWidth={maxWidth}
           arrowProps={
             disableArrow

--- a/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
+++ b/packages/vkui/src/components/PanelHeaderButton/PanelHeaderButton.tsx
@@ -49,7 +49,6 @@ export const PanelHeaderButton = ({
   children,
   primary = false,
   label,
-  className,
   ...restProps
 }: PanelHeaderButtonProps): React.ReactNode => {
   const isPrimitive = isPrimitiveReactNode(children);
@@ -95,14 +94,13 @@ export const PanelHeaderButton = ({
       hoverMode={hoverMode}
       activeEffectDelay={200}
       activeMode={activeMode}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         platformClassNames.hasOwnProperty(platform)
           ? platformClassNames[platform]
           : platformClassNames.android,
         onlyPrimitive && styles.primitive,
         !isPrimitive && !isPrimitiveLabel && styles.notPrimitive,
-        className,
       )}
     >
       {isPrimitive ? <ButtonTypography primary={primary}>{children}</ButtonTypography> : children}

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { mergeStyle } from '../../helpers/mergeStyle';
 import { useExternRef } from '../../hooks/useExternRef';
 import {
   autoUpdateFloatingElement,
@@ -113,7 +112,6 @@ export const Popper = ({
   getRootRef,
   children,
   usePortal = true,
-  style: styleProp,
   onPlacementChange,
   ...restProps
 }: PopperProps): React.ReactNode => {
@@ -166,15 +164,12 @@ export const Popper = ({
       {...restProps}
       baseClassName={styles.host}
       getRootRef={handleRootRef}
-      style={mergeStyle(
-        convertFloatingDataToReactCSSProperties(
-          floatingPositionStrategy,
-          floatingDataX,
-          floatingDataY,
-          sameWidth ? null : undefined,
-          middlewareData,
-        ),
-        styleProp,
+      baseStyle={convertFloatingDataToReactCSSProperties(
+        floatingPositionStrategy,
+        floatingDataX,
+        floatingDataY,
+        sameWidth ? null : undefined,
+        middlewareData,
       )}
     >
       {arrow && (

--- a/packages/vkui/src/components/Progress/Progress.tsx
+++ b/packages/vkui/src/components/Progress/Progress.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { clamp } from '../../helpers/math';
-import { mergeStyle } from '../../helpers/mergeStyle';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Progress.module.css';
@@ -43,7 +42,6 @@ export const Progress = ({
   value = 0,
   appearance = 'accent',
   height,
-  style,
   ...restProps
 }: ProgressProps): React.ReactNode => {
   const progress = clamp(value, PROGRESS_MIN_VALUE, PROGRESS_MAX_VALUE);
@@ -54,12 +52,12 @@ export const Progress = ({
     <RootComponent
       aria-valuenow={value}
       title={title}
-      style={mergeStyle(styleHeight, style)}
       {...restProps}
       role="progressbar"
       aria-valuemin={PROGRESS_MIN_VALUE}
       aria-valuemax={PROGRESS_MAX_VALUE}
       baseClassName={classNames(styles.host, stylesAppearance[appearance])}
+      baseStyle={styleHeight}
     >
       <div className={styles.in} style={{ width: `${progress}%` }} />
     </RootComponent>

--- a/packages/vkui/src/components/RichCell/RichCell.tsx
+++ b/packages/vkui/src/components/RichCell/RichCell.tsx
@@ -89,7 +89,6 @@ export const RichCell: React.FC<RichCellProps> & {
   bottom,
   actions,
   multiline,
-  className,
   afterAlign = 'start',
   ...restProps
 }: RichCellProps) => {
@@ -110,11 +109,10 @@ export const RichCell: React.FC<RichCellProps> & {
   return (
     <Tappable
       {...restProps}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         !multiline && styles.textEllipsis,
         sizeY !== 'regular' && sizeYClassNames[sizeY],
-        className,
       )}
     >
       {before && <div className={styles.before}>{before}</div>}

--- a/packages/vkui/src/components/RootComponent/RootComponent.tsx
+++ b/packages/vkui/src/components/RootComponent/RootComponent.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
+import { mergeStyle } from '../../helpers/mergeStyle';
 import type { HasComponent, HasRootRef } from '../../types';
 import styles from './RootComponent.module.css';
 
@@ -8,6 +9,7 @@ export interface RootComponentProps<T>
     HasRootRef<T>,
     HasComponent {
   baseClassName?: string | false;
+  baseStyle?: React.CSSProperties;
 }
 
 /**
@@ -17,6 +19,8 @@ export const RootComponent = <T,>({
   Component = 'div',
   baseClassName,
   className,
+  baseStyle,
+  style,
   getRootRef,
   ...restProps
 }: RootComponentProps<T>): React.ReactNode => (
@@ -28,6 +32,7 @@ export const RootComponent = <T,>({
       styles.host,
       restProps.hidden === true && styles.hidden,
     )}
+    style={mergeStyle(baseStyle, style)}
     {...restProps}
   />
 );

--- a/packages/vkui/src/components/Separator/Separator.tsx
+++ b/packages/vkui/src/components/Separator/Separator.tsx
@@ -1,5 +1,4 @@
 import { classNames } from '@vkontakte/vkjs';
-import { mergeStyle } from '../../helpers/mergeStyle';
 import { resolveSpacingSize, type SpacingSizeProp } from '../../lib/spacings/sizes';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -56,7 +55,6 @@ export const Separator = ({
   appearance = 'primary',
   direction = 'horizontal',
   align = 'center',
-  style,
   size,
   ...restProps
 }: SeparatorProps): React.ReactNode => {
@@ -75,7 +73,7 @@ export const Separator = ({
         align !== 'center' && alignClassNames[align],
         spacingSizeClassName,
       )}
-      style={mergeStyle(spacingSizeStyle, style)}
+      baseStyle={spacingSizeStyle}
     >
       <hr className={styles.in} />
     </RootComponent>

--- a/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
+++ b/packages/vkui/src/components/SimpleCell/SimpleCell.tsx
@@ -98,7 +98,6 @@ export const SimpleCell = ({
   overTitle,
   subtitle,
   extraSubtitle,
-  className,
   chevronSize = 'm',
   ...restProps
 }: SimpleCellProps): React.ReactNode => {
@@ -112,12 +111,11 @@ export const SimpleCell = ({
   return (
     <Tappable
       {...restProps}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         restProps.disabled && styles.disabled,
         sizeY !== 'regular' && sizeYClassNames[sizeY],
         multiline && styles.mult,
-        className,
       )}
     >
       <div className={classNames(styles.before, platform === 'ios' && styles.beforeIos)}>

--- a/packages/vkui/src/components/SimpleGrid/SimpleGrid.tsx
+++ b/packages/vkui/src/components/SimpleGrid/SimpleGrid.tsx
@@ -1,5 +1,4 @@
 import { classNames } from '@vkontakte/vkjs';
-import { mergeStyle } from '../../helpers/mergeStyle';
 import {
   calculateGap,
   columnGapClassNames,
@@ -57,7 +56,6 @@ export interface SimpleGridProps extends Omit<RootComponentProps<HTMLElement>, '
 export const SimpleGrid = ({
   columns = 1,
   gap,
-  style: styleProp,
   margin = 'none',
   minColWidth,
   align = 'stretch',
@@ -87,7 +85,7 @@ export const SimpleGrid = ({
         typeof columnGap === 'string' && columnGapClassNames[columnGap],
         typeof rowGap === 'string' && rowGapClassNames[rowGap],
       )}
-      style={mergeStyle(style, styleProp)}
+      baseStyle={style}
     />
   );
 };

--- a/packages/vkui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/vkui/src/components/Skeleton/Skeleton.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { millisecondsInSecond } from 'date-fns/constants';
-import { mergeStyle } from '../../helpers/mergeStyle';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useGlobalEventListener } from '../../hooks/useGlobalEventListener';
 import { useStateWithPrev } from '../../hooks/useStateWithPrev';
@@ -140,7 +139,6 @@ export const Skeleton = ({
   maxWidth,
   maxInlineSize,
   borderRadius,
-  style,
   children,
   colorFrom,
   colorTo,
@@ -184,7 +182,7 @@ export const Skeleton = ({
       getRootRef={rootRef}
       Component="span"
       baseClassName={classNames(styles.host, disableAnimation && styles.disableAnimation)}
-      style={mergeStyle(skeletonStyle, style)}
+      baseStyle={skeletonStyle}
       {...restProps}
     >
       {children || <>&zwnj;</>}

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -96,7 +96,6 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
   mode = 'default',
   subtitle,
   offsetY,
-  style,
   getRootRef,
   ...restProps
 }: SnackbarProps) => {
@@ -259,7 +258,7 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
         placementClassNames[placement],
         animationStateClassNames[animationState],
       )}
-      style={resolveOffsetYCssStyle(placement, style, offsetY)}
+      baseStyle={resolveOffsetYCssStyle(placement, offsetY)}
       getRootRef={rootRef}
     >
       <div

--- a/packages/vkui/src/components/Snackbar/utils.ts
+++ b/packages/vkui/src/components/Snackbar/utils.ts
@@ -5,21 +5,20 @@ import type { ShiftData, SnackbarPlacement } from './types';
 
 export function resolveOffsetYCssStyle(
   placement: SnackbarPlacement,
-  style?: React.CSSProperties,
   offsetY?: React.CSSProperties['inset'],
 ): React.CSSProperties | undefined {
   if (offsetY === undefined) {
-    return style;
+    return undefined;
   }
   switch (placement) {
     case 'top-start':
     case 'top':
     case 'top-end':
-      return { ...style, top: offsetY };
+      return { top: offsetY };
     case 'bottom-start':
     case 'bottom':
     case 'bottom-end':
-      return { ...style, bottom: offsetY };
+      return { bottom: offsetY };
   }
 }
 

--- a/packages/vkui/src/components/Spacing/Spacing.tsx
+++ b/packages/vkui/src/components/Spacing/Spacing.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { mergeStyle } from '../../helpers/mergeStyle';
 import { resolveSpacingSize, type SpacingSizeProp } from '../../lib/spacings/sizes';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -25,7 +24,7 @@ export interface SpacingProps extends HTMLAttributesWithRootRef<HTMLDivElement> 
 /**
  * @see https://vkcom.github.io/VKUI/#/Spacing
  */
-export const Spacing = ({ size = 'm', style, ...restProps }: SpacingProps): React.ReactNode => {
+export const Spacing = ({ size = 'm', ...restProps }: SpacingProps): React.ReactNode => {
   const [spacingSizeClassName, spacingSizeStyle] = resolveSpacingSize(
     CUSTOM_CSS_TOKEN_FOR_USER_GAP,
     size,
@@ -33,7 +32,7 @@ export const Spacing = ({ size = 'm', style, ...restProps }: SpacingProps): Reac
   return (
     <RootComponent
       {...restProps}
-      style={mergeStyle(spacingSizeStyle, style)}
+      baseStyle={spacingSizeStyle}
       baseClassName={classNames(styles.host, spacingSizeClassName)}
     />
   );

--- a/packages/vkui/src/components/SplitCol/SplitCol.tsx
+++ b/packages/vkui/src/components/SplitCol/SplitCol.tsx
@@ -78,7 +78,6 @@ export const SplitCol = (props: SplitColProps): React.ReactNode => {
     minWidth,
     animate: animateProp,
     fixed,
-    style,
     autoSpaced,
     stretchedOnMobile,
     getRootRef,
@@ -99,11 +98,10 @@ export const SplitCol = (props: SplitColProps): React.ReactNode => {
   return (
     <RootComponent
       {...restProps}
-      style={{
+      baseStyle={{
         width,
         maxWidth,
         minWidth,
-        ...style,
       }}
       getRootRef={baseRef}
       baseClassName={classNames(

--- a/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
+++ b/packages/vkui/src/components/SubnavigationButton/SubnavigationButton.tsx
@@ -83,7 +83,6 @@ export const SubnavigationButton = ({
   after,
   chevron,
   children,
-  className,
   ...restProps
 }: SubnavigationButtonProps): React.ReactNode => {
   const { sizeY = 'none' } = useAdaptivity();
@@ -93,14 +92,13 @@ export const SubnavigationButton = ({
       {...restProps}
       hasActive={false}
       focusVisibleMode="outside"
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         sizeStyles[size],
         modeStyles[mode],
         appearanceStyles[appearance],
         selected && styles.selected,
         sizeY !== 'regular' && sizeYClassNames[sizeY],
-        className,
       )}
     >
       <span className={styles.in}>

--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -80,7 +80,6 @@ export const TabsItem = ({
   status,
   after,
   selected = false,
-  className,
   role = 'tab',
   tabIndex: tabIndexProp,
   getRootRef,
@@ -184,14 +183,13 @@ export const TabsItem = ({
     <Tappable
       {...restProps}
       getRootRef={rootRef}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         mode && stylesMode[mode],
         selected && styles.selected,
         sizeY !== 'regular' && sizeYClassNames[sizeY],
         withGaps && styles.withGaps,
         layoutFillMode !== 'auto' && fillModeClassNames[layoutFillMode],
-        className,
       )}
       hoverMode={hoverMode}
       activeMode={activeMode}

--- a/packages/vkui/src/components/ToolButton/ToolButton.tsx
+++ b/packages/vkui/src/components/ToolButton/ToolButton.tsx
@@ -54,7 +54,6 @@ export const ToolButton = ({
   mode = 'primary',
   appearance = 'accent',
   direction = 'row',
-  className,
   children,
   IconCompact,
   IconRegular,
@@ -70,8 +69,7 @@ export const ToolButton = ({
       activeMode={styles.active}
       Component={restProps.href ? 'a' : 'button'}
       focusVisibleMode="outside"
-      className={classNames(
-        className,
+      baseClassName={classNames(
         styles.host,
         rounded && getRoundedClassName(direction, hasChildren),
         hasChildren && direction === 'row' && styles.withFakeEndIcon,

--- a/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
+++ b/packages/vkui/src/components/WriteBarIcon/WriteBarIcon.tsx
@@ -58,7 +58,6 @@ export const WriteBarIcon = ({
   mode,
   children,
   count,
-  className,
   label: labelProp,
   ...restProps
 }: WriteBarIconProps): React.ReactNode => {
@@ -112,12 +111,11 @@ export const WriteBarIcon = ({
       Component="button"
       hasHover={false}
       activeMode={styles.active}
-      className={classNames(
+      baseClassName={classNames(
         styles.host,
         platform === 'ios' && styles.ios,
         mode === 'send' && styles.modeSend,
         mode === 'done' && styles.modeDone,
-        className,
       )}
     >
       <span className={styles.in}>

--- a/packages/vkui/src/types.ts
+++ b/packages/vkui/src/types.ts
@@ -65,7 +65,10 @@ export type Exact<A, B> = A extends B ? B : never;
 /**
  * Для возможности указывать css custom properties
  */
-export type CSSCustomProperties<T extends string | undefined = string> = Record<`--${string}`, T>;
+export type CSSCustomProperties<T extends string | number | undefined = string> = Record<
+  `--${string}`,
+  T
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Nothing {}


### PR DESCRIPTION
- [ ] Unit-тесты
- [x] e2e-тесты
- [x] Дизайн-ревью
- [ ] Документация фичи
- [ ] Release notes

## Описание

В многих местах требуется мержить стили передаваемые выше, чаще всего это требуется на корневом элементе.

```jsx
const Component = ({style, ...props}) => <div
  style={{
    color: red,
    ...style,
  }}
  {...props}
/>
```

Также из-за проставления разного приоритета стилей, часто бывают баги

- #7854
- #7829
- #5504

## Изменения

- В RootComponent добавили свойство `baseStyle`
- Отрефачил стили
- Отрефачил класснеймы

## Release notes
-