### PR TITLE
feat(PopoutWrapper): add prop `strategy` and deprecate prop `fixed`

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -149,7 +149,7 @@ export const ActionSheet = ({
         className={className}
         style={style}
         onClick={onCloseWithOther}
-        fixed
+        strategy="fixed"
       >
         {actionSheet}
       </PopoutWrapper>

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -178,6 +178,7 @@ export const Alert = ({
         style={style}
         onClick={close}
         getRootRef={getRootRef}
+        strategy="fixed"
       >
         <FocusTrap
           {...animationHandlers}

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.module.css
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.module.css
@@ -19,6 +19,10 @@
   position: fixed;
 }
 
+.absolute {
+  position: absolute;
+}
+
 .overlay {
   position: fixed;
   inset-inline-start: 0;
@@ -42,7 +46,8 @@
   background: var(--vkui--color_overlay_primary);
 }
 
-.fixed .overlay {
+.fixed .overlay,
+.absolute .overlay {
   position: absolute;
 }
 

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.stories.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.stories.tsx
@@ -16,7 +16,11 @@ export default story;
 type Story = StoryObj<PopoutWrapperProps>;
 
 export const Playground: Story = {
-  render: (args) => <PopoutWrapper {...args} />,
+  render: (args) => (
+    <div style={{ width: 500, height: 500, position: 'relative' }}>
+      <PopoutWrapper {...args} />
+    </div>
+  ),
   args: {
     children: 'Some content',
   },

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { baselineComponent, fakeTimers } from '../../testing/utils';
-import { PopoutWrapper } from './PopoutWrapper';
+import { PopoutWrapper, type PopoutWrapperProps } from './PopoutWrapper';
 import styles from './PopoutWrapper.module.css';
 
 describe(PopoutWrapper, () => {
@@ -19,8 +19,46 @@ describe(PopoutWrapper, () => {
     it('should be closed if closing={true}', () => {
       const result = render(<PopoutWrapper closing={true} data-testid="popout-wrapper" />);
       const locator = result.getByTestId('popout-wrapper');
-      expect(locator).not.toHaveClass(styles.opening);
+      expect(locator).not.toHaveClass(styles.opened);
       expect(locator).toHaveClass(styles.closing);
     });
+
+    const strategyClassNames = [styles.fixed, styles.absolute];
+    it.each<{ strategy?: PopoutWrapperProps['strategy']; fixed?: boolean; className: string }>([
+      {
+        strategy: 'none',
+        className: '',
+      },
+      {
+        strategy: 'fixed',
+        className: styles.fixed,
+      },
+      {
+        strategy: 'absolute',
+        className: styles.absolute,
+      },
+      {
+        fixed: false,
+        className: '',
+      },
+      {
+        fixed: true,
+        className: styles.fixed,
+      },
+      {
+        className: styles.fixed,
+      },
+    ])(
+      'should have className $className when use strategy $strategy, fixed $fixed',
+      ({ strategy, fixed, className }) => {
+        const result = render(
+          <PopoutWrapper strategy={strategy} fixed={fixed} data-testid="popout-wrapper" />,
+        );
+        const locator = result.getByTestId('popout-wrapper');
+        className && expect(locator).toHaveClass(className);
+        const filteredClassNames = strategyClassNames.filter((cn) => cn !== className).join(' ');
+        expect(locator).not.toHaveClass(filteredClassNames);
+      },
+    );
   });
 });

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -73,6 +73,7 @@ export const PopoutWrapper = ({
   closing = false,
   noBackground = false,
   strategy: strategyProp,
+  // TODO [>=8]: удалить свойство
   fixed = true,
   children,
   onClick,

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -44,6 +44,8 @@ export interface PopoutWrapperProps extends HTMLAttributesWithRootRef<HTMLDivEle
    * - `fixed`: у контейнера выставлен `position: fixed`
    * - `absolute`: у контейнера выставлен `position: absolute`
    * - `none`: у контейнера не выставлен `position`
+   *
+   * @default 'fixed'
    */
   strategy?: 'fixed' | 'absolute' | 'none';
   /**

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.tsx
@@ -18,17 +18,34 @@ const stylesAlignY = {
   bottom: styles.alignYBottom,
 };
 
+const stylesStrategy = {
+  fixed: styles.fixed,
+  absolute: styles.absolute,
+  none: undefined,
+};
+
 export interface PopoutWrapperProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
   /**
    * Позволяет сделать прозрачную подложку
    */
   noBackground?: boolean;
   /**
+   * @deprecated будет удалён в **VKUI v8**
+   * Используйте `strategy` вместо этого свойства.
+   *
    * Включает фиксированное позиционирование.
    *
-   * По умолчанию у компонента не задан никакой `position`.
+   * При значении `false` у компонента не задан никакой `position`.
    */
   fixed?: boolean;
+  /**
+   * Стратегия позиционирования:
+   *
+   * - `fixed`: у контейнера выставлен `position: fixed`
+   * - `absolute`: у контейнера выставлен `position: absolute`
+   * - `none`: у контейнера не выставлен `position`
+   */
+  strategy?: 'fixed' | 'absolute' | 'none';
   /**
    * Выравнивает контент по горизонтали.
    */
@@ -55,12 +72,15 @@ export const PopoutWrapper = ({
   alignX = 'center',
   closing = false,
   noBackground = false,
+  strategy: strategyProp,
   fixed = true,
   children,
   onClick,
   zIndex = 'var(--vkui--z_index_popout)',
   ...restProps
 }: PopoutWrapperProps): React.ReactNode => {
+  const strategy = strategyProp || (fixed ? 'fixed' : 'none');
+
   return (
     <RootComponent
       {...restProps}
@@ -69,7 +89,7 @@ export const PopoutWrapper = ({
         stylesAlignY[alignY],
         stylesAlignX[alignX],
         closing ? styles.closing : styles.opened,
-        fixed && styles.fixed,
+        strategy && stylesStrategy[strategy],
         !noBackground && styles.masked,
       )}
       baseStyle={{ zIndex }}

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
@@ -34,7 +34,7 @@ export const ScreenSpinner: React.FC<ScreenSpinnerProps> & {
 
   return (
     <AppRootPortal usePortal={usePortal}>
-      <PopoutWrapper className={className} style={style} noBackground>
+      <PopoutWrapper className={className} style={style} noBackground strategy="fixed">
         <ScreenSpinnerContainer state={state} mode={mode} label={label} customIcon={customIcon}>
           <ScreenSpinnerLoader {...restProps} />
           <ScreenSpinnerSwapIcon onClick={onClick} cancelLabel={cancelLabel} />


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8211 

---

- [x] Unit-тесты
- [x] Документация фичи
- [x] Release notes

## Описание

Нужно добавить свойство `strategy`, которое управляет свойством `position` у `PopoutWrapper`

## Изменения

- Добавил свойство `strategy`
- Задепрекейтил cвойство `fixed`, так как `fixed` позиционирование можно выставить через `strategy`
- Добавил тесты

## Release notes
## Улучшения
- PopoutWrapper: Добавлено свойство `strategy` для управления способом позиционирования компонентом
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
