### PR TITLE
tech(storybook): add storybook addon documentation link button

### DIFF
--- a/packages/vkui/.storybook/addons/documentation-button/DocumentationButton.tsx
+++ b/packages/vkui/.storybook/addons/documentation-button/DocumentationButton.tsx
@@ -1,0 +1,50 @@
+import { IconButton } from '@storybook/components';
+import { useGlobals, useStorybookState } from '@storybook/manager-api';
+import { DocumentIcon } from '@storybook/icons';
+import * as React from 'react';
+
+function getVersionFromUrl() {
+  const url = window.location.href;
+  const match = url.match(/\/(\d+\.\d+\.\d+)\//);
+  return match ? match[1] : '';
+}
+
+const getComponentUrl = (docsBaseUrl: string, componentName: string): string => {
+  const version = getVersionFromUrl();
+  if (version) {
+    return `${docsBaseUrl}${version}/#/${componentName}/`;
+  }
+  return `${docsBaseUrl}#/${componentName}/`;
+};
+
+function extractComponentName(path: string): string {
+  const match = path.match(/\/([^/]+)\/\1\.stories\.tsx$/);
+  return match ? match[1] : '';
+}
+
+export const DocumentationButton = () => {
+  const { index, storyId } = useStorybookState();
+  const [globals] = useGlobals();
+  const story = index?.[storyId];
+  const importPath = story && 'importPath' in story && story.importPath;
+
+  if (!importPath) {
+    return null;
+  }
+
+  const componentName = extractComponentName(importPath);
+  const hasDocumentation = globals.styleguideComponentsMap[componentName];
+  if (!hasDocumentation) {
+    return null;
+  }
+
+  const documentationUrl = getComponentUrl(globals.styleguideBaseUrl, componentName);
+
+  return (
+    <a href={documentationUrl} target="_blank" rel="noreferrer">
+      <IconButton>
+        <DocumentIcon />
+      </IconButton>
+    </a>
+  );
+};

--- a/packages/vkui/.storybook/addons/documentation-button/DocumentationButton.tsx
+++ b/packages/vkui/.storybook/addons/documentation-button/DocumentationButton.tsx
@@ -33,7 +33,7 @@ export const DocumentationButton = () => {
   }
 
   const componentName = extractComponentName(importPath);
-  const hasDocumentation = globals.styleguideComponentsMap[componentName];
+  const hasDocumentation = globals.styleguideComponents.includes(componentName);
   if (!hasDocumentation) {
     return null;
   }

--- a/packages/vkui/.storybook/addons/documentation-button/constants.ts
+++ b/packages/vkui/.storybook/addons/documentation-button/constants.ts
@@ -1,0 +1,1 @@
+export const ADDON_ID = 'storybook/documentation';

--- a/packages/vkui/.storybook/addons/documentation-button/register.ts
+++ b/packages/vkui/.storybook/addons/documentation-button/register.ts
@@ -1,0 +1,11 @@
+import { addons, types } from '@storybook/manager-api';
+import { ADDON_ID } from './constants';
+import { DocumentationButton } from './DocumentationButton';
+
+addons.register(ADDON_ID, () => {
+  addons.add(ADDON_ID, {
+    title: 'Documentation',
+    type: types.TOOL,
+    render: DocumentationButton,
+  });
+});

--- a/packages/vkui/.storybook/addons/source-button/SourceButton.tsx
+++ b/packages/vkui/.storybook/addons/source-button/SourceButton.tsx
@@ -1,17 +1,17 @@
 import { IconButton } from '@storybook/components';
-import { useStorybookState } from '@storybook/manager-api';
+import { useGlobals, useStorybookState } from '@storybook/manager-api';
 import { GithubIcon } from '@storybook/icons';
 import * as React from 'react';
-import { BASE_COMPONENTS_URL } from './constants';
 
-const getComponentUrl = (importPath: string): string => {
+const getComponentUrl = (repositoryUrl: string, importPath: string): string => {
   const pathWithoutFile = importPath.replace(/\/[^/]+\.stories\.tsx$/, '');
   const cleanPath = pathWithoutFile.replace(/^\.\//, '');
-  return `${BASE_COMPONENTS_URL}/${cleanPath}/`;
+  return `${repositoryUrl}/${cleanPath}/`;
 };
 
 export const SourceButton = () => {
   const { index, storyId } = useStorybookState();
+  const [globals] = useGlobals();
 
   const story = index?.[storyId];
   const importPath = story && 'importPath' in story && story.importPath;
@@ -20,7 +20,7 @@ export const SourceButton = () => {
     return null;
   }
 
-  const sourceUrl = getComponentUrl(importPath);
+  const sourceUrl = getComponentUrl(globals.componentsSourceBaseUrl, importPath);
 
   return (
     <a href={sourceUrl} target="_blank" rel="noreferrer">

--- a/packages/vkui/.storybook/addons/source-button/constants.ts
+++ b/packages/vkui/.storybook/addons/source-button/constants.ts
@@ -1,2 +1,1 @@
 export const ADDON_ID = 'storybook/source';
-export const BASE_COMPONENTS_URL = 'https://github.com/VKCOM/VKUI/tree/master/packages/vkui';

--- a/packages/vkui/.storybook/helpers/index.ts
+++ b/packages/vkui/.storybook/helpers/index.ts
@@ -1,0 +1,33 @@
+import styleguideConfig from '../../../../styleguide/config.js';
+
+function extractComponentName(path: string): string {
+  const match = path.match(/\/([^/]+)\/\1\.tsx$/);
+  return match ? match[1] : '';
+}
+
+export function getStyleGuideComponentsMap() {
+  const componentsSection = styleguideConfig.sections.find(
+    (section) => section.name === 'Компоненты',
+  );
+  const resultMap: Record<string, boolean> = {};
+
+  const handleSections = (sections, resultArray: string[]) => {
+    sections.forEach((section) => {
+      const components =
+        typeof section.components === 'function' ? section.components() : section.components;
+      resultArray.push(...components);
+      if (section.sections) {
+        handleSections(section.sections, resultArray);
+      }
+    });
+  };
+
+  const allComponents = [];
+  handleSections(componentsSection.sections, allComponents);
+
+  allComponents.forEach((path) => {
+    resultMap[extractComponentName(path)] = true;
+  });
+
+  return resultMap;
+}

--- a/packages/vkui/.storybook/helpers/index.ts
+++ b/packages/vkui/.storybook/helpers/index.ts
@@ -5,17 +5,16 @@ function extractComponentName(path: string): string {
   return match ? match[1] : '';
 }
 
-export function getStyleGuideComponentsMap() {
+export function getStyleGuideComponents() {
   const componentsSection = styleguideConfig.sections.find(
     (section) => section.name === 'Компоненты',
   );
-  const resultMap: Record<string, boolean> = {};
 
   const handleSections = (sections, resultArray: string[]) => {
     sections.forEach((section) => {
       const components =
         typeof section.components === 'function' ? section.components() : section.components;
-      resultArray.push(...components);
+      resultArray.push(...components.map(extractComponentName));
       if (section.sections) {
         handleSections(section.sections, resultArray);
       }
@@ -25,9 +24,5 @@ export function getStyleGuideComponentsMap() {
   const allComponents = [];
   handleSections(componentsSection.sections, allComponents);
 
-  allComponents.forEach((path) => {
-    resultMap[extractComponentName(path)] = true;
-  });
-
-  return resultMap;
+  return allComponents;
 }

--- a/packages/vkui/.storybook/main.ts
+++ b/packages/vkui/.storybook/main.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { readFileSync } from 'fs';
 import type { StorybookConfig } from '@storybook/react-webpack5';
 import WebpackCommonConfig from '../../../webpack.common.config';
-import { getStyleGuideComponentsMap } from './helpers';
+import { getStyleGuideComponents } from './helpers';
 
 const cssRegExpString = /\.css$/.toString();
 
@@ -70,7 +70,7 @@ const config: StorybookConfig = {
     const packageJSON = JSON.parse(readFileSync('./package.json', 'utf-8'));
     config.plugins.push(
       new DefinePlugin({
-        __STYLEGUIDE_COMPONENTS_CONFIG__: JSON.stringify(getStyleGuideComponentsMap()),
+        __STYLEGUIDE_COMPONENTS_CONFIG__: JSON.stringify(getStyleGuideComponents()),
         __STYLEGUIDE_URL__: JSON.stringify(packageJSON.homepage),
         __COMPONENTS_SOURCE_BASE_URL__: JSON.stringify(
           `${packageJSON.repository.url.replace('.git', '')}/tree/master/${packageJSON.repository.directory}`,

--- a/packages/vkui/.storybook/main.ts
+++ b/packages/vkui/.storybook/main.ts
@@ -1,8 +1,10 @@
-import { Configuration } from 'webpack';
+import { Configuration, DefinePlugin } from 'webpack';
 import type { Options } from '@swc/core';
 import path from 'path';
+import { readFileSync } from 'fs';
 import type { StorybookConfig } from '@storybook/react-webpack5';
 import WebpackCommonConfig from '../../../webpack.common.config';
+import { getStyleGuideComponentsMap } from './helpers';
 
 const cssRegExpString = /\.css$/.toString();
 
@@ -32,6 +34,7 @@ const config: StorybookConfig = {
     './addons/pointer',
     './addons/customPanelHeaderAfter',
     './addons/source-button',
+    './addons/documentation-button',
     './addons/storybook-theme',
     getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
   ],
@@ -64,6 +67,16 @@ const config: StorybookConfig = {
     const rulesWithoutCss = excludeCssRulesFromConfig(config) ?? [];
 
     config.module!.rules = [...rulesWithoutCss, ...commonCssRules];
+    const packageJSON = JSON.parse(readFileSync('./package.json', 'utf-8'));
+    config.plugins.push(
+      new DefinePlugin({
+        __STYLEGUIDE_COMPONENTS_CONFIG__: JSON.stringify(getStyleGuideComponentsMap()),
+        __STYLEGUIDE_URL__: JSON.stringify(packageJSON.homepage),
+        __COMPONENTS_SOURCE_BASE_URL__: JSON.stringify(
+          `${packageJSON.repository.url.replace('.git', '')}/tree/master/${packageJSON.repository.directory}`,
+        ),
+      }),
+    );
 
     return config;
   },

--- a/packages/vkui/.storybook/preview.ts
+++ b/packages/vkui/.storybook/preview.ts
@@ -62,7 +62,7 @@ const preview: Preview = {
     cartesian: { disabled: true },
   },
   globalTypes: {
-    styleguideComponentsMap: {
+    styleguideComponents: {
       defaultValue: __STYLEGUIDE_COMPONENTS_CONFIG__,
     },
     styleguideBaseUrl: {

--- a/packages/vkui/.storybook/preview.ts
+++ b/packages/vkui/.storybook/preview.ts
@@ -9,6 +9,12 @@ import { withConsole } from '@storybook/addon-console';
 import { BREAKPOINTS } from '../src/lib/adaptivity';
 import { withVKUIWrapper } from '../src/storybook/VKUIDecorators';
 
+declare global {
+  const __STYLEGUIDE_COMPONENTS_CONFIG__: Record<string, boolean>;
+  const __STYLEGUIDE_URL__: string;
+  const __COMPONENTS_SOURCE_BASE_URL__: string;
+}
+
 interface CustomViewPortItem {
   name: string;
   styles: {
@@ -56,6 +62,15 @@ const preview: Preview = {
     cartesian: { disabled: true },
   },
   globalTypes: {
+    styleguideComponentsMap: {
+      defaultValue: __STYLEGUIDE_COMPONENTS_CONFIG__,
+    },
+    styleguideBaseUrl: {
+      defaultValue: __STYLEGUIDE_URL__,
+    },
+    componentsSourceBaseUrl: {
+      defaultValue: __COMPONENTS_SOURCE_BASE_URL__,
+    },
     colorScheme: {
       defaultValue: 'light',
     },


### PR DESCRIPTION
- [x] Release notes

## Описание

Сейчас со страницы компонента в styleguide можно перейти на страницу компонента в storybook, а наоборот сделать не получится. Нужно добавить кнопку для перехода в styleguide

## Изменения

- Добавил аддон, который добавляет кнопку с помощью которой можно перейти на страницу с докой по компоненту
- Поскольку не все компоненты из сторибука имеют отдельную страницу в доке, на этапе сборки добавил получение конфига для styleguide-а, откуда вытаскиваю список компонентов. И уже в зависимости от того, есть ли компонент в списке, показываю кнопку для перехода к доке
- Получение базовой ссылки на доку сделал через вытаскивание из package.json ссылки на homepage
- Также переделал получение ссылки на репозиторий проекта, через парсинг package.json 

## Release notes
## Документация
- в storybook добавлена возможность перейти к странице с документацией компонента в styleguide
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
