### PR TITLE
feat: icons v3

### DIFF
--- a/packages/vkui-docs-theme/package.json
+++ b/packages/vkui-docs-theme/package.json
@@ -26,7 +26,7 @@
     "*.css"
   ],
   "dependencies": {
-    "@vkontakte/icons": "^2.159.0",
+    "@vkontakte/icons": "^3.0.0",
     "@vkontakte/vkjs": "^2.0.1",
     "@vkontakte/vkui": "workspace:^",
     "@vkontakte/vkui-tokens": "4.61.3"

--- a/packages/vkui/jest.config.ts
+++ b/packages/vkui/jest.config.ts
@@ -6,11 +6,14 @@ const swcConfig = JSON.parse(fs.readFileSync(`${__dirname}/package.swcrc`, 'utf-
 swcConfig.exclude = [];
 swcConfig.module.resolveFully = false;
 
+// Трансформируем esm пакеты
+const needTransformPackages = ['@vkontakte/vkjs', '@vkontakte/icons', '@vkontakte/icons-sprite'];
+
 const config: Config = {
   transform: {
     '^.+\\.(t|j)sx?$': ['@swc/jest', { ...swcConfig }],
   },
-  transformIgnorePatterns: ['/node_modules/(?!@vkontakte/vkjs/)'],
+  transformIgnorePatterns: [`/node_modules/(?!(${needTransformPackages.join('|')})/)`],
   displayName: 'unit',
   roots: [path.join(__dirname, 'src')],
   setupFilesAfterEnv: [path.join(__dirname, 'jest.setup.ts')],

--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@swc/helpers": "^0.5.15",
-    "@vkontakte/icons": "^2.115.0",
+    "@vkontakte/icons": "^3.0.0",
     "@vkontakte/vkjs": "^2.0.1",
     "@vkontakte/vkui-floating-ui": "^0.2.3",
     "date-fns": "^4.1.0"

--- a/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68aba6d853e3acddf9569dea022ba03adb15002c861fcdf8c6bb288060707df4
-size 139384
+oid sha256:af0a0deb74498fdb7b6e916503cc871d7bccacc22225812f2b790edb6be7304f
+size 139398

--- a/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cec23f83399a331b1f2c2e6185bb92a2e7ddebdf838269be6b124d30f10589c
-size 130768
+oid sha256:faf4f149e3cb37800f6a13fab4f1305b3c85d39196b5fcc289acfbc35164ccae
+size 130787

--- a/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-vkcom-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-vkcom-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ac8aa0dfcea8b6e9c6301eddd341fea1baa3cbaa185411f76e2a0c63f211fd7
-size 142293
+oid sha256:a71c24430b4218dcb4a72f0e66ced30828fd36afeb27aa03e1f8c8ef13ac4c38
+size 142300

--- a/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-vkcom-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Avatar/__image_snapshots__/avatar-vkcom-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2b833f31568339519be605869b98cf4b9cb18bc27a61b64d67768f67f5c9753
-size 136572
+oid sha256:fc601bd8be0ee8bcb80303e28750a6614937c50d466fa4c0ee1b3d15e1f52195
+size 136586

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore.tsx
@@ -73,7 +73,7 @@ export const HorizontalCellShowMore = ({
         hoverMode="opacity"
         {...restProps}
       >
-        <Icon28ChevronRightCircle className={styles.icon} fill="currentColor" />
+        <Icon28ChevronRightCircle className={styles.icon} />
 
         <Subhead className={styles.text} weight="2">
           {children}

--- a/packages/vkui/src/components/ImageBase/validators.ts
+++ b/packages/vkui/src/components/ImageBase/validators.ts
@@ -34,7 +34,7 @@ function parseIconSizeByWidthProp(width: unknown): number | null {
 }
 
 function getElementDisplayName(element: React.JSX.Element): string | null {
-  return element.type.displayName ?? null;
+  return element.type.displayName ?? element.type.name ?? null;
 }
 
 function getElementWidthProp(element: React.JSX.Element): number | string | null {

--- a/packages/vkui/src/components/Spinner/Spinner.tsx
+++ b/packages/vkui/src/components/Spinner/Spinner.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { Icon16Spinner, Icon24Spinner, Icon32Spinner, Icon44Spinner } from '@vkontakte/icons';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { SpinnerAnimation } from './SpinnerAnimation';
+import { Icon16Spinner, Icon24Spinner, Icon32Spinner, Icon44Spinner } from './icons';
 import styles from './Spinner.module.css';
 
 const spinnerIconMap = {

--- a/packages/vkui/src/components/Spinner/icons.tsx
+++ b/packages/vkui/src/components/Spinner/icons.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+export function Icon16Spinner({ children }: React.PropsWithChildren) {
+  return (
+    <svg aria-hidden="true" width="16" height="16">
+      <path
+        fill="currentColor"
+        d="M8 3.25a4.75 4.75 0 0 0-4.149 7.065.75.75 0 1 1-1.31.732A6.25 6.25 0 1 1 8 14.25a.75.75 0 0 1 .001-1.5 4.75 4.75 0 1 0 0-9.5Z"
+      >
+        {children}
+      </path>
+    </svg>
+  );
+}
+
+export function Icon24Spinner({ children }: React.PropsWithChildren) {
+  return (
+    <svg aria-hidden="true" width="24" height="24">
+      <path
+        fill="currentColor"
+        d="M16.394 5.077A8.2 8.2 0 0 0 4.58 15.49a.9.9 0 0 1-1.628.767A10 10 0 1 1 12 22a.9.9 0 0 1 0-1.8 8.2 8.2 0 0 0 4.394-15.123"
+      >
+        {children}
+      </path>
+    </svg>
+  );
+}
+
+export function Icon32Spinner({ children }: React.PropsWithChildren) {
+  return (
+    <svg aria-hidden="true" width="32" height="32">
+      <path
+        fill="currentColor"
+        d="M16 32a1.5 1.5 0 0 1 0-3c7.18 0 13-5.82 13-13S23.18 3 16 3 3 8.82 3 16c0 1.557.273 3.074.8 4.502A1.5 1.5 0 1 1 .986 21.54 16 16 0 0 1 0 16C0 7.163 7.163 0 16 0s16 7.163 16 16-7.163 16-16 16"
+      >
+        {children}
+      </path>
+    </svg>
+  );
+}
+
+export function Icon44Spinner({ children }: React.PropsWithChildren) {
+  return (
+    <svg aria-hidden="true" width="44" height="44">
+      <path
+        fill="currentColor"
+        d="M22 44a1.5 1.5 0 0 1 0-3c10.493 0 19-8.507 19-19S32.493 3 22 3 3 11.507 3 22c0 2.208.376 4.363 1.103 6.397a1.5 1.5 0 1 1-2.825 1.01A22 22 0 0 1 0 22C0 9.85 9.85 0 22 0s22 9.85 22 22-9.85 22-22 22"
+      >
+        {children}
+      </path>
+    </svg>
+  );
+}

--- a/packages/vkui/src/components/Tabs/__image_snapshots__/tabs-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/Tabs/__image_snapshots__/tabs-android-chromium-dark-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5d5a2c91ba6b2edaf0f2c11f8be330bb0b59af01791756a16a96f78a6f891d3
-size 192246
+oid sha256:238568135df5fc2ec467daaec112b4d4374455cd961cc7af7b7f8c645cc65623
+size 190597

--- a/packages/vkui/src/components/Tabs/__image_snapshots__/tabs-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/Tabs/__image_snapshots__/tabs-android-chromium-light-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a94540bed8126c469ba78cb5e15bfe20afe945c04a7ab74d880847368453b308
-size 189181
+oid sha256:fe875919c6cdf10b6387dae75b9f46b2a12de959427bfda6f3f5c65a718e6fbf
+size 186725

--- a/yarn.lock
+++ b/yarn.lock
@@ -5515,25 +5515,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vkontakte/icons-sprite@npm:2.3.1":
-  version: 2.3.1
-  resolution: "@vkontakte/icons-sprite@npm:2.3.1"
+"@vkontakte/icons-sprite@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@vkontakte/icons-sprite@npm:3.0.0"
   dependencies:
     "@swc/helpers": "npm:^0.5.15"
   peerDependencies:
-    react: ^16.9.34 || ^17 || ^18
-  checksum: 10/a81c8da21523c33c4d08684ce6d25796395ca1d3bea8d2bac68cda070b368de0085d24e1a34f8650edae92c7603c1a24f485c0b6fbaf1c07edb481a23cfb2e4c
+    react: ^18 || ^19
+  checksum: 10/127d50533fe7b4d5b46b9e2d766654423e082b990c076db4e9a20bf4b48a32f1a40b6ce9dc3a09b3c07a306036af00602cc8ab1a6213c11beff3dcbc3632f254
   languageName: node
   linkType: hard
 
-"@vkontakte/icons@npm:^2.115.0, @vkontakte/icons@npm:^2.159.0":
-  version: 2.159.0
-  resolution: "@vkontakte/icons@npm:2.159.0"
+"@vkontakte/icons@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@vkontakte/icons@npm:3.0.0"
   dependencies:
-    "@vkontakte/icons-sprite": "npm:2.3.1"
+    "@swc/helpers": "npm:^0.5.15"
+    "@vkontakte/icons-sprite": "npm:3.0.0"
   peerDependencies:
-    react: ^16.9.34 || ^17 || ^18
-  checksum: 10/e7510081e550c1be56b3c3fc4e5275fa75c7c9ae7bcdb1ae7f28c2170de959b1aac6f969d58eed81532d0dfbbcd3656026e5fd86e65e17a84f9b16fa07d675d5
+    react: ^18 || ^19
+  checksum: 10/ad7689c64bab4796d0cf9bd37ab9a434923f38b8d043ec95d8c37a1d31c82dff405ec352cb71558be7e0734a65ef0c1baab31de91d898310361f944b19811ce8
   languageName: node
   linkType: hard
 
@@ -5597,7 +5598,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vkontakte/vkui-docs-theme@workspace:packages/vkui-docs-theme"
   dependencies:
-    "@vkontakte/icons": "npm:^2.159.0"
+    "@vkontakte/icons": "npm:^3.0.0"
     "@vkontakte/vkjs": "npm:^2.0.1"
     "@vkontakte/vkui": "workspace:^"
     "@vkontakte/vkui-tokens": "npm:4.61.3"
@@ -5786,7 +5787,7 @@ __metadata:
     "@storybook/react-webpack5": "npm:8.6.6"
     "@swc/helpers": "npm:^0.5.15"
     "@types/node": "npm:*"
-    "@vkontakte/icons": "npm:^2.115.0"
+    "@vkontakte/icons": "npm:^3.0.0"
     "@vkontakte/vkjs": "npm:^2.0.1"
     "@vkontakte/vkui-floating-ui": "npm:^0.2.3"
     date-fns: "npm:^4.1.0"


### PR DESCRIPTION
- [x] Unit-тесты
- [x] e2e-тесты
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Обновляем иконки до [@vkontakte/icons@3.0.0](https://github.com/VKCOM/icons/releases/tag/%40vkontakte%2Ficons%403.0.0).

## Изменения

Иконки для спиннера вынес отдельно, поскольку в сафари animateTransform не работает для svg

## Release notes
## Зависимости
- @vkontakte/icons обновлены до v3
