### PR TITLE
fix: fix reload story

### DIFF
--- a/packages/vkui/.storybook/addons/documentation-button/DocumentationButton.tsx
+++ b/packages/vkui/.storybook/addons/documentation-button/DocumentationButton.tsx
@@ -28,7 +28,7 @@ export const DocumentationButton = () => {
   const story = index?.[storyId];
   const importPath = story && 'importPath' in story && story.importPath;
 
-  if (!importPath) {
+  if (!importPath || !globals.styleguideComponents || globals.styleguideBaseUrl) {
     return null;
   }
 

--- a/packages/vkui/.storybook/addons/source-button/SourceButton.tsx
+++ b/packages/vkui/.storybook/addons/source-button/SourceButton.tsx
@@ -16,7 +16,7 @@ export const SourceButton = () => {
   const story = index?.[storyId];
   const importPath = story && 'importPath' in story && story.importPath;
 
-  if (!importPath) {
+  if (!importPath || !globals.componentsSourceBaseUrl) {
     return null;
   }
 


### PR DESCRIPTION
- caused by #8259 


---

## Описание

После pr #8259 после перехода на стори и последующей перезагрузки стори не открываетя. Почему-то кнопка открытия доки отрисовывается раньше, чем инициализируются глобальные переменные. Поэтому падает ошибка.

## Изменения

Добавил проверку, что необходимые глобальные переменные проинициализированы 

## Release notes
-
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
