### PR TITLE
fix(CustomSelect): fix props.options and local state option syncronization

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -732,6 +732,34 @@ describe('CustomSelect', () => {
     expect(onChange.mock.calls[0][1]).toBe('1');
   });
 
+  it('(uncontrolled): doesn not calls onChange when click default selected option when defaultValue is string and option value is number', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <CustomSelect
+        labelTextTestId="labelTextTestId"
+        options={[
+          { value: 0, label: 'Mike' },
+          { value: 1, label: 'Josh' },
+        ]}
+        allowClearButton
+        onChange={onChange}
+        defaultValue='0'
+      />,
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+    expect(getCustomSelectValue()).toEqual('Mike');
+
+    fireEvent.click(screen.getByTestId('labelTextTestId'));
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent('Mike');
+    const selectedOption = screen.getByRole('option', { selected: true, name: 'Mike' });
+    fireEvent.mouseEnter(selectedOption);
+    fireEvent.click(selectedOption);
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
   it('(controlled): calls onChange expected amount of times after clearing component and clicking on option without updating controlled prop value', async () => {
     // мы намеренно проверяем кейсы где при нажатии на опцию или на кнопку очистки value проп не меняется
     const onChange = jest.fn();

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -744,7 +744,7 @@ describe('CustomSelect', () => {
         ]}
         allowClearButton
         onChange={onChange}
-        defaultValue='0'
+        defaultValue="0"
       />,
     );
 

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -1401,12 +1401,8 @@ describe('CustomSelect', () => {
   });
 
   it('should not hover disabled option', async () => {
-    const inputRef: React.RefObject<HTMLInputElement | null> = {
-      current: null,
-    };
     render(
       <CustomSelect
-        getSelectInputRef={inputRef}
         data-testid="select"
         options={[
           { value: '0', label: 'Не выбрано' },
@@ -1422,6 +1418,48 @@ describe('CustomSelect', () => {
     await React.act(async () => fireEvent.mouseMove(option, { clientY: 20 }));
 
     expect(option.getAttribute('data-hovered')).toBe('false');
+  });
+
+  it.each([
+    {
+      testName: 'should not lose hover over option on onMouseLeave event when mouse is not moved',
+      expectedHover: 'true',
+    },
+    {
+      testName: 'should lose hover over option on onMouseLeave event when mouse moved',
+      expectedHover: 'false',
+    },
+  ])('$testName', async ({ expectedHover }) => {
+    const inputRef: React.RefObject<HTMLInputElement | null> = {
+      current: null,
+    };
+    render(
+      <CustomSelect
+        data-testid="select"
+        options={[
+          { value: '0', label: 'Не выбрано' },
+          { value: '1', label: 'Категория 1' },
+          { value: '2', label: 'Категория 2' },
+          { value: '3', label: 'Категория 3' },
+        ]}
+        defaultValue="1"
+        getSelectInputRef={inputRef}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('select'));
+    const option = screen.getByRole('option', { name: 'Категория 1' });
+
+    expect(option.getAttribute('data-hovered')).toBe('true');
+
+    if (expectedHover === 'false') {
+      await React.act(async () =>
+        fireEvent.mouseMove(inputRef.current!, { clientY: 20, clientX: 20 }),
+      );
+    }
+
+    await React.act(async () => fireEvent.mouseLeave(option));
+
+    expect(option.getAttribute('data-hovered')).toBe(expectedHover);
   });
 
   it('should not call select option when not focus to option', async () => {

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -336,16 +336,18 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     findSelectedIndex(options, props.value ?? defaultValue ?? null),
   );
 
-  const value =
-    props.value !== undefined ? props.value : remapFromNativeValueToSelectValue(nativeSelectValue);
-
   React.useEffect(
     function updateOptionsIndexes() {
+      const value =
+        props.value !== undefined
+          ? props.value
+          : remapFromNativeValueToSelectValue(nativeSelectValue);
+
       const selectedIndex = findSelectedIndex(options, value);
       setSelectedOptionIndex(selectedIndex);
       setFocusedOptionIndex(selectedIndex);
     },
-    [value, options, filterFn],
+    [props.value, nativeSelectValue, options, filterFn],
   );
 
   React.useEffect(

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -363,12 +363,9 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
   React.useEffect(
     function syncNativeSelectValueWithPropValue() {
-      setNativeSelectValue((nativeSelectValue) => {
-        if (props.value !== undefined) {
-          return remapFromSelectValueToNativeValue(props.value);
-        }
-        return nativeSelectValue;
-      });
+      if (props.value !== undefined) {
+        setNativeSelectValue(remapFromSelectValueToNativeValue(props.value));
+      }
     },
     [props.value, setNativeSelectValue],
   );

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -439,11 +439,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         scrollToElement(index);
       }
 
-      // Это оптимизация, прежде всего, под `onMouseMove`
-      setFocusedOptionIndex((focusedOptionIndex) =>
-        // FIXME: вроде бы использование коллбэка не имеет больше смысла
-        focusedOptionIndex !== index ? index : focusedOptionIndex,
-      );
+      setFocusedOptionIndex(index);
     },
     [options, scrollToElement],
   );
@@ -587,8 +583,6 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   );
 
   const onNativeSelectChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
-    const isTriggeredByClearButton = allowClearButton && nativeSelectValue === NOT_SELECTED.NATIVE;
-
     // для ситуаций, когда в опциях value это string а value/defaultValue это number
     // и наоборот, приводим значение nativeSelectValue из стейта к строке.
     // ведь nativeSelect всегда возвращает string в onChange, а пользователь
@@ -613,6 +607,8 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
     const isNativeValueChanged =
       convertedNativeSelectValue !== prevNativeSelectValue && prevNativeSelectValue !== undefined;
+
+    const isTriggeredByClearButton = allowClearButton && nativeSelectValue === NOT_SELECTED.NATIVE;
 
     const shouldCallOnChange =
       !isCalledWithSameControlledOptionValue && (isNativeValueChanged || isTriggeredByClearButton);


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8334 

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [x] Release notes

## Описание
В #8334 видно, что при асинхронной загрузке опций есть лаг между тем когда `fetching` уже не `true`, но опций ещё нет и мы в дропдауне, вместо лоадера, выводим `Ничего не найдено`.
Опций нет по той причине, что рендерим мы опции из локального стейта, который мы синхронизируем с props.options, а синхронизируем мы через `useEffect`. 
Получается, что должен сработать `useEffect` прежде чем новые, загруженные опции пользователя, переданные через `props.options`, попадут в рендер дропдауна.

## Изменения
- Убран локальный стейт `options`, вместо этого `options` это результат фильтрации `props.options`, обёрнутой в `useMemo`.
- Изменилась логика проверки необходимости вызова `onChange` при клике на опцию из списка.
Раньше она была основана на проверке по индексам опций в списке, типа `﻿﻿selectedOptionIndex`, индекс брался из`options`, отфильтрованной версии `props.options`.
Теперь такая логика не работает для принятия решения по вызову `props.onChange`, потому что `options` фильтруются быстрее, а значит ссылаться на опцию по индексу опасно, индекс опции уже может поменяться между кликом по опции и моментом, когда мы начнём принимать решение о вызове `onChange`.
Переехали на проверку по значению `nativeSelectValue`/`prevNativeSelectValue`, а не по индексу.

## Release notes
## Исправления
- CustomSelect: исправлена задержки вывода опций, переданных в `props.options` при асинхронной загрузке
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
