### PR TITLE
fix(useModalRootContext): add activeModal

### DIFF
--- a/packages/vkui/src/components/ModalRoot/Readme.md
+++ b/packages/vkui/src/components/ModalRoot/Readme.md
@@ -567,11 +567,14 @@ const SomeAsyncEffect = () => {
 const ModalPageWrapper = ({ id, ...restProps }) => {
   const { activeModal } = useModalRootContext();
 
-  useEffect(function enableSomeEffect() {
-    if (id === activeModal) {
-      /* ... */
-    }
-  }, [id, activeModal];
+  useEffect(
+    function enableSomeEffect() {
+      if (id === activeModal) {
+        /* ... */
+      }
+    },
+    [id, activeModal],
+  );
 
   return (
     <ModalPage id={id} {...restProps}>

--- a/packages/vkui/src/components/ModalRoot/types.ts
+++ b/packages/vkui/src/components/ModalRoot/types.ts
@@ -156,5 +156,6 @@ export interface ModalRootContextInterface
     ModalRootBaseProps {}
 
 export interface UseModalRootContext extends ModalRootContextBaseInterface {
+  activeModal?: string | null;
   onClose?: VoidFunction;
 }

--- a/packages/vkui/src/components/ModalRoot/useModalRootContext.ts
+++ b/packages/vkui/src/components/ModalRoot/useModalRootContext.ts
@@ -17,5 +17,5 @@ export const useModalRootContext = (): UseModalRootContext => {
     }
   }, [activeModal, onCloseContext]);
 
-  return { isInsideModal, onClose, updateModalHeight, registerModal };
+  return { activeModal, isInsideModal, onClose, updateModalHeight, registerModal };
 };


### PR DESCRIPTION
- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

По документации useModalRootContext должен возвращать `activeModal`

## Release notes
## Исправления
- [useModalRootContext](https://vkcom.github.io/VKUI/${version}/#/ModalRoot): useModalRootContext не возвращал `activeModal`