### PR TITLE
fix(ModalCard): exclude unused `shouldPreserveSnapPoint`

### DIFF
--- a/packages/vkui/src/components/ModalCard/ModalCard.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.tsx
@@ -29,7 +29,11 @@ export const ModalCard = ({
   const generatingId = useId();
   const id = getNavId({ nav, id: idProp }, warn) || generatingId;
 
-  const { mounted, ...resolvedProps } = useModalManager({
+  const {
+    mounted,
+    shouldPreserveSnapPoint: excludedProp,
+    ...resolvedProps
+  } = useModalManager({
     id,
     open,
     keepMounted,


### PR DESCRIPTION
- caused by #6759

## Описание

Параметр попадал в DOM

## Release notes
## Исправления
- ModalCard: в **DOM** попадал параметр `shouldPreserveSnapPoint`, из-за чего **React** кидал предупреждение в консоль.