### PR TITLE
build(deps-dev): Bump prettier to 3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "postcss-logical": "^8.0.0",
     "postcss-modules": "^6.0.1",
     "postcss-value-parser": "^4.2.0",
-    "prettier": "^3.3.2",
+    "prettier": "^3.4.2",
     "process": "^0.11.10",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.module.css
+++ b/packages/vkui/src/components/Snackbar/subcomponents/Basic/Basic.module.css
@@ -1,9 +1,11 @@
 .body {
   --vkui_internal--snackbar-body_layout_vertical_action_shift: calc(
-    -1 * (
+    -1 *
+      (
         var(--vkui--size_button_small_height--compact) -
           var(--vkui--font_subhead--line_height--compact)
-      ) / 2
+      ) /
+      2
   );
 
   box-sizing: border-box;
@@ -18,20 +20,24 @@
 
 .sizeYRegular {
   --vkui_internal--snackbar-body_layout_vertical_action_shift: calc(
-    -1 * (
+    -1 *
+      (
         var(--vkui--size_button_small_height--regular) -
           var(--vkui--font_subhead--line_height--regular)
-      ) / 2
+      ) /
+      2
   );
 }
 
 @media (--sizeY-regular) {
   .sizeYNone {
     --vkui_internal--snackbar-body_layout_vertical_action_shift: calc(
-      -1 * (
+      -1 *
+        (
           var(--vkui--size_button_small_height--regular) -
             var(--vkui--font_subhead--line_height--regular)
-        ) / 2
+        ) /
+        2
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4385,7 +4385,7 @@ __metadata:
     postcss-logical: "npm:^8.0.0"
     postcss-modules: "npm:^6.0.1"
     postcss-value-parser: "npm:^4.2.0"
-    prettier: "npm:^3.3.2"
+    prettier: "npm:^3.4.2"
     process: "npm:^0.11.10"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -13737,12 +13737,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.3.2":
-  version: 3.3.3
-  resolution: "prettier@npm:3.3.3"
+"prettier@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "prettier@npm:3.4.2"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10/5beac1f30b5b40162532b8e2f7c3a4eb650910a2695e9c8512a62ffdc09dae93190c29db9107fa7f26d1b6c71aad3628ecb9b5de1ecb0911191099be109434d7
+  checksum: 10/a3e806fb0b635818964d472d35d27e21a4e17150c679047f5501e1f23bd4aa806adf660f0c0d35214a210d5d440da6896c2e86156da55f221a57938278dc326e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Описание

Обновляем prettier до 3.4.2, в нем есть поддержка require(ESM) которую включили в node 22.12.0

## Release notes
-