### PR TITLE
fix(useScrollLock): check first effect

### DIFF
--- a/packages/vkui/src/components/AppRoot/ScrollContext.tsx
+++ b/packages/vkui/src/components/AppRoot/ScrollContext.tsx
@@ -61,12 +61,18 @@ export const useScroll = (): ScrollContextInterface => React.useContext(ScrollCo
  * Если счетчик больше нуля, требуется заблокировать прокрутку
  */
 function useScrollLockController(enableScrollLock: () => void, disableScrollLock: () => void) {
+  const isFirstEffect = React.useRef(true);
   const [count, { increment: incrementScrollLockCounter, decrement: decrementScrollLockCounter }] =
     useCounter(0);
 
   const needLockScroll = count > 0;
 
   React.useEffect(() => {
+    if (isFirstEffect.current) {
+      isFirstEffect.current = false;
+      return;
+    }
+
     if (needLockScroll) {
       enableScrollLock();
     } else {


### PR DESCRIPTION

## Описание

При первом рендере выполняется disableScrollLock, из-за чего пользователя может кинуть в 0 позицию, если он прокрутил страницу. Также вызывается лишний reflow

## Изменения

Проверяем что это не первый эффект при управлении скролллоком

## Release notes
## Исправления
- [AppRoot](https://vkcom.github.io/VKUI/${version}/#/AppRoot): исправлено отключение блокировки прокрутки при первом рендере
