### PR TITLE
fix(TabsItem): add Component prop

### DIFF
--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -36,6 +36,7 @@ export interface TabsItemProps
     AnchorHTMLAttributesOnly,
     Pick<
       TappableProps,
+      | 'Component'
       | 'activeMode'
       | 'hoverMode'
       | 'hovered'


### PR DESCRIPTION
## Описание

В TabsItem требуется прокидывать в качестве компонента Link из Next.JS

## Изменения

Разрешаем прокидывать Component

## Release notes
## Исправления
- [TabsItem](https://vkcom.github.io/VKUI/${version}/#/TabsItem): разрешили прокидывать `Component`
