### PR TITLE
fix(Storybook): fix double scroll in controls panel

### DIFF
--- a/packages/vkui/.storybook/addons/source-tab/SourceTab.tsx
+++ b/packages/vkui/.storybook/addons/source-tab/SourceTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { StoryId } from '@storybook/types';
-import { SyntaxHighlighter } from '@storybook/components';
+import { AddonPanel, SyntaxHighlighter } from '@storybook/components';
 import { SNIPPET_RENDERED } from '@storybook/docs-tools';
 import { useChannel } from '@storybook/manager-api';
 
@@ -10,7 +10,7 @@ type SnippetRenderedArgs = {
   source: string;
 };
 
-export const SourceTab = () => {
+export const SourceTab: React.FC<{ active: boolean }> = ({ active }) => {
   const [{ source }, handleSnippetRendered] = React.useState<SnippetRenderedArgs>({
     id: '',
     args: {},
@@ -21,15 +21,21 @@ export const SourceTab = () => {
 
   const sourceAvailable = Boolean(source);
 
+  if (!active) {
+    return null;
+  }
+
   return (
-    <SyntaxHighlighter
-      padded
-      wrapLongLines
-      language="tsx"
-      copyable={sourceAvailable}
-      bordered={sourceAvailable}
-    >
-      {sourceAvailable ? source : 'Compiling...'}
-    </SyntaxHighlighter>
+    <AddonPanel active={true}>
+      <SyntaxHighlighter
+        padded
+        wrapLongLines
+        language="tsx"
+        copyable={sourceAvailable}
+        bordered={sourceAvailable}
+      >
+        {sourceAvailable ? source : 'Compiling...'}
+      </SyntaxHighlighter>
+    </AddonPanel>
   );
 };

--- a/packages/vkui/.storybook/addons/source-tab/register.tsx
+++ b/packages/vkui/.storybook/addons/source-tab/register.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { AddonPanel } from '@storybook/components';
 import { addons, types } from '@storybook/manager-api';
 import { SourceTab } from './SourceTab';
 import { ADDON_ID, PANEL_ID } from './constants';
@@ -9,10 +8,6 @@ addons.register(ADDON_ID, () => {
     type: types.PANEL,
     title: 'Source',
     match: ({ viewMode }) => !!(viewMode && viewMode.match(/^story$/)),
-    render: ({ active = false }) => (
-      <AddonPanel active={active}>
-        <SourceTab />
-      </AddonPanel>
-    ),
+    render: ({ active = false }) => <SourceTab active={active} />,
   });
 });


### PR DESCRIPTION
## Описание

Сейчас на вкладке `Controls` в сторибуке отображается двойной скролл
<img width="1459" alt="image" src="https://github.com/user-attachments/assets/7dda0ff6-6e91-4324-a9a6-fb25d33e86be" />
Нужно избавиться от двойного скролла

## Изменения

Оказалось, чтоб проблема в том, что вкладка `Source` скрывается только визуально, но остается в верстке. А в стилях сторибука важные стили применяются только к первому элементу.
Получается есть два варианта решения проблемы:
1. Перемещаем вкладку `Source` после `Controls`
2. Не рендерим контент  `Source`, если вкладка неактивна

Решил выбрать второй вариант, чтобы не менять порядок вкладок.

**Результат:**
<img width="1531" alt="image" src="https://github.com/user-attachments/assets/a75439c1-e592-4350-a830-4eb728a2c5b9" />


## Release notes
-
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
