### PR TITLE
feat(HorizontalScroll/CardScroll): Rename testId props to prevButton/nextButton

### DIFF
--- a/packages/vkui/src/components/CardScroll/CardScroll.test.tsx
+++ b/packages/vkui/src/components/CardScroll/CardScroll.test.tsx
@@ -67,7 +67,7 @@ type PrepareDataParams = {
 
 const setup = ({ defaultScrollLeft = 50, cardsCount = 6 }: PrepareDataParams) => {
   const { container } = render(
-    <CardScroll size="s" startArrowTestId="ScrollArrowLeft" endArrowTestId="ScrollArrowRight">
+    <CardScroll size="s" prevButtonTestId="ScrollArrowLeft" nextButtonTestId="ScrollArrowRight">
       {new Array(cardsCount).fill(0).map((_, index) => (
         <div key={index} data-testid={`card-${index}`}></div>
       ))}

--- a/packages/vkui/src/components/CardScroll/CardScroll.tsx
+++ b/packages/vkui/src/components/CardScroll/CardScroll.tsx
@@ -17,7 +17,7 @@ const stylesSize = {
 export interface CardScrollProps
   extends HTMLAttributesWithRootRef<HTMLDivElement>,
     HasComponent,
-    Pick<HorizontalScrollProps, 'showArrows' | 'startArrowTestId' | 'endArrowTestId'> {
+    Pick<HorizontalScrollProps, 'showArrows' | 'prevButtonTestId' | 'nextButtonTestId'> {
   /**
    * При `size=false` ширина `Card` будет регулироваться контентом внутри. В остальных случаях — будет явно задана в процентах.
    */
@@ -37,8 +37,8 @@ export const CardScroll = ({
   showArrows = true,
   padding = false,
   Component = 'ul',
-  startArrowTestId,
-  endArrowTestId,
+  prevButtonTestId,
+  nextButtonTestId,
   ...restProps
 }: CardScrollProps): React.ReactNode => {
   const refContainer = React.useRef<HTMLDivElement>(null);
@@ -113,8 +113,8 @@ export const CardScroll = ({
         getScrollToLeft={getScrollToLeft}
         getScrollToRight={getScrollToRight}
         showArrows={showArrows}
-        startArrowTestId={startArrowTestId}
-        endArrowTestId={endArrowTestId}
+        prevButtonTestId={prevButtonTestId}
+        nextButtonTestId={nextButtonTestId}
       >
         <div className={styles.in} ref={refContainer}>
           <span className={styles.gap} ref={gapRef} />

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
@@ -59,7 +59,7 @@ describe('HorizontalScroll', () => {
       <HorizontalScroll
         getRef={mockRef}
         data-testid="horizontal-scroll"
-        endArrowTestId="scroll-arrow-right"
+        nextButtonTestId="scroll-arrow-right"
       >
         <div style={{ width: '800px', height: '50px' }} />
       </HorizontalScroll>,
@@ -109,7 +109,7 @@ describe('HorizontalScroll', () => {
       <HorizontalScroll
         getRef={ref}
         data-testid="horizontal-scroll"
-        endArrowTestId="scroll-arrow-right"
+        nextButtonTestId="scroll-arrow-right"
       >
         <div style={{ width: '1800px', height: '50px' }} />
       </HorizontalScroll>,
@@ -137,7 +137,7 @@ describe('HorizontalScroll', () => {
       <HorizontalScroll
         getRef={ref}
         data-testid="horizontal-scroll"
-        startArrowTestId="scroll-arrow-left"
+        prevButtonTestId="scroll-arrow-left"
       >
         <div style={{ width: '1800px', height: '50px' }} />
       </HorizontalScroll>,
@@ -170,8 +170,8 @@ describe('HorizontalScroll', () => {
         data-testid="horizontal-scroll"
         getScrollToLeft={(left) => left - 100}
         getScrollToRight={(left) => left + 250}
-        startArrowTestId="scroll-arrow-left"
-        endArrowTestId="scroll-arrow-right"
+        prevButtonTestId="scroll-arrow-left"
+        nextButtonTestId="scroll-arrow-right"
       >
         <div style={{ width: '1800px', height: '50px' }} />
       </HorizontalScroll>,
@@ -204,8 +204,8 @@ describe('HorizontalScroll', () => {
       <HorizontalScroll
         getRef={ref}
         data-testid="horizontal-scroll"
-        startArrowTestId="scroll-arrow-left"
-        endArrowTestId="scroll-arrow-right"
+        prevButtonTestId="scroll-arrow-left"
+        nextButtonTestId="scroll-arrow-right"
       >
         <div style={{ width: '1800px', height: '50px' }} />
       </HorizontalScroll>,

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -53,13 +53,13 @@ export interface HorizontalScrollProps
    */
   scrollOnAnyWheel?: boolean;
   /**
-   * Передает атрибут `data-testid` для кнопки прокрутки горизонтального скролла в направлении начала
+   * Передает атрибут `data-testid` для кнопки прокрутки горизонтального скролла в направлении предыдущего элемента
    */
-  startArrowTestId?: string;
+  prevButtonTestId?: string;
   /**
-   * Передает атрибут `data-testid` для кнопки прокрутки горизонтального скролла в направлении конца
+   * Передает атрибут `data-testid` для кнопки прокрутки горизонтального скролла в направлении следующего элемента
    */
-  endArrowTestId?: string;
+  nextButtonTestId?: string;
 }
 
 /**
@@ -175,8 +175,8 @@ export const HorizontalScroll = ({
   scrollAnimationDuration = SCROLL_ONE_FRAME_TIME,
   getRef,
   scrollOnAnyWheel = false,
-  startArrowTestId,
-  endArrowTestId,
+  prevButtonTestId,
+  nextButtonTestId,
   ...restProps
 }: HorizontalScrollProps): React.ReactNode => {
   const [canScrollLeft, setCanScrollLeft] = React.useState(false);
@@ -283,7 +283,7 @@ export const HorizontalScroll = ({
     >
       {showArrows && (hasPointer || hasPointer === undefined) && canScrollLeft && (
         <ScrollArrow
-          data-testid={startArrowTestId}
+          data-testid={prevButtonTestId}
           size={arrowSize}
           offsetY={arrowOffsetY}
           direction="left"
@@ -296,7 +296,7 @@ export const HorizontalScroll = ({
       )}
       {showArrows && (hasPointer || hasPointer === undefined) && canScrollRight && (
         <ScrollArrow
-          data-testid={endArrowTestId}
+          data-testid={nextButtonTestId}
           size={arrowSize}
           offsetY={arrowOffsetY}
           direction="right"


### PR DESCRIPTION
- related https://github.com/VKCOM/VKUI/pull/8032

---
- [x] Unit-тесты
- [x] Release notes | оставлю пустым, и отредактирую Rease Notes из #8032 руками 

## Описание
В [комментарии](https://github.com/VKCOM/VKUI/pull/8032#issuecomment-2532013976) @inomdzhon обратил внимание на то, что мы придерживаемся других имен для кнопок переключения вперёд/назад. 
> в случае HorizontalScroll и CardScroll по семантике не стоило ли назвать prevArrowTestId и nextArrowTestId?
>
> UPD
> или prevButtonTestId и nextButtonTestId

Например, в Calendar или Pagination мы используем `prevButton`/`nextButton` а не названия из логических свойств.
https://github.com/VKCOM/VKUI/blob/ef2d07e80aaab4505e743aa364f1f0a766d0e0d9/packages/vkui/src/components/Calendar/Calendar.tsx#L140-L141
https://github.com/VKCOM/VKUI/blob/ef2d07e80aaab4505e743aa364f1f0a766d0e0d9/packages/vkui/src/components/Pagination/Pagination.tsx#L128-L129

## Release notes
-
