### PR TITLE
fix(TabbarItem): avoid double focus

### DIFF
--- a/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
@@ -5,6 +5,7 @@ import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';
 import { useFocusVisible } from '../../hooks/useFocusVisible';
 import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
 import { usePlatform } from '../../hooks/usePlatform';
+import { callMultiple } from '../../lib/callMultiple';
 import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
 import type { HasComponent, HasRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -63,28 +64,13 @@ export const TabbarItem = ({
     focusVisible,
   });
 
-  const handleFocus = React.useCallback(
-    (event: React.FocusEvent<HTMLElement>) => {
-      handleFocusVisibleOnFocus(event);
-      onFocusProp?.(event);
-    },
-    [onFocusProp, handleFocusVisibleOnFocus],
-  );
-  const handleBlur = React.useCallback(
-    (event: React.FocusEvent<HTMLElement>) => {
-      handleFocusVisibleOnBlur(event);
-      onBlurProp?.(event);
-    },
-    [onBlurProp, handleFocusVisibleOnBlur],
-  );
-
   return (
     <RootComponent
       Component={Component}
       {...restProps}
       disabled={disabled}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
+      onFocus={callMultiple(handleFocusVisibleOnFocus, onFocusProp)}
+      onBlur={callMultiple(handleFocusVisibleOnBlur, onBlurProp)}
       href={href}
       baseClassName={classNames(
         styles.host,

--- a/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 import { classNames, hasReactNode, noop } from '@vkontakte/vkjs';
+import { useFocusVisible } from '../../hooks/useFocusVisible';
+import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
 import { usePlatform } from '../../hooks/usePlatform';
 import { COMMON_WARNINGS, warnOnce } from '../../lib/warnOnce';
 import type { HasComponent, HasRootRef } from '../../types';
@@ -38,6 +40,8 @@ export const TabbarItem = ({
   href,
   Component = href ? 'a' : 'button',
   disabled,
+  onFocus: onFocusProp,
+  onBlur: onBlurProp,
   ...restProps
 }: TabbarItemProps): React.ReactNode => {
   const platform = usePlatform();
@@ -50,11 +54,37 @@ export const TabbarItem = ({
     }
   }
 
+  const {
+    focusVisible,
+    onFocus: handleFocusVisibleOnFocus,
+    onBlur: handleFocusVisibleOnBlur,
+  } = useFocusVisible();
+  const focusVisibleClassNames = useFocusVisibleClassName({
+    focusVisible,
+  });
+
+  const handleFocus = React.useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      handleFocusVisibleOnFocus(event);
+      onFocusProp?.(event);
+    },
+    [onFocusProp, handleFocusVisibleOnFocus],
+  );
+  const handleBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      handleFocusVisibleOnBlur(event);
+      onBlurProp?.(event);
+    },
+    [onBlurProp, handleFocusVisibleOnBlur],
+  );
+
   return (
     <RootComponent
       Component={Component}
       {...restProps}
       disabled={disabled}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       href={href}
       baseClassName={classNames(
         styles.host,
@@ -69,8 +99,9 @@ export const TabbarItem = ({
         activeMode={platform === 'ios' ? styles.tappableActive : 'background'}
         activeEffectDelay={platform === 'ios' ? 0 : 300}
         hasHover={false}
-        className={styles.tappable}
+        className={classNames(styles.tappable, focusVisibleClassNames)}
         onClick={noop}
+        tabIndex={-1}
       />
       <div className={styles.in}>
         <div className={styles.icon}>


### PR DESCRIPTION
- close #2743 

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Release notes

## Описание
Двойной фокус при переходе через `TabbarItem`'s табом происходит в основном из-за того, что внутри `TabbarItem`, который является кнопкой/ссылкой, лежит интерактивный `Tappable`. `Tappable` внутри нужен для того, чтобы на android был ripple эффект.

------

Видел решение https://github.com/VKCOM/VKUI/pull/5914. Тоже изначально думал как бы оставить один Tappable, но решил сделать быстрый фикс конкретно этого поведения. Но в целом, в будущем стоит отрефакторить TabbarItem, чтобы избавиться от ненужных нод и упростить компонент.

## Изменения
- убраем возможность фокуса на `Tappable` через tabindex="-1".
- добавляем focus-visible у `Tappable` при фокусировании на `TabbarItem`. Так как иначе при фокусе с клавиатуры вообще фокуса видно не будет, из-за tabindex="-1".

## Release notes
## Исправления
- TabItem: исправляем необходимость дважды нажимать таб на одном элементе
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
