### PR TITLE
fix(ChipsSelect): fix closing dropdown when placement change

### DIFF
--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -249,6 +249,7 @@ export const ChipsSelect = <Option extends ChipOption>({
   // Связано с ChipsInputProps
   const rootRef = useExternRef(getRootRef);
   const inputRef = useExternRef(getRef, inputRefHook);
+  const forbidCloseByOutsideClick = React.useRef(false);
 
   // Связано с CustomSelectDropdownProps
   const [dropdownVerticalPlacement, setDropdownVerticalPlacement] = React.useState<
@@ -424,7 +425,10 @@ export const ChipsSelect = <Option extends ChipOption>({
   }, [setFocusedOptionIndex]);
 
   const handleClickOutside = React.useCallback(() => {
-    setOpened(false);
+    if (!forbidCloseByOutsideClick.current) {
+      setOpened(false);
+    }
+    forbidCloseByOutsideClick.current = false;
   }, [setOpened]);
 
   useGlobalOnClickOutside(
@@ -497,6 +501,7 @@ export const ChipsSelect = <Option extends ChipOption>({
                 if (!event.defaultPrevented) {
                   closeAfterSelect && setOpened(false);
                   addOption(option);
+                  forbidCloseByOutsideClick.current = true;
                   clearInput();
                 }
               },


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #6772

---

- [x] Release notes

## Описание

Если ChipsSelect близко к нижнему краю страницы, то как только выбирается итем, который переносит контент на следующую строку и сдвигает всплывающую область вниз, всплывающая область пытается отразиться наверх, на пол секунды у неё получается, но потом она просто закрывается. Тот же баг есть, если наверху не хватает места, и он пытается отражаться вниз.


Поисследовал проблему, оказалось, что:
- При mousedown на опцию, она сразу добавляется
- Происходит перерисовка и высота инпута увеличивается
- Дропдаун не помещается и отзеркаливается
- При отпускании мыши срабатывает `onClick`, который уже срабатывает за пределами дропдауна
- Срабатывает закрытие дропдауна, потому что клик за пределами 

## Изменения

Добавил флаг `forbidCloseByOutsideClick`, который устанавливается в `true` при `mousedown` на опцию, и запрещает закрывать дропдаун по событию `click` за пределами. Когда срабатывает обработчик `click` за пределами флаг сбрасывается в `false`. В результате дропдаун не закрывается

## Release notes
## Исправления
- ChipsSelect: Поправлен баг с закрытием дропдауна при отзеркаливании
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
