### PR TITLE
fix(Tappable): deprecate duplicate props

### DIFF
--- a/packages/vkui/src/components/Tappable/Tappable.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.tsx
@@ -31,6 +31,20 @@ export interface TappableProps extends ClickableProps, StateProps {
    * В режиме `auto` на маленьких экранах `border-radius: 0`, иначе определяется токеном `--vkui--size_border_radius--regular`
    */
   borderRadiusMode?: 'auto' | 'inherit';
+  /** Переделать на Omit<ClickableProps, 'activeClassName' | 'hoverClassName'>  */
+  /**
+   * @deprecated since 7.3.0
+   *
+   * Свойство устарело и будет удалено в `v8`, используйте свойство `activeMode`.
+   */
+  activeClassName?: string;
+  /** Переделать на Omit<ClickableProps, 'activeClassName' | 'hoverClassName'>  */
+  /**
+   * @deprecated since 7.3.0
+   *
+   * Свойство устарело и будет удалено в `v8`, используйте свойство `hoverMode`.
+   */
+  hoverClassName?: string;
 }
 
 export const Tappable = ({


### PR DESCRIPTION
- [x] Документация фичи
- [x] Release notes

## Описание

Сейчас все компоненты на базе `Tappable` могут задавать либо `activeClassName`, либо `activeMode` (`activeClassName` частный случай `activeMode`), оставляем только `activeMode`, чтобы не дублировать функционал (то же самое про `hover*`).


## Release notes

## Улучшения
 - cвойства интерактивных компонентов `activeClassName` и `hoverClassName` устарели, используйте  `activeMode` и `hoverMode` соответственно. 

