### PR TITLE
fix(ToolButton): rm alpha from bg for `mode="secondary"`

### DIFF
--- a/packages/vkui/src/components/ToolButton/ToolButton.module.css
+++ b/packages/vkui/src/components/ToolButton/ToolButton.module.css
@@ -76,28 +76,28 @@
 }
 
 .modePrimary.appearanceNeutral {
-  background-color: var(--vkui--color_background_modal_inverse);
+  background-color: var(--vkui--color_background_content_inverse);
 }
 
 .modePrimary.appearanceNeutral.hover {
-  background-color: var(--vkui--color_background_modal_inverse--hover);
+  background-color: var(--vkui--color_background_content_inverse--hover);
 }
 
 .modePrimary.appearanceNeutral.active {
-  background-color: var(--vkui--color_background_modal_inverse--active);
+  background-color: var(--vkui--color_background_content_inverse--active);
 }
 
 /* Mode = Secondary */
 .modeSecondary {
-  background-color: var(--vkui--color_background_secondary_alpha);
+  background-color: var(--vkui--color_background_secondary);
 }
 
 .modeSecondary.hover {
-  background-color: var(--vkui--color_background_secondary_alpha--hover);
+  background-color: var(--vkui--color_background_secondary--hover);
 }
 
 .modeSecondary.active {
-  background-color: var(--vkui--color_background_secondary_alpha--active);
+  background-color: var(--vkui--color_background_secondary--active);
 }
 
 /* Mode = Tertiary */

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02a41b217bec6fea5b4289189f38229cfdb5f78c6bbc12d16e9ca89aa347c57e
-size 111554
+oid sha256:bea564402d234922d876de2650e62d0217836f38483246eea1c2cd7626885aea
+size 112274

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-ios-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1bcdd7c4d32bbce9e9f428b7d68d355726d797e1c404fabcbf9976c2ec25bb8
-size 141996
+oid sha256:0f2d0027ae85c2ca21d859b04bac85232ab29bdc9e2609500a758e2a08daac3d
+size 142812

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2d12cd6cbaab9ff3d5224c78c792e68e7c86b2a1d5f24c5e9d7025efb064211
-size 80262
+oid sha256:4b59d13251ce37371cc38a38b3a0c0d26e3d0d53436649935f5811e6799228d2
+size 80618

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8452251cf1595b798aef67be59ee04d850a9c224e1047455eab9ba20851306e0
-size 78471
+oid sha256:5f2eaec7d2f1c86409dd7dffab14ba899df38627ba2fce3bddf219d4f4071180
+size 78444

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-firefox-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a31e8835d69ba2423344f5296e1b9b8106f9a7bfa9846852dca28a3f32abf60d
-size 99182
+oid sha256:1fce8fe7099b29211f1b7e7487deaa72b5139f5cc4412c962387b45b7718ac3a
+size 99300

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-firefox-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf80d6fa810e542b510cdf5f6c1fb28ab31e84c0b7a1e80e691f06b552ea8b10
-size 100896
+oid sha256:eb7b50d57c120004dd63d060547f3a2289bbacd818d2fb8f9777fc326b0d9b61
+size 101241

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-webkit-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbfe597a543a137d03816ed077891afd7e71fe59d7f89c27294bbe2ecf8c7b2a
-size 103731
+oid sha256:7e2fa6faa9da066c076536ce8d0a139137812e4ec5da511489845e27d3bb673f
+size 104015

--- a/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/ToolButton/__image_snapshots__/toolbutton-vkcom-webkit-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c5f8b58a8adc0679e1a29d10adb2706aa6002211c847dea3dd878b408c8c777
-size 103228
+oid sha256:38dc17482c6ae6c174b999c2200f6b7b62e059770e084162b62739aee2c690bb
+size 103235


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8198

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~
- ~[ ] Документация фичи~
- [x] Дизайн-ревью
- [x] e2e-тесты
- [x] Release notes

## Описание

см. #8198

## Release notes
## Исправления
- ToolButton:
  - при `mode="secondary"` у фона теперь нет прозрачности;
  - для `mode="primary" appearance="neutral"` заменён токен с `--vkui--color_background_modal_inverse` на `--vkui--color_background_content_inverse`.
