### PR TITLE
fix(Calendar): fix tab ordering when we use enableTime and doneButtonShow

### DIFF
--- a/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
@@ -147,6 +147,42 @@ describe('CalendarTime', () => {
       expect(document.activeElement).toBe(screen.getByText('Следующая кнопка'));
     });
 
+    it('should handle Enter navigation between hours, minutes and done button', async () => {
+      jest.useFakeTimers();
+      render(
+        <div>
+          <CalendarTime
+            value={dayDate}
+            hoursTestId="hours-picker"
+            minutesTestId="minutes-picker"
+            doneButtonTestId="done-button"
+          />
+          <button type="button">Следующая кнопка</button>
+        </div>,
+      );
+
+      const hoursInput = screen.getByTestId('hours-picker');
+      const minutesInput = screen.getByTestId('minutes-picker');
+      const doneButton = screen.getByTestId('done-button');
+
+      // Начинаем с часов
+      act(() => hoursInput.focus());
+      expect(document.activeElement).toBe(hoursInput);
+
+      // Enter к минутам
+      await act(() => userEvent.keyboard('{Enter}'));
+      expect(document.activeElement).toBe(minutesInput);
+
+      // Enter к кнопке "Готово"
+      await act(() => userEvent.keyboard('{Enter}'));
+      expect(document.activeElement).toBe(doneButton);
+
+      // C кнопки "Готово" Enter уже никуда фокус не уводит
+      await act(() => userEvent.keyboard('{Enter}'));
+      expect(document.activeElement).not.toBe(screen.getByText('Следующая кнопка'));
+      expect(document.activeElement).toBe(doneButton);
+    });
+
     it('should handle Tab navigation between hours, minutes without done button', async () => {
       jest.useFakeTimers();
       render(
@@ -175,6 +211,37 @@ describe('CalendarTime', () => {
       // Tab к кнопке "Следующая кнопка" после CalendarTime
       await act(() => userEvent.tab());
       expect(document.activeElement).toBe(screen.getByText('Следующая кнопка'));
+    });
+
+    it('should handle Enter navigation between hours, minutes without done button', async () => {
+      jest.useFakeTimers();
+      render(
+        <div>
+          <CalendarTime
+            value={dayDate}
+            hoursTestId="hours-picker"
+            minutesTestId="minutes-picker"
+            doneButtonShow={false}
+          />
+          <button type="button">Следующая кнопка</button>
+        </div>,
+      );
+
+      const hoursInput = screen.getByTestId('hours-picker');
+      const minutesInput = screen.getByTestId('minutes-picker');
+
+      // Начинаем с часов
+      act(() => hoursInput.focus());
+      expect(document.activeElement).toBe(hoursInput);
+
+      // Enter к минутам
+      await act(() => userEvent.keyboard('{Enter}'));
+      expect(document.activeElement).toBe(minutesInput);
+
+      // C минут Enter уже никуда фокус не уводит
+      await act(() => userEvent.keyboard('{Enter}'));
+      expect(document.activeElement).not.toBe(screen.getByText('Следующая кнопка'));
+      expect(document.activeElement).toBe(minutesInput);
     });
 
     it('should handle Shift+Tab navigation', async () => {

--- a/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
@@ -122,9 +122,7 @@ describe('CalendarTime', () => {
             minutesTestId="minutes-picker"
             doneButtonTestId="done-button"
           />
-          <button type="button">
-            Следующая кнопка
-          </button>
+          <button type="button">Следующая кнопка</button>
         </div>,
       );
 
@@ -159,9 +157,7 @@ describe('CalendarTime', () => {
             minutesTestId="minutes-picker"
             doneButtonShow={false}
           />
-          <button type="button">
-            Следующая кнопка
-          </button>
+          <button type="button">Следующая кнопка</button>
         </div>,
       );
 

--- a/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
@@ -174,8 +174,7 @@ export const CalendarTime = ({
       Boolean(ref.current),
     );
     const currentStepIndex = steps.findIndex((step) => step.current === e.target);
-    const diff = e.key === 'Tab' && e.shiftKey ? -1 : 1;
-    const nextStepIndex = currentStepIndex + diff;
+    const nextStepIndex = currentStepIndex + 1;
     if (nextStepIndex < 0 || nextStepIndex >= steps.length) {
       return;
     }

--- a/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
@@ -175,7 +175,7 @@ export const CalendarTime = ({
     );
     const currentStepIndex = steps.findIndex((step) => step.current === e.target);
     const nextStepIndex = currentStepIndex + 1;
-    if (nextStepIndex < 0 || nextStepIndex >= steps.length) {
+    if (nextStepIndex >= steps.length) {
       return;
     }
     const nextStep = steps[nextStepIndex];

--- a/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { type ChangeEvent, useRef } from 'react';
+import { type ChangeEvent } from 'react';
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { setHours, setMinutes } from 'date-fns';
-import { Keys, pressedKey } from '../../lib/accessibility';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
 import { Button, type ButtonProps } from '../Button/Button';
 import { CustomSelect, type SelectProps } from '../CustomSelect/CustomSelect';
@@ -115,10 +114,6 @@ export const CalendarTime = ({
   doneButtonTestId,
   DoneButton,
 }: CalendarTimeProps): React.ReactNode => {
-  const hoursInputRef = useRef<HTMLInputElement | null>(null);
-  const minutesInputRef = useRef<HTMLInputElement | null>(null);
-  const doneButtonRef = useRef<HTMLButtonElement | null>(null);
-
   const localHours = isDayDisabled
     ? hours.map((hour) => {
         return { ...hour, disabled: isDayDisabled(setHours(value, hour.value), true) };
@@ -162,22 +157,6 @@ export const CalendarTime = ({
     [onChange, value],
   );
 
-  const onPickerKeyDown = (e: React.KeyboardEvent) => {
-    const key = pressedKey(e);
-    if (key === Keys.ENTER || key === Keys.TAB) {
-      const steps = [hoursInputRef, minutesInputRef, doneButtonRef];
-      const currentStepIndex = steps.findIndex((step) => step.current === e.target);
-      const diff = e.key === 'Tab' && e.shiftKey ? -1 : 1;
-      const nextStepIndex = currentStepIndex + diff;
-      if (nextStepIndex < 0 || nextStepIndex >= steps.length) {
-        return;
-      }
-      e.preventDefault();
-      const nextStep = steps[nextStepIndex];
-      nextStep.current?.focus();
-    }
-  };
-
   const renderDoneButton = () => {
     const ButtonComponent = DoneButton ?? Button;
     return (
@@ -185,8 +164,6 @@ export const CalendarTime = ({
         mode="secondary"
         onClick={onDoneButtonClick}
         size="l"
-        getRootRef={doneButtonRef}
-        onKeyDown={onPickerKeyDown}
         disabled={doneButtonDisabled}
         data-testid={doneButtonTestId}
       >
@@ -207,8 +184,6 @@ export const CalendarTime = ({
             searchable
             filterFn={selectFilterFn}
             onInputChange={onHoursInputChange}
-            onInputKeyDown={onPickerKeyDown}
-            getSelectInputRef={hoursInputRef}
             aria-label={changeHoursLabel}
             data-testid={hoursTestId}
           />
@@ -225,8 +200,6 @@ export const CalendarTime = ({
             searchable
             filterFn={selectFilterFn}
             onInputChange={onMinutesInputChange}
-            getSelectInputRef={minutesInputRef}
-            onInputKeyDown={onPickerKeyDown}
             aria-label={changeMinutesLabel}
             data-testid={minutesTestId}
           />

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -998,6 +998,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         {selected?.label}
       </CustomSelectInput>
       <select
+        tabIndex={-1}
         ref={selectElRef}
         name={name}
         onChange={onNativeSelectChange}

--- a/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
+++ b/packages/vkui/src/components/CustomSelectDropdown/CustomSelectDropdown.tsx
@@ -67,6 +67,7 @@ export const CustomSelectDropdown = ({
         getRootRef={scrollBoxRef}
         className={noMaxHeight ? undefined : styles.inWithMaxHeight}
         overscrollBehavior={overscrollBehavior}
+        tabIndex={-1}
       >
         {fetching ? (
           <div className={styles.fetching}>


### PR DESCRIPTION
- close https://github.com/VKCOM/VKUI/issues/8455

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [x] Release notes

## Описание
Исправляем поведение CalendarTime и логику фокуса.
Сейчас, если мы рендерим `Calendar` со временем, но без кнопки "Готово", то при проходе по `Calendar` с помощью `Tab` мы застреваем на инпуте с минутами.

С одной стороны это из-за того, что мы не учли, что кнопки "Готово" может не быть в https://github.com/VKCOM/VKUI/pull/8002

Но даже если это исправить, можно заметить, что фокус, если дропдаун селекта открыт, хоть и переходит из инпута минут куда-то, но он явно не попадает на следующий интерактивный элемент при одном нажатии `Tab`. Только со следующего нажатия `Tab` фокус действительно переходит дальше. (Это доводльно фрустрирующее поведение).

Оказалось, что причина в том, что в `CustomSelect`, когда дропдаун с опциями открыт и имеет много элементов так, что появляется скролл, то при нажатии `Tab` мы фокусируемся на дропдауне. Но, из-за того, что дропдаун закрывается сразу после нажатия `Tab`, то фокус переходит на `document`. Так как это происходит очень быстро, то даже не понятно что такой эффект вообще есть.
Мы частично решили эту проблему в https://github.com/VKCOM/VKUI/pull/8002 путём ручного управления фокусом, и это помогло в связке `| инпут Часов | инпут Минут | кнопка Готово |`, но дальнейший переход на следующий, в порядке `DOM`, интерактивный элемент всё равно сломан.

Решил установкой `tabIndex=-1` на `CustomScrollView` внутри `CustomSelectDropdown`. Это исправляет проблему.

----

В `CustomSelect` добавил` tabIndex=-1` для нативного селекта, чтобы в тестах фокус не попадал на этот селект.

## Release notes
## Исправления
- Calendar: исправлено застревание на селекте минут при переходе по элементам с помощью нажатия `Tab` с клавиатуры.
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
