### PR TITLE
fix(DateInput): fix clear date by button

### DIFF
--- a/packages/vkui/src/components/Calendar/Calendar.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.tsx
@@ -55,11 +55,11 @@ export interface CalendarProps
   /**
    * Текущая выбранная дата.
    */
-  value?: Date;
+  value?: Date | null;
   /**
    * Начальная дата при монтировании.
    */
-  defaultValue?: Date;
+  defaultValue?: Date | null;
   /**
    * Запрещает выбор даты в прошлом.
    * Применяется, если не заданы `shouldDisableDate` и `disableFuture`.
@@ -97,7 +97,7 @@ export interface CalendarProps
   /**
    * Обработчик изменения выбранной даты.
    */
-  onChange?: (value?: Date) => void;
+  onChange?: (value?: Date) => void; // TODO [>=8]: поменять тип на `(value?: Date | null) => void`
   /**
    * Функция для проверки запрета выбора даты.
    */
@@ -182,20 +182,20 @@ export const Calendar = ({
   ...props
 }: CalendarProps): React.ReactNode => {
   const _onChange = React.useCallback(
-    (date: Date | undefined) => {
+    (date: Date | null | undefined) => {
       onChange?.(convertDateFromTimeZone(date, timezone) || undefined);
     },
     [onChange, timezone],
   );
 
-  const [value, updateValue] = useCustomEnsuredControl<Date | undefined>({
+  const [value, updateValue] = useCustomEnsuredControl<Date | null | undefined>({
     value: valueProp,
     defaultValue,
     onChange: _onChange,
   });
 
-  const timeZonedValue: Date | undefined = React.useMemo(
-    () => convertDateToTimeZone(value, timezone) || undefined,
+  const timeZonedValue: Date | null | undefined = React.useMemo(
+    () => convertDateToTimeZone(value, timezone),
     [timezone, value],
   );
 

--- a/packages/vkui/src/components/CalendarDays/CalendarDays.tsx
+++ b/packages/vkui/src/components/CalendarDays/CalendarDays.tsx
@@ -32,7 +32,7 @@ export interface CalendarDaysProps
   /**
    * Выбранная дата или диапазон дат.
    */
-  value?: Date | Array<Date | null>;
+  value?: Date | Array<Date | null> | null;
   /**
    * Дата, определяющая отображаемый месяц.
    */

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -58,11 +58,11 @@ export interface CalendarRangeProps
   /**
    * Текущий выбранный промежуток.
    */
-  value?: DateRangeType;
+  value?: DateRangeType | null;
   /**
    * Начальный промежуток при монтировании.
    */
-  defaultValue?: DateRangeType;
+  defaultValue?: DateRangeType | null;
   /**
    * Запрещает выбор даты в прошлом.
    * Применяется, если не заданы `shouldDisableDate` и `disableFuture`.
@@ -88,7 +88,7 @@ export interface CalendarRangeProps
   /**
    * Обработчик изменения выбранного промежутка.
    */
-  onChange?: (value: DateRangeType | undefined) => void;
+  onChange?: (value: DateRangeType | undefined) => void; // TODO [>=8]: поменять тип на `(value?: DateRangeType | null) => void`
   /**
    * Функция для проверки запрета выбора даты.
    */
@@ -99,7 +99,7 @@ export interface CalendarRangeProps
   onClose?: () => void;
 }
 
-const getIsDaySelected = (day: Date, value?: DateRangeType) => {
+const getIsDaySelected = (day: Date, value?: DateRangeType | null) => {
   if (!value?.[0] || !value[1]) {
     return false;
   }
@@ -135,10 +135,15 @@ export const CalendarRange = ({
   getRootRef,
   ...props
 }: CalendarRangeProps): React.ReactNode => {
-  const [value, updateValue] = useCustomEnsuredControl<DateRangeType | undefined>({
+  const _onChange = React.useCallback(
+    (newValue: DateRangeType | null | undefined) => onChange?.(newValue || undefined),
+    [onChange],
+  );
+
+  const [value, updateValue] = useCustomEnsuredControl<DateRangeType | null | undefined>({
     value: valueProp,
     defaultValue,
-    onChange,
+    onChange: _onChange,
   });
 
   const {

--- a/packages/vkui/src/components/DateInput/DateInput.test.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.test.tsx
@@ -8,21 +8,23 @@ import { DateInput, type DateInputPropsTestsProps } from './DateInput';
 
 const date = new Date(2024, 6, 31, 11, 20, 0, 0);
 
-const testIds: DateInputPropsTestsProps = {
+const testIds: Required<DateInputPropsTestsProps> = {
   dayFieldTestId: 'day-picker',
   monthFieldTestId: 'month-picker',
   yearFieldTestId: 'year-picker',
   hourFieldTestId: 'hour-picker',
   minuteFieldTestId: 'minute-picker',
+  clearButtonTestId: 'clear-button',
+  showCalendarButtonTestId: 'show-calendar-button',
 };
 
 const getInputsLike = () => {
   return [
-    screen.queryByTestId('day-picker'),
-    screen.queryByTestId('month-picker'),
-    screen.queryByTestId('year-picker'),
-    screen.queryByTestId('hour-picker'),
-    screen.queryByTestId('minute-picker'),
+    screen.queryByTestId(testIds.dayFieldTestId),
+    screen.queryByTestId(testIds.monthFieldTestId),
+    screen.queryByTestId(testIds.yearFieldTestId),
+    screen.queryByTestId(testIds.hourFieldTestId),
+    screen.queryByTestId(testIds.minuteFieldTestId),
   ].filter(Boolean) as HTMLElement[];
 };
 
@@ -335,5 +337,15 @@ describe('DateInput', () => {
     await userEvent.click(dates);
 
     expect(screen.queryByText('Вчера')).toBeFalsy();
+  });
+
+  it('should call onChange with undefined when click on clear button', async () => {
+    const onChange = jest.fn();
+
+    render(<DateInput value={new Date(2023, 5, 30)} onChange={onChange} {...testIds} />);
+
+    fireEvent.click(screen.getByTestId(testIds.clearButtonTestId));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
   });
 });

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -50,6 +50,14 @@ export type DateInputPropsTestsProps = {
    * Передает атрибут `data-testid` для поля ввода минут.
    */
   minuteFieldTestId?: string;
+  /**
+   * Передает атрибут `data-testid` для кнопки показа календаря.
+   */
+  showCalendarButtonTestId?: string;
+  /**
+   * Передает атрибут `data-testid` для кнопки очистки даты.
+   */
+  clearButtonTestId?: string;
 };
 
 export interface DateInputProps
@@ -227,6 +235,8 @@ export const DateInput = ({
   yearFieldTestId,
   hourFieldTestId,
   minuteFieldTestId,
+  showCalendarButtonTestId,
+  clearButtonTestId,
   id,
   onApply,
   renderCustomValue,
@@ -239,12 +249,13 @@ export const DateInput = ({
   const hoursRef = React.useRef<HTMLSpanElement>(null);
   const minutesRef = React.useRef<HTMLSpanElement>(null);
 
-  const { value, updateValue, setInternalValue, getLastUpdatedValue } = useDateInputValue({
-    value: valueProp,
-    defaultValue,
-    onChange,
-    timezone,
-  });
+  const { value, updateValue, setInternalValue, getLastUpdatedValue, clearValue } =
+    useDateInputValue({
+      value: valueProp,
+      defaultValue,
+      onChange,
+      timezone,
+    });
 
   const maxElement = enableTime ? 4 : 2;
 
@@ -295,7 +306,7 @@ export const DateInput = ({
     autoFocus,
     disabled,
     elementsConfig,
-    onChange: updateValue,
+    onClear: clearValue,
     onInternalValueChange,
     getInternalValue,
     value,
@@ -317,6 +328,9 @@ export const DateInput = ({
 
   const onCalendarChange = React.useCallback(
     (value?: Date | undefined) => {
+      if (!value) {
+        return;
+      }
       if (enableTime) {
         setInternalValue(value);
         return;
@@ -330,13 +344,16 @@ export const DateInput = ({
   );
 
   const onDoneButtonClick = React.useCallback(() => {
+    if (!value) {
+      return;
+    }
     const newValue = updateValue(value);
     onApply?.(newValue);
     removeFocusFromField();
   }, [onApply, removeFocusFromField, updateValue, value]);
 
   const customValue = React.useMemo(
-    () => !open && renderCustomValue?.(value),
+    () => !open && renderCustomValue?.(value || undefined),
     [open, renderCustomValue, value],
   );
 
@@ -354,11 +371,21 @@ export const DateInput = ({
       getRootRef={handleRootRef}
       after={
         value ? (
-          <IconButton hoverMode="opacity" label={clearFieldLabel} onClick={clear}>
+          <IconButton
+            hoverMode="opacity"
+            label={clearFieldLabel}
+            onClick={clear}
+            data-testid={clearButtonTestId}
+          >
             <Icon16Clear />
           </IconButton>
         ) : (
-          <IconButton hoverMode="opacity" label={showCalendarLabel} onClick={openCalendar}>
+          <IconButton
+            hoverMode="opacity"
+            label={showCalendarLabel}
+            onClick={openCalendar}
+            data-testid={showCalendarButtonTestId}
+          >
             <Icon20CalendarOutline />
           </IconButton>
         )

--- a/packages/vkui/src/components/DateInput/hooks.test.ts
+++ b/packages/vkui/src/components/DateInput/hooks.test.ts
@@ -5,7 +5,7 @@ describe('useMergedState', () => {
   it('works in uncontrolled mode', () => {
     const { result } = renderHook(() => useDateInputValue({}));
 
-    expect(result.current.value).toBe(undefined);
+    expect(result.current.value).toBe(null);
 
     const newDate = new Date();
 
@@ -83,7 +83,7 @@ describe('useMergedState', () => {
       initialProps: {},
     });
 
-    expect(result.current.value).toBe(undefined);
+    expect(result.current.value).toBe(null);
 
     const controlledValue = new Date();
     rerender({ value: controlledValue });
@@ -91,5 +91,18 @@ describe('useMergedState', () => {
 
     rerender({});
     expect(result.current.value).toBe(controlledValue);
+  });
+
+  it('correctly clear value', () => {
+    const defaultValue = new Date();
+    const onChange = jest.fn();
+    const { result } = renderHook(() => useDateInputValue({ defaultValue, onChange }));
+
+    expect(result.current.value).toBe(defaultValue);
+    act(() => {
+      result.current.clearValue();
+    });
+
+    expect(result.current.value).toBe(null);
   });
 });

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.test.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { addDays, format } from 'date-fns';
 import { baselineComponent, userEvent } from '../../testing/utils';
-import { DateRangeInput, type DateRangeInputTestsProps } from './DateRangeInput';
+import { DateRangeInput } from './DateRangeInput';
 
 const startDate = new Date(2024, 6, 20);
 const endDate = new Date(2024, 6, 31);
 
 const dayTestId = (day: Date) => format(day, 'dd.MM.yyyy');
 
-const testsProps: DateRangeInputTestsProps = {
+const testsProps = {
   startDateTestsProps: {
     day: 'start-day',
     month: 'start-month',
@@ -20,16 +20,18 @@ const testsProps: DateRangeInputTestsProps = {
     month: 'end-month',
     year: 'end-year',
   },
+  clearButtonTestId: 'clear-button',
+  showCalendarButtonTestId: 'show-calendar-button',
 };
 
 const getInputsLike = () => {
   return [
-    screen.getByTestId('start-day'),
-    screen.getByTestId('start-month'),
-    screen.getByTestId('start-year'),
-    screen.getByTestId('end-day'),
-    screen.getByTestId('end-month'),
-    screen.getByTestId('end-year'),
+    screen.getByTestId(testsProps.startDateTestsProps.day),
+    screen.getByTestId(testsProps.startDateTestsProps.month),
+    screen.getByTestId(testsProps.startDateTestsProps.year),
+    screen.getByTestId(testsProps.endDateTestsProps.day),
+    screen.getByTestId(testsProps.endDateTestsProps.month),
+    screen.getByTestId(testsProps.endDateTestsProps.year),
   ];
 };
 
@@ -186,5 +188,14 @@ describe('DateRangeInput', () => {
     expect(onCalendarOpenChanged.mock.calls[1][0]).toBeFalsy();
 
     expect(container.contains(document.activeElement)).toBeFalsy();
+  });
+
+  it('should call onChange with undefined when click on clear button', async () => {
+    const onChange = jest.fn();
+    render(<DateRangeInput value={[startDate, endDate]} onChange={onChange} {...testsProps} />);
+
+    fireEvent.click(screen.getByTestId(testsProps.clearButtonTestId));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
   });
 });

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -57,6 +57,14 @@ export type DateRangeInputTestsProps = {
    * Передает атрибуты `data-testid` для полей ввода конечной даты.
    */
   endDateTestsProps?: DateTestsProps;
+  /**
+   * Передает атрибут `data-testid` для кнопки показа календаря.
+   */
+  showCalendarButtonTestId?: string;
+  /**
+   * Передает атрибут `data-testid` для кнопки очистки даты.
+   */
+  clearButtonTestId?: string;
 };
 
 export interface DateRangeInputProps
@@ -219,6 +227,8 @@ export const DateRangeInput = ({
   calendarTestsProps,
   startDateTestsProps,
   endDateTestsProps,
+  clearButtonTestId,
+  showCalendarButtonTestId,
   id,
   ...props
 }: DateRangeInputProps): React.ReactNode => {
@@ -229,10 +239,15 @@ export const DateRangeInput = ({
   const monthsEndRef = React.useRef<HTMLSpanElement>(null);
   const yearsEndRef = React.useRef<HTMLSpanElement>(null);
 
-  const [value, updateValue] = useCustomEnsuredControl<DateRangeType | undefined>({
+  const _onChange = React.useCallback(
+    (newValue: DateRangeType | null | undefined) => onChange?.(newValue || undefined),
+    [onChange],
+  );
+
+  const [value, updateValue] = useCustomEnsuredControl<DateRangeType | null | undefined>({
     value: valueProp,
     defaultValue,
-    onChange,
+    onChange: _onChange,
   });
 
   const onInternalValueChange = React.useCallback(
@@ -284,6 +299,8 @@ export const DateRangeInput = ({
     [daysStartRef, monthsStartRef, yearsStartRef, daysEndRef, monthsEndRef, yearsEndRef],
   );
 
+  const onClear = React.useCallback(() => updateValue(undefined), [updateValue]);
+
   const {
     rootRef,
     calendarRef,
@@ -302,7 +319,7 @@ export const DateRangeInput = ({
     autoFocus,
     disabled,
     elementsConfig,
-    onChange: updateValue,
+    onClear,
     onInternalValueChange,
     getInternalValue,
     value,
@@ -337,12 +354,16 @@ export const DateRangeInput = ({
       getRootRef={handleRootRef}
       after={
         value ? (
-          <IconButton hoverMode="opacity" onClick={clear}>
+          <IconButton hoverMode="opacity" onClick={clear} data-testid={clearButtonTestId}>
             <VisuallyHidden>{clearFieldLabel}</VisuallyHidden>
             <Icon16Clear />
           </IconButton>
         ) : (
-          <IconButton hoverMode="opacity" onClick={openCalendar}>
+          <IconButton
+            hoverMode="opacity"
+            onClick={openCalendar}
+            data-testid={showCalendarButtonTestId}
+          >
             <VisuallyHidden>{showCalendarLabel}</VisuallyHidden>
             <Icon20CalendarOutline />
           </IconButton>

--- a/packages/vkui/src/hooks/useCalendar.ts
+++ b/packages/vkui/src/hooks/useCalendar.ts
@@ -15,7 +15,7 @@ export interface UseCalendarDependencies
     | 'disableFuture'
     | 'disablePast'
   > {
-  value?: Array<Date | null> | Date;
+  value?: Array<Date | null> | Date | null;
 }
 
 export function useCalendar({

--- a/packages/vkui/src/hooks/useDateInput.ts
+++ b/packages/vkui/src/hooks/useDateInput.ts
@@ -9,15 +9,15 @@ export interface UseDateInputDependencies<T, D> {
   refs: Array<React.RefObject<T | null>>;
   autoFocus?: boolean;
   disabled?: boolean;
-  value?: D;
+  value?: D | null;
   elementsConfig: (index: number) => {
     length: number;
     min: number;
     max: number;
   };
   onInternalValueChange: (value: string[]) => void;
-  getInternalValue: (value?: D | undefined) => string[];
-  onChange?: (value?: D | undefined) => void;
+  getInternalValue: (value?: D | null | undefined) => string[];
+  onClear: () => void;
   onCalendarOpenChanged?: (opened: boolean) => void;
 }
 
@@ -27,7 +27,7 @@ export function useDateInput<T extends HTMLElement, D>({
   autoFocus,
   disabled,
   elementsConfig,
-  onChange,
+  onClear,
   onInternalValueChange,
   getInternalValue,
   value,
@@ -128,9 +128,9 @@ export function useDateInput<T extends HTMLElement, D>({
   }, [disabled, focusedElement, _onCalendarOpen, refs, window]);
 
   const clear = React.useCallback(() => {
-    onChange?.(undefined);
+    onClear?.();
     selectFirst();
-  }, [onChange, selectFirst]);
+  }, [onClear, selectFirst]);
 
   const handleFieldEnter = React.useCallback(() => {
     if (!open) {

--- a/packages/vkui/src/lib/date.ts
+++ b/packages/vkui/src/lib/date.ts
@@ -120,6 +120,9 @@ export const convertDateToTimeZone = (
   if (!timezone) {
     return date;
   }
+  if (date === null) {
+    return null;
+  }
   return date ? TZDateMini.tz(timezone, date) : undefined;
 };
 
@@ -129,6 +132,9 @@ export const convertDateFromTimeZone = (
 ): Date | undefined | null => {
   if (!timezone) {
     return date;
+  }
+  if (date === null) {
+    return null;
   }
   // eslint-disable-next-line new-cap
   const systemTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8451

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Release notes

## Описание

Если DateInput контролируемый и дата задана, то кнопка очистки значения срабатывает только со второго раза.
Хорошо воспроизводиться в доке: [v7.2.0](https://vkcom.github.io/VKUI/7.2.0/#/DateInput)

Поисследовал проблему: у нас для пустого состояния сейчас используется значение `undefined` и это же значение является индикатором того, что компонент неконтролируемый. Получается ситуация, что компонент был контролируемым и вдруг стал неконтроллируемым.

По идее нужно явно разделить неконтроллируемое состояние и пустое. Предлагаю для пустого использовать `null`.

## Изменения

У компонента `Calendar` расширил тип для `value` и `defaultValue`, добавив `null`. Это изменение не ломающее обратную совместимость. По идее, также надо бы сделать для типа свойства `onChange`:
  сейчас он
  ```typescript
  onChange?: (value?: Date) => void;
  ``` 
  А нужно сделать
  ```typescript
  onChange?: (value?: Date | null) => void;
  ``` 
  Но это изменение уже может сломать обратную совместимость.  Как минимум тайпскрипт будет ругаться.
Поэтому реализовал правку так, чтобы при очистке, наружу отправлялость значение `undefined`, но внутри сохранялось значение `null`. В v8 можно будет сделать нормально - оставил пока TODO

**Доп изменения:**
Добавил свойства для удобного написания теста:
```typescript
  /**
   * Передает атрибут `data-testid` для кнопки показа календаря.
   */
  showCalendarButtonTestId?: string;
  /**
   * Передает атрибут `data-testid` для кнопки очистки даты.
   */
  clearButtonTestId?: string;
``` 

## Release notes
## Исправления
- DateInput: Поправлен баг с тем, что очистка поля не срабатывала с первого нажатия на кнопку очистки
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
