### PR TITLE
feat(ModalCard,ModalPage): add prop restoreFocus

### DIFF
--- a/packages/vkui/src/components/ModalCard/ModalCardInternal.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCardInternal.tsx
@@ -66,6 +66,7 @@ export const ModalCardInternal = ({
   dismissButtonMode,
   dismissLabel,
   noFocusToDialog,
+  restoreFocus,
   onOpen,
   onOpened,
   onClose = noop,
@@ -136,7 +137,11 @@ export const ModalCardInternal = ({
   );
 
   useScrollLock(!hidden);
-  useFocusTrap(ref, { autoFocus: !noFocusToDialog, disabled: !opened || hidden });
+  useFocusTrap(ref, {
+    autoFocus: !noFocusToDialog,
+    disabled: !opened || hidden,
+    restoreFocus,
+  });
 
   return (
     <ModalOutlet hidden={hidden} onKeyDown={handleEscKeyDown}>

--- a/packages/vkui/src/components/ModalCard/types.ts
+++ b/packages/vkui/src/components/ModalCard/types.ts
@@ -1,4 +1,5 @@
 import type { UIEvent } from 'react';
+import { type UseFocusTrapProps } from '../../hooks/useFocusTrap';
 import type { NavIdProps } from '../../lib/getNavId';
 import type { UseBottomSheetHandlers } from '../../lib/sheet';
 import type { ModalCardBaseProps } from '../ModalCardBase/ModalCardBase';
@@ -11,7 +12,8 @@ export type ModalCardCloseReason =
 
 export interface ModalCardProps
   extends NavIdProps,
-    Omit<ModalCardBaseProps, 'id' | 'onClose' | 'onTransitionEnd' | keyof UseBottomSheetHandlers> {
+    Omit<ModalCardBaseProps, 'id' | 'onClose' | 'onTransitionEnd' | keyof UseBottomSheetHandlers>,
+    Pick<UseFocusTrapProps, 'restoreFocus'> {
   /**
    * Состояние видимости.
    *

--- a/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
@@ -70,6 +70,7 @@ export const ModalPageInternal = ({
   hideCloseButton,
   preventClose,
   disableContentPanningGesture,
+  restoreFocus,
   onOpen,
   onOpened,
   onClose = noop,
@@ -166,6 +167,7 @@ export const ModalPageInternal = ({
       <FocusTrap
         {...restProps}
         autoFocus={!noFocusToDialog}
+        restoreFocus={restoreFocus}
         role="dialog"
         aria-modal="true"
         disabled={!opened || hidden}

--- a/packages/vkui/src/components/ModalPage/types.ts
+++ b/packages/vkui/src/components/ModalPage/types.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactNode, Ref, UIEvent } from 'react';
+import { type UseFocusTrapProps } from '../../hooks/useFocusTrap';
 import type { NavIdProps } from '../../lib/getNavId';
 import type { HTMLAttributesWithRootRef } from '../../types';
 
@@ -15,6 +16,7 @@ type OmittedStyleAttribute = {
 export interface ModalPageProps
   extends NavIdProps,
     Omit<HTMLAttributesWithRootRef<HTMLDivElement>, 'id' | 'style'>,
+    Pick<UseFocusTrapProps, 'restoreFocus'>,
     OmittedStyleAttribute {
   /**
    * Состояние видимости.


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8069 

---

- [x] Unit-тесты
- [x] Release notes

## Описание

До  рефакторинга модалок контент модалок был обернуть в `FocusTrap` с параметрами `restoreFocus=false` всегда. Теперь же по  `restoreFocus` всегда `true`. Из-за этого при закрытии модалки будет происходить восстановление фокуса и доскрол по необходимости

## Изменения

- Добавил возможность прокинуть свойство `restoreFocus`  в компоненты `ModalCard`, `ModalPage`
- Добавил тесты

## Release notes
## Улучшения
- ModalCard: Добавлена возможность прокинуть свойство `restoreFocus`, которое управляет тем, нужно ли восстанавливать фокус после закрытия модалки
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
