### PR TITLE
fix: useScrollLockController rm useEffect

### DIFF
--- a/packages/vkui/src/components/AppRoot/ScrollContext.test.tsx
+++ b/packages/vkui/src/components/AppRoot/ScrollContext.test.tsx
@@ -46,6 +46,10 @@ describe(useScrollLock, () => {
           </GlobalScrollController>
         ),
       });
+
+      h.rerender(false);
+      h.rerender();
+
       expect(beforeScrollLockFn).toHaveBeenCalled();
 
       expect(getStyleAttributeObject(document.body)).toEqual({
@@ -69,6 +73,32 @@ describe(useScrollLock, () => {
       expect(jestWorkaroundGetOverscrollBehaviorPropertyValue(document.documentElement)).toBe('');
 
       clearWindowMeasuresMock();
+    });
+
+    test('unmount check', () => {
+      const h = renderHook(useScrollLock, {
+        wrapper: ({ children }) => (
+          <GlobalScrollController elRef={createRef<HTMLElement>()}>
+            {children}
+          </GlobalScrollController>
+        ),
+      });
+
+      expect(getStyleAttributeObject(document.body)).toEqual({
+        'position': 'fixed',
+        'top': `-${0}px`,
+        'left': `-${0}px`,
+        'right': '0px',
+        'overflow-x': 'scroll',
+        'overflow-y': 'scroll',
+      });
+      expect(jestWorkaroundGetOverscrollBehaviorPropertyValue(document.body)).toBe('none');
+      expect(jestWorkaroundGetOverscrollBehaviorPropertyValue(document.documentElement)).toBe('none'); // prettier-ignore
+
+      h.unmount();
+      expect(getStyleAttributeObject(document.body)).toEqual({});
+      expect(jestWorkaroundGetOverscrollBehaviorPropertyValue(document.body)).toBe('');
+      expect(jestWorkaroundGetOverscrollBehaviorPropertyValue(document.documentElement)).toBe('');
     });
 
     test('context api', () => {
@@ -110,13 +140,19 @@ describe(useScrollLock, () => {
 
       const beforeScrollLockFn = jest.fn();
       const h = renderHook(useScrollLock, {
-        wrapper: ({ children }) => (
-          <ElementScrollController elRef={elRef}>
-            {children}
-            <ChildWithContext beforeScrollLockFn={beforeScrollLockFn} />
-          </ElementScrollController>
-        ),
+        wrapper: ({ children }) => {
+          return (
+            <ElementScrollController elRef={elRef}>
+              {children}
+              <ChildWithContext beforeScrollLockFn={beforeScrollLockFn} />
+            </ElementScrollController>
+          );
+        },
       });
+
+      h.rerender(false);
+      h.rerender();
+
       expect(beforeScrollLockFn).toHaveBeenCalled();
 
       expect(getStyleAttributeObject(elRef.current)).toEqual({


### PR DESCRIPTION
- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

При анмаунте компонентов контроллер скролл лока ожидает ререндера для проверки на необходимость разблокирования, но он не произойдет 

## Изменения

Меняем функции обновления значения счетчика сразу вызывая функции управления скролл локом

## Release notes
- [AppRoot](https://vkcom.github.io/VKUI/${version}/#/AppRoot): Прокрутка могла не разблокироваться при анмаунте