### PR TITLE
feat: deprecate hasHover for AdaptivityProvider

### DIFF
--- a/packages/vkui/src/components/AdaptivityProvider/AdaptivityContext.tsx
+++ b/packages/vkui/src/components/AdaptivityProvider/AdaptivityContext.tsx
@@ -28,7 +28,9 @@ export interface AdaptivityProps extends SizeProps {
    */
   hasPointer?: boolean;
   /**
-   * Флаг поддержки эффекта наведения на устройстве.
+   * @deprecated Since 7.3.0.
+   *
+   * Свойство нигде не используется и будет удалено в `v8`.
    */
   hasHover?: boolean;
 }

--- a/packages/vkui/src/components/Tappable/Tappable.e2e-playground.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.e2e-playground.tsx
@@ -1,7 +1,6 @@
 import { noop } from '@vkontakte/vkjs';
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { type FocusVisibleMode } from '../../hooks/useFocusVisibleClassName';
-import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
 import { Tappable, type TappableProps } from './Tappable';
 
 export const TappablePlayground = (props: ComponentPlaygroundProps) => {
@@ -22,11 +21,7 @@ export const TappablePlayground = (props: ComponentPlaygroundProps) => {
         },
       ]}
     >
-      {(props: TappableProps) => (
-        <AdaptivityProvider hasHover>
-          <Tappable onClick={noop} {...props} />
-        </AdaptivityProvider>
-      )}
+      {(props: TappableProps) => <Tappable onClick={noop} {...props} />}
     </ComponentPlayground>
   );
 };


### PR DESCRIPTION
## Изменения

- related #6009

Депрекейтим свойство, которое нигде не используется

## Release notes

 ## Улучшения
 - AdaptivityProvider: неиспользуемое свойство `hasHover` устарело и будет удалено в следующем мажорном релизе
