### PR TITLE
feat(vkui): use `name` for components

### DIFF
--- a/packages/vkui-docs-theme/src/components/Anchor.tsx
+++ b/packages/vkui-docs-theme/src/components/Anchor.tsx
@@ -9,10 +9,13 @@ const EXTERNAL_HREF_REGEX = /https?:\/\//;
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
   <VKUILink {...props} getRootRef={ref} />
 ));
-Link.displayName = 'VKUILinkWithRef';
-Object.defineProperty(Link, 'name', {
-  value: 'VKUILinkWithRef',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  Link.displayName = 'VKUILinkWithRef';
+  Object.defineProperty(Link, 'name', {
+    value: 'VKUILinkWithRef',
+  });
+}
 
 export function Anchor({ href = '', children, ...props }: LinkProps) {
   const newWindow = EXTERNAL_HREF_REGEX.test(href);

--- a/packages/vkui-docs-theme/src/components/Anchor.tsx
+++ b/packages/vkui-docs-theme/src/components/Anchor.tsx
@@ -10,6 +10,9 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
   <VKUILink {...props} getRootRef={ref} />
 ));
 Link.displayName = 'VKUILinkWithRef';
+Object.defineProperty(Link, 'name', {
+  value: 'VKUILinkWithRef',
+});
 
 export function Anchor({ href = '', children, ...props }: LinkProps) {
   const newWindow = EXTERNAL_HREF_REGEX.test(href);

--- a/packages/vkui-docs-theme/src/contexts/color-scheme/script.tsx
+++ b/packages/vkui-docs-theme/src/contexts/color-scheme/script.tsx
@@ -19,10 +19,13 @@ export const ColorSchemeScript = React.memo(
     );
   },
 );
-ColorSchemeScript.displayName = 'ColorSchemeScript';
-Object.defineProperty(ColorSchemeScript, 'name', {
-  value: 'ColorSchemeScript',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  ColorSchemeScript.displayName = 'ColorSchemeScript';
+  Object.defineProperty(ColorSchemeScript, 'name', {
+    value: 'ColorSchemeScript',
+  });
+}
 
 function script(storageKey: string, defaultColorScheme: 'light' | 'dark') {
   const LIGHT_CLASS_NAME = 'vkui--vkBase--light';

--- a/packages/vkui-docs-theme/src/contexts/color-scheme/script.tsx
+++ b/packages/vkui-docs-theme/src/contexts/color-scheme/script.tsx
@@ -20,6 +20,9 @@ export const ColorSchemeScript = React.memo(
   },
 );
 ColorSchemeScript.displayName = 'ColorSchemeScript';
+Object.defineProperty(ColorSchemeScript, 'name', {
+  value: 'ColorSchemeScript',
+});
 
 function script(storageKey: string, defaultColorScheme: 'light' | 'dark') {
   const LIGHT_CLASS_NAME = 'vkui--vkBase--light';

--- a/packages/vkui-docs-theme/src/mdx/Overview/Overview.tsx
+++ b/packages/vkui-docs-theme/src/mdx/Overview/Overview.tsx
@@ -17,6 +17,9 @@ function OverviewTags({ children }: { children: React.ReactNode }) {
   );
 }
 OverviewTags.displayName = 'OverviewTags';
+Object.defineProperty(OverviewTags, 'name', {
+  value: 'OverviewTags',
+});
 
 const IconsMap = {
   github: GithubIcon,
@@ -41,6 +44,9 @@ function OverviewTag({
   );
 }
 OverviewTag.displayName = 'OverviewTag';
+Object.defineProperty(OverviewTag, 'name', {
+  value: 'OverviewTag',
+});
 
 export function Overview({ children }: OverviewProps) {
   return (
@@ -51,9 +57,18 @@ export function Overview({ children }: OverviewProps) {
 }
 
 Overview.displayName = 'Overview';
+Object.defineProperty(Overview, 'name', {
+  value: 'Overview',
+});
 
 Overview.Tag = OverviewTag;
 Overview.Tag.displayName = 'Overview.Tag';
+Object.defineProperty(Overview.Tag, 'name', {
+  value: 'Overview.Tag',
+});
 
 Overview.Tags = OverviewTags;
 Overview.Tags.displayName = 'Overview.Tags';
+Object.defineProperty(Overview.Tags, 'name', {
+  value: 'Overview.Tags',
+});

--- a/packages/vkui-docs-theme/src/mdx/Overview/Overview.tsx
+++ b/packages/vkui-docs-theme/src/mdx/Overview/Overview.tsx
@@ -16,10 +16,13 @@ function OverviewTags({ children }: { children: React.ReactNode }) {
     </ButtonGroup>
   );
 }
-OverviewTags.displayName = 'OverviewTags';
-Object.defineProperty(OverviewTags, 'name', {
-  value: 'OverviewTags',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  OverviewTags.displayName = 'OverviewTags';
+  Object.defineProperty(OverviewTags, 'name', {
+    value: 'OverviewTags',
+  });
+}
 
 const IconsMap = {
   github: GithubIcon,
@@ -43,10 +46,13 @@ function OverviewTag({
     </Button>
   );
 }
-OverviewTag.displayName = 'OverviewTag';
-Object.defineProperty(OverviewTag, 'name', {
-  value: 'OverviewTag',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  OverviewTag.displayName = 'OverviewTag';
+  Object.defineProperty(OverviewTag, 'name', {
+    value: 'OverviewTag',
+  });
+}
 
 export function Overview({ children }: OverviewProps) {
   return (
@@ -56,19 +62,21 @@ export function Overview({ children }: OverviewProps) {
   );
 }
 
-Overview.displayName = 'Overview';
-Object.defineProperty(Overview, 'name', {
-  value: 'Overview',
-});
+if (process.env.NODE_ENV !== 'production') {
+  Overview.displayName = 'Overview';
+  Object.defineProperty(Overview, 'name', {
+    value: 'Overview',
+  });
 
-Overview.Tag = OverviewTag;
-Overview.Tag.displayName = 'Overview.Tag';
-Object.defineProperty(Overview.Tag, 'name', {
-  value: 'Overview.Tag',
-});
+  Overview.Tag = OverviewTag;
+  Overview.Tag.displayName = 'Overview.Tag';
+  Object.defineProperty(Overview.Tag, 'name', {
+    value: 'Overview.Tag',
+  });
 
-Overview.Tags = OverviewTags;
-Overview.Tags.displayName = 'Overview.Tags';
-Object.defineProperty(Overview.Tags, 'name', {
-  value: 'Overview.Tags',
-});
+  Overview.Tags = OverviewTags;
+  Overview.Tags.displayName = 'Overview.Tags';
+  Object.defineProperty(Overview.Tags, 'name', {
+    value: 'Overview.Tags',
+  });
+}

--- a/packages/vkui/docs/common/components/OverviewLayout.tsx
+++ b/packages/vkui/docs/common/components/OverviewLayout.tsx
@@ -148,3 +148,6 @@ const Section = memo<{
 );
 
 Section.displayName = 'Section';
+Object.defineProperty(Section, 'name', {
+  value: 'Section',
+});

--- a/packages/vkui/src/components/Accordion/Accordion.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.tsx
@@ -72,9 +72,18 @@ export const Accordion: React.FC<AccordionProps> & {
 };
 
 Accordion.displayName = 'Accordion';
+Object.defineProperty(Accordion, 'name', {
+  value: 'Accordion',
+});
 
 Accordion.Summary = AccordionSummary;
 Accordion.Summary.displayName = 'Accordion.Summary';
+Object.defineProperty(Accordion.Summary, 'name', {
+  value: 'Accordion.Summary',
+});
 
 Accordion.Content = AccordionContent;
 Accordion.Content.displayName = 'Accordion.Content';
+Object.defineProperty(Accordion.Content, 'name', {
+  value: 'Accordion.Content',
+});

--- a/packages/vkui/src/components/Accordion/Accordion.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.tsx
@@ -71,19 +71,17 @@ export const Accordion: React.FC<AccordionProps> & {
   return <AccordionContext.Provider value={context}>{children}</AccordionContext.Provider>;
 };
 
-Accordion.displayName = 'Accordion';
-Object.defineProperty(Accordion, 'name', {
-  value: 'Accordion',
-});
-
 Accordion.Summary = AccordionSummary;
-Accordion.Summary.displayName = 'Accordion.Summary';
-Object.defineProperty(Accordion.Summary, 'name', {
-  value: 'Accordion.Summary',
-});
-
 Accordion.Content = AccordionContent;
-Accordion.Content.displayName = 'Accordion.Content';
-Object.defineProperty(Accordion.Content, 'name', {
-  value: 'Accordion.Content',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  Accordion.Summary.displayName = 'Accordion.Summary';
+  Object.defineProperty(Accordion.Summary, 'name', {
+    value: 'Accordion.Summary',
+  });
+
+  Accordion.Content.displayName = 'Accordion.Content';
+  Object.defineProperty(Accordion.Content, 'name', {
+    value: 'Accordion.Content',
+  });
+}

--- a/packages/vkui/src/components/Accordion/Accordion.tsx
+++ b/packages/vkui/src/components/Accordion/Accordion.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useCustomEnsuredControl } from '../../hooks/useEnsuredControl';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import type { HasChildren } from '../../types';
 import { AccordionContent } from './AccordionContent';
 import { AccordionContext } from './AccordionContext';
@@ -75,13 +76,6 @@ Accordion.Summary = AccordionSummary;
 Accordion.Content = AccordionContent;
 
 if (process.env.NODE_ENV !== 'production') {
-  Accordion.Summary.displayName = 'Accordion.Summary';
-  Object.defineProperty(Accordion.Summary, 'name', {
-    value: 'Accordion.Summary',
-  });
-
-  Accordion.Content.displayName = 'Accordion.Content';
-  Object.defineProperty(Accordion.Content, 'name', {
-    value: 'Accordion.Content',
-  });
+  defineComponentDisplayNames(Accordion.Summary, 'Accordion.Summary');
+  defineComponentDisplayNames(Accordion.Content, 'Accordion.Content');
 }

--- a/packages/vkui/src/components/Accordion/AccordionContent.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionContent.tsx
@@ -83,3 +83,6 @@ export const AccordionContent: React.FC<AccordionContentProps> = ({
 };
 
 AccordionContent.displayName = 'AccordionContent';
+Object.defineProperty(AccordionContent, 'name', {
+  value: 'AccordionContent',
+});

--- a/packages/vkui/src/components/Accordion/AccordionContent.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionContent.tsx
@@ -25,13 +25,13 @@ export interface AccordionContentProps
     HasRef<HTMLDivElement>,
     React.HTMLAttributes<HTMLDivElement> {}
 
-export const AccordionContent: React.FC<AccordionContentProps> = ({
+export const AccordionContent = ({
   getRootRef,
   getRef,
   className,
   children,
   ...restProps
-}) => {
+}: AccordionContentProps) => {
   const { expanded, labelId, contentId } = React.useContext(AccordionContext);
 
   const inRef = useExternRef(getRef);

--- a/packages/vkui/src/components/Accordion/AccordionContent.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionContent.tsx
@@ -81,8 +81,3 @@ export const AccordionContent: React.FC<AccordionContentProps> = ({
     </div>
   );
 };
-
-AccordionContent.displayName = 'AccordionContent';
-Object.defineProperty(AccordionContent, 'name', {
-  value: 'AccordionContent',
-});

--- a/packages/vkui/src/components/Accordion/AccordionSummary.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionSummary.tsx
@@ -71,3 +71,6 @@ export const AccordionSummary: React.FC<AccordionSummaryProps> = ({
 };
 
 AccordionSummary.displayName = 'AccordionSummary';
+Object.defineProperty(AccordionSummary, 'name', {
+  value: 'AccordionSummary',
+});

--- a/packages/vkui/src/components/Accordion/AccordionSummary.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionSummary.tsx
@@ -22,7 +22,7 @@ export interface AccordionSummaryProps extends Omit<SimpleCellProps, 'chevron'> 
   iconPosition?: 'before' | 'after';
 }
 
-export const AccordionSummary: React.FC<AccordionSummaryProps> = ({
+export const AccordionSummary = ({
   after,
   before,
   ExpandIcon = Icon24ChevronDown,

--- a/packages/vkui/src/components/Accordion/AccordionSummary.tsx
+++ b/packages/vkui/src/components/Accordion/AccordionSummary.tsx
@@ -69,8 +69,3 @@ export const AccordionSummary: React.FC<AccordionSummaryProps> = ({
     </SimpleCell>
   );
 };
-
-AccordionSummary.displayName = 'AccordionSummary';
-Object.defineProperty(AccordionSummary, 'name', {
-  value: 'AccordionSummary',
-});

--- a/packages/vkui/src/components/Avatar/Avatar.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.tsx
@@ -127,27 +127,24 @@ export const Avatar: React.FC<AvatarProps> & {
   );
 };
 
-Avatar.displayName = 'Avatar';
-Object.defineProperty(Avatar, 'name', {
-  value: 'Avatar',
-});
-
 Avatar.Badge = AvatarBadge;
-Avatar.Badge.displayName = 'Avatar.Badge';
-Object.defineProperty(Avatar.Badge, 'name', {
-  value: 'Avatar.Badge',
-});
-
 Avatar.BadgeWithPreset = AvatarBadgeWithPreset;
-Avatar.BadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';
-Object.defineProperty(Avatar.BadgeWithPreset, 'name', {
-  value: 'Avatar.BadgeWithPreset',
-});
-
 Avatar.Overlay = ImageBaseOverlay;
-Avatar.Overlay.displayName = 'Avatar.Overlay';
-Object.defineProperty(Avatar.Overlay, 'name', {
-  value: 'Avatar.Overlay',
-});
-
 Avatar.getInitialsFontSize = getInitialsFontSize;
+
+if (process.env.NODE_ENV !== 'production') {
+  Avatar.Badge.displayName = 'Avatar.Badge';
+  Object.defineProperty(Avatar.Badge, 'name', {
+    value: 'Avatar.Badge',
+  });
+
+  Avatar.BadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';
+  Object.defineProperty(Avatar.BadgeWithPreset, 'name', {
+    value: 'Avatar.BadgeWithPreset',
+  });
+
+  Avatar.Overlay.displayName = 'Avatar.Overlay';
+  Object.defineProperty(Avatar.Overlay, 'name', {
+    value: 'Avatar.Overlay',
+  });
+}

--- a/packages/vkui/src/components/Avatar/Avatar.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,5 @@
 import { classNames } from '@vkontakte/vkjs';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { ImageBase, type ImageBaseProps } from '../ImageBase/ImageBase';
 import {
   ImageBaseOverlay,
@@ -133,18 +134,7 @@ Avatar.Overlay = ImageBaseOverlay;
 Avatar.getInitialsFontSize = getInitialsFontSize;
 
 if (process.env.NODE_ENV !== 'production') {
-  Avatar.Badge.displayName = 'Avatar.Badge';
-  Object.defineProperty(Avatar.Badge, 'name', {
-    value: 'Avatar.Badge',
-  });
-
-  Avatar.BadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';
-  Object.defineProperty(Avatar.BadgeWithPreset, 'name', {
-    value: 'Avatar.BadgeWithPreset',
-  });
-
-  Avatar.Overlay.displayName = 'Avatar.Overlay';
-  Object.defineProperty(Avatar.Overlay, 'name', {
-    value: 'Avatar.Overlay',
-  });
+  defineComponentDisplayNames(Avatar.Badge, 'Avatar.Badge');
+  defineComponentDisplayNames(Avatar.BadgeWithPreset, 'Avatar.BadgeWithPreset');
+  defineComponentDisplayNames(Avatar.Overlay, 'Avatar.Overlay');
 }

--- a/packages/vkui/src/components/Avatar/Avatar.tsx
+++ b/packages/vkui/src/components/Avatar/Avatar.tsx
@@ -128,14 +128,26 @@ export const Avatar: React.FC<AvatarProps> & {
 };
 
 Avatar.displayName = 'Avatar';
+Object.defineProperty(Avatar, 'name', {
+  value: 'Avatar',
+});
 
 Avatar.Badge = AvatarBadge;
 Avatar.Badge.displayName = 'Avatar.Badge';
+Object.defineProperty(Avatar.Badge, 'name', {
+  value: 'Avatar.Badge',
+});
 
 Avatar.BadgeWithPreset = AvatarBadgeWithPreset;
 Avatar.BadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';
+Object.defineProperty(Avatar.BadgeWithPreset, 'name', {
+  value: 'Avatar.BadgeWithPreset',
+});
 
 Avatar.Overlay = ImageBaseOverlay;
 Avatar.Overlay.displayName = 'Avatar.Overlay';
+Object.defineProperty(Avatar.Overlay, 'name', {
+  value: 'Avatar.Overlay',
+});
 
 Avatar.getInitialsFontSize = getInitialsFontSize;

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
@@ -19,8 +19,3 @@ export const AvatarBadge: React.FC<AvatarBadgeProps> = ({
     />
   );
 };
-
-AvatarBadge.displayName = 'Avatar.Badge';
-Object.defineProperty(AvatarBadge, 'name', {
-  value: 'Avatar.Badge',
-});

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
@@ -21,3 +21,6 @@ export const AvatarBadge: React.FC<AvatarBadgeProps> = ({
 };
 
 AvatarBadge.displayName = 'Avatar.Badge';
+Object.defineProperty(AvatarBadge, 'name', {
+  value: 'Avatar.Badge',
+});

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadge.tsx
@@ -7,10 +7,7 @@ import styles from './AvatarBadge.module.css';
 
 export type AvatarBadgeProps = ImageBaseBadgeProps;
 
-export const AvatarBadge: React.FC<AvatarBadgeProps> = ({
-  className,
-  ...restProps
-}: AvatarBadgeProps) => {
+export const AvatarBadge = ({ className, ...restProps }: AvatarBadgeProps) => {
   const { size } = React.useContext(ImageBaseContext);
   return (
     <ImageBase.Badge

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
@@ -22,7 +22,7 @@ export interface AvatarBadgeWithPresetProps
   preset?: 'online' | 'online-mobile';
 }
 
-export const AvatarBadgeWithPreset: React.FC<AvatarBadgeWithPresetProps> = ({
+export const AvatarBadgeWithPreset = ({
   preset = 'online',
   className,
   ...restProps

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
@@ -47,3 +47,6 @@ export const AvatarBadgeWithPreset: React.FC<AvatarBadgeWithPresetProps> = ({
 };
 
 AvatarBadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';
+Object.defineProperty(AvatarBadgeWithPreset, 'name', {
+  value: 'Avatar.BadgeWithPreset',
+});

--- a/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
+++ b/packages/vkui/src/components/Avatar/AvatarBadge/AvatarBadgeWithPreset.tsx
@@ -45,8 +45,3 @@ export const AvatarBadgeWithPreset: React.FC<AvatarBadgeWithPresetProps> = ({
     </ImageBase.Badge>
   );
 };
-
-AvatarBadgeWithPreset.displayName = 'Avatar.BadgeWithPreset';
-Object.defineProperty(AvatarBadgeWithPreset, 'name', {
-  value: 'Avatar.BadgeWithPreset',
-});

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.tsx
@@ -65,8 +65,3 @@ export const ButtonGroup = ({
     />
   );
 };
-
-ButtonGroup.displayName = 'ButtonGroup';
-Object.defineProperty(ButtonGroup, 'name', {
-  value: 'ButtonGroup',
-});

--- a/packages/vkui/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/vkui/src/components/ButtonGroup/ButtonGroup.tsx
@@ -67,3 +67,6 @@ export const ButtonGroup = ({
 };
 
 ButtonGroup.displayName = 'ButtonGroup';
+Object.defineProperty(ButtonGroup, 'name', {
+  value: 'ButtonGroup',
+});

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
@@ -205,7 +205,9 @@ export const CalendarDay: React.FC<CalendarDayProps> = React.memo(
   },
 );
 
-CalendarDay.displayName = 'CalendarDay';
-Object.defineProperty(CalendarDay, 'name', {
-  value: 'CalendarDay',
-});
+if (process.env.NODE_ENV !== 'production') {
+  CalendarDay.displayName = 'CalendarDay';
+  Object.defineProperty(CalendarDay, 'name', {
+    value: 'CalendarDay',
+  });
+}

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { ENABLE_KEYBOARD_INPUT_EVENT_NAME } from '../../hooks/useKeyboardInputTracker';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';
 import { Tappable } from '../Tappable/Tappable';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
@@ -95,7 +96,8 @@ export interface CalendarDayProps extends CalendarDayElementProps, CalendarDayTe
   renderDayContent?: (day: Date) => React.ReactNode;
 }
 
-export const CalendarDay: React.FC<CalendarDayProps> = React.memo(
+// eslint-disable-next-line react/display-name -- используется defineComponentDisplayNames
+export const CalendarDay = React.memo(
   ({
     day,
     today,
@@ -206,8 +208,5 @@ export const CalendarDay: React.FC<CalendarDayProps> = React.memo(
 );
 
 if (process.env.NODE_ENV !== 'production') {
-  CalendarDay.displayName = 'CalendarDay';
-  Object.defineProperty(CalendarDay, 'name', {
-    value: 'CalendarDay',
-  });
+  defineComponentDisplayNames(CalendarDay, 'CalendarDay');
 }

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
@@ -206,3 +206,6 @@ export const CalendarDay: React.FC<CalendarDayProps> = React.memo(
 );
 
 CalendarDay.displayName = 'CalendarDay';
+Object.defineProperty(CalendarDay, 'name', {
+  value: 'CalendarDay',
+});

--- a/packages/vkui/src/components/CarouselBase/Bullets.tsx
+++ b/packages/vkui/src/components/CarouselBase/Bullets.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
-import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { type BaseGalleryProps } from './types';
 import styles from './CarouselBase.module.css';
@@ -23,7 +22,7 @@ const stylesBullets = {
   light: styles.bulletsLight,
 };
 
-export const Bullets: React.FC<BulletsProps> = ({ bullets, slideIndex, count, bulletTestId }) => {
+export const Bullets = ({ bullets, slideIndex, count, bulletTestId }: BulletsProps) => {
   return (
     <div aria-hidden className={classNames(styles.bullets, stylesBullets[bullets])}>
       {Array.from({ length: count }).map((_, index) => (

--- a/packages/vkui/src/components/CarouselBase/CarouselViewPort.tsx
+++ b/packages/vkui/src/components/CarouselBase/CarouselViewPort.tsx
@@ -17,7 +17,7 @@ type GalleryViewPortProps = Pick<BaseGalleryProps, 'slideWidth' | 'slideTestId'>
     layerRef?: React.Ref<HTMLDivElement>;
   };
 
-export const CarouselViewPort: React.FC<GalleryViewPortProps> = ({
+export const CarouselViewPort = ({
   slideTestId,
   slideWidth,
   onStart,
@@ -27,7 +27,7 @@ export const CarouselViewPort: React.FC<GalleryViewPortProps> = ({
   layerRef,
   children,
   setSlideRef,
-}) => {
+}: GalleryViewPortProps) => {
   return (
     <Touch
       className={styles.viewport}

--- a/packages/vkui/src/components/CarouselBase/ScrollArrows.tsx
+++ b/packages/vkui/src/components/CarouselBase/ScrollArrows.tsx
@@ -44,7 +44,7 @@ interface ScrollArrowsProps
   onSlideRight: (e: React.MouseEvent) => void;
 }
 
-export const ScrollArrows: React.FC<ScrollArrowsProps> = ({
+export const ScrollArrows = ({
   hasPointer,
   canSlideLeft,
   canSlideRight,
@@ -55,7 +55,7 @@ export const ScrollArrows: React.FC<ScrollArrowsProps> = ({
   arrowAreaHeight = 'stretch',
   nextArrowTestId,
   prevArrowTestId,
-}) => {
+}: ScrollArrowsProps) => {
   return showArrows && hasPointer ? (
     <>
       {canSlideLeft && (

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
@@ -15,6 +15,12 @@ export const CellButtonGroup = (props: CellButtonGroupProps): React.ReactNode =>
 };
 
 CellButtonGroup.displayName = 'CellButtonGroup';
+Object.defineProperty(CellButtonGroup, 'name', {
+  value: 'CellButtonGroup',
+});
 
 CellButtonGroup.Separator = CellButtonGroupSeparator;
 CellButtonGroup.Separator.displayName = 'CellButtonGroup.Separator';
+Object.defineProperty(CellButtonGroup.Separator, 'name', {
+  value: 'CellButtonGroup.Separator',
+});

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { type HTMLAttributesWithRootRef } from '../../types';
 import { ButtonGroup } from '../ButtonGroup/ButtonGroup';
 import { CellButtonGroupSeparator } from './CellButtonGroupSeparator/CellButtonGroupSeparator';
@@ -17,8 +18,5 @@ export const CellButtonGroup = (props: CellButtonGroupProps): React.ReactNode =>
 CellButtonGroup.Separator = CellButtonGroupSeparator;
 
 if (process.env.NODE_ENV !== 'production') {
-  CellButtonGroup.Separator.displayName = 'CellButtonGroup.Separator';
-  Object.defineProperty(CellButtonGroup.Separator, 'name', {
-    value: 'CellButtonGroup.Separator',
-  });
+  defineComponentDisplayNames(CellButtonGroup.Separator, 'CellButtonGroup.Separator');
 }

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroup.tsx
@@ -14,13 +14,11 @@ export const CellButtonGroup = (props: CellButtonGroupProps): React.ReactNode =>
   return <ButtonGroup gap="none" stretched {...props} />;
 };
 
-CellButtonGroup.displayName = 'CellButtonGroup';
-Object.defineProperty(CellButtonGroup, 'name', {
-  value: 'CellButtonGroup',
-});
-
 CellButtonGroup.Separator = CellButtonGroupSeparator;
-CellButtonGroup.Separator.displayName = 'CellButtonGroup.Separator';
-Object.defineProperty(CellButtonGroup.Separator, 'name', {
-  value: 'CellButtonGroup.Separator',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  CellButtonGroup.Separator.displayName = 'CellButtonGroup.Separator';
+  Object.defineProperty(CellButtonGroup.Separator, 'name', {
+    value: 'CellButtonGroup.Separator',
+  });
+}

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroupSeparator/CellButtonGroupSeparator.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroupSeparator/CellButtonGroupSeparator.tsx
@@ -4,10 +4,10 @@ import styles from './CellButtonGroupSeparator.module.css';
 
 type CellButtonGroupSeparatorProps = Omit<SeparatorProps, 'direction' | 'padding'>;
 
-export const CellButtonGroupSeparator = ({
+export const CellButtonGroupSeparator: React.FC<CellButtonGroupSeparatorProps> = ({
   className,
   ...restProps
-}: CellButtonGroupSeparatorProps) => {
+}) => {
   return (
     <Separator
       className={classNames(styles.root, className)}
@@ -17,8 +17,3 @@ export const CellButtonGroupSeparator = ({
     />
   );
 };
-
-CellButtonGroupSeparator.displayName = 'CellButtonGroupSeparator';
-Object.defineProperty(CellButtonGroupSeparator, 'name', {
-  value: 'CellButtonGroupSeparator',
-});

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroupSeparator/CellButtonGroupSeparator.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroupSeparator/CellButtonGroupSeparator.tsx
@@ -4,10 +4,10 @@ import styles from './CellButtonGroupSeparator.module.css';
 
 type CellButtonGroupSeparatorProps = Omit<SeparatorProps, 'direction' | 'padding'>;
 
-export const CellButtonGroupSeparator: React.FC<CellButtonGroupSeparatorProps> = ({
+export const CellButtonGroupSeparator = ({
   className,
   ...restProps
-}) => {
+}: CellButtonGroupSeparatorProps) => {
   return (
     <Separator
       className={classNames(styles.root, className)}

--- a/packages/vkui/src/components/CellButtonGroup/CellButtonGroupSeparator/CellButtonGroupSeparator.tsx
+++ b/packages/vkui/src/components/CellButtonGroup/CellButtonGroupSeparator/CellButtonGroupSeparator.tsx
@@ -19,3 +19,6 @@ export const CellButtonGroupSeparator = ({
 };
 
 CellButtonGroupSeparator.displayName = 'CellButtonGroupSeparator';
+Object.defineProperty(CellButtonGroupSeparator, 'name', {
+  value: 'CellButtonGroupSeparator',
+});

--- a/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
@@ -119,6 +119,12 @@ export const ContentBadge: React.FC<ContentBadgeProps> & {
 };
 
 ContentBadge.displayName = 'ContentBadge';
+Object.defineProperty(ContentBadge, 'name', {
+  value: 'ContentBadge',
+});
 
 ContentBadge.SlotIcon = ContentBadgeSlotIcon;
 ContentBadge.SlotIcon.displayName = 'ContentBadge.SlotIcon';
+Object.defineProperty(ContentBadge.SlotIcon, 'name', {
+  value: 'ContentBadge.SlotIcon',
+});

--- a/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
@@ -118,13 +118,11 @@ export const ContentBadge: React.FC<ContentBadgeProps> & {
   );
 };
 
-ContentBadge.displayName = 'ContentBadge';
-Object.defineProperty(ContentBadge, 'name', {
-  value: 'ContentBadge',
-});
-
 ContentBadge.SlotIcon = ContentBadgeSlotIcon;
-ContentBadge.SlotIcon.displayName = 'ContentBadge.SlotIcon';
-Object.defineProperty(ContentBadge.SlotIcon, 'name', {
-  value: 'ContentBadge.SlotIcon',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  ContentBadge.SlotIcon.displayName = 'ContentBadge.SlotIcon';
+  Object.defineProperty(ContentBadge.SlotIcon, 'name', {
+    value: 'ContentBadge.SlotIcon',
+  });
+}

--- a/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { Caption } from '../Typography/Caption/Caption';
 import { Footnote } from '../Typography/Footnote/Footnote';
@@ -121,8 +122,5 @@ export const ContentBadge: React.FC<ContentBadgeProps> & {
 ContentBadge.SlotIcon = ContentBadgeSlotIcon;
 
 if (process.env.NODE_ENV !== 'production') {
-  ContentBadge.SlotIcon.displayName = 'ContentBadge.SlotIcon';
-  Object.defineProperty(ContentBadge.SlotIcon, 'name', {
-    value: 'ContentBadge.SlotIcon',
-  });
+  defineComponentDisplayNames(ContentBadge.SlotIcon, 'ContentBadge.SlotIcon');
 }

--- a/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
@@ -43,8 +43,3 @@ export const ContentBadgeSlotIcon: React.FC<ContentBadgeSlotIconProps> = ({
     </div>
   );
 };
-
-ContentBadgeSlotIcon.displayName = 'ContentBadgeSlotIcon';
-Object.defineProperty(ContentBadgeSlotIcon, 'name', {
-  value: 'ContentBadgeSlotIcon',
-});

--- a/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
@@ -18,7 +18,7 @@ const singleIconClassNames = {
 
 export type ContentBadgeSlotIconProps = HTMLAttributesWithRootRef<HTMLDivElement>;
 
-export const ContentBadgeSlotIcon: React.FC<ContentBadgeSlotIconProps> = ({
+export const ContentBadgeSlotIcon = ({
   className,
   getRootRef,
   children,

--- a/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadgeSlotIcon.tsx
@@ -45,3 +45,6 @@ export const ContentBadgeSlotIcon: React.FC<ContentBadgeSlotIconProps> = ({
 };
 
 ContentBadgeSlotIcon.displayName = 'ContentBadgeSlotIcon';
+Object.defineProperty(ContentBadgeSlotIcon, 'name', {
+  value: 'ContentBadgeSlotIcon',
+});

--- a/packages/vkui/src/components/DropZone/DropZone.tsx
+++ b/packages/vkui/src/components/DropZone/DropZone.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { callMultiple } from '../../lib/callMultiple';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { DropZoneGrid } from './components/DropZoneGrid';
@@ -62,8 +63,5 @@ export const DropZone: React.FC<DropZoneProps> & {
 DropZone.Grid = DropZoneGrid;
 
 if (process.env.NODE_ENV !== 'production') {
-  DropZone.Grid.displayName = 'DropZone.Grid';
-  Object.defineProperty(DropZone.Grid, 'name', {
-    value: 'DropZone.Grid',
-  });
+  defineComponentDisplayNames(DropZone.Grid, 'DropZone.Grid');
 }

--- a/packages/vkui/src/components/DropZone/DropZone.tsx
+++ b/packages/vkui/src/components/DropZone/DropZone.tsx
@@ -59,13 +59,11 @@ export const DropZone: React.FC<DropZoneProps> & {
   );
 };
 
-DropZone.displayName = 'DropZone';
-Object.defineProperty(DropZone, 'name', {
-  value: 'DropZone',
-});
-
 DropZone.Grid = DropZoneGrid;
-DropZone.Grid.displayName = 'DropZone.Grid';
-Object.defineProperty(DropZone.Grid, 'name', {
-  value: 'DropZone.Grid',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  DropZone.Grid.displayName = 'DropZone.Grid';
+  Object.defineProperty(DropZone.Grid, 'name', {
+    value: 'DropZone.Grid',
+  });
+}

--- a/packages/vkui/src/components/DropZone/DropZone.tsx
+++ b/packages/vkui/src/components/DropZone/DropZone.tsx
@@ -60,6 +60,12 @@ export const DropZone: React.FC<DropZoneProps> & {
 };
 
 DropZone.displayName = 'DropZone';
+Object.defineProperty(DropZone, 'name', {
+  value: 'DropZone',
+});
 
 DropZone.Grid = DropZoneGrid;
 DropZone.Grid.displayName = 'DropZone.Grid';
+Object.defineProperty(DropZone.Grid, 'name', {
+  value: 'DropZone.Grid',
+});

--- a/packages/vkui/src/components/DropZone/components/DropZoneGrid.tsx
+++ b/packages/vkui/src/components/DropZone/components/DropZoneGrid.tsx
@@ -23,3 +23,6 @@ export const DropZoneGrid: React.FC<DropZoneGridProps> = ({
 );
 
 DropZoneGrid.displayName = 'DropZoneGrid';
+Object.defineProperty(DropZoneGrid, 'name', {
+  value: 'DropZoneGrid',
+});

--- a/packages/vkui/src/components/DropZone/components/DropZoneGrid.tsx
+++ b/packages/vkui/src/components/DropZone/components/DropZoneGrid.tsx
@@ -21,8 +21,3 @@ export const DropZoneGrid: React.FC<DropZoneGridProps> = ({
 }: DropZoneGridProps) => (
   <RootComponent baseClassName={classNames(styles.host, directionStyle[direction])} {...props} />
 );
-
-DropZoneGrid.displayName = 'DropZoneGrid';
-Object.defineProperty(DropZoneGrid, 'name', {
-  value: 'DropZoneGrid',
-});

--- a/packages/vkui/src/components/DropZone/components/DropZoneGrid.tsx
+++ b/packages/vkui/src/components/DropZone/components/DropZoneGrid.tsx
@@ -15,9 +15,6 @@ export interface DropZoneGridProps extends HTMLAttributesWithRootRef<HTMLDivElem
   direction?: 'row' | 'column';
 }
 
-export const DropZoneGrid: React.FC<DropZoneGridProps> = ({
-  direction = 'column',
-  ...props
-}: DropZoneGridProps) => (
+export const DropZoneGrid = ({ direction = 'column', ...props }: DropZoneGridProps) => (
   <RootComponent baseClassName={classNames(styles.host, directionStyle[direction])} {...props} />
 );

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -174,12 +174,24 @@ export const FormItem: React.FC<FormItemProps> & {
 };
 
 FormItem.displayName = 'FormItem';
+Object.defineProperty(FormItem, 'name', {
+  value: 'FormItem',
+});
 
 FormItem.Top = FormItemTop;
 FormItem.Top.displayName = 'FormItem.Top';
+Object.defineProperty(FormItem.Top, 'name', {
+  value: 'FormItem.Top',
+});
 
 FormItem.TopLabel = FormItemTopLabel;
 FormItem.TopLabel.displayName = 'FormItem.TopLabel';
+Object.defineProperty(FormItem.TopLabel, 'name', {
+  value: 'FormItem.TopLabel',
+});
 
 FormItem.TopAside = FormItemTopAside;
 FormItem.TopAside.displayName = 'FormItem.TopAside';
+Object.defineProperty(FormItem.TopAside, 'name', {
+  value: 'FormItem.TopAside',
+});

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -173,25 +173,23 @@ export const FormItem: React.FC<FormItemProps> & {
   );
 };
 
-FormItem.displayName = 'FormItem';
-Object.defineProperty(FormItem, 'name', {
-  value: 'FormItem',
-});
-
 FormItem.Top = FormItemTop;
-FormItem.Top.displayName = 'FormItem.Top';
-Object.defineProperty(FormItem.Top, 'name', {
-  value: 'FormItem.Top',
-});
-
 FormItem.TopLabel = FormItemTopLabel;
-FormItem.TopLabel.displayName = 'FormItem.TopLabel';
-Object.defineProperty(FormItem.TopLabel, 'name', {
-  value: 'FormItem.TopLabel',
-});
-
 FormItem.TopAside = FormItemTopAside;
-FormItem.TopAside.displayName = 'FormItem.TopAside';
-Object.defineProperty(FormItem.TopAside, 'name', {
-  value: 'FormItem.TopAside',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  FormItem.Top.displayName = 'FormItem.Top';
+  Object.defineProperty(FormItem.Top, 'name', {
+    value: 'FormItem.Top',
+  });
+
+  FormItem.TopLabel.displayName = 'FormItem.TopLabel';
+  Object.defineProperty(FormItem.TopLabel, 'name', {
+    value: 'FormItem.TopLabel',
+  });
+
+  FormItem.TopAside.displayName = 'FormItem.TopAside';
+  Object.defineProperty(FormItem.TopAside, 'name', {
+    value: 'FormItem.TopAside',
+  });
+}

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { classNames, hasReactNode, isPrimitiveReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import type { HasComponent, HasRootRef } from '../../types';
 import { Removable, type RemovableProps } from '../Removable/Removable';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -178,18 +179,7 @@ FormItem.TopLabel = FormItemTopLabel;
 FormItem.TopAside = FormItemTopAside;
 
 if (process.env.NODE_ENV !== 'production') {
-  FormItem.Top.displayName = 'FormItem.Top';
-  Object.defineProperty(FormItem.Top, 'name', {
-    value: 'FormItem.Top',
-  });
-
-  FormItem.TopLabel.displayName = 'FormItem.TopLabel';
-  Object.defineProperty(FormItem.TopLabel, 'name', {
-    value: 'FormItem.TopLabel',
-  });
-
-  FormItem.TopAside.displayName = 'FormItem.TopAside';
-  Object.defineProperty(FormItem.TopAside, 'name', {
-    value: 'FormItem.TopAside',
-  });
+  defineComponentDisplayNames(FormItem.Top, 'FormItem.Top');
+  defineComponentDisplayNames(FormItem.TopLabel, 'FormItem.TopLabel');
+  defineComponentDisplayNames(FormItem.TopAside, 'FormItem.TopAside');
 }

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTop.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTop.tsx
@@ -13,8 +13,3 @@ export interface FormItemTopProps extends HTMLAttributesWithRootRef<HTMLDivEleme
 export const FormItemTop: React.FC<FormItemTopProps> = (props: FormItemTopProps) => (
   <RootComponent {...props} baseClassName={styles.top} />
 );
-
-FormItemTop.displayName = 'FormItemTop';
-Object.defineProperty(FormItemTop, 'name', {
-  value: 'FormItemTop',
-});

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTop.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTop.tsx
@@ -10,6 +10,6 @@ export interface FormItemTopProps extends HTMLAttributesWithRootRef<HTMLDivEleme
  * @since 6.1.0
  *
  */
-export const FormItemTop: React.FC<FormItemTopProps> = (props: FormItemTopProps) => (
+export const FormItemTop = (props: FormItemTopProps) => (
   <RootComponent {...props} baseClassName={styles.top} />
 );

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTop.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTop.tsx
@@ -15,3 +15,6 @@ export const FormItemTop: React.FC<FormItemTopProps> = (props: FormItemTopProps)
 );
 
 FormItemTop.displayName = 'FormItemTop';
+Object.defineProperty(FormItemTop, 'name', {
+  value: 'FormItemTop',
+});

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopAside.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopAside.tsx
@@ -14,10 +14,7 @@ export interface FormItemTopAsideProps
  * @since 6.1.0
  *
  */
-export const FormItemTopAside: React.FC<FormItemTopAsideProps> = ({
-  children,
-  ...restProps
-}: FormItemTopAsideProps) => {
+export const FormItemTopAside = ({ children, ...restProps }: FormItemTopAsideProps) => {
   return (
     <Subhead className={styles.aside} {...restProps}>
       {children}

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopAside.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopAside.tsx
@@ -26,3 +26,6 @@ export const FormItemTopAside: React.FC<FormItemTopAsideProps> = ({
 };
 
 FormItemTopAside.displayName = 'FormItemTopAside';
+Object.defineProperty(FormItemTopAside, 'name', {
+  value: 'FormItemTopAside',
+});

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopAside.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopAside.tsx
@@ -24,8 +24,3 @@ export const FormItemTopAside: React.FC<FormItemTopAsideProps> = ({
     </Subhead>
   );
 };
-
-FormItemTopAside.displayName = 'FormItemTopAside';
-Object.defineProperty(FormItemTopAside, 'name', {
-  value: 'FormItemTopAside',
-});

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
@@ -19,7 +19,7 @@ export interface FormItemTopLabelProps
  * @since 6.1.0
  *
  */
-export const FormItemTopLabel: React.FC<FormItemTopLabelProps> = ({
+export const FormItemTopLabel = ({
   children,
   Component: componentProp,
   htmlFor,

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
@@ -44,8 +44,3 @@ export const FormItemTopLabel: React.FC<FormItemTopLabelProps> = ({
     </Subhead>
   );
 };
-
-FormItemTopLabel.displayName = 'FormItemTopLabel';
-Object.defineProperty(FormItemTopLabel, 'name', {
-  value: 'FormItemTopLabel',
-});

--- a/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
+++ b/packages/vkui/src/components/FormItem/FormItemTop/FormItemTopLabel.tsx
@@ -46,3 +46,6 @@ export const FormItemTopLabel: React.FC<FormItemTopLabelProps> = ({
 };
 
 FormItemTopLabel.displayName = 'FormItemTopLabel';
+Object.defineProperty(FormItemTopLabel, 'name', {
+  value: 'FormItemTopLabel',
+});

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -34,27 +34,29 @@ export const Group: React.FC<GroupProps> & {
   );
 };
 
-Group.displayName = 'Group';
-Object.defineProperty(Group, 'name', {
-  value: 'Group',
-});
 Group.Container = GroupContainer;
-Group.Container.displayName = 'Group.Container';
-Object.defineProperty(Group.Container, 'name', {
-  value: 'Group.Container',
-});
 Group.Header = GroupHeader;
-Group.Header.displayName = 'Group.Header';
-Object.defineProperty(Group.Header, 'name', {
-  value: 'Group.Header',
-});
 Group.Description = GroupDescription;
-Group.Description.displayName = 'Group.Description';
-Object.defineProperty(Group.Description, 'name', {
-  value: 'Group.Description',
-});
 Group.ExpandedContent = GroupExpandedContent;
-Group.ExpandedContent.displayName = 'Group.ExpandedContent';
-Object.defineProperty(Group.ExpandedContent, 'name', {
-  value: 'Group.ExpandedContent',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  Group.Container.displayName = 'Group.Container';
+  Object.defineProperty(Group.Container, 'name', {
+    value: 'Group.Container',
+  });
+
+  Group.Header.displayName = 'Group.Header';
+  Object.defineProperty(Group.Header, 'name', {
+    value: 'Group.Header',
+  });
+
+  Group.Description.displayName = 'Group.Description';
+  Object.defineProperty(Group.Description, 'name', {
+    value: 'Group.Description',
+  });
+
+  Group.ExpandedContent.displayName = 'Group.ExpandedContent';
+  Object.defineProperty(Group.ExpandedContent, 'name', {
+    value: 'Group.ExpandedContent',
+  });
+}

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -35,11 +35,26 @@ export const Group: React.FC<GroupProps> & {
 };
 
 Group.displayName = 'Group';
+Object.defineProperty(Group, 'name', {
+  value: 'Group',
+});
 Group.Container = GroupContainer;
 Group.Container.displayName = 'Group.Container';
+Object.defineProperty(Group.Container, 'name', {
+  value: 'Group.Container',
+});
 Group.Header = GroupHeader;
 Group.Header.displayName = 'Group.Header';
+Object.defineProperty(Group.Header, 'name', {
+  value: 'Group.Header',
+});
 Group.Description = GroupDescription;
 Group.Description.displayName = 'Group.Description';
+Object.defineProperty(Group.Description, 'name', {
+  value: 'Group.Description',
+});
 Group.ExpandedContent = GroupExpandedContent;
 Group.ExpandedContent.displayName = 'Group.ExpandedContent';
+Object.defineProperty(Group.ExpandedContent, 'name', {
+  value: 'Group.ExpandedContent',
+});

--- a/packages/vkui/src/components/Group/Group.tsx
+++ b/packages/vkui/src/components/Group/Group.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { hasReactNode } from '@vkontakte/vkjs';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { GroupContainer, type GroupContainerProps } from './GroupContainer';
 import { GroupDescription } from './GroupDescription';
 import { GroupExpandedContent } from './GroupExpandedContent';
@@ -40,23 +41,8 @@ Group.Description = GroupDescription;
 Group.ExpandedContent = GroupExpandedContent;
 
 if (process.env.NODE_ENV !== 'production') {
-  Group.Container.displayName = 'Group.Container';
-  Object.defineProperty(Group.Container, 'name', {
-    value: 'Group.Container',
-  });
-
-  Group.Header.displayName = 'Group.Header';
-  Object.defineProperty(Group.Header, 'name', {
-    value: 'Group.Header',
-  });
-
-  Group.Description.displayName = 'Group.Description';
-  Object.defineProperty(Group.Description, 'name', {
-    value: 'Group.Description',
-  });
-
-  Group.ExpandedContent.displayName = 'Group.ExpandedContent';
-  Object.defineProperty(Group.ExpandedContent, 'name', {
-    value: 'Group.ExpandedContent',
-  });
+  defineComponentDisplayNames(Group.Container, 'Group.Container');
+  defineComponentDisplayNames(Group.Header, 'Group.Header');
+  defineComponentDisplayNames(Group.Description, 'Group.Description');
+  defineComponentDisplayNames(Group.ExpandedContent, 'Group.ExpandedContent');
 }

--- a/packages/vkui/src/components/Group/GroupContainer.tsx
+++ b/packages/vkui/src/components/Group/GroupContainer.tsx
@@ -82,7 +82,7 @@ export type GroupContainerProps = HTMLAttributesWithRootRef<HTMLElement> &
 
 const warn = warnOnce('Group');
 
-export const GroupContainer: React.FC<GroupContainerProps> = ({
+export const GroupContainer = ({
   children,
   separator = 'auto',
   mode: modeProps,

--- a/packages/vkui/src/components/Group/GroupContainer.tsx
+++ b/packages/vkui/src/components/Group/GroupContainer.tsx
@@ -149,3 +149,6 @@ export const GroupContainer: React.FC<GroupContainerProps> = ({
   );
 };
 GroupContainer.displayName = 'GroupContainer';
+Object.defineProperty(GroupContainer, 'name', {
+  value: 'GroupContainer',
+});

--- a/packages/vkui/src/components/Group/GroupContainer.tsx
+++ b/packages/vkui/src/components/Group/GroupContainer.tsx
@@ -148,7 +148,3 @@ export const GroupContainer: React.FC<GroupContainerProps> = ({
     </>
   );
 };
-GroupContainer.displayName = 'GroupContainer';
-Object.defineProperty(GroupContainer, 'name', {
-  value: 'GroupContainer',
-});

--- a/packages/vkui/src/components/Group/GroupDescription.tsx
+++ b/packages/vkui/src/components/Group/GroupDescription.tsx
@@ -11,7 +11,3 @@ export const GroupDescription: React.FC<GroupDescriptionProps> = ({
 }: GroupDescriptionProps): React.ReactNode => (
   <Footnote className={classNames(className, styles.description)} {...restProps} />
 );
-GroupDescription.displayName = 'GroupDescription';
-Object.defineProperty(GroupDescription, 'name', {
-  value: 'GroupDescription',
-});

--- a/packages/vkui/src/components/Group/GroupDescription.tsx
+++ b/packages/vkui/src/components/Group/GroupDescription.tsx
@@ -12,3 +12,6 @@ export const GroupDescription: React.FC<GroupDescriptionProps> = ({
   <Footnote className={classNames(className, styles.description)} {...restProps} />
 );
 GroupDescription.displayName = 'GroupDescription';
+Object.defineProperty(GroupDescription, 'name', {
+  value: 'GroupDescription',
+});

--- a/packages/vkui/src/components/Group/GroupDescription.tsx
+++ b/packages/vkui/src/components/Group/GroupDescription.tsx
@@ -1,13 +1,10 @@
-import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HasComponent, HTMLAttributesWithRootRef } from '../../types';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import styles from './Group.module.css';
 
 export type GroupDescriptionProps = HTMLAttributesWithRootRef<HTMLElement> & HasComponent;
-export const GroupDescription: React.FC<GroupDescriptionProps> = ({
-  className,
-  ...restProps
-}: GroupDescriptionProps): React.ReactNode => (
+
+export const GroupDescription = ({ className, ...restProps }: GroupDescriptionProps) => (
   <Footnote className={classNames(className, styles.description)} {...restProps} />
 );

--- a/packages/vkui/src/components/Group/GroupExpandedContent.tsx
+++ b/packages/vkui/src/components/Group/GroupExpandedContent.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HasComponent, HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -16,7 +15,7 @@ export type GroupExpandedContentProps = HTMLAttributesWithRootRef<HTMLElement> &
      */
     direction?: 'inline' | 'block';
   };
-export const GroupExpandedContent: React.FC<GroupExpandedContentProps> = ({
+export const GroupExpandedContent = ({
   direction = 'inline',
   ...restProps
 }: GroupExpandedContentProps) => {

--- a/packages/vkui/src/components/Group/GroupHeader.tsx
+++ b/packages/vkui/src/components/Group/GroupHeader.tsx
@@ -10,7 +10,3 @@ export const GroupHeader: React.FC<GroupHeaderProps> = ({
 }: GroupHeaderProps): React.ReactNode => (
   <div className={classNames(className, styles.header)} {...restProps} />
 );
-GroupHeader.displayName = 'GroupHeader';
-Object.defineProperty(GroupHeader, 'name', {
-  value: 'GroupHeader',
-});

--- a/packages/vkui/src/components/Group/GroupHeader.tsx
+++ b/packages/vkui/src/components/Group/GroupHeader.tsx
@@ -1,12 +1,8 @@
-import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import type { HasComponent, HTMLAttributesWithRootRef } from '../../types';
 import styles from './Group.module.css';
 
 export type GroupHeaderProps = HTMLAttributesWithRootRef<HTMLElement> & HasComponent;
-export const GroupHeader: React.FC<GroupHeaderProps> = ({
-  className,
-  ...restProps
-}: GroupHeaderProps): React.ReactNode => (
+export const GroupHeader = ({ className, ...restProps }: GroupHeaderProps) => (
   <div className={classNames(className, styles.header)} {...restProps} />
 );

--- a/packages/vkui/src/components/Group/GroupHeader.tsx
+++ b/packages/vkui/src/components/Group/GroupHeader.tsx
@@ -11,3 +11,6 @@ export const GroupHeader: React.FC<GroupHeaderProps> = ({
   <div className={classNames(className, styles.header)} {...restProps} />
 );
 GroupHeader.displayName = 'GroupHeader';
+Object.defineProperty(GroupHeader, 'name', {
+  value: 'GroupHeader',
+});

--- a/packages/vkui/src/components/Image/Image.tsx
+++ b/packages/vkui/src/components/Image/Image.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { mergeStyle } from '../../helpers/mergeStyle';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { type CSSCustomProperties } from '../../types';
 import { ImageBase, type ImageBaseOverlayProps, type ImageBaseProps } from '../ImageBase/ImageBase';
 import { ImageBadge, type ImageBadgeProps } from './ImageBadge/ImageBadge';
@@ -174,18 +175,7 @@ Image.Overlay = ImageBase.Overlay;
 Image.FloatElement = ImageBase.FloatElement;
 
 if (process.env.NODE_ENV !== 'production') {
-  Image.Badge.displayName = 'Image.Badge';
-  Object.defineProperty(Image.Badge, 'name', {
-    value: 'Image.Badge',
-  });
-
-  Image.Overlay.displayName = 'Image.Overlay';
-  Object.defineProperty(Image.Overlay, 'name', {
-    value: 'Image.Overlay',
-  });
-
-  Image.FloatElement.displayName = 'Image.FloatElement';
-  Object.defineProperty(Image.FloatElement, 'name', {
-    value: 'Image.FloatElement',
-  });
+  defineComponentDisplayNames(Image.Badge, 'Image.Badge');
+  defineComponentDisplayNames(Image.Overlay, 'Image.Overlay');
+  defineComponentDisplayNames(Image.FloatElement, 'Image.FloatElement');
 }

--- a/packages/vkui/src/components/Image/Image.tsx
+++ b/packages/vkui/src/components/Image/Image.tsx
@@ -170,12 +170,24 @@ export const Image: React.FC<ImageProps> & {
 };
 
 Image.displayName = 'Image';
+Object.defineProperty(Image, 'name', {
+  value: 'Image',
+});
 
 Image.Badge = ImageBadge;
 Image.Badge.displayName = 'Image.Badge';
+Object.defineProperty(Image.Badge, 'name', {
+  value: 'Image.Badge',
+});
 
 Image.Overlay = ImageBase.Overlay;
 Image.Overlay.displayName = 'Image.Overlay';
+Object.defineProperty(Image.Overlay, 'name', {
+  value: 'Image.Overlay',
+});
 
 Image.FloatElement = ImageBase.FloatElement;
 Image.FloatElement.displayName = 'Image.FloatElement';
+Object.defineProperty(Image.FloatElement, 'name', {
+  value: 'Image.FloatElement',
+});

--- a/packages/vkui/src/components/Image/Image.tsx
+++ b/packages/vkui/src/components/Image/Image.tsx
@@ -169,25 +169,23 @@ export const Image: React.FC<ImageProps> & {
   );
 };
 
-Image.displayName = 'Image';
-Object.defineProperty(Image, 'name', {
-  value: 'Image',
-});
-
 Image.Badge = ImageBadge;
-Image.Badge.displayName = 'Image.Badge';
-Object.defineProperty(Image.Badge, 'name', {
-  value: 'Image.Badge',
-});
-
 Image.Overlay = ImageBase.Overlay;
-Image.Overlay.displayName = 'Image.Overlay';
-Object.defineProperty(Image.Overlay, 'name', {
-  value: 'Image.Overlay',
-});
-
 Image.FloatElement = ImageBase.FloatElement;
-Image.FloatElement.displayName = 'Image.FloatElement';
-Object.defineProperty(Image.FloatElement, 'name', {
-  value: 'Image.FloatElement',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  Image.Badge.displayName = 'Image.Badge';
+  Object.defineProperty(Image.Badge, 'name', {
+    value: 'Image.Badge',
+  });
+
+  Image.Overlay.displayName = 'Image.Overlay';
+  Object.defineProperty(Image.Overlay, 'name', {
+    value: 'Image.Overlay',
+  });
+
+  Image.FloatElement.displayName = 'Image.FloatElement';
+  Object.defineProperty(Image.FloatElement, 'name', {
+    value: 'Image.FloatElement',
+  });
+}

--- a/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
+++ b/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
@@ -19,8 +19,3 @@ export const ImageBadge: React.FC<ImageBadgeProps> = ({
     />
   );
 };
-
-ImageBadge.displayName = 'ImageBadge';
-Object.defineProperty(ImageBadge, 'name', {
-  value: 'ImageBadge',
-});

--- a/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
+++ b/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
@@ -7,10 +7,7 @@ import styles from './ImageBadge.module.css';
 
 export type ImageBadgeProps = ImageBaseBadgeProps;
 
-export const ImageBadge: React.FC<ImageBadgeProps> = ({
-  className,
-  ...restProps
-}: ImageBadgeProps) => {
+export const ImageBadge = ({ className, ...restProps }: ImageBadgeProps) => {
   const { size } = React.useContext(ImageBaseContext);
   return (
     <ImageBase.Badge

--- a/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
+++ b/packages/vkui/src/components/Image/ImageBadge/ImageBadge.tsx
@@ -21,3 +21,6 @@ export const ImageBadge: React.FC<ImageBadgeProps> = ({
 };
 
 ImageBadge.displayName = 'ImageBadge';
+Object.defineProperty(ImageBadge, 'name', {
+  value: 'ImageBadge',
+});

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -331,12 +331,24 @@ export const ImageBase: React.FC<ImageBaseProps> & {
 };
 
 ImageBase.displayName = 'ImageBase';
+Object.defineProperty(ImageBase, 'name', {
+  value: 'ImageBase',
+});
 
 ImageBase.Badge = ImageBaseBadge;
 ImageBase.Badge.displayName = 'ImageBase.Badge';
+Object.defineProperty(ImageBase.Badge, 'name', {
+  value: 'ImageBase.Badge',
+});
 
 ImageBase.Overlay = ImageBaseOverlay;
 ImageBase.Overlay.displayName = 'ImageBase.Overlay';
+Object.defineProperty(ImageBase.Overlay, 'name', {
+  value: 'ImageBase.Overlay',
+});
 
 ImageBase.FloatElement = ImageBaseFloatElement;
 ImageBase.FloatElement.displayName = 'ImageBase.FloatElement';
+Object.defineProperty(ImageBase.FloatElement, 'name', {
+  value: 'ImageBase.FloatElement',
+});

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -329,26 +329,23 @@ export const ImageBase: React.FC<ImageBaseProps> & {
     </ImageBaseContext.Provider>
   );
 };
-
-ImageBase.displayName = 'ImageBase';
-Object.defineProperty(ImageBase, 'name', {
-  value: 'ImageBase',
-});
-
 ImageBase.Badge = ImageBaseBadge;
-ImageBase.Badge.displayName = 'ImageBase.Badge';
-Object.defineProperty(ImageBase.Badge, 'name', {
-  value: 'ImageBase.Badge',
-});
-
 ImageBase.Overlay = ImageBaseOverlay;
-ImageBase.Overlay.displayName = 'ImageBase.Overlay';
-Object.defineProperty(ImageBase.Overlay, 'name', {
-  value: 'ImageBase.Overlay',
-});
-
 ImageBase.FloatElement = ImageBaseFloatElement;
-ImageBase.FloatElement.displayName = 'ImageBase.FloatElement';
-Object.defineProperty(ImageBase.FloatElement, 'name', {
-  value: 'ImageBase.FloatElement',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  ImageBase.Badge.displayName = 'ImageBase.Badge';
+  Object.defineProperty(ImageBase.Badge, 'name', {
+    value: 'ImageBase.Badge',
+  });
+
+  ImageBase.Overlay.displayName = 'ImageBase.Overlay';
+  Object.defineProperty(ImageBase.Overlay, 'name', {
+    value: 'ImageBase.Overlay',
+  });
+
+  ImageBase.FloatElement.displayName = 'ImageBase.FloatElement';
+  Object.defineProperty(ImageBase.FloatElement, 'name', {
+    value: 'ImageBase.FloatElement',
+  });
+}

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -6,6 +6,7 @@ import { classNames } from '@vkontakte/vkjs';
 import { mergeStyle } from '../../helpers/mergeStyle';
 import { useExternRef } from '../../hooks/useExternRef';
 import { minOr } from '../../lib/comparing';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { getFetchPriorityProp } from '../../lib/utils';
 import type {
   AnchorHTMLAttributesOnly,
@@ -334,18 +335,7 @@ ImageBase.Overlay = ImageBaseOverlay;
 ImageBase.FloatElement = ImageBaseFloatElement;
 
 if (process.env.NODE_ENV !== 'production') {
-  ImageBase.Badge.displayName = 'ImageBase.Badge';
-  Object.defineProperty(ImageBase.Badge, 'name', {
-    value: 'ImageBase.Badge',
-  });
-
-  ImageBase.Overlay.displayName = 'ImageBase.Overlay';
-  Object.defineProperty(ImageBase.Overlay, 'name', {
-    value: 'ImageBase.Overlay',
-  });
-
-  ImageBase.FloatElement.displayName = 'ImageBase.FloatElement';
-  Object.defineProperty(ImageBase.FloatElement, 'name', {
-    value: 'ImageBase.FloatElement',
-  });
+  defineComponentDisplayNames(ImageBase.Badge, 'ImageBase.Badge');
+  defineComponentDisplayNames(ImageBase.Overlay, 'ImageBase.Overlay');
+  defineComponentDisplayNames(ImageBase.FloatElement, 'ImageBase.FloatElement');
 }

--- a/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
@@ -69,3 +69,6 @@ export const ImageBaseBadge: React.FC<ImageBaseBadgeProps> = ({
 };
 
 ImageBaseBadge.displayName = 'ImageBaseBadge';
+Object.defineProperty(ImageBaseBadge, 'name', {
+  value: 'ImageBaseBadge',
+});

--- a/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
@@ -51,10 +51,7 @@ export interface ImageBaseBadgeProps extends HTMLAttributesWithRootRef<HTMLDivEl
  *
  * > Не используйте при `size < 24`.
  */
-export const ImageBaseBadge: React.FC<ImageBaseBadgeProps> = ({
-  background = 'shadow',
-  ...restProps
-}: ImageBaseBadgeProps) => {
+export const ImageBaseBadge = ({ background = 'shadow', ...restProps }: ImageBaseBadgeProps) => {
   return (
     <>
       <RootComponent

--- a/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseBadge/ImageBaseBadge.tsx
@@ -67,8 +67,3 @@ export const ImageBaseBadge: React.FC<ImageBaseBadgeProps> = ({
     </>
   );
 };
-
-ImageBaseBadge.displayName = 'ImageBaseBadge';
-Object.defineProperty(ImageBaseBadge, 'name', {
-  value: 'ImageBaseBadge',
-});

--- a/packages/vkui/src/components/ImageBase/ImageBaseFloatElement/ImageBaseFloatElement.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseFloatElement/ImageBaseFloatElement.tsx
@@ -91,7 +91,7 @@ export interface ImageBaseFloatElementProps extends HTMLAttributesWithRootRef<HT
   visibility?: 'always' | 'on-hover';
 }
 
-export const ImageBaseFloatElement: React.FC<ImageBaseFloatElementProps> = ({
+export const ImageBaseFloatElement = ({
   placement,
   visibility = 'always',
   style,
@@ -99,7 +99,7 @@ export const ImageBaseFloatElement: React.FC<ImageBaseFloatElementProps> = ({
   inlineIndent,
   blockIndent,
   ...restProps
-}) => {
+}: ImageBaseFloatElementProps) => {
   const [hidden, setHidden] = React.useState(visibility !== 'always');
   const { onMouseOverHandlers, onMouseOutHandlers } = React.useContext(ImageBaseContext);
 

--- a/packages/vkui/src/components/ImageBase/ImageBaseFloatElement/ImageBaseFloatElement.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseFloatElement/ImageBaseFloatElement.tsx
@@ -91,7 +91,7 @@ export interface ImageBaseFloatElementProps extends HTMLAttributesWithRootRef<HT
   visibility?: 'always' | 'on-hover';
 }
 
-export const ImageBaseFloatElement = ({
+export const ImageBaseFloatElement: React.FC<ImageBaseFloatElementProps> = ({
   placement,
   visibility = 'always',
   style,
@@ -99,7 +99,7 @@ export const ImageBaseFloatElement = ({
   inlineIndent,
   blockIndent,
   ...restProps
-}: ImageBaseFloatElementProps) => {
+}) => {
   const [hidden, setHidden] = React.useState(visibility !== 'always');
   const { onMouseOverHandlers, onMouseOutHandlers } = React.useContext(ImageBaseContext);
 
@@ -164,8 +164,3 @@ export const ImageBaseFloatElement = ({
     />
   );
 };
-
-ImageBaseFloatElement.displayName = 'ImageBaseFloatElement';
-Object.defineProperty(ImageBaseFloatElement, 'name', {
-  value: 'ImageBaseFloatElement',
-});

--- a/packages/vkui/src/components/ImageBase/ImageBaseFloatElement/ImageBaseFloatElement.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseFloatElement/ImageBaseFloatElement.tsx
@@ -166,3 +166,6 @@ export const ImageBaseFloatElement = ({
 };
 
 ImageBaseFloatElement.displayName = 'ImageBaseFloatElement';
+Object.defineProperty(ImageBaseFloatElement, 'name', {
+  value: 'ImageBaseFloatElement',
+});

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
@@ -121,3 +121,6 @@ export const ImageBaseOverlay: React.FC<ImageBaseOverlayProps> = ({
 };
 
 ImageBaseOverlay.displayName = 'ImageBaseOverlay';
+Object.defineProperty(ImageBaseOverlay, 'name', {
+  value: 'ImageBaseOverlay',
+});

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
@@ -87,7 +87,7 @@ const ImageBaseOverlayNonInteractive = ({
 /**
  * Оверлей над картинкой.
  */
-export const ImageBaseOverlay: React.FC<ImageBaseOverlayProps> = ({
+export const ImageBaseOverlay = ({
   className,
   theme: themeProp,
   visibility: visibilityProp,

--- a/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBaseOverlay/ImageBaseOverlay.tsx
@@ -119,8 +119,3 @@ export const ImageBaseOverlay: React.FC<ImageBaseOverlayProps> = ({
 
   return <ImageBaseOverlayInteractive {...restProps} {...commonProps} />;
 };
-
-ImageBaseOverlay.displayName = 'ImageBaseOverlay';
-Object.defineProperty(ImageBaseOverlay, 'name', {
-  value: 'ImageBaseOverlay',
-});

--- a/packages/vkui/src/components/InputLike/InputLike.tsx
+++ b/packages/vkui/src/components/InputLike/InputLike.tsx
@@ -30,7 +30,7 @@ function getMaskElements(length: number) {
   return result;
 }
 
-export const InputLike: React.FC<InputLikeProps> = ({
+export const InputLike = ({
   value,
   length,
   index,

--- a/packages/vkui/src/components/InputLike/InputLike.tsx
+++ b/packages/vkui/src/components/InputLike/InputLike.tsx
@@ -68,8 +68,3 @@ export const InputLike: React.FC<InputLikeProps> = ({
     </RootComponent>
   );
 };
-
-InputLike.displayName = 'InputLike';
-Object.defineProperty(InputLike, 'name', {
-  value: 'InputLike',
-});

--- a/packages/vkui/src/components/InputLike/InputLike.tsx
+++ b/packages/vkui/src/components/InputLike/InputLike.tsx
@@ -70,3 +70,6 @@ export const InputLike: React.FC<InputLikeProps> = ({
 };
 
 InputLike.displayName = 'InputLike';
+Object.defineProperty(InputLike, 'name', {
+  value: 'InputLike',
+});

--- a/packages/vkui/src/components/ModalPage/ModalPageBase.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPageBase.tsx
@@ -32,7 +32,7 @@ export interface ModalPageBaseProps
   closable?: boolean;
 }
 
-export const ModalPageBase: React.FC<ModalPageBaseProps> = ({
+export const ModalPageBase = ({
   isDesktop,
   getRef,
   disableContentPanningGesture,
@@ -47,7 +47,7 @@ export const ModalPageBase: React.FC<ModalPageBaseProps> = ({
   closable,
   onClose = noop,
   ...restProps
-}) => {
+}: ModalPageBaseProps) => {
   const disableContentPanningGestureProp = disableContentPanningGesture
     ? BLOCK_SHEET_BEHAVIOR_DATA_ATTRIBUTE
     : undefined;

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltipContainer.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltipContainer.tsx
@@ -33,7 +33,9 @@ export const OnboardingTooltipContainer: React.ForwardRefExoticComponent<
   },
 );
 
-OnboardingTooltipContainer.displayName = 'OnboardingTooltipContainer';
-Object.defineProperty(OnboardingTooltipContainer, 'name', {
-  value: 'OnboardingTooltipContainer',
-});
+if (process.env.NODE_ENV !== 'production') {
+  OnboardingTooltipContainer.displayName = 'OnboardingTooltipContainer';
+  Object.defineProperty(OnboardingTooltipContainer, 'name', {
+    value: 'OnboardingTooltipContainer',
+  });
+}

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltipContainer.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltipContainer.tsx
@@ -34,3 +34,6 @@ export const OnboardingTooltipContainer: React.ForwardRefExoticComponent<
 );
 
 OnboardingTooltipContainer.displayName = 'OnboardingTooltipContainer';
+Object.defineProperty(OnboardingTooltipContainer, 'name', {
+  value: 'OnboardingTooltipContainer',
+});

--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltipContainer.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltipContainer.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useExternRef } from '../../hooks/useExternRef';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import type { HasComponent, HasDataAttribute } from '../../types';
 import { OnboardingTooltipContext } from './OnboardingTooltipContext';
 
@@ -18,6 +19,7 @@ type OnboardingTooltipContainerProps = React.HTMLAttributes<HTMLDivElement> &
 
 export const OnboardingTooltipContainer: React.ForwardRefExoticComponent<
   React.PropsWithoutRef<OnboardingTooltipContainerProps> & React.RefAttributes<HTMLDivElement>
+  // eslint-disable-next-line react/display-name -- используется defineComponentDisplayNames
 > = React.forwardRef<HTMLDivElement, OnboardingTooltipContainerProps>(
   ({ fixed = false, Component = 'div', ...props }, ref) => {
     const containerRef = useExternRef(ref);
@@ -34,8 +36,5 @@ export const OnboardingTooltipContainer: React.ForwardRefExoticComponent<
 );
 
 if (process.env.NODE_ENV !== 'production') {
-  OnboardingTooltipContainer.displayName = 'OnboardingTooltipContainer';
-  Object.defineProperty(OnboardingTooltipContainer, 'name', {
-    value: 'OnboardingTooltipContainer',
-  });
+  defineComponentDisplayNames(OnboardingTooltipContainer, 'OnboardingTooltipContainer');
 }

--- a/packages/vkui/src/components/PanelSpinner/PanelSpinner.tsx
+++ b/packages/vkui/src/components/PanelSpinner/PanelSpinner.tsx
@@ -18,3 +18,6 @@ export const PanelSpinner: React.FC<PanelSpinnerProps> = React.memo(
 );
 
 PanelSpinner.displayName = 'PanelSpinner';
+Object.defineProperty(PanelSpinner, 'name', {
+  value: 'PanelSpinner',
+});

--- a/packages/vkui/src/components/PanelSpinner/PanelSpinner.tsx
+++ b/packages/vkui/src/components/PanelSpinner/PanelSpinner.tsx
@@ -17,7 +17,9 @@ export const PanelSpinner: React.FC<PanelSpinnerProps> = React.memo(
   ),
 );
 
-PanelSpinner.displayName = 'PanelSpinner';
-Object.defineProperty(PanelSpinner, 'name', {
-  value: 'PanelSpinner',
-});
+if (process.env.NODE_ENV !== 'production') {
+  PanelSpinner.displayName = 'PanelSpinner';
+  Object.defineProperty(PanelSpinner, 'name', {
+    value: 'PanelSpinner',
+  });
+}

--- a/packages/vkui/src/components/PanelSpinner/PanelSpinner.tsx
+++ b/packages/vkui/src/components/PanelSpinner/PanelSpinner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { Spinner, type SpinnerProps } from '../Spinner/Spinner';
 
 export interface PanelSpinnerProps extends SpinnerProps {
@@ -11,15 +12,13 @@ export interface PanelSpinnerProps extends SpinnerProps {
 /**
  * @see https://vkcom.github.io/VKUI/#/PanelSpinner
  */
-export const PanelSpinner: React.FC<PanelSpinnerProps> = React.memo(
+// eslint-disable-next-line react/display-name -- используется defineComponentDisplayNames
+export const PanelSpinner = React.memo(
   ({ height = 96, style, ...restProps }: PanelSpinnerProps) => (
     <Spinner size="m" {...restProps} style={{ height, ...style }} />
   ),
 );
 
 if (process.env.NODE_ENV !== 'production') {
-  PanelSpinner.displayName = 'PanelSpinner';
-  Object.defineProperty(PanelSpinner, 'name', {
-    value: 'PanelSpinner',
-  });
+  defineComponentDisplayNames(PanelSpinner, 'PanelSpinner');
 }

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
 import { useScrollLock } from '../AppRoot/ScrollContext';
 import { PopoutWrapper } from '../PopoutWrapper/PopoutWrapper';
@@ -49,18 +50,7 @@ ScreenSpinner.Loader = ScreenSpinnerLoader;
 ScreenSpinner.SwapIcon = ScreenSpinnerSwapIcon;
 
 if (process.env.NODE_ENV !== 'production') {
-  ScreenSpinner.Container.displayName = 'ScreenSpinner.Container';
-  Object.defineProperty(ScreenSpinner.Container, 'name', {
-    value: 'ScreenSpinner.Container',
-  });
-
-  ScreenSpinner.Loader.displayName = 'ScreenSpinner.Loader';
-  Object.defineProperty(ScreenSpinner.Loader, 'name', {
-    value: 'ScreenSpinner.Loader',
-  });
-
-  ScreenSpinner.SwapIcon.displayName = 'ScreenSpinner.SwapIcon';
-  Object.defineProperty(ScreenSpinner.SwapIcon, 'name', {
-    value: 'ScreenSpinner.SwapIcon',
-  });
+  defineComponentDisplayNames(ScreenSpinner.Container, 'ScreenSpinner.Container');
+  defineComponentDisplayNames(ScreenSpinner.Loader, 'ScreenSpinner.Loader');
+  defineComponentDisplayNames(ScreenSpinner.SwapIcon, 'ScreenSpinner.SwapIcon');
 }

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
@@ -45,12 +45,24 @@ export const ScreenSpinner: React.FC<ScreenSpinnerProps> & {
 };
 
 ScreenSpinner.displayName = 'ScreenSpinner';
+Object.defineProperty(ScreenSpinner, 'name', {
+  value: 'ScreenSpinner',
+});
 
 ScreenSpinner.Container = ScreenSpinnerContainer;
 ScreenSpinner.Container.displayName = 'ScreenSpinner.Container';
+Object.defineProperty(ScreenSpinner.Container, 'name', {
+  value: 'ScreenSpinner.Container',
+});
 
 ScreenSpinner.Loader = ScreenSpinnerLoader;
 ScreenSpinner.Loader.displayName = 'ScreenSpinner.Loader';
+Object.defineProperty(ScreenSpinner.Loader, 'name', {
+  value: 'ScreenSpinner.Loader',
+});
 
 ScreenSpinner.SwapIcon = ScreenSpinnerSwapIcon;
 ScreenSpinner.SwapIcon.displayName = 'ScreenSpinner.SwapIcon';
+Object.defineProperty(ScreenSpinner.SwapIcon, 'name', {
+  value: 'ScreenSpinner.SwapIcon',
+});

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
@@ -44,25 +44,23 @@ export const ScreenSpinner: React.FC<ScreenSpinnerProps> & {
   );
 };
 
-ScreenSpinner.displayName = 'ScreenSpinner';
-Object.defineProperty(ScreenSpinner, 'name', {
-  value: 'ScreenSpinner',
-});
-
 ScreenSpinner.Container = ScreenSpinnerContainer;
-ScreenSpinner.Container.displayName = 'ScreenSpinner.Container';
-Object.defineProperty(ScreenSpinner.Container, 'name', {
-  value: 'ScreenSpinner.Container',
-});
-
 ScreenSpinner.Loader = ScreenSpinnerLoader;
-ScreenSpinner.Loader.displayName = 'ScreenSpinner.Loader';
-Object.defineProperty(ScreenSpinner.Loader, 'name', {
-  value: 'ScreenSpinner.Loader',
-});
-
 ScreenSpinner.SwapIcon = ScreenSpinnerSwapIcon;
-ScreenSpinner.SwapIcon.displayName = 'ScreenSpinner.SwapIcon';
-Object.defineProperty(ScreenSpinner.SwapIcon, 'name', {
-  value: 'ScreenSpinner.SwapIcon',
-});
+
+if (process.env.NODE_ENV !== 'production') {
+  ScreenSpinner.Container.displayName = 'ScreenSpinner.Container';
+  Object.defineProperty(ScreenSpinner.Container, 'name', {
+    value: 'ScreenSpinner.Container',
+  });
+
+  ScreenSpinner.Loader.displayName = 'ScreenSpinner.Loader';
+  Object.defineProperty(ScreenSpinner.Loader, 'name', {
+    value: 'ScreenSpinner.Loader',
+  });
+
+  ScreenSpinner.SwapIcon.displayName = 'ScreenSpinner.SwapIcon';
+  Object.defineProperty(ScreenSpinner.SwapIcon, 'name', {
+    value: 'ScreenSpinner.SwapIcon',
+  });
+}

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
@@ -53,3 +53,6 @@ export const ScreenSpinnerContainer: React.FC<ScreenSpinnerContainerProps> = ({
 };
 
 ScreenSpinnerContainer.displayName = 'ScreenSpinnerContainer';
+Object.defineProperty(ScreenSpinnerContainer, 'name', {
+  value: 'ScreenSpinnerContainer',
+});

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
@@ -22,7 +21,7 @@ const modeClassNames = {
 type ScreenSpinnerContainerProps = HTMLAttributesWithRootRef<HTMLSpanElement> &
   Pick<ScreenSpinnerProps, 'state' | 'mode' | 'label' | 'customIcon'>;
 
-export const ScreenSpinnerContainer: React.FC<ScreenSpinnerContainerProps> = ({
+export const ScreenSpinnerContainer = ({
   state = 'loading',
   mode = 'shadow',
   customIcon,

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
@@ -51,8 +51,3 @@ export const ScreenSpinnerContainer: React.FC<ScreenSpinnerContainerProps> = ({
     </ScreenSpinnerContext.Provider>
   );
 };
-
-ScreenSpinnerContainer.displayName = 'ScreenSpinnerContainer';
-Object.defineProperty(ScreenSpinnerContainer, 'name', {
-  value: 'ScreenSpinnerContainer',
-});

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
@@ -24,8 +24,3 @@ export const ScreenSpinnerLoader: React.FC<Omit<SpinnerProps, 'size'>> = ({
     </Spinner>
   );
 };
-
-ScreenSpinnerLoader.displayName = 'ScreenSpinnerLoader';
-Object.defineProperty(ScreenSpinnerLoader, 'name', {
-  value: 'ScreenSpinnerLoader',
-});

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
@@ -7,10 +7,9 @@ import type { SpinnerProps } from '../Spinner/Spinner';
 import { ScreenSpinnerContext } from './context';
 import styles from './ScreenSpinner.module.css';
 
-export const ScreenSpinnerLoader: React.FC<Omit<SpinnerProps, 'size'>> = ({
-  children,
-  ...restProps
-}) => {
+type ScreenSpinnerLoaderProps = Omit<SpinnerProps, 'size'>;
+
+export const ScreenSpinnerLoader = ({ children, ...restProps }: ScreenSpinnerLoaderProps) => {
   const { label } = React.useContext(ScreenSpinnerContext);
   const a11yText = children ?? label;
   return (

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerLoader.tsx
@@ -26,3 +26,6 @@ export const ScreenSpinnerLoader: React.FC<Omit<SpinnerProps, 'size'>> = ({
 };
 
 ScreenSpinnerLoader.displayName = 'ScreenSpinnerLoader';
+Object.defineProperty(ScreenSpinnerLoader, 'name', {
+  value: 'ScreenSpinnerLoader',
+});

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
@@ -17,7 +17,7 @@ type ScreenSpinnerSwapIconProps = HTMLAttributesWithRootRef<HTMLElement> & {
   cancelLabel?: ScreenSpinnerProps['cancelLabel'];
 };
 
-const ScreenSpinnerCancelIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
+const ScreenSpinnerCancelIcon = ({
   onKeyDown,
   'aria-label': ariaLabel = 'Отменить',
   ...restProps
@@ -42,7 +42,7 @@ const ScreenSpinnerCancelIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
   );
 };
 
-export const ScreenSpinnerSwapIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
+export const ScreenSpinnerSwapIcon = ({
   cancelLabel,
   ...restProps
 }: ScreenSpinnerSwapIconProps) => {

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
@@ -42,11 +42,6 @@ const ScreenSpinnerCancelIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
   );
 };
 
-ScreenSpinnerCancelIcon.displayName = 'ScreenSpinnerCancelIcon';
-Object.defineProperty(ScreenSpinnerCancelIcon, 'name', {
-  value: 'ScreenSpinnerCancelIcon',
-});
-
 export const ScreenSpinnerSwapIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
   cancelLabel,
   ...restProps
@@ -77,8 +72,3 @@ export const ScreenSpinnerSwapIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
     </RootComponent>
   );
 };
-
-ScreenSpinnerSwapIcon.displayName = 'ScreenSpinnerSwapIcon';
-Object.defineProperty(ScreenSpinnerSwapIcon, 'name', {
-  value: 'ScreenSpinnerSwapIcon',
-});

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerSwapIcon.tsx
@@ -43,6 +43,9 @@ const ScreenSpinnerCancelIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
 };
 
 ScreenSpinnerCancelIcon.displayName = 'ScreenSpinnerCancelIcon';
+Object.defineProperty(ScreenSpinnerCancelIcon, 'name', {
+  value: 'ScreenSpinnerCancelIcon',
+});
 
 export const ScreenSpinnerSwapIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
   cancelLabel,
@@ -76,3 +79,6 @@ export const ScreenSpinnerSwapIcon: React.FC<ScreenSpinnerSwapIconProps> = ({
 };
 
 ScreenSpinnerSwapIcon.displayName = 'ScreenSpinnerSwapIcon';
+Object.defineProperty(ScreenSpinnerSwapIcon, 'name', {
+  value: 'ScreenSpinnerSwapIcon',
+});

--- a/packages/vkui/src/components/Spinner/Spinner.tsx
+++ b/packages/vkui/src/components/Spinner/Spinner.tsx
@@ -56,7 +56,9 @@ export const Spinner: React.FC<SpinnerProps> = React.memo(
   },
 );
 
-Spinner.displayName = 'Spinner';
-Object.defineProperty(Spinner, 'name', {
-  value: 'Spinner',
-});
+if (process.env.NODE_ENV !== 'production') {
+  Spinner.displayName = 'Spinner';
+  Object.defineProperty(Spinner, 'name', {
+    value: 'Spinner',
+  });
+}

--- a/packages/vkui/src/components/Spinner/Spinner.tsx
+++ b/packages/vkui/src/components/Spinner/Spinner.tsx
@@ -57,3 +57,6 @@ export const Spinner: React.FC<SpinnerProps> = React.memo(
 );
 
 Spinner.displayName = 'Spinner';
+Object.defineProperty(Spinner, 'name', {
+  value: 'Spinner',
+});

--- a/packages/vkui/src/components/Spinner/Spinner.tsx
+++ b/packages/vkui/src/components/Spinner/Spinner.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
+import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
@@ -32,7 +33,8 @@ export interface SpinnerProps extends HTMLAttributesWithRootRef<HTMLSpanElement>
 /**
  * @see https://vkcom.github.io/VKUI/#/Spinner
  */
-export const Spinner: React.FC<SpinnerProps> = React.memo(
+// eslint-disable-next-line react/display-name -- используется defineComponentDisplayNames
+export const Spinner = React.memo(
   ({
     size = 'm',
     children = 'Загружается...',
@@ -57,8 +59,5 @@ export const Spinner: React.FC<SpinnerProps> = React.memo(
 );
 
 if (process.env.NODE_ENV !== 'production') {
-  Spinner.displayName = 'Spinner';
-  Object.defineProperty(Spinner, 'name', {
-    value: 'Spinner',
-  });
+  defineComponentDisplayNames(Spinner, 'Spinner');
 }

--- a/packages/vkui/src/components/Tabs/Tabs.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.tsx
@@ -105,3 +105,6 @@ export const Tabs = ({
 // чтобы styleguidist не путал компонент
 // с другими именованными экспортами
 Tabs.displayName = 'Tabs';
+Object.defineProperty(Tabs, 'name', {
+  value: 'Tabs',
+});

--- a/packages/vkui/src/components/Tabs/Tabs.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.tsx
@@ -101,10 +101,3 @@ export const Tabs = ({
     </RootComponent>
   );
 };
-
-// чтобы styleguidist не путал компонент
-// с другими именованными экспортами
-Tabs.displayName = 'Tabs';
-Object.defineProperty(Tabs, 'name', {
-  value: 'Tabs',
-});

--- a/packages/vkui/src/lib/react/defineComponentDisplayNames.ts
+++ b/packages/vkui/src/lib/react/defineComponentDisplayNames.ts
@@ -1,0 +1,6 @@
+export function defineComponentDisplayNames(Component: React.FC<any>, name: string) {
+  Component.displayName = name;
+  Object.defineProperty(Component, 'name', {
+    value: name,
+  });
+}

--- a/styleguide/propsParser.config.js
+++ b/styleguide/propsParser.config.js
@@ -64,6 +64,8 @@ module.exports = {
       version: 0,
     });
 
+    const componentNameFromPath = path.basename(file, '.tsx');
+
     const components = parser
       .parseWithProgramProvider(file, function () {
         if (languageService) {
@@ -89,6 +91,16 @@ module.exports = {
         return component;
       });
 
-    return components;
+    // Стайлгайд забирает первый компонент из массива
+    return components.sort((a, b) => {
+      if (a.displayName === componentNameFromPath) {
+        return -1;
+      }
+      if (b.displayName === componentNameFromPath) {
+        return 1;
+      }
+
+      return 0;
+    });
   },
 };


### PR DESCRIPTION
- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Добавляем `name` для правильного отображении в консоли названия функций-компонентов

## Release notes
## Улучшения
- У компонентов добавленно поле `name` для правильного обозначения в Dev Tools