### PR TITLE
fix(CustomSelect/DateInput): placement configuration

### DIFF
--- a/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
+++ b/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
@@ -58,6 +58,7 @@ export const CustomSelectDropdown = ({
       )}
       usePortal={forcePortal}
       autoUpdateOnTargetResize
+      flipMiddlewareFallbackAxisSideDirection="none"
       {...restProps}
     >
       <CustomScrollView

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -160,7 +160,7 @@ export const DateInput = ({
   maxDateTime,
   value: valueProp,
   onChange,
-  calendarPlacement = 'bottom-start',
+  calendarPlacement: calendarPlacementProp = 'bottom-start',
   style,
   className,
   doneButtonText,
@@ -312,6 +312,13 @@ export const DateInput = ({
     [open, renderCustomValue, value],
   );
 
+  // при переключении месяцев высота календаря может меняться,
+  // чтобы календарь не прыгал при переключении месяцев каждый раз на
+  // лучшую позицию мы запоминаем последнюю удачную, чтобы календарь оставался
+  // на ней, пока помещается.
+  const [calendarPlacement, setCalendarPlacement] =
+    React.useState<PlacementWithAuto>(calendarPlacementProp);
+
   return (
     <FormField
       style={style}
@@ -413,6 +420,7 @@ export const DateInput = ({
           targetRef={rootRef}
           offsetByMainAxis={8}
           placement={calendarPlacement}
+          onPlacementChange={setCalendarPlacement}
           autoUpdateOnTargetResize
         >
           <Calendar

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -148,7 +148,7 @@ export const DateRangeInput = ({
   disablePast,
   value,
   onChange,
-  calendarPlacement = 'bottom-start',
+  calendarPlacement: calendarPlacementProp = 'bottom-start',
   style,
   className,
   closeOnChange = true,
@@ -278,6 +278,13 @@ export const DateRangeInput = ({
     [onChange, closeOnChange, value, removeFocusFromField],
   );
 
+  // при переключении месяцев высота календаря может меняться,
+  // чтобы календарь не прыгал при переключении месяцев каждый раз на
+  // лучшую позицию мы запоминаем последнюю удачную, чтобы календарь оставался
+  // на ней, пока помещается.
+  const [calendarPlacement, setCalendarPlacement] =
+    React.useState<PlacementWithAuto>(calendarPlacementProp);
+
   return (
     <FormField
       style={style}
@@ -377,7 +384,12 @@ export const DateRangeInput = ({
         </Text>
       </div>
       {open && !disableCalendar && (
-        <Popper targetRef={rootRef} offsetByMainAxis={8} placement={calendarPlacement}>
+        <Popper
+          targetRef={rootRef}
+          offsetByMainAxis={8}
+          placement={calendarPlacement}
+          onPlacementChange={setCalendarPlacement}
+        >
           <CalendarRange
             value={value}
             onChange={onCalendarChange}

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -55,6 +55,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'customMiddlewares'
   | 'onPlacementChange'
   | 'disableFlipMiddleware'
+  | 'flipMiddlewareFallbackAxisSideDirection'
 >;
 
 export interface PopperCommonProps
@@ -103,6 +104,7 @@ export const Popper = ({
   arrowPadding = DEFAULT_ARROW_PADDING,
   customMiddlewares,
   disableFlipMiddleware = false,
+  flipMiddlewareFallbackAxisSideDirection,
 
   // UseFloatingProps
   autoUpdateOnTargetResize = false,
@@ -137,6 +139,7 @@ export const Popper = ({
     hideWhenReferenceHidden,
     customMiddlewares,
     disableFlipMiddleware,
+    flipMiddlewareFallbackAxisSideDirection,
   });
 
   const {

--- a/packages/vkui/src/lib/floating/adapters.ts
+++ b/packages/vkui/src/lib/floating/adapters.ts
@@ -19,6 +19,8 @@ export {
   getOverflowAncestors,
 } from '@vkontakte/vkui-floating-ui/react-dom';
 
+export type { FlipOptions as FlipMiddlewareOptions } from '@vkontakte/vkui-floating-ui/react-dom';
+
 const defaultOptions = {
   ancestorScroll: true,
   ancestorResize: true,

--- a/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
+++ b/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
@@ -3,6 +3,7 @@ import {
   arrowMiddleware,
   autoPlacementMiddleware,
   flipMiddleware,
+  type FlipMiddlewareOptions,
   hideMiddleware,
   offsetMiddleware,
   shiftMiddleware,
@@ -26,6 +27,7 @@ export interface UseFloatingMiddlewaresBootstrapOptions {
    * Не оказывает влияния при `placement` значениях - `'auto' | 'auto-start' | 'auto-end'`
    */
   disableFlipMiddleware?: boolean;
+  flipMiddlewareFallbackAxisSideDirection?: FlipMiddlewareOptions['fallbackAxisSideDirection'];
   /**
    * Отступ по главной оси.
    */
@@ -73,6 +75,7 @@ export const useFloatingMiddlewaresBootstrap = ({
   customMiddlewares,
   hideWhenReferenceHidden,
   disableFlipMiddleware = false,
+  flipMiddlewareFallbackAxisSideDirection = 'start',
 }: UseFloatingMiddlewaresBootstrapOptions): {
   middlewares: UseFloatingMiddleware[];
   strictPlacement: Placement | undefined;
@@ -92,7 +95,8 @@ export const useFloatingMiddlewaresBootstrap = ({
     } else if (!disableFlipMiddleware) {
       middlewares.push(
         flipMiddleware({
-          fallbackAxisSideDirection: 'start',
+          fallbackAxisSideDirection: flipMiddlewareFallbackAxisSideDirection,
+          crossAxis: false,
         }),
       );
     }
@@ -137,6 +141,7 @@ export const useFloatingMiddlewaresBootstrap = ({
     arrowHeight,
     offsetByMainAxis,
     disableFlipMiddleware,
+    flipMiddlewareFallbackAxisSideDirection,
     sameWidth,
     customMiddlewares,
     hideWhenReferenceHidden,


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [x] Release notes

## Описание
### CustomSelect:
Было замечено, что при наличии переноса в опции, и при недостатке места по вертикали, CustomSelect может отрендерить список сбоку от инпута. По дизайну у нас нету такой поддержки, и стили выглядят странно.
<img width="541" alt="file kFIIHv" src="https://github.com/user-attachments/assets/30c59ab6-b077-41b4-ac60-e54fa7ee87fe" />

<details>
<summary>
Пример кода
</summary>

```tsx
import {
  CustomSelect,
  FormItem,
  Group,
  Panel,
  PanelHeader,
  SimpleCell,
  View,
} from "@vkontakte/vkui";

export default function App() {
  const options = [
    {
      value: "1",
      label:
        "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
    },
    {
      value: "2",
      label: "Lorem Ipsum",
    },
  ];

  return (
    <View activePanel="profile">
      <Panel id="profile">
        <PanelHeader>VKUI</PanelHeader>
        <div
          style={{
            width: "360px",
          }}
        >
          <FormItem>
            <CustomSelect options={options} />
          </FormItem>
        </div>
      </Panel>
    </View>
  );
}

```
</details>

В качестве решения отключил возможность рендерить дропдаун сбоку от инпута. Только сверху или снизу.

Кроме того, заметил, что у нас существует [конфликт](https://floating-ui.com/docs/flip#combining-with-shift) между flip и shift middlewares. Добавил crossAxis: false во flip, чтобы при использовании вместе с shift() приоритом был shift, а потом уже в крайнем случае flip. 


### DateInput/DateRangeInput:
Календарь меняет свою высоту в зависимости от количества дней в месяце.
При переключении месяцев календарь может прыгать, позициионируясь то сверху, то снизу от инпута.
Это очень не удобно, если требуется продолжать перекючать месяцы.
Допустимо, чтобы календарь один раз менял свою позицию, запомнил свою последнюю удачную и больше не прыгал.


https://github.com/user-attachments/assets/97f389e6-1a2d-4fbe-b938-2934d5722244

<details>
<summary>
Пример кода:
</summary>

```tsx
import {
  DateInput,
  Group,
  Panel,
  PanelHeader,
  SimpleCell,
  View,
} from "@vkontakte/vkui";

export default function App() {
  return (
    <View activePanel="profile">
      <Panel id="profile">
        <PanelHeader>VKUI</PanelHeader>
        <div
          style={{
            position: "absolute",
            bottom: "340px",
          }}
        >
          <DateInput value={new Date("2024-11-01")} />
        </div>
      </Panel>
    </View>
  );
}

```
</details>

В качестве решения мы запонимаем последнюю удачную позицию в стейте.

## Release notes
- ## Исправления
- CustomSelect: при нехватке места запрещаем позиционирование доропдауна сбоку
- DateInput: исправляем постоянную смену позиции календаря при переключении месяца
- DateRangeInput: исправляем постоянную смену позиции календаря при переключении месяца
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
