### PR TITLE
feat(CellButtonGroup): add component

### DIFF
--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.e2e-playground.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.e2e-playground.tsx
@@ -1,0 +1,18 @@
+import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
+import { CellButton } from '../CellButton/CellButton';
+import { CellButtonGroup, type CellButtonGroupProps } from './CellButtonGroup';
+
+export const CellButtonGroupPlayground = (props: ComponentPlaygroundProps) => {
+  return (
+    <ComponentPlayground {...props}>
+      {(props: CellButtonGroupProps) => (
+        <CellButtonGroup {...props}>
+          <CellButton appearance="negative" centered>
+            Пожаловаться
+          </CellButton>
+          <CellButton centered>Отмена</CellButton>
+        </CellButtonGroup>
+      )}
+    </ComponentPlayground>
+  );
+};

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.e2e.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.e2e.tsx
@@ -1,0 +1,11 @@
+import { test } from '@vkui-e2e/test';
+import { CellButtonGroupPlayground } from './CellButtonGroup.e2e-playground';
+
+test('CellButtonGroup', async ({
+  mount,
+  expectScreenshotClippedToContent,
+  componentPlaygroundProps,
+}) => {
+  await mount(<CellButtonGroupPlayground {...componentPlaygroundProps} />);
+  await expectScreenshotClippedToContent();
+});

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.module.css
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.module.css
@@ -1,0 +1,15 @@
+.host {
+  display: flex;
+  inline-size: 100%;
+  max-inline-size: 100%;
+}
+
+/* stylelint-disable-next-line selector-max-universal */
+.host > *:not(.separator) {
+  flex: 1;
+  min-inline-size: 0;
+}
+
+.separator {
+  --vkui--size_base_padding_horizontal--regular: 10px;
+}

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.stories.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { noop } from '@vkontakte/vkjs';
+import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
+import { CellButton } from '../CellButton/CellButton';
+import { CellButtonGroup, type CellButtonGroupProps } from './CellButtonGroup';
+
+const story: Meta<CellButtonGroupProps> = {
+  title: 'Blocks/CellButtonGroup',
+  component: CellButtonGroup,
+  parameters: { ...CanvasFullLayout, ...DisableCartesianParam },
+};
+
+export default story;
+
+type Story = StoryObj<CellButtonGroupProps>;
+
+export const Playground: Story = {
+  render: (args) => (
+    <CellButtonGroup {...args}>
+      <CellButton onClick={noop} appearance="negative" centered>
+        Пожаловаться
+      </CellButton>
+      <CellButton onClick={noop} centered>
+        Отмена
+      </CellButton>
+    </CellButtonGroup>
+  ),
+};

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.test.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.test.tsx
@@ -1,0 +1,6 @@
+import { baselineComponent } from '../../testing/utils';
+import { CellButtonGroup } from './CellButtonGroup';
+
+describe(CellButtonGroup, () => {
+  baselineComponent(CellButtonGroup);
+});

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { RootComponent, type RootComponentProps } from '../RootComponent/RootComponent';
+import { Separator } from '../Separator/Separator';
+import styles from './CellButtonGroup.module.css';
+
+export type CellButtonGroupProps = Omit<
+  RootComponentProps<HTMLElement>,
+  'baseClassName' | 'baseStyle'
+>;
+
+/**
+ * @see https://vkcom.github.io/VKUI/#/CellButtonGroup
+ */
+export const CellButtonGroup = ({
+  children,
+  ...restProps
+}: CellButtonGroupProps): React.ReactNode => {
+  return (
+    <RootComponent baseClassName={styles.host} role="group" {...restProps}>
+      {React.Children.toArray(children).map((child, index) => (
+        <React.Fragment key={index}>
+          {index > 0 && <Separator className={styles.separator} padding direction="vertical" />}
+          {child}
+        </React.Fragment>
+      ))}
+    </RootComponent>
+  );
+};

--- a/packages/vkui/src/components/CellButtonGroup/Readme.md
+++ b/packages/vkui/src/components/CellButtonGroup/Readme.md
@@ -1,0 +1,23 @@
+Группирует компоненты [CellButton](#!/CellButton).
+
+## Что следует знать?
+
+- [CellButtonGroup](#!/CellButtonGroup) не отвечает за параметры вложенных [CellButton](#!/CellButton).
+
+```jsx
+<View activePanel="CellButtonGroup">
+  <Panel id="CellButtonGroup">
+    <PanelHeader>CellButtonGroup</PanelHeader>
+    <Group header={<Header size="s">Базовый пример</Header>}>
+      <CellButtonGroup>
+        <CellButton onClick={() => {}} appearance="negative" centered>
+          Пожаловаться
+        </CellButton>
+        <CellButton onClick={() => {}} centered>
+          Отмена
+        </CellButton>
+      </CellButtonGroup>
+    </Group>
+  </Panel>
+</View>
+```

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-android-chromium-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b90fc3cf2a046d2ecfcaf113d0d9b3d4cd853f2e12b35015f9e26c6a63ab8290
+size 2941

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dd114301d93652abc728b7469e4cd320e1b58de2f85a2c3f38b1c28993cd8cd
+size 3051

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-ios-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-ios-webkit-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a188c8e310985a5fe5e9e8d8ec097292a69fd482de9e1d5740b88c715e15796
+size 3326

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-ios-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-ios-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae355b10fa1c59ea557ab845dcaefbcabe45b486938949cb422d2638bd8e28b6
+size 3267

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-chromium-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09f45354a7e72d39a10dc332ffb85fae4dbafbdffeae1345b369c99dc5f1e9a7
+size 2130

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:695e3fd03f621e200e8791e5e1c48f62b8a4bab2323d020b0810ec4f3339bf09
+size 2148

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-firefox-dark-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-firefox-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1058af2ceb65e8241056d074a58b141f7946cf9c330ae5013ad664fa1c17cf7b
+size 2943

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-firefox-light-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-firefox-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:900075a9fc3bb74807bc6f8947398d74b940887e80ccb262df42110ad984123f
+size 2881

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-webkit-dark-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-webkit-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:508c13fc25461622a081ee47fb5e551ccf82c0cfd459f929df1607d759a846be
+size 2577

--- a/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-webkit-light-1-snap.png
+++ b/packages/vkui/src/components/CellButtonGroup/__image_snapshots__/cellbuttongroup-vkcom-webkit-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eb752168820a077f1d9ee00270b39abc2d146eeb274f19ce7e4ff2156bee095
+size 2576

--- a/styleguide/config.js
+++ b/styleguide/config.js
@@ -257,6 +257,7 @@ const baseConfig = {
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/Button/Button.tsx`,
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/ToolButton/ToolButton.tsx`,
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/CellButton/CellButton.tsx`,
+            `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/CellButtonGroup/CellButtonGroup.tsx`,
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/IconButton/IconButton.tsx`,
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/Div/Div.tsx`,
             `../${VKUI_PACKAGE.PATHS.COMPONENTS_DIR}/Link/Link.tsx`,


### PR DESCRIPTION
- close #6360 

---

- [x] Unit-тесты
- [x] e2e-тесты
- [x] Дизайн-ревью
- [x] Документация фичи
- [x] Release notes

## Описание

Создаем компонент для группировки

## Release notes

 ## Новые компоненты
 - CellButtonGroup: компонент для группировки `CellButton`
    <picture>
          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/cc0a8aba-1635-4dfd-aa93-e03345f72aac" />
          <img width="640" src="https://github.com/user-attachments/assets/61052f6f-3b03-4aae-b6af-32f4d5b9a6f8"/>
      </picture>