### PR TITLE
lint: enable erasableSyntaxOnly

### DIFF
--- a/packages/vkui/.eslintrc.cjs
+++ b/packages/vkui/.eslintrc.cjs
@@ -122,10 +122,6 @@ module.exports = {
         selector: 'ImportDefaultSpecifier[local.name="React"][parent.source.value="react"]',
         message: 'Не используйте импорт React по умолчанию',
       },
-      {
-        selector: 'TSEnumDeclaration',
-        message: 'Не используйте enum',
-      },
     ],
 
     'import/no-default-export': 'error',

--- a/packages/vkui/src/lib/floating/customResizeObserver.ts
+++ b/packages/vkui/src/lib/floating/customResizeObserver.ts
@@ -42,8 +42,9 @@ export class CustomResizeObserver {
     iframe: HTMLIFrameElement;
   }> = [];
   mutationObserverFallback: MutationObserver | null = null;
+  private readonly updateFunction: () => void;
 
-  constructor(private readonly updateFunction: () => void) {
+  constructor(updateFunction: () => void) {
     this.updateFunction = updateFunction;
   }
 

--- a/packages/vkui/src/lib/sheet/controllers/BottomSheetController.ts
+++ b/packages/vkui/src/lib/sheet/controllers/BottomSheetController.ts
@@ -26,8 +26,10 @@ export type BottomSheetControllerOptions = {
 };
 
 export class BottomSheetController {
+  private readonly sheetEl: HTMLElement;
+
   constructor(
-    private readonly sheetEl: HTMLElement,
+    sheetEl: HTMLElement,
     {
       sheetScrollEl,
       sheetTransitionController,
@@ -36,6 +38,7 @@ export class BottomSheetController {
       onDismiss,
     }: BottomSheetControllerOptions,
   ) {
+    this.sheetEl = sheetEl;
     this.onSnapPointChange = onSnapPointChange;
     this.onDismiss = onDismiss;
     this.panGestureRecognizer = new UIPanGestureRecognizer();

--- a/packages/vkui/src/lib/sheet/controllers/CSSTransitionController.ts
+++ b/packages/vkui/src/lib/sheet/controllers/CSSTransitionController.ts
@@ -1,10 +1,13 @@
 export type CSSTransitionControllerUnit = 'px' | '%' | '';
 
 export class CSSTransitionController<V extends number | string = number> {
-  constructor(
-    public readonly el: HTMLElement,
-    public readonly property: string,
-  ) {}
+  public readonly el: HTMLElement;
+  public readonly property: string;
+
+  constructor(el: HTMLElement, property: string) {
+    this.el = el;
+    this.property = property;
+  }
 
   set(to: V) {
     this.el.style.setProperty(this.property, `${to}`);

--- a/packages/vkui/src/testing/e2e/utils.tsx
+++ b/packages/vkui/src/testing/e2e/utils.tsx
@@ -22,10 +22,12 @@ export function getAdaptivePxWidth(viewWidth: ViewWidthType) {
 }
 
 class CustomValueWithLabel<T> {
-  public constructor(
-    public value: T,
-    public label: string,
-  ) {}
+  public value: T;
+  public label: string;
+  public constructor(value: T, label: string) {
+    this.value = value;
+    this.label = label;
+  }
 }
 
 type DecoratedPropValue<T> = T | CustomValueWithLabel<T>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "skipLibCheck": true,
     "baseUrl": "./",
     "outDir": ".cache/ts",
+    // "erasableSyntaxOnly": true, включить в v5.8.0
     "paths": {
       "@vkontakte/vkui": ["./packages/vkui/src"],
       // FIXME дублируем, чтобы не падал `yarn run lint:types`.


### PR DESCRIPTION
## Описание

Включаем [erasableSyntaxOnly](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option), который запрещает специфичный ts синтаксис

Это позволяет использовать  ts в node.JS из коробки, а также запрещает enum-ы и прочие приколы

Требует ts 5.8.0

## Изменения

Удалены объявление полей из конструктора

## Release notes
-