### PR TITLE
chore: fix next integration

### DIFF
--- a/packages/vkui/src/components/Calendar/Calendar.test.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { format } from 'date-fns';
-import { baselineComponent, userEvent } from '../../testing/utils';
+import { baselineComponent, setNodeEnv, userEvent } from '../../testing/utils';
 import { Calendar } from './Calendar';
 
 const targetDate = new Date('2023-09-20T07:40:00.000Z');
@@ -13,9 +13,6 @@ const dayTestId = (day: Date) => format(day, 'dd.MM.yyyy');
 
 describe('Calendar', () => {
   baselineComponent(Calendar);
-
-  beforeEach(() => (process.env.NODE_ENV = 'development'));
-  afterEach(() => (process.env.NODE_ENV = 'test'));
 
   it('fires onChange', () => {
     const onChange = jest.fn();
@@ -103,30 +100,31 @@ describe('Calendar', () => {
     expect(screen.getByTestId(monthDropdownTestId(8))).toBeInTheDocument();
   });
 
-  it('check calls Calendar DEV errors', () => {
-    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
+  describe('DEV errors', () => {
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
 
-    process.env.NODE_ENV = 'development';
+    it('check calls Calendar', () => {
+      const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
 
-    const { rerender } = render(<Calendar value={lastDayDate} disablePickers={false} size="s" />);
+      const { rerender } = render(<Calendar value={lastDayDate} disablePickers={false} size="s" />);
 
-    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
-    expect(consoleErrorMock).toHaveBeenCalledWith(
-      "%c[VKUI/Calendar] Нельзя включить селекты выбора месяца/года, если размер календаря 's'",
-      undefined,
-    );
-
-    rerender(<Calendar value={lastDayDate} enableTime size="s" />);
-
-    expect(consoleErrorMock).toHaveBeenCalledTimes(2);
-    expect(consoleErrorMock.mock.calls).toEqual([
-      [
+      expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+      expect(consoleErrorMock).toHaveBeenCalledWith(
         "%c[VKUI/Calendar] Нельзя включить селекты выбора месяца/года, если размер календаря 's'",
         undefined,
-      ],
-      ["%c[VKUI/Calendar] Нельзя включить выбор времени, если размер календаря 's'", undefined],
-    ]);
+      );
 
-    process.env.NODE_ENV = 'test';
+      rerender(<Calendar value={lastDayDate} enableTime size="s" />);
+
+      expect(consoleErrorMock).toHaveBeenCalledTimes(2);
+      expect(consoleErrorMock.mock.calls).toEqual([
+        [
+          "%c[VKUI/Calendar] Нельзя включить селекты выбора месяца/года, если размер календаря 's'",
+          undefined,
+        ],
+        ["%c[VKUI/Calendar] Нельзя включить выбор времени, если размер календаря 's'", undefined],
+      ]);
+    });
   });
 });

--- a/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { getDocumentBody } from '../../lib/dom';
 import { Platform } from '../../lib/platform';
-import { baselineComponent, fakeTimers, userEvent } from '../../testing/utils';
+import { baselineComponent, fakeTimers, setNodeEnv, userEvent } from '../../testing/utils';
 import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { Checkbox } from './Checkbox';
 
@@ -63,27 +63,31 @@ describe('Checkbox', () => {
     expect(screen.getByRole<HTMLInputElement>('checkbox').indeterminate).toBeTruthy();
   });
 
-  it('check dev errors', () => {
-    process.env.NODE_ENV = 'development';
-    const errorStub = jest.spyOn(console, 'error');
-    render(
-      <>
-        <Checkbox defaultIndeterminate={true} defaultChecked={true} />
-        <Checkbox indeterminate={true} checked={true} />
-        <Checkbox defaultChecked={true} checked={true} />
-      </>,
-    );
-    expect(errorStub.mock.calls[0]).toEqual([
-      '%c[VKUI/Checkbox] defaultIndeterminate и defaultChecked не могут быть true одновременно',
-      undefined,
-    ]);
-    expect(errorStub.mock.calls[1]).toEqual([
-      '%c[VKUI/Checkbox] indeterminate и checked не могут быть true одновременно',
-      undefined,
-    ]);
-    expect(errorStub.mock.calls[2]).toEqual([
-      '%c[VKUI/Checkbox] defaultChecked и checked не могут быть true одновременно',
-      undefined,
-    ]);
+  describe('DEV errors', () => {
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
+
+    it('check calls Checkbox', () => {
+      const errorStub = jest.spyOn(console, 'error');
+      render(
+        <>
+          <Checkbox defaultIndeterminate={true} defaultChecked={true} />
+          <Checkbox indeterminate={true} checked={true} />
+          <Checkbox defaultChecked={true} checked={true} />
+        </>,
+      );
+      expect(errorStub.mock.calls[0]).toEqual([
+        '%c[VKUI/Checkbox] defaultIndeterminate и defaultChecked не могут быть true одновременно',
+        undefined,
+      ]);
+      expect(errorStub.mock.calls[1]).toEqual([
+        '%c[VKUI/Checkbox] indeterminate и checked не могут быть true одновременно',
+        undefined,
+      ]);
+      expect(errorStub.mock.calls[2]).toEqual([
+        '%c[VKUI/Checkbox] defaultChecked и checked не могут быть true одновременно',
+        undefined,
+      ]);
+    });
   });
 });

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -3,7 +3,12 @@ import { useState } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import type { Placement, useFloating } from '../../lib/floating';
-import { baselineComponent, userEvent, waitForFloatingPosition } from '../../testing/utils';
+import {
+  baselineComponent,
+  setNodeEnv,
+  userEvent,
+  waitForFloatingPosition,
+} from '../../testing/utils';
 import { Avatar } from '../Avatar/Avatar';
 import { CustomSelectOption } from '../CustomSelectOption/CustomSelectOption';
 import { CustomSelect, type CustomSelectRenderOption, type SelectProps } from './CustomSelect';
@@ -1416,25 +1421,27 @@ describe('CustomSelect', () => {
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
-  it('check dev error when use different type of values', () => {
-    process.env.NODE_ENV = 'development';
-    const errorStub = jest.spyOn(global.console, 'error').mockImplementationOnce(noop);
+  describe('DEV errors', () => {
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
 
-    render(
-      <CustomSelect
-        options={[
-          { value: 0, label: 'Mike' },
-          { value: '1', label: 'Josh' },
-        ]}
-      />,
-    );
+    it('check error when use different type of values', () => {
+      const errorStub = jest.spyOn(global.console, 'error').mockImplementationOnce(noop);
 
-    expect(errorStub).toHaveBeenCalledWith(
-      '%c[VKUI/CustomSelect] Некоторые значения ваших опций имеют разные типы. onChange всегда возвращает строковый тип.',
-      undefined,
-    );
+      render(
+        <CustomSelect
+          options={[
+            { value: 0, label: 'Mike' },
+            { value: '1', label: 'Josh' },
+          ]}
+        />,
+      );
 
-    process.env.NODE_ENV = 'test';
+      expect(errorStub).toHaveBeenCalledWith(
+        '%c[VKUI/CustomSelect] Некоторые значения ваших опций имеют разные типы. onChange всегда возвращает строковый тип.',
+        undefined,
+      );
+    });
   });
 
   it('checks CustomSelect placement class for borders when dropdown is opened and closed during  placement change', async () => {

--- a/packages/vkui/src/components/Gallery/Gallery.test.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, setNodeEnv } from '../../testing/utils';
 import type { AlignType } from '../../types';
 import { ANIMATION_DURATION } from '../CarouselBase/constants';
 import { type BaseGalleryProps } from '../CarouselBase/types';
@@ -594,26 +594,29 @@ describe('Gallery', () => {
       checkActiveSlide(0);
     });
 
-    it('check dev error when slides width incorrect', () => {
-      process.env.NODE_ENV = 'development';
-      const onChange = jest.fn();
-      const warn = jest.spyOn(console, 'warn').mockImplementation(noop);
+    describe('DEV errors', () => {
+      beforeEach(() => setNodeEnv('development'));
+      afterEach(() => setNodeEnv('test'));
 
-      setup({
-        looped: true,
-        defaultSlideIndex: 0,
-        slideWidth: 40,
-        containerWidth: 200,
-        viewPortWidth: 200,
-        onChange,
+      it('check dev error when slides width incorrect', () => {
+        const onChange = jest.fn();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(noop);
+
+        setup({
+          looped: true,
+          defaultSlideIndex: 0,
+          slideWidth: 40,
+          containerWidth: 200,
+          viewPortWidth: 200,
+          onChange,
+        });
+
+        expect(warn).toHaveBeenCalledWith(
+          '%c[VKUI/Gallery] Ширины слайдов недостаточно для корректной работы свойства "looped". Пожалуйста, сделайте её больше.',
+          undefined,
+        );
+        warn.mockRestore();
       });
-
-      expect(warn).toHaveBeenCalledWith(
-        '%c[VKUI/Gallery] Ширины слайдов недостаточно для корректной работы свойства "looped". Пожалуйста, сделайте её больше.',
-        undefined,
-      );
-      warn.mockRestore();
-      process.env.NODE_ENV = 'test';
     });
   });
 

--- a/packages/vkui/src/components/GridAvatar/GridAvatar.test.tsx
+++ b/packages/vkui/src/components/GridAvatar/GridAvatar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { IconExampleForBadgeBasedOnImageBaseSize } from '../../testing/icons';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, setNodeEnv } from '../../testing/utils';
 import { GridAvatar, type GridAvatarProps, MAX_GRID_LENGTH } from './GridAvatar';
 import styles from './GridAvatar.module.css';
 import gridAvatarBadgeStyles from './GridAvatarBadge/GridAvatarBadge.module.css';
@@ -24,16 +24,19 @@ const getGridAvatarItemEls = () => getGridAvatarRootEl().querySelectorAll(`.${st
 describe(GridAvatar, () => {
   baselineComponent(GridAvatar);
 
-  it(`should not show more than ${MAX_GRID_LENGTH} items in grid`, () => {
-    process.env.NODE_ENV = 'development';
-    const error = jest.spyOn(console, 'error').mockImplementation(noop);
-    render(<GridAvatarTest src={['#01', '#02', '#03', '#04', '#05']} />);
-    expect(error).toHaveBeenCalledWith(
-      `%c[VKUI/GridAvatar] Длина массива src (5) больше максимальной (4)`,
-      undefined,
-    );
-    expect(getGridAvatarItemEls().length).toBe(MAX_GRID_LENGTH);
-    process.env.NODE_ENV = 'test';
+  describe('DEV errors', () => {
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
+
+    it(`should not show more than ${MAX_GRID_LENGTH} items in grid`, () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(noop);
+      render(<GridAvatarTest src={['#01', '#02', '#03', '#04', '#05']} />);
+      expect(error).toHaveBeenCalledWith(
+        `%c[VKUI/GridAvatar] Длина массива src (5) больше максимальной (4)`,
+        undefined,
+      );
+      expect(getGridAvatarItemEls().length).toBe(MAX_GRID_LENGTH);
+    });
   });
 });
 

--- a/packages/vkui/src/components/Group/Group.test.tsx
+++ b/packages/vkui/src/components/Group/Group.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { ModalContext } from '../../context/ModalContext';
 import type { SizeTypeValues } from '../../lib/adaptivity';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, setNodeEnv } from '../../testing/utils';
 import { AdaptivityContext } from '../AdaptivityProvider/AdaptivityContext';
 import {
   AppRootContext,
@@ -130,20 +130,22 @@ describe('Group', () => {
     }
   });
 
-  it('check DEV errors', () => {
-    process.env.NODE_ENV = 'development';
-    const error = jest.spyOn(console, 'warn').mockImplementation(noop);
-    render(
-      <Group role="tabpanel">
-        <div />
-      </Group>,
-    );
+  describe('DEV errors', () => {
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
 
-    expect(error).toHaveBeenCalledWith(
-      '%c[VKUI/Group] При использовании роли "tabpanel" необходимо задать значение свойств "aria-controls" и "id"',
-      undefined,
-    );
+    it('check DEV errors', () => {
+      const error = jest.spyOn(console, 'warn').mockImplementation(noop);
+      render(
+        <Group role="tabpanel">
+          <div />
+        </Group>,
+      );
 
-    process.env.NODE_ENV = 'test';
+      expect(error).toHaveBeenCalledWith(
+        '%c[VKUI/Group] При использовании роли "tabpanel" необходимо задать значение свойств "aria-controls" и "id"',
+        undefined,
+      );
+    });
   });
 });

--- a/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
@@ -5,7 +5,7 @@ import {
   IconExampleForBadgeBasedOnImageBaseSize,
   IconExampleForFallbackBasedOnImageBaseSize,
 } from '../../testing/icons';
-import { baselineComponent, imgOnlyAttributes } from '../../testing/utils';
+import { baselineComponent, imgOnlyAttributes, setNodeEnv } from '../../testing/utils';
 import {
   getBadgeIconSizeByImageBaseSize,
   getFallbackIconSizeByImageBaseSize,
@@ -38,12 +38,10 @@ const getImageBaseImgEl = (elParent = getImageBaseRootEl()) => within(elParent).
 
 let logStub: jest.SpyInstance | null = null;
 beforeEach(() => {
-  process.env.NODE_ENV = 'development';
   logStub = jest.spyOn(console, 'log').mockImplementation(noop);
 });
 
 afterEach(() => {
-  process.env.NODE_ENV = 'test';
   logStub?.mockRestore();
 });
 
@@ -216,17 +214,22 @@ describe(ImageBase, () => {
     expect(getImageBaseRootEl()).toHaveClass(styles.transparentBackground);
   });
 
-  it('check dev error when use incorrect size of icon', () => {
-    render(<ImageBaseTest fallbackIcon={<Icon20Add />} size={28} />);
-    expect(logStub).toHaveBeenCalledTimes(1);
-  });
-
   it('should apply custom objectPosition style', () => {
     render(<ImageBaseTest src="#" objectPosition="center bottom" />);
 
     expect(getImageBaseImgEl()).toHaveClass(styles.withObjectPosition);
     expect(getImageBaseImgEl()).toHaveStyle({
       '--vkui_internal--ImageBase_object_position': 'center bottom',
+    });
+  });
+
+  describe('DEV errros', () => {
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
+
+    it('check error when use incorrect size of icon', () => {
+      render(<ImageBaseTest fallbackIcon={<Icon20Add />} size={28} />);
+      expect(logStub).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/vkui/src/components/TabsItem/TabsItem.test.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, setNodeEnv } from '../../testing/utils';
 import { Tabs } from '../Tabs/Tabs';
 import { TabsItem } from './TabsItem';
 
@@ -73,27 +73,29 @@ describe('TabsItem', () => {
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(0);
   });
 
-  it('check DEV warnings', () => {
-    process.env.NODE_ENV = 'development';
-    const warn = jest.spyOn(console, 'warn').mockImplementation(noop);
-    const { rerender } = render(
-      <TabsItem data-testid="first" selected={false}>
-        test
-      </TabsItem>,
-    );
-    expect(warn.mock.calls[0][0]).toBe(
-      '%c[VKUI/TabsItem] Передайте в "aria-controls" id контролируемого блока',
-    );
+  describe('DEV errros', () => {
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
 
-    rerender(
-      <TabsItem aria-controls="control" data-testid="first" selected={false}>
-        test
-      </TabsItem>,
-    );
-    expect(warn.mock.calls[1][0]).toBe(
-      '%c[VKUI/TabsItem] Передайте "id" компоненту для использования в "aria-labelledby" контролируемого блока',
-    );
+    it('check calls TabsItem', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(noop);
+      const { rerender } = render(
+        <TabsItem data-testid="first" selected={false}>
+          test
+        </TabsItem>,
+      );
+      expect(warn.mock.calls[0][0]).toBe(
+        '%c[VKUI/TabsItem] Передайте в "aria-controls" id контролируемого блока',
+      );
 
-    process.env.NODE_ENV = 'test';
+      rerender(
+        <TabsItem aria-controls="control" data-testid="first" selected={false}>
+          test
+        </TabsItem>,
+      );
+      expect(warn.mock.calls[1][0]).toBe(
+        '%c[VKUI/TabsItem] Передайте "id" компоненту для использования в "aria-labelledby" контролируемого блока',
+      );
+    });
   });
 });

--- a/packages/vkui/src/lib/getNavId.test.ts
+++ b/packages/vkui/src/lib/getNavId.test.ts
@@ -1,3 +1,4 @@
+import { setNodeEnv } from '../testing/utils';
 import { getNavId } from './getNavId';
 
 describe(getNavId, () => {
@@ -5,8 +6,9 @@ describe(getNavId, () => {
   it('Gets "id" prop', () => expect(getNavId({ id: 'ok' })).toBe('ok'));
   it('"nav" overrides "id"', () => expect(getNavId({ nav: 'ok', id: 'dont' })).toBe('ok'));
   describe('strict mode', () => {
-    beforeEach(() => (process.env.NODE_ENV = 'development'));
-    afterEach(() => (process.env.NODE_ENV = 'test'));
+    beforeEach(() => setNodeEnv('development'));
+    afterEach(() => setNodeEnv('test'));
+
     it('does not error if nav id present', () => {
       const warn = jest.fn();
       getNavId({ nav: 'ok' }, warn);

--- a/packages/vkui/src/testing/utils.tsx
+++ b/packages/vkui/src/testing/utils.tsx
@@ -480,3 +480,9 @@ export function mouseEventMock({
     target,
   };
 }
+
+export function setNodeEnv(value: 'development' | 'production' | 'test') {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+  });
+}

--- a/packages/vkui/types/env.d.ts
+++ b/packages/vkui/types/env.d.ts
@@ -12,7 +12,7 @@ declare module 'process' {
     namespace NodeJS {
       interface Process {
         env: {
-          NODE_ENV: 'development' | 'production' | 'test';
+          readonly NODE_ENV: 'development' | 'production' | 'test';
         };
       }
     }


### PR DESCRIPTION
## Описание

При интеграции в проект NextJS проекта, возникают ошибки при общей проверке типов в проекте (из-за конфликтующих глобальных типов - @inomdzhon глаз алмаз х)):

![image](https://github.com/user-attachments/assets/20a4cb76-8251-4cfb-be48-f0918d0122eb)
 

## Изменения

- в тех тестах, где мы подменяет `env`-переменную используем, утилиту `setDevNodeEnv`.

- в наших типах также устанавливаем переменную в `readonly`

## Release notes
-