### PR TITLE
doc(DateInput/FormLayoutGroup): Segmented example without visible labels

### DIFF
--- a/packages/vkui/src/components/DateInput/DateInput.test.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.test.tsx
@@ -275,11 +275,18 @@ describe('DateInput', () => {
         <>
           <DateInput
             value={dateValue}
-            renderCustomValue={(date) =>
-              date ? undefined : (
-                <span style={{ color: 'var(--vkui--color_text_secondary)' }}>Не задано</span>
-              )
-            }
+            renderCustomValue={(date) => {
+              if (!date) {
+                return undefined;
+              }
+              if (isToday(date)) {
+                return 'Сегодня';
+              }
+              if (isYesterday(date)) {
+                return 'Вчера';
+              }
+              return undefined;
+            }}
             onChange={noop}
             {...testIds}
           />

--- a/packages/vkui/src/components/DateInput/DateInput.test.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.test.tsx
@@ -275,18 +275,11 @@ describe('DateInput', () => {
         <>
           <DateInput
             value={dateValue}
-            renderCustomValue={(date) => {
-              if (!date) {
-                return undefined;
-              }
-              if (isToday(date)) {
-                return 'Сегодня';
-              }
-              if (isYesterday(date)) {
-                return 'Вчера';
-              }
-              return undefined;
-            }}
+            renderCustomValue={(date) =>
+              date ? undefined : (
+                <span style={{ color: 'var(--vkui--color_text_secondary)' }}>Не задано</span>
+              )
+            }
             onChange={noop}
             {...testIds}
           />

--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
@@ -39,10 +39,10 @@ export const Playground: Story = {
 export const AccessibleHorizontalSegmeted: Story = {
   render: (args) => (
     <FormLayoutGroup mode="horizontal" segmented {...args}>
-      <VisuallyHidden Component="label" htmlFor="nikname-id">
-        Никнейм или имя
-      </VisuallyHidden>
       <FormItem>
+        <VisuallyHidden Component="label" htmlFor="nikname-id">
+          Никнейм или имя
+        </VisuallyHidden>
         <Input id="nickname-id" placeholder="Никнейм или имя" />
       </FormItem>
       <FormItem>

--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
@@ -1,8 +1,11 @@
+import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
+import { DateInput } from '../DateInput/DateInput';
 import { FormItem } from '../FormItem/FormItem';
 import { Input } from '../Input/Input';
 import { Select } from '../Select/Select';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { FormLayoutGroup, type FormLayoutGroupProps } from './FormLayoutGroup';
 
 const story: Meta<FormLayoutGroupProps> = {
@@ -32,4 +35,49 @@ export const Playground: Story = {
       </FormItem>
     </FormLayoutGroup>
   ),
+};
+
+function Render(props: FormLayoutGroupProps) {
+  const dateInputId = React.useId();
+  const nicknameInputId = React.useId();
+  const linkOrIdInputId = React.useId();
+  const [dateValue, setDateValue] = React.useState<Date | undefined>();
+
+  return (
+    <FormLayoutGroup mode="horizontal" segmented {...props}>
+      <VisuallyHidden Component="label" htmlFor={nicknameInputId}>
+        Никнейм или имя
+      </VisuallyHidden>
+      <FormItem>
+        <Input id={nicknameInputId} placeholder="Никнейм или имя" />
+      </FormItem>
+      <FormItem>
+        <VisuallyHidden Component="label" htmlFor={dateInputId}>
+          Ссылка на ID
+        </VisuallyHidden>
+        <Input id={linkOrIdInputId} placeholder="Ссылка на ID" />
+      </FormItem>
+      <FormItem>
+        <VisuallyHidden Component="label" htmlFor={dateInputId}>
+          Дата или диапазон
+        </VisuallyHidden>
+        <DateInput
+          id={dateInputId}
+          value={dateValue}
+          onChange={(date) => setDateValue(date)}
+          renderCustomValue={(date: Date | undefined) =>
+            date ? undefined : (
+              <span aria-hidden style={{ color: 'var(--vkui--color_text_secondary)' }}>
+                Дата или диапазон
+              </span>
+            )
+          }
+        />
+      </FormItem>
+    </FormLayoutGroup>
+  );
+}
+
+export const HorizontalSegmeted: Story = {
+  render: (args) => <Render {...args} />,
 };

--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
 import { DateInput } from '../DateInput/DateInput';
@@ -37,34 +36,27 @@ export const Playground: Story = {
   ),
 };
 
-function Render(props: FormLayoutGroupProps) {
-  const dateInputId = React.useId();
-  const nicknameInputId = React.useId();
-  const linkOrIdInputId = React.useId();
-  const [dateValue, setDateValue] = React.useState<Date | undefined>();
-
-  return (
-    <FormLayoutGroup mode="horizontal" segmented {...props}>
-      <VisuallyHidden Component="label" htmlFor={nicknameInputId}>
+export const AccessibleHorizontalSegmeted: Story = {
+  render: (args) => (
+    <FormLayoutGroup mode="horizontal" segmented {...args}>
+      <VisuallyHidden Component="label" htmlFor="nikname-id">
         Никнейм или имя
       </VisuallyHidden>
       <FormItem>
-        <Input id={nicknameInputId} placeholder="Никнейм или имя" />
+        <Input id="nickname-id" placeholder="Никнейм или имя" />
       </FormItem>
       <FormItem>
-        <VisuallyHidden Component="label" htmlFor={dateInputId}>
+        <VisuallyHidden Component="label" htmlFor="link-or-id-input-id">
           Ссылка на ID
         </VisuallyHidden>
-        <Input id={linkOrIdInputId} placeholder="Ссылка на ID" />
+        <Input id="link-or-id-input-id" placeholder="Ссылка на ID" />
       </FormItem>
       <FormItem>
-        <VisuallyHidden Component="label" htmlFor={dateInputId}>
+        <VisuallyHidden Component="label" htmlFor="date-id">
           Дата или диапазон
         </VisuallyHidden>
         <DateInput
-          id={dateInputId}
-          value={dateValue}
-          onChange={(date) => setDateValue(date)}
+          id="date-id"
           renderCustomValue={(date: Date | undefined) =>
             date ? undefined : (
               <span aria-hidden style={{ color: 'var(--vkui--color_text_secondary)' }}>
@@ -75,9 +67,5 @@ function Render(props: FormLayoutGroupProps) {
         />
       </FormItem>
     </FormLayoutGroup>
-  );
-}
-
-export const HorizontalSegmeted: Story = {
-  render: (args) => <Render {...args} />,
+  ),
 };

--- a/packages/vkui/src/components/FormLayoutGroup/Readme.md
+++ b/packages/vkui/src/components/FormLayoutGroup/Readme.md
@@ -7,6 +7,38 @@
 - Рекомендуется предавать в компонент атрибуты `aria-labelledby`, `aria-label` и `aria-describedby` для предоставления
   дополнительной информации об элементе
 
+### Сегментированный дизайн, где лейблы визуально лежат в плейсхолдерах инпутов
+
+Если по дизайну требуется использовать сегментированный режим `segmented`, где все поля слиты вместе и отделяются вертикальным разделителем, при этом над полями нету текста (лэйблов), то есть нельзя использовать свойства `htmlFor` и `top` у [FormItem](#!/FormItem) для связывания инпутов и лэйблов, то стоит добавить скрытые лэйблы, используя сервисный компонент [VisuallyHidden](#!/VisuallyHidden) и связать их с инпутами через `id` и `htmlFor` дублируя текс плейсхолдера.
+Живой пример ниже.
+
+```jsx static
+<FormLayoutGroup mode="horizontal" segmented>
+  <VisuallyHidden Component="label" htmlFor="nickname-id">
+    Никнейм или имя
+  </VisuallyHidden>
+  <FormItem>
+    <Input id="nickname-id" placeholder="Никнейм или имя" />
+  </FormItem>
+  <FormItem>
+    <VisuallyHidden Component="label" htmlFor='dateinput-id'>
+      Дата или диапазон
+    </VisuallyHidden>
+    <DateInput
+      id="dateinput-id"
+      {/* специальное свойство, позволяющее отрисовать плейсхолдер у DateInput */}
+      renderCustomValue={(date: Date | undefined) =>
+        date ? undefined : (
+          <span aria-hidden style={{ color: 'var(--vkui--color_text_secondary)' }}>
+            Дата или диапазон
+          </span>
+        )
+      }
+    />
+  </FormItem>
+</FormLayoutGroup>
+```
+
 ```jsx
 const Example = () => {
   const [showDates, setShowDates] = useState(true);
@@ -74,6 +106,36 @@ const Example = () => {
                 </FormItem>
               </FormLayoutGroup>
             )}
+          </FormLayoutGroup>
+        </Group>
+        <Group
+          header={
+            <Header>Сегментированный режим с лейблами, визуально лежащими в плейсхолдерах</Header>
+          }
+        >
+          <FormLayoutGroup mode="horizontal" segmented>
+            <VisuallyHidden Component="label" htmlFor="nickname-id">
+              Никнейм или имя
+            </VisuallyHidden>
+            <FormItem>
+              <Input id="nickname-id" placeholder="Никнейм или имя" />
+            </FormItem>
+            <FormItem>
+              <VisuallyHidden Component="label" htmlFor="dateinput-id">
+                Дата или диапазон
+              </VisuallyHidden>
+              <DateInput
+                id="dateinput-id"
+                // специальное свойство, позволяющее отрисовать плейсхолдер у DateInput
+                renderCustomValue={(date) =>
+                  date ? undefined : (
+                    <span aria-hidden style={{ color: 'var(--vkui--color_text_secondary)' }}>
+                      Дата или диапазон
+                    </span>
+                  )
+                }
+              />
+            </FormItem>
           </FormLayoutGroup>
         </Group>
       </Panel>

--- a/packages/vkui/src/components/FormLayoutGroup/Readme.md
+++ b/packages/vkui/src/components/FormLayoutGroup/Readme.md
@@ -9,15 +9,15 @@
 
 ### Сегментированный дизайн, где лейблы визуально лежат в плейсхолдерах инпутов
 
-Если по дизайну требуется использовать сегментированный режим `segmented`, где все поля слиты вместе и отделяются вертикальным разделителем, при этом над полями нету текста (лэйблов), то есть нельзя использовать свойства `htmlFor` и `top` у [FormItem](#!/FormItem) для связывания инпутов и лэйблов, то стоит добавить скрытые лэйблы, используя сервисный компонент [VisuallyHidden](#!/VisuallyHidden) и связать их с инпутами через `id` и `htmlFor` дублируя текс плейсхолдера.
+Если по дизайну требуется использовать сегментированный режим `segmented`, где все поля слиты вместе и отделяются вертикальным разделителем, при этом над полями нету текста (лэйблов), то есть нельзя использовать свойства `htmlFor` и `top` у [FormItem](#!/FormItem) для связывания инпутов и лэйблов, то стоит добавить скрытые лэйблы, используя сервисный компонент [VisuallyHidden](#!/VisuallyHidden) и связать их с инпутами через `id` и `htmlFor` дублируя текст плейсхолдера.
 Живой пример ниже.
 
 ```jsx static
 <FormLayoutGroup mode="horizontal" segmented>
-  <VisuallyHidden Component="label" htmlFor="nickname-id">
-    Никнейм или имя
-  </VisuallyHidden>
   <FormItem>
+    <VisuallyHidden Component="label" htmlFor="nickname-id">
+      Никнейм или имя
+    </VisuallyHidden>
     <Input id="nickname-id" placeholder="Никнейм или имя" />
   </FormItem>
   <FormItem>
@@ -114,10 +114,10 @@ const Example = () => {
           }
         >
           <FormLayoutGroup mode="horizontal" segmented>
-            <VisuallyHidden Component="label" htmlFor="nickname-id">
-              Никнейм или имя
-            </VisuallyHidden>
             <FormItem>
+              <VisuallyHidden Component="label" htmlFor="nickname-id">
+                Никнейм или имя
+              </VisuallyHidden>
               <Input id="nickname-id" placeholder="Никнейм или имя" />
             </FormItem>
             <FormItem>


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7867

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [ ] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [ ] Release notes

## Описание
Пока изучал проблематику задачи #7867 вспомнил, что возможноcть передачи `placeholder` в `DateInput` мы уже реализовали с помощью свойства `rederCustomValue` в #8168

Собственно проблема задачи #7867 в том, что вот такой дизайн, где лейблы над полями отстутсвуют, и текст лэйблов на самом деле лежит как `placeholder` у инпутов, было сложно реализовать без #8168
<img width="808" alt="Screenshot 2025-02-14 at 13 15 07" src="https://github.com/user-attachments/assets/fd157738-1bc3-4a6d-809a-7fe209968324" />

Оставался лишь вопрос как это реализовать доступно, чтобы скринридер зачитал названия полей, например, даже когда в них введен текст.

Как решение можно воспользоваться нашим сервисным компонентом `VisuallyHidden`, в котором можно задать тег `label` через свойство `Component="label"`, продублировать текст из плейсхолдера и связать через `id` и `htmlFor` с инпутом.
Добавли пример в сторибук и в доку, чтобы ссылаться на него.

В `VoiceOver` и `NVDA` текст зачитывается очень даже не плохо. Надо ещё проконсультироваться со специалистом по доступности.

## Release notes
### Документация
- FormLayoutGroup: добавлен пример доступного `FormLayoutGroup` в режиме `segmented`, для дизайна, когда лейблы визуально находятся в инпутах на месте плейсхолдера
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
