### PR TITLE
fix(ModalPage, ModalCard): fix id warn

### DIFF
--- a/packages/vkui/src/components/ModalCard/ModalCard.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useId } from 'react';
+import { useContext, useId } from 'react';
 import { ModalContext } from '../../context/ModalContext';
 import { getNavId } from '../../lib/getNavId';
 import { warnOnce } from '../../lib/warnOnce';
+import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { useModalManager } from '../ModalRoot/useModalManager';
 import { ModalCardInternal } from './ModalCardInternal';
 import type { ModalCardProps } from './types';
@@ -27,7 +28,8 @@ export const ModalCard = ({
   ...restProps
 }: ModalCardProps): React.ReactNode => {
   const generatingId = useId();
-  const id = getNavId({ nav, id: idProp }, warn) || generatingId;
+  const { isInsideModal: isInsideModalRoot } = useContext(ModalRootContext);
+  const id = getNavId({ nav, id: idProp }, isInsideModalRoot ? warn : undefined) || generatingId;
 
   const {
     mounted,

--- a/packages/vkui/src/components/ModalCard/ModalCard.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCard.tsx
@@ -1,15 +1,9 @@
 'use client';
 
-import { useContext, useId } from 'react';
 import { ModalContext } from '../../context/ModalContext';
-import { getNavId } from '../../lib/getNavId';
-import { warnOnce } from '../../lib/warnOnce';
-import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { useModalManager } from '../ModalRoot/useModalManager';
 import { ModalCardInternal } from './ModalCardInternal';
 import type { ModalCardProps } from './types';
-
-const warn = warnOnce('ModalCard');
 
 /**
  * @see https://vkcom.github.io/VKUI/#/ModalCard
@@ -27,16 +21,13 @@ export const ModalCard = ({
   keepMounted = false,
   ...restProps
 }: ModalCardProps): React.ReactNode => {
-  const generatingId = useId();
-  const { isInsideModal: isInsideModalRoot } = useContext(ModalRootContext);
-  const id = getNavId({ nav, id: idProp }, isInsideModalRoot ? warn : undefined) || generatingId;
-
   const {
     mounted,
     shouldPreserveSnapPoint: excludedProp,
+    id,
     ...resolvedProps
   } = useModalManager({
-    id,
+    id: nav || idProp,
     open,
     keepMounted,
     modalOverlayTestId,

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -1,17 +1,12 @@
 'use client';
 
-import { useContext, useId, useMemo } from 'react';
+import { useMemo } from 'react';
 import { ModalContext } from '../../context/ModalContext';
 import { inRange } from '../../helpers/range';
-import { getNavId } from '../../lib/getNavId';
 import { SNAP_POINT_DETENTS, SNAP_POINT_SAFE_RANGE, type SnapPoint } from '../../lib/sheet';
-import { warnOnce } from '../../lib/warnOnce';
-import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { useModalManager } from '../ModalRoot/useModalManager';
 import { ModalPageInternal } from './ModalPageInternal';
 import type { ModalPageProps } from './types';
-
-const warn = warnOnce('ModalPage');
 
 const snapPointCache = new Map<string, Exclude<SnapPoint, 'auto'>>();
 
@@ -34,12 +29,8 @@ export const ModalPage = ({
   keepMounted = false,
   ...restProps
 }: ModalPageProps) => {
-  const generatingId = useId();
-  const { isInsideModal: isInsideModalRoot } = useContext(ModalRootContext);
-  const id = getNavId({ nav, id: idProp }, isInsideModalRoot ? warn : undefined) || generatingId;
-
-  const { mounted, shouldPreserveSnapPoint, ...resolvedProps } = useModalManager({
-    id,
+  const { mounted, shouldPreserveSnapPoint, id, ...resolvedProps } = useModalManager({
+    id: nav || idProp,
     open,
     keepMounted,
     modalOverlayTestId,

--- a/packages/vkui/src/components/ModalPage/ModalPage.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useId, useMemo } from 'react';
+import { useContext, useId, useMemo } from 'react';
 import { ModalContext } from '../../context/ModalContext';
 import { inRange } from '../../helpers/range';
 import { getNavId } from '../../lib/getNavId';
 import { SNAP_POINT_DETENTS, SNAP_POINT_SAFE_RANGE, type SnapPoint } from '../../lib/sheet';
 import { warnOnce } from '../../lib/warnOnce';
+import { ModalRootContext } from '../ModalRoot/ModalRootContext';
 import { useModalManager } from '../ModalRoot/useModalManager';
 import { ModalPageInternal } from './ModalPageInternal';
 import type { ModalPageProps } from './types';
@@ -34,7 +35,8 @@ export const ModalPage = ({
   ...restProps
 }: ModalPageProps) => {
   const generatingId = useId();
-  const id = getNavId({ nav, id: idProp }, warn) || generatingId;
+  const { isInsideModal: isInsideModalRoot } = useContext(ModalRootContext);
+  const id = getNavId({ nav, id: idProp }, isInsideModalRoot ? warn : undefined) || generatingId;
 
   const { mounted, shouldPreserveSnapPoint, ...resolvedProps } = useModalManager({
     id,

--- a/packages/vkui/src/components/ModalRoot/useModalManager.tsx
+++ b/packages/vkui/src/components/ModalRoot/useModalManager.tsx
@@ -1,13 +1,16 @@
-import { useContext, useState } from 'react';
+import { useContext, useId, useState } from 'react';
+import { getNavId } from '../../lib/getNavId';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
+import { warnOnce } from '../../lib/warnOnce';
 import type { AnyFunction } from '../../types';
 import { ModalOverlay, type ModalOverlayProps } from '../ModalOverlay/ModalOverlay';
 import { ModalRootContext } from './ModalRootContext';
 import { VisuallyHiddenModalOverlay } from './VisuallyHiddenModalOverlay/VisuallyHiddenModalOverlay';
 import type { ModalRootCallbackFunction } from './types';
 
+const warn = warnOnce('useModalManager');
 export interface UseModalManager {
-  id: string;
+  id?: string;
   open: boolean;
   keepMounted: boolean;
   modalOverlayTestId?: string;
@@ -19,6 +22,7 @@ export interface UseModalManager {
 }
 
 export interface UseModalManagerResolvedProps {
+  id: string;
   open: boolean;
   noFocusToDialog?: boolean;
   modalOverlayTestId?: string;
@@ -30,11 +34,11 @@ export interface UseModalManagerResolvedProps {
 }
 
 export type UseModalManagerResult =
-  | { mounted: false; shouldPreserveSnapPoint: boolean }
+  | { mounted: false; shouldPreserveSnapPoint: boolean; id: UseModalManagerResolvedProps['id'] }
   | ({ mounted: true; shouldPreserveSnapPoint: boolean } & UseModalManagerResolvedProps);
 
 export const useModalManager = ({
-  id,
+  id: idProp,
   open,
   keepMounted,
   modalOverlayTestId,
@@ -45,6 +49,8 @@ export const useModalManager = ({
   onClosed,
 }: UseModalManager): UseModalManagerResult => {
   const context = useContext(ModalRootContext);
+  const generatingId = useId();
+  const id = getNavId({ nav: idProp }, context.isInsideModal ? warn : undefined) || generatingId;
   const opened = context.isInsideModal ? context.activeModal === id : open;
   const shouldPreserveSnapPoint = context.isInsideModal ? context.activeModal !== null : false;
 
@@ -60,10 +66,11 @@ export const useModalManager = ({
   );
 
   if (unmounted) {
-    return { mounted: false, shouldPreserveSnapPoint };
+    return { mounted: false, shouldPreserveSnapPoint, id };
   }
 
   return {
+    id,
     mounted: true,
     open: opened,
     shouldPreserveSnapPoint,


### PR DESCRIPTION
- [x] Release notes

## Описание

Мы ошибочно генерируем предупреждение об отсутствующем `id`/`nav` для `ModalPage`/`ModalCard` в случае, когда они рендерятся без `ModalRoot`. 

## Release notes

## Исправления
 
- ModalPage: исправлено предупреждение об отсутствующем `id`/`nav` при использовании вне `ModalRoot`

- ModalCard: исправлено предупреждение об отсутствующем `id`/`nav` при использовании вне `ModalRoot`