### PR TITLE
fix(Alert): Move dismiss button before actions to focus on it first

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.stories.tsx
+++ b/packages/vkui/src/components/Alert/Alert.stories.tsx
@@ -28,16 +28,11 @@ export const Playground: StoryObj<AlertProps> = {
   },
   args: {
     actions: [
-      {
-        title: 'Отмена',
-        mode: 'cancel',
-      },
-      {
-        title: 'Удалить',
-        mode: 'destructive',
-      },
+      { title: 'Отмена', mode: 'cancel' },
+      { title: 'Удалить', mode: 'destructive' },
     ],
     actionsLayout: 'horizontal',
+    dismissLabel: 'Отмена',
     title: 'Удаление документа',
     description: 'Вы уверены, что хотите удалить этот документ?',
   },

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -223,6 +223,11 @@ export const Alert = ({
               </IconButton>
             )}
           </div>
+          {isDismissButtonVisible && dismissButtonMode === 'outside' && (
+            <ModalDismissButton onClick={close} data-testid={dismissButtonTestId}>
+              {dismissLabel}
+            </ModalDismissButton>
+          )}
           <AlertActions
             actions={actions}
             actionsAlign={actionsAlign}
@@ -230,11 +235,6 @@ export const Alert = ({
             renderAction={renderAction}
             onItemClick={onItemClick}
           />
-          {isDismissButtonVisible && dismissButtonMode === 'outside' && (
-            <ModalDismissButton onClick={close} data-testid={dismissButtonTestId}>
-              {dismissLabel}
-            </ModalDismissButton>
-          )}
         </FocusTrap>
       </PopoutWrapper>
     </AppRootPortal>

--- a/packages/vkui/src/components/Alert/Readme.md
+++ b/packages/vkui/src/components/Alert/Readme.md
@@ -10,6 +10,25 @@
 - используя свойство `aria-label`;
 - используя свойство `aria-labelledby`;
 
+### Доступные имена кнопок
+
+Если две кнопки находятся в разных местах, но выполняют одну функцию, то лучше дать им одинаковые имена.
+Это относится, например, к кнопке закрытия (крестик на декстопах), имя которой можно задать через свойство `dismissLabel`.
+Если у вас среди кнопок действия есть кнопка `Отмена`, которая без дополнительного действия просто закрывает `Alert`, ровно
+как и кнопка закрытия, то кнопке закрытия следует дать то же имя `Отмена` через свойство `dismissLabel`.
+
+```jsx static
+<Alert
+  dismissLabel="Отмена"
+  actions={[
+    { title: 'Отмена', mode: 'cancel' },
+    { title: 'Удалить', mode: 'destructive', action: () => addActionLogItem('Документ удален.') },
+  ]}
+  title="Удаление документа"
+  description="Вы уверены, что хотите удалить этот документ?"
+/>
+```
+
 ## Типы кнопок
 
 В Алертах особое внимание нужно уделить кнопкам. Всего есть три типа кнопок:
@@ -56,11 +75,9 @@ const Example = () => {
             mode: 'destructive',
             action: () => addActionLogItem('Право на модерацию контента убрано.'),
           },
-          {
-            title: 'Отмена',
-            mode: 'cancel',
-          },
+          { title: 'Отмена', mode: 'cancel' },
         ]}
+        dismissLabel="Отмена"
         actionsLayout="vertical"
         onClose={closePopout}
         title="Подтвердите действие"
@@ -73,10 +90,7 @@ const Example = () => {
     setPopout(
       <Alert
         actions={[
-          {
-            title: 'Отмена',
-            mode: 'cancel',
-          },
+          { title: 'Отмена', mode: 'cancel' },
           {
             title: 'Удалить',
             mode: 'destructive',
@@ -84,6 +98,7 @@ const Example = () => {
           },
         ]}
         actionsLayout="horizontal"
+        dismissLabel="Отмена"
         dismissButtonMode="inside"
         onClose={closePopout}
         title="Удаление документа"
@@ -136,15 +151,10 @@ const Example = () => {
     setPopout(
       <Alert
         actions={[
-          {
-            title: 'Лишить права',
-            mode: 'destructive',
-          },
-          {
-            title: 'Отмена',
-            mode: 'cancel',
-          },
+          { title: 'Лишить права', mode: 'destructive' },
+          { title: 'Отмена', mode: 'cancel' },
         ]}
+        dismissLabel="Отмена"
         actionsAlign="left"
         actionsLayout="horizontal"
         renderAction={renderAction}

--- a/packages/vkui/src/types.ts
+++ b/packages/vkui/src/types.ts
@@ -51,7 +51,8 @@ export interface Version {
 export type AnchorHTMLAttributesOnly = Omit<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   keyof React.HTMLAttributes<HTMLAnchorElement>
->;
+> &
+  React.AriaAttributes;
 
 /**
  * Проверяет, является ли тип подтипом другого.


### PR DESCRIPTION
- close #3042

---
- [x] Release notes

## Описание
В задаче #3042 указаны две явные проблемы:
- фокус должен попадать на заголовок, а он не попадает 
  Исходя из рекоммендаций [W3C спецификации](https://w3c.github.io/aria/#alertdialog) и других ресурсов ([[1]](https://doka.guide/a11y/role-alertdialog/), [[2]](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role)) выходит, что лучше всего иммено фокус на интерактивном элементе, редко когда встречается совет фокусироваться на начале текста, и то, только если текста много.
  Наш `Alert` требование фокуса выполняет. В это PR я лишь передвинул кнопку закрытия алерта выше в дереве, чтобы при её наличии фокус был на ней, и пользователь не мог случайно согласиться на какое-то действие.
  Пожелание из #3042 от том, что нужен фокус на заголовке обусловлен тем, что нужно, чтобы скринридер прочитал текст в `Alert` при его появлении. `NVDA` и `VoiceOver` читают текст, так как мы используем внутри связь алерта с заголовком и содержимым чере aria-labelledby и area-describedby.

- Кнопки выполняют одинаковые действия, но называются по разному. 
  > Кажется, что первая и третья кнопки выполняют одно и то же действие, и по смыслу дублируют друг друга:
  > Отмена
  > Удалить
  > Закрыть предупреждение

  Долго думал как бы спрятать или предоставить пользователям библиотеки возможность прятать лишние дублирующие кнопки, но после общения со специалистом по доступности понял, что проблема не в дублировании, а в том, что кнопки называются по разному и могут сбивать с толку, если выполняют одно и то же действие.
Решением тут вижу только исправление примера в Storybook и доке и указание в доке о том, что если кнопка закрытия алерта и кнопка действия по сути выполняют одно и то же действие, то имена у них в дереве доступности должны быть одинаковыми.
Решение: если кнопка действия и кнопка закрытия выполняют одинаковые действия их имена в дереве доступности должный быть одинаковыми. В частности кнопка закрытия через свойство `dismissLabel` должно повторять имя одной из кнопок действия.

  Были мысли проверять есть ли action у кнопки с режимом 'cancel` и тогда кнопку закрытия прятать от скринридера, чтобы избежать дублирования, но пришел к выводу, что тут можно только хуже сделать и усложнить.
Примера должно быть достаточно.  Варианты использования могут быть разными и не зависеть от action mode.

## Release notes
## Исправления
- Alert: улучшена доступность компонента
Кнопка закрытия, при наличии, первой получает фокус при открытии алерта
В документацию по доступности компонента добавлен пункт по поводу имен кнопок с одинаковыми действиями
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
