### PR TITLE
fix(ActionSheet, Alert): add stopPropagation ignore

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.test.tsx
@@ -261,4 +261,40 @@ describe(ActionSheet, () => {
     // desktop Android
     expect(screen.queryByText('Отмена')).toBeFalsy();
   });
+
+  describe('handle allowClickPropagation correctly', () => {
+    it.each([
+      ['menu', ActionSheetMenu],
+      ['sheet', ActionSheetSheet],
+    ])('%s', async (_name, ActionSheet) => {
+      const onClose = jest.fn();
+      const onClick = jest.fn();
+      const { rerender } = render(
+        <div onClick={onClick}>
+          <ActionSheet data-testid="container" onClose={onClose}>
+            <div data-testid="content" />
+          </ActionSheet>
+        </div>,
+      );
+      await waitForFloatingPosition();
+      act(jest.runAllTimers);
+
+      await userEvent.click(screen.getByTestId('content'));
+      expect(onClick).not.toHaveBeenCalled();
+
+      rerender(
+        <div onClick={onClick}>
+          <ActionSheet data-testid="container" onClose={onClose} allowClickPropagation>
+            <div data-testid="content" />
+          </ActionSheet>
+        </div>,
+      );
+
+      await waitForFloatingPosition();
+      act(jest.runAllTimers);
+
+      await userEvent.click(screen.getByTestId('content'));
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -23,7 +23,10 @@ export interface ActionSheetOnCloseOptions {
 }
 
 export interface ActionSheetProps
-  extends Pick<SharedDropdownProps, 'toggleRef' | 'popupOffsetDistance' | 'placement'>,
+  extends Pick<
+      SharedDropdownProps,
+      'toggleRef' | 'popupOffsetDistance' | 'placement' | 'allowClickPropagation'
+    >,
     Omit<UseFocusTrapProps, 'onClose'>,
     Omit<React.HTMLAttributes<HTMLDivElement>, 'autoFocus' | 'title'> {
   title?: React.ReactNode;

--- a/packages/vkui/src/components/ActionSheet/ActionSheetDropdownMenu.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetDropdownMenu.tsx
@@ -8,6 +8,8 @@ import { useEventListener } from '../../hooks/useEventListener';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useDOM } from '../../lib/dom';
 import { isRefObject } from '../../lib/isRefObject';
+import { mergeCalls } from '../../lib/mergeCalls';
+import { stopPropagation } from '../../lib/utils';
 import { warnOnce } from '../../lib/warnOnce';
 import { FocusTrap } from '../FocusTrap/FocusTrap';
 import { Popper } from '../Popper/Popper';
@@ -30,6 +32,8 @@ export const ActionSheetDropdownMenu = ({
   placement,
   onAnimationStart,
   onAnimationEnd,
+  allowClickPropagation = false,
+  onClick,
   ...restProps
 }: SharedDropdownProps): React.ReactNode => {
   const { document } = useDOM();
@@ -57,8 +61,6 @@ export const ActionSheetDropdownMenu = ({
     });
   }, [bodyClickListener, document]);
 
-  const onClick = React.useCallback((e: React.MouseEvent<HTMLElement>) => e.stopPropagation(), []);
-
   const targetRef = React.useMemo(() => {
     if (isRefObject<SharedDropdownProps['toggleRef'], HTMLElement>(toggleRef)) {
       return toggleRef;
@@ -66,6 +68,14 @@ export const ActionSheetDropdownMenu = ({
 
     return { current: toggleRef as HTMLElement };
   }, [toggleRef]);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (!allowClickPropagation) {
+      stopPropagation(event);
+    }
+  };
+
+  const clickHandlers = mergeCalls({ onClick: handleClick }, { onClick });
 
   return (
     <Popper
@@ -86,7 +96,7 @@ export const ActionSheetDropdownMenu = ({
       onAnimationStart={onAnimationStart}
       onAnimationEnd={onAnimationEnd}
     >
-      <FocusTrap onClose={onClose} {...restProps} onClick={onClick}>
+      <FocusTrap onClose={onClose} {...restProps} {...clickHandlers}>
         {children}
       </FocusTrap>
     </Popper>

--- a/packages/vkui/src/components/ActionSheet/ActionSheetDropdownSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetDropdownSheet.tsx
@@ -4,11 +4,11 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { usePlatform } from '../../hooks/usePlatform';
+import { mergeCalls } from '../../lib/mergeCalls';
+import { stopPropagation } from '../../lib/utils';
 import { FocusTrap } from '../FocusTrap/FocusTrap';
 import type { SharedDropdownProps } from './types';
 import styles from './ActionSheet.module.css';
-
-const stopPropagation: React.MouseEventHandler = (e) => e.stopPropagation();
 
 export type ActionSheetDropdownProps = Omit<
   SharedDropdownProps,
@@ -21,15 +21,25 @@ export const ActionSheetDropdownSheet = ({
   // these 2 props are only omitted - ActionSheetDesktop compat
   toggleRef,
   className,
+  onClick,
+  allowClickPropagation = false,
   ...restProps
 }: SharedDropdownProps): React.ReactNode => {
   const { sizeY } = useAdaptivityWithJSMediaQueries();
   const platform = usePlatform();
 
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (!allowClickPropagation) {
+      stopPropagation(event);
+    }
+  };
+
+  const clickHandlers = mergeCalls({ onClick: handleClick }, { onClick });
+
   return (
     <FocusTrap
       {...restProps}
-      onClick={stopPropagation}
+      {...clickHandlers}
       className={classNames(
         styles.host,
         platform === 'ios' && styles.ios,

--- a/packages/vkui/src/components/ActionSheet/types.ts
+++ b/packages/vkui/src/components/ActionSheet/types.ts
@@ -20,4 +20,8 @@ export interface SharedDropdownProps extends FocusTrapProps {
    * Отступ, где заданное кол-во единиц равняется пикселям
    * */
   popupOffsetDistance?: number;
+  /**
+   * По умолчанию событие onClick не всплывает
+   */
+  allowClickPropagation?: boolean;
 }

--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -333,4 +333,32 @@ describe('Alert', () => {
       descriptionClassNames.forEach((className) => expect(textElement).toHaveClass(className));
     },
   );
+
+  it('handle allowClickPropagation correctly', async () => {
+    const onClose = jest.fn();
+    const onClick = jest.fn();
+    const action = {
+      'title': 'Item',
+      'data-testid': '__action__',
+      'autoCloseDisabled': true,
+      'mode': 'default' as const,
+    };
+    const result = render(
+      <div onClick={onClick}>
+        <Alert onClose={onClose} actions={[action]} />
+      </div>,
+    );
+
+    await userEvent.click(result.getByTestId('__action__'));
+    expect(onClick).not.toHaveBeenCalled();
+
+    result.rerender(
+      <div onClick={onClick}>
+        <Alert onClose={onClose} actions={[action]} allowClickPropagation />
+      </div>,
+    );
+
+    await userEvent.click(result.getByTestId('__action__'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -7,6 +7,7 @@ import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJS
 import { type UseFocusTrapProps } from '../../hooks/useFocusTrap';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useCSSKeyframesAnimationController } from '../../lib/animation';
+import { mergeCalls } from '../../lib/mergeCalls';
 import { stopPropagation } from '../../lib/utils';
 import type {
   AlignType,
@@ -73,6 +74,10 @@ export interface AlertProps
    */
   dismissButtonTestId?: string;
   usePortal?: AppRootPortalProps['usePortal'];
+  /**
+   * По умолчанию событие onClick не всплывает
+   */
+  allowClickPropagation?: boolean;
 }
 
 /**
@@ -94,6 +99,8 @@ export const Alert = ({
   dismissButtonTestId,
   getRootRef,
   usePortal,
+  onClick,
+  allowClickPropagation = false,
   ...restProps
 }: AlertProps): React.ReactNode => {
   const generatedId = React.useId();
@@ -139,6 +146,14 @@ export const Alert = ({
     [close],
   );
 
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (!allowClickPropagation) {
+      stopPropagation(event);
+    }
+  };
+
+  const clickHandlers = mergeCalls({ onClick: handleClick }, { onClick });
+
   useScrollLock();
 
   return (
@@ -153,8 +168,8 @@ export const Alert = ({
         <FocusTrap
           {...restProps}
           {...animationHandlers}
+          {...clickHandlers}
           getRootRef={elementRef}
-          onClick={stopPropagation}
           onClose={close}
           autoFocus={animationState === 'entered'}
           className={classNames(


### PR DESCRIPTION
- [x] Unit-тесты
- [x] Документация фичи
- [x] Release notes

## Описание

На корневую обертку `ActionSheet`/`Alert` мы навешиваем обработчик на `onClick` с `stopPropagation`. Возможно, для того, чтобы клики на всплывашках не аффектили основное приложение? Но в `Alert` [добавили](https://github.com/VKCOM/VKUI/commit/aad15e4f511f74ee19325cab2a39ee0bcdc428e7) обработчик, чтобы предотвратить ложные срабатывания `onClose` - больше это не проблема, мы поменяли немного логику.

Для чего клики нужны - глобальные обработчики клика для сбора аналитики.

Ещё у `ActionSheetDropdownMenu` навешивается обработчик на `body` - он не особо нужен, потому что у нас `overlay` растягивается на весь экран

## Изменения

- добавлены `allowClickPropagation` для компонентов `ActionSheet`/`Alert` + есть возможность теперь прокинуть свои обработчики `onClick`. Но, наверное, будет не совсем правильно убирать это в рамках минорной версии. Оставим на `v8`?

## Release notes

- ActionSheet: добавлено свойство `allowClickPropagation` для всплытия `onClick` и возможность передать кастомный `onClick`
- Alert: добавлено свойство `allowClickPropagation` для всплытия `onClick` и возможность передать кастомный `onClick`
