### PR TITLE
feat(Calendar): Make Calendar accessible from keyboard and screen reader

### DIFF
--- a/packages/vkui/src/components/Calendar/Calendar.test.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { format } from 'date-fns';
 import { baselineComponent, setNodeEnv, userEvent } from '../../testing/utils';
 import { Calendar } from './Calendar';
@@ -13,6 +13,37 @@ const dayTestId = (day: Date) => format(day, 'dd.MM.yyyy');
 
 describe('Calendar', () => {
   baselineComponent(Calendar);
+
+  it('checks aria roles', async () => {
+    jest.useFakeTimers({ now: targetDate });
+    render(<Calendar defaultValue={targetDate} dayTestId={dayTestId} />);
+
+    expect(screen.getByRole('grid', { name: 'сентябрь 2023 г.' })).toBeDefined();
+    expect(screen.getByRole('gridcell', { name: 'среда, 20 сентября' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'понедельник' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'вторник' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'среда' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'четверг' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'пятница' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'суббота' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'воскресенье' })).toBeDefined();
+
+    let currentDate = screen.getByRole('gridcell', { name: 'среда, 20 сентября' });
+    expect(currentDate.getAttribute('aria-current')).toBe('date');
+    expect(currentDate.getAttribute('aria-selected')).toBe('true');
+
+    await act(() =>
+      userEvent.click(screen.getByRole('gridcell', { name: 'вторник, 19 сентября' })),
+    );
+
+    currentDate = screen.getByRole('gridcell', { name: 'среда, 20 сентября' });
+    expect(currentDate.getAttribute('aria-current')).toBe('date');
+    expect(currentDate.getAttribute('aria-selected')).toBe('false');
+
+    const selectedDate = screen.getByRole('gridcell', { name: 'вторник, 19 сентября' });
+    expect(selectedDate.getAttribute('aria-current')).toBe(null);
+    expect(selectedDate.getAttribute('aria-selected')).toBe('true');
+  });
 
   it('fires onChange', () => {
     const onChange = jest.fn();
@@ -98,6 +129,102 @@ describe('Calendar', () => {
     await userEvent.keyboard('{ArrowUp}');
 
     expect(screen.getByTestId(monthDropdownTestId(8))).toBeInTheDocument();
+  });
+
+  it('checks that previous focusable day still focusable after navigation out of Calendar using Tab', async () => {
+    jest.useFakeTimers();
+    const day = new Date('2023-09-30T07:40:00.000Z');
+    const dayBeforeTarget = new Date('2023-09-29T07:40:00.000Z');
+
+    render(
+      <div>
+        <Calendar value={day} dayTestId={dayTestId} />
+        <button type="button">Следующая кнопка</button>
+      </div>,
+    );
+
+    const getTargetDay = () => screen.getByTestId(dayTestId(day));
+    const getDayBeforeTarget = () => screen.getByTestId(dayTestId(dayBeforeTarget));
+
+    // текущая дата календаря фокусируемая
+    expect(getTargetDay().tabIndex).toBe(0);
+    // соседний день нет
+    expect(getDayBeforeTarget().tabIndex).toBe(-1);
+
+    // фокусируемся с помощью клика на текущем дне
+    await act(() => userEvent.click(getTargetDay()));
+    // переходим на предыдущий день с помощью клавиатуры
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+
+    // текущая дата календаря больше не фокусируемая
+    expect(getTargetDay().tabIndex).toBe(-1);
+    // соседний день должен стать фокусируемым с клавиатуры
+    expect(getDayBeforeTarget().tabIndex).toBe(0);
+
+    // уводим фокус с помощью клавиатуры за пределы календаря
+    await act(() => userEvent.tab());
+    expect(document.activeElement).toBe(screen.getByText('Следующая кнопка'));
+
+    // на последний выбранный день календаря всё ещё можно сфокусироваться
+    expect(getDayBeforeTarget().tabIndex).toBe(0);
+
+    // возвращаемся назад с помощью Shift + Tab
+    await act(() => userEvent.tab({ shift: true }));
+    // последний выбранный день снова в фокусе
+    expect(document.activeElement).toStrictEqual(getDayBeforeTarget());
+  });
+
+  it('checks that Enter or Space triggers click on day cell', async () => {
+    jest.useFakeTimers();
+    const day = new Date('2023-09-30T07:40:00.000Z');
+
+    const onChangeStub = jest.fn();
+
+    render(<Calendar value={day} dayTestId={dayTestId} onChange={onChangeStub} />);
+
+    const getTargetDay = () => screen.getByTestId(dayTestId(day));
+
+    // текущая дата календаря фокусируемая
+    expect(getTargetDay().tabIndex).toBe(0);
+
+    // фокусируемся с помощью клика на текущем дне
+    await act(() => userEvent.click(getTargetDay()));
+
+    expect(onChangeStub).toHaveBeenCalledWith(day);
+    // переходим на предыдущий день с помощью клавиатуры
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+
+    // нажимаем Enter
+    await act(() => userEvent.keyboard('{Enter}'));
+    expect(onChangeStub).toHaveBeenLastCalledWith(new Date('2023-09-27T07:40:00.000Z'));
+
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+
+    // нажимаем Space
+    await act(() => userEvent.keyboard(' '));
+    expect(onChangeStub).toHaveBeenLastCalledWith(new Date('2023-09-26T07:40:00.000Z'));
+  });
+
+  it('checks focusable days', async () => {
+    jest.useFakeTimers();
+    render(<Calendar value={targetDate} dayTestId={dayTestId} />);
+
+    // при открытии календаря focusable день соответствует значению в value
+    expect(screen.getByTestId('20.09.2023').tabIndex).toBe(0);
+    expect(screen.getByTestId('21.09.2023').tabIndex).toBe(-1);
+
+    await act(() => userEvent.click(screen.getByTestId('20.09.2023')));
+    // при переходе к следующему дню с клавиатуры, следующий день становится фокусируемым
+    await act(() => userEvent.keyboard('{ArrowRight}'));
+
+    expect(screen.getByTestId('20.09.2023').tabIndex).toBe(-1);
+    expect(screen.getByTestId('21.09.2023').tabIndex).toBe(0);
+
+    // при смене месяца факусируемым становится первый день месяца
+    await act(() => userEvent.click(screen.getByText(/Следующий месяц/)));
+    expect(screen.getByTestId('01.10.2023').tabIndex).toBe(0);
   });
 
   it('should display correct timezone time', () => {

--- a/packages/vkui/src/components/Calendar/Calendar.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.tsx
@@ -2,11 +2,12 @@
 
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { isSameDay, isSameMonth } from 'date-fns';
+import { isSameDay, isSameMonth, startOfMonth } from 'date-fns';
 import { useCalendar } from '../../hooks/useCalendar';
 import { useCustomEnsuredControl } from '../../hooks/useEnsuredControl';
 import { clamp, isFirstDay, isLastDay, navigateDate, setTimeEqual } from '../../lib/calendar';
 import { convertDateFromTimeZone, convertDateToTimeZone } from '../../lib/date';
+import { isHTMLElement } from '../../lib/dom';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { warnOnce } from '../../lib/warnOnce';
 import type { HTMLAttributesWithRootRef } from '../../types';
@@ -80,6 +81,11 @@ export interface CalendarProps
   disablePickers?: boolean;
   /**
    * `aria-label` для изменения дня.
+   *
+   * @deprecated Будет удалeно в **VKUI v8**.
+   * Использовалось для задания aria-label для контейнера дней в календаре.
+   * Теперь этот контейнер является таблицей (с помощью role="grid") и
+   * в aria-label рендерится текущий открытый в календаре месяц и год.
    */
   changeDayLabel?: string;
   /**
@@ -134,7 +140,7 @@ const warn = warnOnce('Calendar');
  */
 export const Calendar = ({
   getRootRef,
-  value: valueProp,
+  'value': valueProp,
   defaultValue,
   onChange,
   disablePast,
@@ -148,6 +154,7 @@ export const Calendar = ({
   DoneButton,
   weekStartsOn = 1,
   disablePickers,
+  'aria-label': ariaLabel = 'Календарь',
   changeHoursLabel = 'Изменить час',
   changeMinutesLabel = 'Изменить минуту',
   prevMonthLabel = 'Предыдущий месяц',
@@ -155,9 +162,8 @@ export const Calendar = ({
   changeMonthLabel = 'Изменить месяц',
   changeYearLabel = 'Изменить год',
   showNeighboringMonth,
-  changeDayLabel = 'Изменить день',
   size = 'm',
-  viewDate: externalViewDate,
+  'viewDate': externalViewDate,
   onHeaderChange,
   onNextMonth,
   onPrevMonth,
@@ -206,9 +212,10 @@ export const Calendar = ({
     setNextMonth,
     focusedDay,
     setFocusedDay,
+    focusableDay,
+    setFocusableDay,
     isDayFocused,
     isDayDisabled,
-    resetSelectedDay,
     isMonthDisabled,
     isYearDisabled,
   } = useCalendar({
@@ -239,18 +246,44 @@ export const Calendar = ({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+      if (
+        [
+          'ArrowUp',
+          'ArrowDown',
+          'ArrowLeft',
+          'ArrowRight',
+          'Home',
+          'End',
+          'PageUp',
+          'PageDown',
+        ].includes(event.key)
+      ) {
         event.preventDefault();
+
+        const newFocusedDay = navigateDate(focusedDay ?? timeZonedValue, event.key);
+
+        if (newFocusedDay && !isSameMonth(newFocusedDay, viewDate)) {
+          setViewDate(newFocusedDay);
+        }
+        setFocusedDay(newFocusedDay);
+        setFocusableDay(newFocusedDay);
+
+        return;
       }
 
-      const newFocusedDay = navigateDate(focusedDay ?? timeZonedValue, event.key);
+      if (event.key === 'Tab') {
+        setFocusedDay(undefined);
+        setFocusableDay(focusedDay);
 
-      if (newFocusedDay && !isSameMonth(newFocusedDay, viewDate)) {
-        setViewDate(newFocusedDay);
+        return;
       }
-      setFocusedDay(newFocusedDay);
+
+      if ((event.key === 'Enter' || event.key === ' ') && isHTMLElement(event.target)) {
+        event.preventDefault();
+        event.target.click?.();
+      }
     },
-    [focusedDay, setFocusedDay, setViewDate, timeZonedValue, viewDate],
+    [focusedDay, setFocusedDay, setFocusableDay, setViewDate, timeZonedValue, viewDate],
   );
 
   const onDayChange = React.useCallback(
@@ -260,17 +293,66 @@ export const Calendar = ({
         actualDate = clamp(actualDate, { min: minDateTime, max: maxDateTime });
       }
       updateValue(actualDate);
+      setFocusedDay(actualDate);
+      setFocusableDay(actualDate);
     },
-    [timeZonedValue, updateValue, maxDateTime, minDateTime],
+    [timeZonedValue, updateValue, maxDateTime, minDateTime, setFocusedDay, setFocusableDay],
   );
 
+  const onDayFocus = React.useCallback(
+    (date: Date) => {
+      if (focusedDay && isSameDay(focusedDay, date)) {
+        return;
+      }
+
+      setFocusedDay(date);
+    },
+    [focusedDay, setFocusedDay],
+  );
+
+  // activeDay это день в календаре соответствующий значению в инпуте
   const isDayActive = React.useCallback(
     (day: Date) => Boolean(timeZonedValue && isSameDay(day, timeZonedValue)),
     [timeZonedValue],
   );
 
+  const isFocusableDayInViewDateMonth = focusableDay && isSameMonth(focusableDay, viewDate);
+  const isInputValueDateInViewDateMonth = timeZonedValue && isSameMonth(timeZonedValue, viewDate);
+  /**
+   * Функция позволяет проверить является ли день в календаре днём на который
+   * можно попасть с помощью Tab.
+   * Единственный день в таблице календаря у которого есть tabIndex="0"
+   * Чтобы на него можно было попасть из заголовка календаря.
+   */
+  const isDayFocusable = React.useCallback(
+    (day: Date) => {
+      // если focusableDay день находится среди дней открытого сейчас месяца, то такой день получит tabIndex="0",
+      if (isFocusableDayInViewDateMonth) {
+        return isSameDay(focusableDay, day);
+      }
+
+      // при открытии календаря focusableDay не определён,
+      // поэтому tabIndex="0" будет у дня, соответствующего дню в инпуте
+      if (isInputValueDateInViewDateMonth) {
+        return isDayActive(day);
+      }
+
+      // при переключении месяца любая навигация с помощью Tab начинается
+      // с первого дня месяца.
+      return isSameDay(startOfMonth(viewDate), day);
+    },
+    [
+      focusableDay,
+      viewDate,
+      isDayActive,
+      isFocusableDayInViewDateMonth,
+      isInputValueDateInViewDateMonth,
+    ],
+  );
+
   return (
     <RootComponent
+      aria-label={ariaLabel}
       {...props}
       baseClassName={classNames(styles.host, size === 's' && styles.sizeS)}
       getRootRef={getRootRef}
@@ -301,16 +383,15 @@ export const Calendar = ({
         viewDate={externalViewDate || viewDate}
         value={timeZonedValue}
         weekStartsOn={weekStartsOn}
-        isDayFocused={isDayFocused}
-        tabIndex={0}
-        aria-label={changeDayLabel}
         onKeyDown={handleKeyDown}
         onDayChange={onDayChange}
         isDayActive={isDayActive}
+        onDayFocus={onDayFocus}
+        isDayFocused={isDayFocused}
+        isDayFocusable={isDayFocusable}
         isDaySelectionStart={isFirstDay}
         isDaySelectionEnd={isLastDay}
         isDayDisabled={isDayDisabled}
-        onBlur={resetSelectedDay}
         showNeighboringMonth={showNeighboringMonth}
         size={size}
         dayProps={dayProps}

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.tsx
@@ -11,7 +11,7 @@ import styles from './CalendarDay.module.css';
 
 export type CalendarDayElementProps = Omit<
   React.AllHTMLAttributes<HTMLElement>,
-  'onChange' | 'size' | 'disabled' | 'selected'
+  'onChange' | 'size' | 'disabled' | 'selected' | 'onFocus'
 >;
 
 export type CalendarDayTestsProps = {
@@ -91,6 +91,10 @@ export interface CalendarDayProps extends CalendarDayElementProps, CalendarDayTe
    */
   onLeave?: (value: Date) => void;
   /**
+   * Обработчик фокуса на дне.
+   */
+  onFocus?: (value: Date) => void;
+  /**
    * Кастомизация отображения содержимого дня.
    */
   renderDayContent?: (day: Date) => React.ReactNode;
@@ -111,6 +115,7 @@ export const CalendarDay = React.memo(
     focused,
     onEnter,
     onLeave,
+    onFocus,
     hinted,
     hintedSelectionStart,
     hintedSelectionEnd,
@@ -119,6 +124,8 @@ export const CalendarDay = React.memo(
     children,
     renderDayContent,
     testId,
+    role,
+    'aria-colindex': colIndex,
     ...restProps
   }: CalendarDayProps) => {
     const { locale, direction } = useConfigProvider();
@@ -126,10 +133,10 @@ export const CalendarDay = React.memo(
     const onClick = React.useCallback(() => onChange(day), [day, onChange]);
     const handleEnter = React.useCallback(() => onEnter?.(day), [day, onEnter]);
     const handleLeave = React.useCallback(() => onLeave?.(day), [day, onLeave]);
+    const handleFocus = React.useCallback(() => onFocus?.(day), [day, onFocus]);
 
     const label = new Intl.DateTimeFormat(locale, {
       weekday: 'long',
-      year: 'numeric',
       month: 'long',
       day: 'numeric',
     }).format(day);
@@ -154,7 +161,13 @@ export const CalendarDay = React.memo(
     }, [renderDayContent, day, children, label]);
 
     if (hidden) {
-      return <div className={classNames(styles.hidden, size === 's' && styles.sizeS)} />;
+      return (
+        <div
+          role={role}
+          aria-colindex={colIndex}
+          className={classNames(styles.hidden, size === 's' && styles.sizeS)}
+        />
+      );
     }
 
     return (
@@ -164,12 +177,14 @@ export const CalendarDay = React.memo(
           size === 's' && styles.sizeS,
           direction === 'rtl' && styles.rtl,
         )}
+        role={role}
+        aria-colindex={colIndex}
         hoverMode={styles.hostHovered}
         activeMode={styles.hostActivated}
         hasActive={false}
         onClick={onClick}
+        onFocus={handleFocus}
         disabled={disabled}
-        tabIndex={-1}
         getRootRef={ref}
         focusVisibleMode={active ? 'outside' : 'inside'}
         onPointerEnter={handleEnter}

--- a/packages/vkui/src/components/CalendarDays/CalendarDays.tsx
+++ b/packages/vkui/src/components/CalendarDays/CalendarDays.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { isSameDay, isSameMonth } from 'date-fns';
-import { useExternRef } from '../../hooks/useExternRef';
 import { useTodayDate } from '../../hooks/useTodayDate';
 import { getDaysNames, getWeeks } from '../../lib/calendar';
 import type { HTMLAttributesWithRootRef } from '../../types';
@@ -16,6 +15,7 @@ import {
 import { useConfigProvider } from '../ConfigProvider/ConfigProviderContext';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { Footnote } from '../Typography/Footnote/Footnote';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import styles from './CalendarDays.module.css';
 
 export type CalendarDaysTestsProps = {
@@ -90,6 +90,10 @@ export interface CalendarDaysProps
    */
   isDayHinted?: (value: Date) => boolean;
   /**
+   * Проверяет, возможно ли сфокусироваться на дне с клавиатуры.
+   */
+  isDayFocusable?: (value: Date) => boolean;
+  /**
    * Проверяет, выбран ли день.
    */
   isDaySelected?: (value: Date) => boolean;
@@ -105,6 +109,10 @@ export interface CalendarDaysProps
    * Обработчик события 'pointerleave' на элементе дня.
    */
   onDayLeave?: (value: Date) => void;
+  /**
+   * Обработчик события `focus` на элементе дня.
+   */
+  onDayFocus?: (value: Date) => void;
 }
 
 export const CalendarDays = ({
@@ -118,10 +126,12 @@ export const CalendarDays = ({
   isDaySelectionStart,
   onDayEnter,
   onDayLeave,
+  onDayFocus,
   isDayHinted,
   isHintedDaySelectionStart,
   isHintedDaySelectionEnd,
   isDayFocused,
+  isDayFocusable,
   isDayDisabled,
   size,
   showNeighboringMonth = false,
@@ -133,7 +143,6 @@ export const CalendarDays = ({
   ...props
 }: CalendarDaysProps): React.ReactNode => {
   const { locale } = useConfigProvider();
-  const ref = useExternRef(getRootRef);
   const now = useTodayDate(listenDayChangesForUpdate);
 
   const weeks = React.useMemo(() => getWeeks(viewDate, weekStartsOn), [weekStartsOn, viewDate]);
@@ -146,55 +155,106 @@ export const CalendarDays = ({
   const handleDayChange = React.useCallback(
     (date: Date) => {
       onDayChange(date);
-
-      ref.current?.focus();
     },
-    [onDayChange, ref],
+    [onDayChange],
   );
 
-  return (
-    <RootComponent {...props} baseClassName={styles.host} getRootRef={ref}>
-      <div className={classNames(styles.row, size === 's' && styles.rowSizeS)}>
-        {daysNames.map((dayName) => (
-          <Footnote key={dayName} className={styles.weekday}>
-            {dayName}
-          </Footnote>
-        ))}
-      </div>
+  const viewDateLabelId = React.useId();
+  const currentMonthLabel = value
+    ? new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'long',
+      }).format(viewDate)
+    : null;
 
-      {weeks.map((week, i) => (
-        <div className={classNames(styles.row, size === 's' && styles.rowSizeS)} key={i}>
-          {week.map((day, i) => {
-            const sameMonth = isSameMonth(day, viewDate);
-            return (
-              <CalendarDay
-                key={day.toISOString()}
-                day={day}
-                today={isSameDay(day, now)}
-                active={isDayActive(day)}
-                onChange={handleDayChange}
-                hidden={!showNeighboringMonth && !sameMonth}
-                disabled={isDayDisabled(day)}
-                selectionStart={isDaySelectionStart(day, i)}
-                selectionEnd={isDaySelectionEnd(day, i)}
-                hintedSelectionStart={isHintedDaySelectionStart?.(day, i)}
-                hintedSelectionEnd={isHintedDaySelectionEnd?.(day, i)}
-                selected={isDaySelected?.(day)}
-                focused={isDayFocused(day)}
-                onEnter={onDayEnter}
-                onLeave={onDayLeave}
-                hinted={isDayHinted?.(day)}
-                sameMonth={sameMonth}
-                size={size}
-                renderDayContent={renderDayContent}
-                testId={dayTestId}
-                {...dayProps}
-                className={classNames(dayProps?.className, styles.rowDay)}
-              />
-            );
-          })}
+  return (
+    <React.Fragment>
+      {/*
+       * Нельзя помещать текст currentMonthLabel внутрь role="grid" или с помощью aria-label,
+       * иначе пользователи NVDA не смогут ходить по таблице
+       * с помощью горячих клавиш <Ctrl+Alt+стрелочки>.
+       * Имеется ввиду связка (применение которой визуально не видно):
+       * - из заголовка календаря прыжок в таблицу с помощью клавиши <T>
+       * - переход по ячейкам с помощью <Ctrl+Alrt+стрелочки>
+       * NVDA будет говорить, что пользователь вне ячейки таблицы.
+       * Также важно оставить aria-live="polite". Так NVDA зачитывает текущий
+       * месяц и год при переключении месяца и года в заголовке календаря.
+       */}
+      <VisuallyHidden aria-live="polite" id={viewDateLabelId}>
+        {currentMonthLabel}
+      </VisuallyHidden>
+      <RootComponent
+        role="grid"
+        {...props}
+        baseClassName={styles.host}
+        aria-labelledby={viewDateLabelId}
+      >
+        <div
+          role="row"
+          aria-rowindex={1}
+          className={classNames(styles.row, size === 's' && styles.rowSizeS)}
+        >
+          {daysNames.map(({ short: shortDayName, long: longDayName }) => (
+            <Footnote
+              role="columnheader"
+              aria-label={longDayName}
+              key={shortDayName}
+              className={styles.weekday}
+            >
+              {shortDayName}
+            </Footnote>
+          ))}
         </div>
-      ))}
-    </RootComponent>
+
+        {weeks.map((week, i) => (
+          <div
+            role="row"
+            aria-rowindex={i + 2}
+            className={classNames(styles.row, size === 's' && styles.rowSizeS)}
+            key={i}
+          >
+            {week.map((day, i) => {
+              const sameMonth = isSameMonth(day, viewDate);
+              const isHidden = !showNeighboringMonth && !sameMonth;
+              const isToday = isSameDay(day, now);
+              const isActive = isDayActive(day);
+              const isFocused = isDayFocused(day);
+              return (
+                <CalendarDay
+                  role="gridcell"
+                  aria-current={isToday ? 'date' : undefined}
+                  aria-selected={isActive ? 'true' : 'false'}
+                  aria-colindex={i + 1}
+                  tabIndex={isDayFocusable?.(day) ? 0 : -1}
+                  key={day.toISOString()}
+                  day={day}
+                  today={isToday}
+                  active={isActive}
+                  onChange={handleDayChange}
+                  hidden={isHidden}
+                  disabled={isDayDisabled(day)}
+                  selectionStart={isDaySelectionStart(day, i)}
+                  selectionEnd={isDaySelectionEnd(day, i)}
+                  hintedSelectionStart={isHintedDaySelectionStart?.(day, i)}
+                  hintedSelectionEnd={isHintedDaySelectionEnd?.(day, i)}
+                  selected={isDaySelected?.(day)}
+                  focused={isFocused}
+                  onEnter={onDayEnter}
+                  onLeave={onDayLeave}
+                  onFocus={onDayFocus}
+                  hinted={isDayHinted?.(day)}
+                  sameMonth={sameMonth}
+                  size={size}
+                  renderDayContent={renderDayContent}
+                  testId={dayTestId}
+                  {...dayProps}
+                  className={classNames(dayProps?.className, styles.rowDay)}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </RootComponent>
+    </React.Fragment>
   );
 };

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.test.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { addDays, endOfDay, format, startOfDay } from 'date-fns';
 import { getDocumentBody } from '../../lib/dom';
-import { baselineComponent } from '../../testing/utils';
+import { baselineComponent, userEvent } from '../../testing/utils';
 import { CalendarRange } from './CalendarRange';
 import dayStyles from '../CalendarDay/CalendarDay.module.css';
 import daysStyles from '../CalendarDays/CalendarDays.module.css';
@@ -111,6 +111,33 @@ describe('CalendarRange', () => {
 
     expect(screen.getByTestId(`left-month-picker-7`));
     checkActiveDay(new Date(2023, 8, 1));
+  });
+
+  it('checks day selection by keyboard', async () => {
+    jest.useFakeTimers();
+    const onChangeStub = jest.fn();
+    const startDate = new Date(2024, 2, 1);
+    const endDate = new Date(2024, 2, 10);
+    render(
+      <CalendarRange
+        value={[startDate, endDate]}
+        onChange={onChangeStub}
+        dayTestId={(day) => `${day.getDate()}`}
+      />,
+    );
+    await act(() => userEvent.click(screen.getAllByRole('gridcell', { selected: true })[0]));
+    expect(onChangeStub).toHaveBeenCalledTimes(1);
+
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+
+    // выбираем день с помощью Space
+    await act(() => userEvent.keyboard(' '));
+    expect(onChangeStub).toHaveBeenCalledTimes(2);
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+    await act(() => userEvent.keyboard('{ArrowLeft}'));
+    // выбираем день с помощью Enter
+    await act(() => userEvent.keyboard('{Enter}'));
+    expect(onChangeStub).toHaveBeenCalledTimes(3);
   });
 
   it('check click on same day', () => {

--- a/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
+++ b/packages/vkui/src/components/CalendarRange/CalendarRange.tsx
@@ -15,6 +15,7 @@ import {
 import { useCalendar } from '../../hooks/useCalendar';
 import { useCustomEnsuredControl } from '../../hooks/useEnsuredControl';
 import { isFirstDay, isLastDay, navigateDate } from '../../lib/calendar';
+import { isHTMLElement } from '../../lib/dom';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import {
   CalendarDays,
@@ -117,7 +118,6 @@ export const CalendarRange = ({
   disablePast,
   disableFuture,
   shouldDisableDate,
-  onClose,
   weekStartsOn = 1,
   disablePickers,
   prevMonthLabel = 'Предыдущий месяц',
@@ -165,20 +165,37 @@ export const CalendarRange = ({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
-        event.preventDefault();
-      }
-
-      const newFocusedDay = navigateDate(focusedDay ?? value?.[1], event.key);
-
       if (
-        newFocusedDay &&
-        !isSameMonth(newFocusedDay, viewDate) &&
-        !isSameMonth(newFocusedDay, addMonths(viewDate, 1))
+        [
+          'ArrowUp',
+          'ArrowDown',
+          'ArrowLeft',
+          'ArrowRight',
+          'Home',
+          'End',
+          'PageUp',
+          'PageDown',
+        ].includes(event.key)
       ) {
-        setViewDate(newFocusedDay);
+        event.preventDefault();
+
+        const newFocusedDay = navigateDate(focusedDay ?? value?.[1], event.key);
+
+        if (
+          newFocusedDay &&
+          !isSameMonth(newFocusedDay, viewDate) &&
+          !isSameMonth(newFocusedDay, addMonths(viewDate, 1))
+        ) {
+          setViewDate(newFocusedDay);
+        }
+        setFocusedDay(newFocusedDay);
+        return;
       }
-      setFocusedDay(newFocusedDay);
+
+      if ((event.key === 'Enter' || event.key === ' ') && isHTMLElement(event.target)) {
+        event.preventDefault();
+        event.target.click?.();
+      }
     },
     [focusedDay, setFocusedDay, setViewDate, value, viewDate],
   );

--- a/packages/vkui/src/components/DateInput/DateInput.test.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.test.tsx
@@ -155,7 +155,7 @@ describe('DateInput', () => {
   it('should call onChange callback when change data by calendar', async () => {
     jest.useFakeTimers();
     const onChange = jest.fn();
-    const { container } = render(
+    render(
       <DateInput
         value={date}
         onChange={onChange}

--- a/packages/vkui/src/components/DateInput/DateInput.test.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.test.tsx
@@ -180,18 +180,18 @@ describe('DateInput', () => {
     const resultDate = new Date(date);
     resultDate.setDate(date.getDate() - 1);
 
-    expect(container.contains(document.activeElement)).toBeTruthy();
+    expect(screen.queryByLabelText('Календарь')).toBeTruthy();
     fireEvent.click(screen.getByTestId(dayTestId(resultDate)));
 
     expect(onChange).toHaveBeenCalledWith(resultDate);
 
-    expect(container.contains(document.activeElement)).toBeFalsy();
+    expect(screen.queryByLabelText('Календарь')).toBeFalsy();
   });
 
   it('should call onCloseCalendar calendar was closed', async () => {
     jest.useFakeTimers();
     const onCalendarOpenChanged = jest.fn();
-    const { container } = render(
+    render(
       <DateInput
         value={date}
         onCalendarOpenChanged={onCalendarOpenChanged}
@@ -209,13 +209,13 @@ describe('DateInput', () => {
     expect(onCalendarOpenChanged).toHaveBeenCalledTimes(1);
     expect(onCalendarOpenChanged.mock.calls[0][0]).toBeTruthy();
 
-    expect(container.contains(document.activeElement)).toBeTruthy();
+    expect(screen.queryByLabelText('Календарь')).toBeTruthy();
     fireEvent.click(screen.getByTestId(dayTestId(subDays(date, 1))));
 
     expect(onCalendarOpenChanged).toHaveBeenCalledTimes(2);
     expect(onCalendarOpenChanged.mock.calls[1][0]).toBeFalsy();
 
-    expect(container.contains(document.activeElement)).toBeFalsy();
+    expect(screen.queryByLabelText('Календарь')).toBeFalsy();
   });
 
   it('should call onApply when clicking Done button', async () => {

--- a/packages/vkui/src/hooks/useCalendar.ts
+++ b/packages/vkui/src/hooks/useCalendar.ts
@@ -35,6 +35,8 @@ export function useCalendar({
   setNextMonth: () => void;
   focusedDay: Date | undefined;
   setFocusedDay: React.Dispatch<React.SetStateAction<Date | undefined>>;
+  focusableDay: Date | undefined;
+  setFocusableDay: React.Dispatch<React.SetStateAction<Date | undefined>>;
   isDayFocused: (day: Date) => boolean;
   isDayDisabled: (day: Date, withTime?: boolean) => boolean;
   resetSelectedDay: () => void;
@@ -44,7 +46,11 @@ export function useCalendar({
   const [viewDate, setViewDate] = React.useState(
     (Array.isArray(value) ? value[0] : value) ?? new Date(),
   );
+  // соответствует дню, на котором сейчас есть фокус
+  // меняется при переключении дней с помощью стрелок
   const [focusedDay, setFocusedDay] = React.useState<Date>();
+  // соотвествует дню, на котором можно сфокусироваться с помощью Tab
+  const [focusableDay, setFocusableDay] = React.useState<Date>();
 
   const setPrevMonth = React.useCallback(() => {
     onPrevMonth?.();
@@ -149,6 +155,8 @@ export function useCalendar({
     setNextMonth,
     focusedDay,
     setFocusedDay,
+    focusableDay,
+    setFocusableDay,
     isDayFocused,
     isDayDisabled,
     resetSelectedDay,

--- a/packages/vkui/src/lib/calendar.test.tsx
+++ b/packages/vkui/src/lib/calendar.test.tsx
@@ -1,4 +1,4 @@
-import { clamp, getYears, isDayMinMaxRestricted, setTimeEqual } from './calendar';
+import { clamp, getYears, isDayMinMaxRestricted, navigateDate, setTimeEqual } from './calendar';
 
 describe('calendar utils', () => {
   describe('setTimeEqual', () => {
@@ -138,6 +138,27 @@ describe('calendar utils', () => {
       ({ targetDate, min, max, expected }) => {
         const result = clamp(targetDate, { max, min });
         expect(result.toISOString()).toBe(expected);
+      },
+    );
+  });
+
+  describe(navigateDate, () => {
+    const targetDate = new Date('2023-09-15T10:35:00.000Z');
+    test.each`
+      targetDate    | key             | expectedDate
+      ${targetDate} | ${'ArrowRight'} | ${'2023-09-16T10:35:00.000Z'}
+      ${targetDate} | ${'ArrowLeft'}  | ${'2023-09-14T10:35:00.000Z'}
+      ${targetDate} | ${'ArrowUp'}    | ${'2023-09-08T10:35:00.000Z'}
+      ${targetDate} | ${'ArrowDown'}  | ${'2023-09-22T10:35:00.000Z'}
+      ${targetDate} | ${'Home'}       | ${'2023-09-11T00:00:00.000Z'}
+      ${targetDate} | ${'End'}        | ${'2023-09-17T23:59:59.999Z'}
+      ${targetDate} | ${'PageUp'}     | ${'2023-08-15T10:35:00.000Z'}
+      ${targetDate} | ${'PageDown'}   | ${'2023-10-15T10:35:00.000Z'}
+    `(
+      'returns $expectedDate when key $key pressed on date $targetDate',
+      ({ targetDate, key, expectedDate }) => {
+        const result = navigateDate(targetDate, key);
+        expect(result.toISOString()).toBe(expectedDate);
       },
     );
   });

--- a/packages/vkui/src/lib/calendar.ts
+++ b/packages/vkui/src/lib/calendar.ts
@@ -1,5 +1,6 @@
 import {
   addDays,
+  addMonths,
   addWeeks,
   eachDayOfInterval,
   endOfMonth,
@@ -12,6 +13,7 @@ import {
   startOfMonth,
   startOfWeek,
   subDays,
+  subMonths,
   subWeeks,
 } from 'date-fns';
 import { clamp as clampNumber } from '../helpers/math';
@@ -70,14 +72,17 @@ export const getDaysNames = (
   now: Date,
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6,
   locale?: string,
-): string[] => {
-  const formatter = new Intl.DateTimeFormat(locale, {
+): Array<{ short: string; long: string }> => {
+  const shortFormatter = new Intl.DateTimeFormat(locale, {
     weekday: 'short',
+  });
+  const longFormatter = new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
   });
   return eachDayOfInterval({
     start: startOfWeek(now, { weekStartsOn }),
     end: endOfWeek(now, { weekStartsOn }),
-  }).map((day) => formatter.format(day));
+  }).map((day) => ({ short: shortFormatter.format(day), long: longFormatter.format(day) }));
 };
 
 export const navigateDate = (date?: Date | null, key?: string): Date => {
@@ -95,6 +100,18 @@ export const navigateDate = (date?: Date | null, key?: string): Date => {
       break;
     case 'ArrowDown':
       newDate = addWeeks(newDate, 1);
+      break;
+    case 'Home':
+      newDate = startOfWeek(newDate, { weekStartsOn: 1 });
+      break;
+    case 'End':
+      newDate = endOfWeek(newDate, { weekStartsOn: 1 });
+      break;
+    case 'PageUp':
+      newDate = subMonths(newDate, 1);
+      break;
+    case 'PageDown':
+      newDate = addMonths(newDate, 1);
       break;
   }
 


### PR DESCRIPTION
- related to #4932
- часть большого PR https://github.com/VKCOM/VKUI/pull/8419
  - первая часть: #8487 (ревью начинать с неё)
  - вторая часть: https://github.com/VKCOM/VKUI/pull/8488
 
---

- [x] Unit-тесты
- [x] e2e-тесты
- [ ] Дизайн-ревью
- [x] Документация фичи
- [x] Release notes

## Описание
Переработана структура календаря так, что его элементы были доступны пользователям ассистивных технологий.

- Данные календаря теперь лежат в таблице. Таблица описана с помощью ролей (`role="grid"`), а не нативных элементов, чтобы не портить текущие стили.  
  Заголовком таблицы являются названия дней недели, основное тело таблицы это дни. 
  Заголовок размечен с помощью роли `columnheader`. 
  Ячейки с помощью роли `gridcell`.
  Это позволяет пользователям NVDA эффективнее перемещаться по элементам календаря. Они привыкли к тому, что календарь это всегда таблица, и ожидают, что смогут прыгнуть в тело ближайшей таблицы (в дни) нажатием клавиши `<T>`, а потом перемещаться по таблице с помощью `<Ctrl>+<Alt>+<Стрелочки>`.
- Таблице добавлен лэйбл с текущим месяцем и годом. Он также зачитывается каждый раз при переключении месяца с помощью кнопок в заголовке Календаря, или при изменении месяца/года с помощью селектов в заголовке.
- В таблице, в каждый момент времени `tabIndex="0"` теперь имеет только один день из всех. Это сделано специально, чтобы не надо было переходить по всему календарю с помщью `Tab`, чтобы выйти за пределы таблицы. Переход по дням календаря реализован с помощью стрелочек.  
  Обычно, когда календарь только открыт, день с фокусом это текущий выбранный в календаре день. Так проще на него перейти, просто нажам `Tab`. 
  Если пользователь переключил месяц, то фокус может иметь первый день месяца.
  Если пользователь перемещался по календарю, а потом вернулся к кнопкам заголовка календаря, `tabIndex="0"` будет у последнего дня, на котором у пользователя был фокус. Подобное есть в Material UI.
- Добавлена поддержка `Home/End/PageUp/PageDown` кнопок для быстрого перемещения по календарю.

## Release notes
## Улучшения
- Calendar: улучшена навигация с помощью клавиатуры и скринридера
- CalendarRange: улучшена навигация с помощью клавиатуры и скринридера
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
