### PR TITLE
test(todo): mv getFake*Event to *EventMock

### DIFF
--- a/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
@@ -3,11 +3,11 @@ import { MEDIA_QUERIES, ViewWidth } from '../../lib/adaptivity';
 import {
   baselineComponent,
   fireEventPatch,
-  getFakeMouseEvent,
-  getFakeTouchEvent,
   matchMediaMock,
   mockRect,
+  mouseEventMock,
   requestAnimationFrameMock,
+  touchEventMock,
   userEvent,
   waitCSSKeyframesAnimation,
 } from '../../testing/utils';
@@ -270,9 +270,10 @@ function transformDomRectToEventData(
   { x = 0, y = 0 }: DOMRectInit,
 ) {
   const nativeEventType = eventType.toLowerCase();
-  return eventType.startsWith('touch')
-    ? { nativeEvent: getFakeTouchEvent(nativeEventType, x, y) }
-    : { nativeEvent: getFakeMouseEvent(nativeEventType, x, y) };
+  if (eventType.startsWith('touch')) {
+    return new TouchEvent(nativeEventType, touchEventMock({ clientX: x, clientY: y }));
+  }
+  return new MouseEvent(nativeEventType, mouseEventMock({ clientX: x, clientY: y }));
 }
 
 function getMovedContentRectByPlacement(

--- a/packages/vkui/src/lib/dom.test.ts
+++ b/packages/vkui/src/lib/dom.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent } from '@testing-library/react';
-import { getFakeMouseEvent, getFakeTouchEvent } from '../testing/utils';
+import { mouseEventMock, touchEventMock } from '../testing/utils';
 import {
   contains,
   getActiveElementByAnotherElement,
@@ -229,14 +229,20 @@ describe(contains, () => {
 });
 
 describe(getFirstTouchEventData, () => {
+  const createTouchEvent = (type: string, clientX: number, clientY: number) =>
+    new TouchEvent(type, touchEventMock({ clientX, clientY }));
+
+  const createMouserEvent = (type: string, clientX: number, clientY: number) =>
+    new MouseEvent(type, mouseEventMock({ clientX, clientY }));
+
   it.each([
-    { type: 'touchstart', event: getFakeTouchEvent('touchstart', 10, 10) },
-    { type: 'touchmove', event: getFakeTouchEvent('touchmove', 10, 10) },
-    { type: 'touchend', event: getFakeTouchEvent('touchend', 10, 10) },
-    { type: 'mousedown', event: getFakeMouseEvent('mousedown', 10, 10) },
-    { type: 'mousemove', event: getFakeMouseEvent('mousemove', 10, 10) },
-    { type: 'mouseup', event: getFakeMouseEvent('mouseup', 10, 10) },
-    { type: 'mouseleave', event: getFakeMouseEvent('mouseleave', 10, 10) },
+    { type: 'touchstart', event: createTouchEvent('touchstart', 10, 10) },
+    { type: 'touchmove', event: createTouchEvent('touchmove', 10, 10) },
+    { type: 'touchend', event: createTouchEvent('touchend', 10, 10) },
+    { type: 'mousedown', event: createMouserEvent('mousedown', 10, 10) },
+    { type: 'mousemove', event: createMouserEvent('mousemove', 10, 10) },
+    { type: 'mouseup', event: createMouserEvent('mouseup', 10, 10) },
+    { type: 'mouseleave', event: createMouserEvent('mouseleave', 10, 10) },
   ])('should return touch data for expected event type (#type)', ({ event }) => {
     const { clientX, clientY } = getFirstTouchEventData(event);
     expect(clientX).toBe(10);

--- a/packages/vkui/src/lib/sheet/useBottomSheet.test.tsx
+++ b/packages/vkui/src/lib/sheet/useBottomSheet.test.tsx
@@ -1,7 +1,7 @@
 import { act } from 'react';
 import { fireEvent, render, renderHook } from '@testing-library/react';
 import { clamp } from '../../helpers/math';
-import { requestAnimationFrameMock } from '../../testing/utils';
+import { requestAnimationFrameMock, touchEventMock } from '../../testing/utils';
 import { rubberbandIfOutOfBounds } from '../animation';
 import {
   BLOCK_SHEET_BEHAVIOR_DATA_ATTRIBUTE,
@@ -875,34 +875,3 @@ describe(useBottomSheet, () => {
     });
   });
 });
-
-/**
- * TODO перенести в ../../testing/utils и для замены getFakeTouchEvent
- */
-function touchEventMock(dataRaw: Partial<Touch>) {
-  const data = {
-    identifier: 0,
-    screenX: 0,
-    screenY: 0,
-    pageX: 0,
-    pageY: 0,
-    radiusX: 0,
-    radiusY: 0,
-    force: 0,
-    rotationAngle: 0,
-    target: new EventTarget(),
-    ...dataRaw,
-  };
-  const touch = {
-    clientX: 0,
-    clientY: 0,
-    ...data,
-  };
-  return {
-    ...data,
-    changedTouches: [touch],
-    touches: [touch],
-    bubbles: true,
-    cancelable: true,
-  };
-}

--- a/packages/vkui/src/lib/touch/UIPanGestureRecognizer.test.ts
+++ b/packages/vkui/src/lib/touch/UIPanGestureRecognizer.test.ts
@@ -1,10 +1,13 @@
-import { getFakeTouchEvent } from '../../testing/utils';
+import { touchEventMock } from '../../testing/utils';
 import { UIPanGestureRecognizer } from './UIPanGestureRecognizer';
+
+const createTouchEvent = (type: string, clientX: number, clientY: number) =>
+  new TouchEvent(type, touchEventMock({ clientX, clientY }));
 
 describe(UIPanGestureRecognizer, () => {
   it('should set start coords', () => {
     const panGestureRecognizer = new UIPanGestureRecognizer();
-    panGestureRecognizer.setStartCoords(getFakeTouchEvent('touchstart', 10, 10));
+    panGestureRecognizer.setStartCoords(createTouchEvent('touchstart', 10, 10));
     expect(panGestureRecognizer.x1).toBe(10);
     expect(panGestureRecognizer.y1).toBe(10);
     expect(panGestureRecognizer.x2).toBe(0);
@@ -13,7 +16,7 @@ describe(UIPanGestureRecognizer, () => {
 
   it('should set end coords', () => {
     const panGestureRecognizer = new UIPanGestureRecognizer();
-    panGestureRecognizer.setEndCoords(getFakeTouchEvent('touchmove', 10, 10));
+    panGestureRecognizer.setEndCoords(createTouchEvent('touchmove', 10, 10));
 
     expect(panGestureRecognizer.x1).toBe(0);
     expect(panGestureRecognizer.y1).toBe(0);
@@ -23,31 +26,31 @@ describe(UIPanGestureRecognizer, () => {
 
   it('should calculate delta', () => {
     const panGestureRecognizer = new UIPanGestureRecognizer();
-    panGestureRecognizer.setStartCoords(getFakeTouchEvent('touchstart', 5, 5));
-    panGestureRecognizer.setEndCoords(getFakeTouchEvent('touchmove', 8, 8));
+    panGestureRecognizer.setStartCoords(createTouchEvent('touchstart', 5, 5));
+    panGestureRecognizer.setEndCoords(createTouchEvent('touchmove', 8, 8));
 
     expect(panGestureRecognizer.delta()).toEqual({ x: 3, y: 3 });
   });
 
   it('should calculate distance', () => {
     const panGestureRecognizer = new UIPanGestureRecognizer();
-    panGestureRecognizer.setStartCoords(getFakeTouchEvent('touchstart', 5, 5));
-    panGestureRecognizer.setEndCoords(getFakeTouchEvent('touchmove', 8, 8));
+    panGestureRecognizer.setStartCoords(createTouchEvent('touchstart', 5, 5));
+    panGestureRecognizer.setEndCoords(createTouchEvent('touchmove', 8, 8));
 
     expect(panGestureRecognizer.distance()).toBe(Math.sqrt(Math.pow(3, 2) + Math.pow(3, 2)));
   });
 
   it.each([
-    { event: getFakeTouchEvent('touchmove', 0, 0), angle: 0 },
-    { event: getFakeTouchEvent('touchmove', 5, 0), angle: 0 },
-    { event: getFakeTouchEvent('touchmove', 5, 5), angle: 45 },
-    { event: getFakeTouchEvent('touchmove', 0, 5), angle: 90 },
-    { event: getFakeTouchEvent('touchmove', -5, 0), angle: 180 },
-    { event: getFakeTouchEvent('touchmove', -5, -5), angle: 225 },
-    { event: getFakeTouchEvent('touchmove', 0, -5), angle: 270 },
+    { event: createTouchEvent('touchmove', 0, 0), angle: 0 },
+    { event: createTouchEvent('touchmove', 5, 0), angle: 0 },
+    { event: createTouchEvent('touchmove', 5, 5), angle: 45 },
+    { event: createTouchEvent('touchmove', 0, 5), angle: 90 },
+    { event: createTouchEvent('touchmove', -5, 0), angle: 180 },
+    { event: createTouchEvent('touchmove', -5, -5), angle: 225 },
+    { event: createTouchEvent('touchmove', 0, -5), angle: 270 },
   ])('should calculate angle', ({ event, angle }) => {
     const panGestureRecognizer = new UIPanGestureRecognizer();
-    panGestureRecognizer.setStartCoords(getFakeTouchEvent('touchstart', 0, 0));
+    panGestureRecognizer.setStartCoords(createTouchEvent('touchstart', 0, 0));
 
     panGestureRecognizer.setEndCoords(event);
     expect(panGestureRecognizer.angle()).toBe(angle);
@@ -57,8 +60,8 @@ describe(UIPanGestureRecognizer, () => {
     jest.useFakeTimers();
 
     const panGestureRecognizer = new UIPanGestureRecognizer();
-    panGestureRecognizer.setStartCoords(getFakeTouchEvent('touchstart', 0, 0));
-    panGestureRecognizer.setEndCoords(getFakeTouchEvent('touchmove', 10, 10));
+    panGestureRecognizer.setStartCoords(createTouchEvent('touchstart', 0, 0));
+    panGestureRecognizer.setEndCoords(createTouchEvent('touchmove', 10, 10));
 
     jest.setSystemTime(new Date('1970-01-01T00:00:00'));
     panGestureRecognizer.setInitialTimeOnce();
@@ -72,8 +75,8 @@ describe(UIPanGestureRecognizer, () => {
 
   it('should reset coords', () => {
     const panGestureRecognizer = new UIPanGestureRecognizer();
-    panGestureRecognizer.setStartCoords(getFakeTouchEvent('touchstart', 10, 10));
-    panGestureRecognizer.setEndCoords(getFakeTouchEvent('touchmove', 10, 10));
+    panGestureRecognizer.setStartCoords(createTouchEvent('touchstart', 10, 10));
+    panGestureRecognizer.setEndCoords(createTouchEvent('touchmove', 10, 10));
 
     panGestureRecognizer.reset();
     expect(panGestureRecognizer.x1).toBe(0);

--- a/packages/vkui/src/testing/utils.tsx
+++ b/packages/vkui/src/testing/utils.tsx
@@ -434,51 +434,49 @@ export const matchMediaMock = (queries?: string | string[]) => {
   });
 };
 
-export function getFakeTouchEvent(
-  type: string,
-  clientX: number,
-  clientY: number,
-  rest?: Partial<Omit<Touch, 'clientX' | 'clientY'>>,
-) {
-  const touch = {
+export function touchEventMock({ target = new EventTarget(), ...dataRaw }: Partial<Touch>) {
+  const touch: Touch = {
     identifier: 0,
-    screenX: 0,
-    screenY: 0,
+    clientX: 0,
+    clientY: 0,
     pageX: 0,
     pageY: 0,
+    screenY: 0,
+    screenX: 0,
     radiusX: 0,
     radiusY: 0,
     force: 0,
     rotationAngle: 0,
-    target: new EventTarget(),
-    ...rest,
-    clientX,
-    clientY,
+    target,
+    ...dataRaw,
   };
-  return new TouchEvent(type, {
+  return {
+    ...touch,
     changedTouches: [touch],
     touches: [touch],
     bubbles: true,
     cancelable: true,
-  });
+
+    // для fireEvent
+    target,
+  };
 }
 
-export function getFakeMouseEvent(
-  type: string,
-  clientX: number,
-  clientY: number,
-  rest?: Partial<Omit<MouseEvent, 'clientX' | 'clientY'>>,
-) {
-  return new MouseEvent(type, {
-    movementX: 0,
-    movementY: 0,
+export function mouseEventMock({
+  target = new EventTarget(),
+  ...dataRaw
+}: Partial<MouseEventInit & { target: any }>): MouseEventInit & { target: any } {
+  return {
     screenX: 0,
     screenY: 0,
-    relatedTarget: new EventTarget(),
-    ...rest,
-    clientX,
-    clientY,
-    bubbles: true,
-    cancelable: true,
-  });
+    movementX: 0,
+    movementY: 0,
+    clientX: 0,
+    clientY: 0,
+    relatedTarget: null,
+    ...dataRaw,
+
+    // для fireEvent
+    target,
+  };
 }


### PR DESCRIPTION
## Описание

Зарезолвил TODO в тесте `useBottomSheet()`, который оставлял в #6759

Упростил `getFakeTouchEvent` и `getFakeMouseEvent` до функций, которые возвращают объект.

Заметил, что если вторым аргументом в `fireEvent` из `testing-library/react` передавать объект события, то он работает не корректно – лучше передавать сразу опции, которые принимают те или иные события.

## Release notes
-
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
