### PR TITLE
fix: add use client for createContext

### DIFF
--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityContext.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import type { SizeTypeValues, ViewHeightType, ViewWidthType } from '../../lib/adaptivity';
 

--- a/packages/vkui/src/components/ColorSchemeProvider/ColorSchemeProvider.tsx
+++ b/packages/vkui/src/components/ColorSchemeProvider/ColorSchemeProvider.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+// TODO [@vkontakte/icons-sprite>=2.3.1]: Удалить use client, если он появился в IconAppearanceProvider
+
 import * as React from 'react';
 import { IconAppearanceProvider } from '@vkontakte/icons';
 import type { ColorSchemeType } from '../../lib/colorScheme';

--- a/packages/vkui/src/components/ConfigProvider/ConfigProviderContext.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProviderContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import type { ColorSchemeType } from '../../lib/colorScheme';
 import { platform, type PlatformType } from '../../lib/platform';

--- a/packages/vkui/src/components/ContentBadge/ContentBadgeContext.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadgeContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import type { ContentBadgeSizeType } from './types';
 

--- a/packages/vkui/src/components/ModalRoot/ModalRootContext.tsx
+++ b/packages/vkui/src/components/ModalRoot/ModalRootContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import type { ModalElements, ModalsStateEntry, ModalType } from './types';

--- a/packages/vkui/src/components/NavIdContext/NavIdContext.tsx
+++ b/packages/vkui/src/components/NavIdContext/NavIdContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 export const NavViewIdContext: React.Context<string | undefined> = React.createContext<

--- a/packages/vkui/src/components/ScreenSpinner/context.ts
+++ b/packages/vkui/src/components/ScreenSpinner/context.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { type ScreenSpinnerProps } from './types';
 


### PR DESCRIPTION
- fix #6288

---

- [x] Unit-тесты (не требуются)
- [x] e2e-тесты (не требуются)
- [x] Дизайн-ревью (не требуются)
- [x] Документация фичи (не требуются)
- [x] Release notes

## Описание

Отсутствуют директивы `"use client"` в местах использования `createContext`

## Изменения

Добавил директив. Требуется добавить их обработку в eslint-plugin-react-server-components

## Release notes
## Исправления
- Добавлены директивы `"use client"` в местах использования `createContext`
