### PR TITLE
ci(dependabot): group next

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,10 @@ updates:
       rspack:
         patterns:
           - '@rspack/*'
+      next:
+        patterns:
+          - 'next'
+          - '@next/*'
     versioning-strategy: increase
     open-pull-requests-limit: 20
     reviewers:


### PR DESCRIPTION
## Описание

dependabot присылает два PR-а для next зависимостей

## Изменения

Группируем обновления для next, чтобы не создавалось несколько PR-ов

## Release notes
-