### PR TITLE
fix(ChipsSelect): renderChip prop type fix

### DIFF
--- a/packages/vkui/src/components/ChipsInputBase/types.ts
+++ b/packages/vkui/src/components/ChipsInputBase/types.ts
@@ -102,7 +102,7 @@ export interface ChipsInputBaseProps<O extends ChipOption = ChipOption>
    *
    * @default Используется [Chip](#/Chip)
    */
-  renderChip?: RenderChip;
+  renderChip?: RenderChip<O>;
   /**
    * Показывать ли кнопку для очистки значения
    */


### PR DESCRIPTION
## Описание
​В компоненте `ChipsSelect` второй аргумент функции, передаваемой через рендер проп `renderChip`,  имеет тип `any`, даже при явном указании дженерика.

## Изменения
Прокинул дженерик в тип `RenderChip`, чтобы использовать правильный тип вместо типа по умолчанию.

## Release notes

## Исправления
- ChipsSelect: Исправлена типизация – в `renderChip` не передавался аргумент дженерик