### PR TITLE
fix(HorizontalScroll): remove wheels event from container

### DIFF
--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.test.tsx
@@ -19,11 +19,6 @@ const setup = (element: HTMLElement, startScrollLeft = 0) => {
 
   jest.spyOn(element.firstElementChild!, 'scrollWidth', 'get').mockImplementation(() => 500);
 
-  // @ts-expect-error: TS2322 есть другой тип, но в компоненте он не используется
-  element.scrollBy = (options?: ScrollToOptions) => {
-    scrollLeft = scrollLeft + (options?.left || 0);
-  };
-
   return {
     get scrollLeft() {
       return scrollLeft;
@@ -194,39 +189,6 @@ describe('HorizontalScroll', () => {
     await waitFor(() => {
       expect(mockedData.scrollLeft).toBe(200);
     });
-  });
-
-  it('scroll by arrow', () => {
-    const ref: React.RefObject<HTMLDivElement | null> = {
-      current: null,
-    };
-    render(
-      <HorizontalScroll
-        getRef={ref}
-        data-testid="horizontal-scroll"
-        prevButtonTestId="scroll-arrow-left"
-        nextButtonTestId="scroll-arrow-right"
-      >
-        <div style={{ width: '1800px', height: '50px' }} />
-      </HorizontalScroll>,
-    );
-
-    const mockedData = setup(ref.current!, 50);
-
-    fireEvent.mouseEnter(screen.getByTestId('horizontal-scroll'));
-
-    const arrowLeft = screen.getByTestId('scroll-arrow-left');
-    const arrowRight = screen.getByTestId('scroll-arrow-right');
-
-    fireEvent.wheel(arrowRight, {
-      deltaX: 20,
-    });
-    expect(mockedData.scrollLeft).toBe(70);
-
-    fireEvent.wheel(arrowLeft, {
-      deltaX: 20,
-    });
-    expect(mockedData.scrollLeft).toBe(90);
   });
 });
 


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- reverts #7882, #8177

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~
- [x] Release notes

## Описание

В **Firefox** событие `onwheel` на контейнере и одновременная прокрутка скроллируемого элемента (`scrollBy` или `scrollLeft`) **тач-падом** негативно влияет на перерисовку контента во время скролла.

Чтобы решить проблему #7774, можно навесить `onwheel` на каждую из стрелок навигации, но у этого решения есть свой баг: если начать крутить колесо с сначала или конца, то появление стрелки навигации заблоркирует прокрутку, то тех пор пока не двинешь мышкой над ней, чтобы началась обработка события `onwheel` на стрелке.

Из-за этих проблем оптимальным будет откатить фикс #7774 и пометить его как **Won't Fix**. Это будет являться ограничением компонента.

Тестировалось на версиях **Firefox** `134` и `135`.

Наблюдается с `v6.7.4` до `v7.1.1` при передаче `scrollOnAnyWheel`, а с `v7.1.2` всегда (связано с #8177).

https://github.com/user-attachments/assets/008907de-e6bd-4807-bbea-b0e7f69a8605

## Release notes
## Исправления
- HorizontalScroll: отменён фикс #7774 из-за проблем перерисовок в **Firefox** при прокрутке через тач-пад, теперь невозможность прокрутить колесом мыши над стрелкой навигации будет считаться ограничением компонента