### PR TITLE
ci: use github.event.pull_request.user.login

### DIFF
--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -27,7 +27,7 @@ jobs:
           label: 'patch'
 
       - name: VKUI-tokens
-        if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.title, '@vkontakte/vkui-tokens') }}
+        if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.title, '@vkontakte/vkui-tokens') }}
         uses: ./.github/actions/add-label-to-pull-request
         with:
           issue_number: ${{ github.event.pull_request.number }}
@@ -38,7 +38,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: ${{ github.event.action == 'opened' && github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.action == 'opened' && github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Описание

`github.actor` может быть слабым, требуется использовать `github.event.pull_request.user.login`

См https://www.synacktiv.com/publications/github-actions-exploitation-dependabot

## Release notes
-