### PR TITLE
doc: Help styleguidist to detect proper name for Tabs page

### DIFF
--- a/packages/vkui/src/components/Tabs/Tabs.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.tsx
@@ -100,3 +100,7 @@ export const Tabs = ({
     </RootComponent>
   );
 };
+
+// чтобы styleguidist не путал компонент
+// с другими именованными экспортами
+Tabs.displayName = 'Tabs';


### PR DESCRIPTION
В доке, начиная в версиях 7.1.0 7.1.1 пропала страница Tabs. Точнее она есть, но под другим именем `TabsModeContext`: https://vkcom.github.io/VKUI/7.1.0/#/TabsModeContext

`Styleguide` перестал адекватно понимать где в файле `Tabs` именно компонент `Tabs`.
Можно были либо перенести `TabsModeContext` из файла `Tabs` в отдельный, либо добавить `displayName` в соответсвии с документацией [styleguide](https://react-styleguidist.js.org/docs/components#default-vs-named-exports)

Проверил по коду, с остальными компонентами такой проблемы нету.

----

Явных причин по коду в изменениях между 7.0.1 и 7.1.0 для такого эффекта не заметил, возможно, что что-то в типах поменялось.
