### PR TITLE
fix(RootComponent): deprecate internal props

### DIFF
--- a/packages/vkui/src/components/RootComponent/RootComponent.tsx
+++ b/packages/vkui/src/components/RootComponent/RootComponent.tsx
@@ -8,7 +8,19 @@ export interface RootComponentProps<T>
   extends React.AllHTMLAttributes<T>,
     HasRootRef<T>,
     HasComponent {
+  /** Перенести свойство в RootComponentInternalProps, в непубличное API */
+  /**
+   * @deprecated since 7.3.0
+   *
+   * Свойство устарело и будет удалено в `v8`, используйте свойство `className`.
+   */
   baseClassName?: string | false;
+  /** Перенести свойство в RootComponentInternalProps, в непубличное API */
+  /**
+   * @deprecated since 7.3.0
+   *
+   * Свойство устарело и будет удалено в `v8`, используйте свойство `style`.
+   */
   baseStyle?: React.CSSProperties;
 }
 


### PR DESCRIPTION
- [x] Документация фичи
- [x] Release notes

## Описание

В `v8` нужно будет убрать внутренние пропы из публичного `API`.

## Release notes

## Исправления
- В компонентах свойства `baseClassName` и `baseStyle` помечены устаревшими, используйте `className` и `style`
