### PR TITLE
feat(Alert): add testid for title and description

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -340,14 +340,20 @@ describe('Alert', () => {
     async ({ title, description, titleClassNames, descriptionClassNames, platform }) => {
       const result = render(
         <ConfigProvider platform={platform}>
-          <Alert onClose={jest.fn()} title={title} description={description} />
+          <Alert
+            onClose={jest.fn()}
+            titleTestId="titleTestId"
+            descriptionTestId="descriptionTestId"
+            title={title}
+            description={description}
+          />
         </ConfigProvider>,
       );
       await waitCSSKeyframesAnimation(result.getByRole('alertdialog'), {
         runOnlyPendingTimers: true,
       });
-      const headerElement = result.container.getElementsByClassName(styles.title)[0];
-      const textElement = result.container.getElementsByClassName(styles.description)[0];
+      const headerElement = screen.getByTestId('titleTestId');
+      const textElement = screen.getByTestId('descriptionTestId');
 
       titleClassNames.forEach((className) => expect(headerElement).toHaveClass(className));
       descriptionClassNames.forEach((className) => expect(textElement).toHaveClass(className));

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -75,6 +75,14 @@ export interface AlertProps
    * Передает атрибут `data-testid` для кнопки закрытия
    */
   dismissButtonTestId?: string;
+  /**
+   * Передает атрибут `data-testid` для заголовка
+   */
+  titleTestId?: string;
+  /**
+   * Передает атрибут `data-testid` для описания
+   */
+  descriptionTestId?: string;
   usePortal?: AppRootPortalProps['usePortal'];
   /**
    * По умолчанию событие onClick не всплывает
@@ -105,6 +113,8 @@ export const Alert = ({
   usePortal,
   onClick,
   allowClickPropagation = false,
+  titleTestId,
+  descriptionTestId,
   ...restProps
 }: AlertProps): React.ReactNode => {
   const generatedId = React.useId();
@@ -205,9 +215,15 @@ export const Alert = ({
               dismissButtonMode === 'inside' && styles.contentWithButton,
             )}
           >
-            {hasReactNode(title) && <AlertTitle id={titleId}>{title}</AlertTitle>}
+            {hasReactNode(title) && (
+              <AlertTitle data-testid={titleTestId} id={titleId}>
+                {title}
+              </AlertTitle>
+            )}
             {hasReactNode(description) && (
-              <AlertDescription id={descriptionId}>{description}</AlertDescription>
+              <AlertDescription data-testid={descriptionTestId} id={descriptionId}>
+                {description}
+              </AlertDescription>
             )}
             {children}
             {isDismissButtonVisible && dismissButtonMode === 'inside' && (

--- a/packages/vkui/src/components/Alert/AlertTypography.tsx
+++ b/packages/vkui/src/components/Alert/AlertTypography.tsx
@@ -10,7 +10,8 @@ import { Title } from '../Typography/Title/Title';
 import styles from './Alert.module.css';
 
 interface AlertTypography extends HasChildren {
-  id: string;
+  'id': string;
+  'data-testid'?: string;
 }
 export const AlertTitle = (props: AlertTypography): React.ReactNode => {
   const platform = usePlatform();


### PR DESCRIPTION
- [x] Unit-тесты
- [x] Документация фичи
- [x] Release notes

## Описание

Добавляем `data-testid` для `title` и `description`

## Release notes

Пример:
 ## Улучшения
 - Alert: добавлены `data-testid` для `title` (`titleTestId`) и `description` (`descriptionTestId`)

