### PR TITLE
fix(Textarea): fix scroll when disabled

### DIFF
--- a/packages/vkui/src/components/Textarea/Textarea.module.css
+++ b/packages/vkui/src/components/Textarea/Textarea.module.css
@@ -38,6 +38,10 @@
   color: var(--vkui--color_text_secondary);
 }
 
+.el:disabled {
+  pointer-events: auto;
+}
+
 .alignCenter .el {
   text-align: center;
 }


### PR DESCRIPTION
- [x] Release notes

## Описание

`Textarea` нет возможности прокрутить, если она `disabled`

## Release notes

 ## Исправления
 - Textarea: компонент со свойством `disabled` теперь можно прокручивать

