### PR TITLE
doc(Select): Use Select instead of CustomSelect in Select doc

### DIFF
--- a/packages/vkui/src/components/Select/Readme.md
+++ b/packages/vkui/src/components/Select/Readme.md
@@ -23,7 +23,7 @@
 
 ```jsx static
 <label htmlFor="select-id">Администратор</label>
-<CustomSelect
+<Select
   id="select-id"
   placeholder="Не выбран"
   options={users}
@@ -34,7 +34,7 @@
 
 ```jsx static
 <FormItem top="Администратор" htmlFor="select-id">
-  <CustomSelect id="select-id" placeholder="Не выбран" options={users} />
+  <Select id="select-id" placeholder="Не выбран" options={users} />
 </FormItem>
 ```
 
@@ -42,7 +42,7 @@
 
 ```jsx static
 <VisuallyHidden Component="label" htmlFor="select-id">Администратор</VisuallyHidden>
-<CustomSelect
+<Select
   id="select-id"
   placeholder="Не выбран"
   options={users}
@@ -53,7 +53,7 @@
 
 ```jsx static
 <span id="select-label-id">Администратор</span>
-<CustomSelect
+<Select
   aria-labelledby="select-label-id"
   placeholder="Не выбран"
   options={users}
@@ -64,7 +64,7 @@
 
 ```jsx static
 <VisuallyHidden Component="span" id="select-label-id">Администратор</VisuallyHidden>
-<CustomSelect
+<Select
   aria-labelledby="select-label-id"
   placeholder="Не выбран"
   options={users}
@@ -74,7 +74,7 @@
 - вместе с [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
 
 ```jsx static
-<CustomSelect aria-label="Администратор" placeholder="Не выбран" options={users} />
+<Select aria-label="Администратор" placeholder="Не выбран" options={users} />
 ```
 
 ## Тестирование (e2e)


### PR DESCRIPTION
- close #6780

---


## Описание
Убираем использование CustomSelect в примерах документации Select

## Release notes
-
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
