### PR TITLE
docs: fix NativeSelect name

### DIFF
--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -32,6 +32,9 @@ export const NOT_SELECTED = {
   CUSTOM: null,
 };
 
+/**
+ * @visibleName NativeSelect
+ */
 export const remapFromSelectValueToNativeValue = (value: SelectValue): NativeSelectValue =>
   value === NOT_SELECTED.CUSTOM ? NOT_SELECTED.NATIVE : value;
 
@@ -78,7 +81,7 @@ export interface NativeSelectProps
 /**
  * @see https://vkcom.github.io/VKUI/#/NativeSelect
  */
-const NativeSelect = ({
+export const NativeSelect = ({
   style,
   align,
   placeholder,
@@ -168,5 +171,3 @@ const NativeSelect = ({
     </FormField>
   );
 };
-
-export { NativeSelect };


### PR DESCRIPTION
## Описание

`styleguidist` по умолчанию опирается на первый импорт чего-то, что напоминает реакт-компонент, поэтому иногда ловим артефакты с неправильным наименованием:

![image](https://github.com/user-attachments/assets/4fbbcbc2-6393-4a2a-9acb-2be14c4a6135)

Т.к. мы не можем влиять на это поведение извне, а уносить эту функцию в отдельный файл не очень хочется - пока оставляем "костыль" 🙃  

## Release notes

## Документация
 - NativeSelect: исправлено наименование компонента