### PR TITLE
feat(ColorSchemeProvider): rm use client

### DIFF
--- a/packages/vkui/src/components/ColorSchemeProvider/ColorSchemeProvider.tsx
+++ b/packages/vkui/src/components/ColorSchemeProvider/ColorSchemeProvider.tsx
@@ -1,7 +1,3 @@
-'use client';
-
-// TODO [@vkontakte/icons-sprite>=2.3.1]: Удалить use client, если он появился в IconAppearanceProvider
-
 import * as React from 'react';
 import { IconAppearanceProvider } from '@vkontakte/icons';
 import type { ColorSchemeType } from '../../lib/colorScheme';


### PR DESCRIPTION
- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] ~Release notes~ (обновление иконок в v7.3.0)

## Описание

Удаляем `use client` из ColorSchemeProvider, так как он больше не требуется

## Release notes
-