### PR TITLE
fix(CustomSelect): fix option props drilling

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -797,6 +797,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
             // C mousemove такой проблемы нет, что позволяет реализовать поведение при наведении с клавиатуры и при наведении мышью идентично `<select>`.
             onMouseMove: (e) => focusOptionOnMouseMove(e, index),
             id: `${popupAriaId}-${option.value}`,
+            ...option,
           })}
         </React.Fragment>
       );


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Release notes

## Описание

Предположим мы хотим , чтобы у некоторых опций в `CustomSelect` был отрисован дополнительный элемент `after`
```typescript
options: [
      {
        label: 'Санкт-Петербург',
        description: 'Россия',
        value: '0',
        after: <ContentBadge>Badge</ContentBadge>,
      },
      {
        label: 'Москва',
        description: 'Россия',
        value: '1',
      },
    ],
```
Сейчас по умолчанию в `renderOption` используется `CustomSelectOption`, который может принимать `after` и ожидается, что все должно сработать. Но `after` не отрисовывается, потому что не прокидывается до функции отрисовки `renderOption`, хотя по логике должно. Помимо `after` есть и другие свойства, которые не доходят до функции отрисовки и по сути они вообще никогда ничего не делают

## Изменения

Добавил прокидывание свойств `option` из массива `options` при вызове `renderOption`

## Release notes
## Исправления
- CustomSelect: Поправлено прокидывание свойств `option` до функции отрисовки
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
