### PR TITLE
fix(ModalPage): expect number for height

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
@@ -2,6 +2,7 @@
 
 import { type ComponentType, type KeyboardEvent, useCallback } from 'react';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';
+import { mergeStyle } from '../../helpers/mergeStyle';
 import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useVirtualKeyboardState } from '../../hooks/useVirtualKeyboardState';
@@ -184,11 +185,7 @@ export const ModalPageInternal = ({
           desktopMaxWidthClassName,
           sizeX === 'regular' && 'vkuiInternalModalPage--sizeX-regular',
         )}
-        style={{
-          ...style,
-          ...desktopMaxWidthStyle,
-          ...getHeightCSSVariable(height),
-        }}
+        style={mergeStyle(mergeStyle(desktopMaxWidthStyle, getHeightCSSVariable(height)), style)}
       >
         <div
           {...bottomSheetEventHandlers}
@@ -243,6 +240,9 @@ function resolveDesktopMaxWidth(
 
 function getHeightCSSVariable(height?: number | string): CSSCustomProperties | undefined {
   return height !== undefined
-    ? { '--vkui_internal_ModalPage--userHeight': `${height}` }
+    ? {
+        '--vkui_internal_ModalPage--userHeight':
+          typeof height === 'number' ? `${height}px` : height,
+      }
     : undefined;
 }


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~
- [x] Release notes

## Описание

Раньше `height` вставлялся в `style`, что позволяло передать без `px`.  С переходом на CSS переменную эта возможность пропала, поэтому проверяем, что `height` это число и добавляем `px`.

- related to #6759

## Изменения

Применил `megeStyle` в `style`, чтобы не применять object-spread когда не надо.

## Release notes
## Исправления
- ModalPage: числовые значения в `height` не приводились к `${height}px`
