### PR TITLE
feat(Popper): add prop strategy

### DIFF
--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -48,6 +48,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'hideWhenReferenceHidden'
   | 'sameWidth'
   | 'zIndex'
+  | 'strategy'
   | 'usePortal'
   | 'customMiddlewares'
   | 'onPlacementChange'
@@ -103,6 +104,7 @@ export const Popper = ({
 
   // UseFloatingProps
   autoUpdateOnTargetResize = false,
+  strategy: strategyProp = 'fixed',
 
   // ArrowProps
   arrowProps,
@@ -143,6 +145,7 @@ export const Popper = ({
     middlewareData,
   } = useFloating({
     placement: strictPlacement,
+    strategy: strategyProp,
     middleware: middlewares,
     whileElementsMounted(...args) {
       /* istanbul ignore next: не знаю как проверить */


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8175

---

- [x] Release notes

## Изменения

Добавил свойство `strategy` в `Popper` и прокинул в `useFloating`

## Release notes
## Улучшения
- Popper: Добавлено свойство `strategy`
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
