### PR TITLE
build(deps): Ignore 0.0.0-experimental-* compiler version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       # Игнорируем https://www.npmjs.com/package/eslint-plugin-react-compiler/v/0.0.0 (это самый первый релиз),
       # чтобы использовать только экспериментальные версии и версии выше.
       - dependency-name: 'eslint-plugin-react-compiler'
-        versions: ['0.0.0', '0.0.0-experimental-7670337-20240918']
+        versions: ['0.0.0', '0.0.0-experimental-*']
     groups:
       react:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,9 @@ updates:
       - dependency-name: '@types/react*'
         update-types: ['version-update:semver-major']
       # Игнорируем https://www.npmjs.com/package/eslint-plugin-react-compiler/v/0.0.0 (это самый первый релиз),
-      # чтобы использовать только экспериментальные версии и версии выше.
+      # и экспериментальные версии, так как они слишком нестабильные.
       - dependency-name: 'eslint-plugin-react-compiler'
-        versions: ['0.0.0', '0.0.0-experimental-*']
+        versions: ['<0.0.1']
     groups:
       react:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       # Игнорируем https://www.npmjs.com/package/eslint-plugin-react-compiler/v/0.0.0 (это самый первый релиз),
       # чтобы использовать только экспериментальные версии и версии выше.
       - dependency-name: 'eslint-plugin-react-compiler'
-        versions: ['0.0.0']
+        versions: ['0.0.0', '0.0.0-experimental-7670337-20240918']
     groups:
       react:
         patterns:


### PR DESCRIPTION
Попытка проигнорировать экспериментальные версии react-compiler, чтобы упростить обновление группы `eslint` с `dependabot`.


- see https://github.com/VKCOM/VKUI/pull/7643#issuecomment-2368477097 – здесь полный лог ошибок
- related to https://github.com/facebook/react/issues/30782, https://github.com/facebook/react/issues/31330
- related to https://github.com/VKCOM/VKUI/pull/8073