### PR TITLE
feat(Search): Add testid for find button

### DIFF
--- a/packages/vkui/src/components/Search/Search.test.tsx
+++ b/packages/vkui/src/components/Search/Search.test.tsx
@@ -6,7 +6,7 @@ import styles from './Search.module.css';
 
 const getInput = () => screen.getByRole('searchbox');
 const getClearIcon = () => screen.getByTestId('clear-button');
-const getFindButton = () => document.querySelector(`.${styles.findButton}`)!;
+const getFindButton = () => screen.getByTestId('find-button');
 
 jest.mock('../../lib/touch', () => {
   const originalModule = jest.requireActual('../../lib/touch');
@@ -169,7 +169,7 @@ describe(Search, () => {
 
   it('calls onFindButtonClick', async () => {
     const cb = jest.fn();
-    render(<Search value="test" onFindButtonClick={cb} />);
+    render(<Search value="test" onFindButtonClick={cb} findButtonTestId="find-button" />);
     await userEvent.click(getFindButton());
     act(jest.runAllTimers);
     expect(cb).toHaveBeenCalled();

--- a/packages/vkui/src/components/Search/Search.tsx
+++ b/packages/vkui/src/components/Search/Search.tsx
@@ -55,6 +55,10 @@ export interface SearchProps
    * Коллбэк для кнопки Найти
    */
   onFindButtonClick?: React.MouseEventHandler<HTMLElement>;
+  /**
+   * Передает атрибут `data-testid` для кнопки поиска
+   */
+  findButtonTestId?: string;
 }
 
 /**
@@ -78,6 +82,7 @@ export const Search = ({
   noPadding,
   getRootRef,
   findButtonText = 'Найти',
+  findButtonTestId,
   onFindButtonClick,
   ...inputProps
 }: SearchProps): React.ReactNode => {
@@ -233,6 +238,7 @@ export const Search = ({
               focusVisibleMode="inside"
               onClick={onFindButtonClick}
               tabIndex={hasValue ? undefined : -1}
+              data-testid={findButtonTestId}
             >
               {findButtonText}
             </Button>


### PR DESCRIPTION

- [x] Unit-тесты
- [x] Документация фичи
- [x] Release notes

## Описание
Добавляем `testid` для find button чтобы упростить тестирование компонента в `e2e`.
related: #8333 


## Release notes
## Улучшения
- Search: добавлено новое свойство `findButtonTestId` для e2e тестирования кнопки поиска.
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
