### PR TITLE
fix: docs theme redefine

### DIFF
--- a/styleguide/Components/Preview.js
+++ b/styleguide/Components/Preview.js
@@ -14,7 +14,6 @@ import {
   usePlatform,
 } from '@vkui';
 import { BREAKPOINTS } from '@vkui/lib/adaptivity';
-import { getVKUIConfigProviderTokensClassNamesWithGlobalAppearance } from '../lib/theme';
 import { useLoadThemeTokens } from '../lib/theme/useLoadThemeTokens';
 import { useViewPortSize } from '../utils';
 import { Frame } from './Frame/Frame';
@@ -43,14 +42,7 @@ const Config = ({
   ...config
 }) => {
   return (
-    <ConfigProvider
-      {...config}
-      colorScheme={colorScheme}
-      tokensClassNames={getVKUIConfigProviderTokensClassNamesWithGlobalAppearance(
-        themeName,
-        colorSchemeOptions,
-      )}
-    >
+    <ConfigProvider {...config} colorScheme={colorScheme}>
       <AdaptivityProvider hasPointer={hasPointer}>
         <AppRoot layout={layout}>{children}</AppRoot>
       </AdaptivityProvider>
@@ -124,10 +116,6 @@ class Preview extends PreviewParent {
             <ConfigProvider
               platform={styleGuideContext.platform}
               colorScheme={styleGuideContext.colorScheme}
-              tokensClassNames={getVKUIConfigProviderTokensClassNamesWithGlobalAppearance(
-                styleGuideContext.themeName,
-                styleGuideContext.colorSchemeOptions,
-              )}
             >
               <div
                 className={classNames(

--- a/styleguide/lib/theme/functions.js
+++ b/styleguide/lib/theme/functions.js
@@ -15,7 +15,7 @@ export const makeTokenClassName = (themeName, colorScheme) => {
  * @param {object} colorSchemeOptions
  * @return {object}
  */
-export const getVKUIConfigProviderTokensClassNamesWithGlobalAppearance = (
+const getVKUIConfigProviderTokensClassNamesWithGlobalAppearance = (
   themeName,
   colorSchemeOptions = [],
 ) => {

--- a/styleguide/lib/theme/index.js
+++ b/styleguide/lib/theme/index.js
@@ -11,7 +11,6 @@ export { useLoadThemeTokens } from './useLoadThemeTokens';
 
 export {
   makeTokenClassName,
-  getVKUIConfigProviderTokensClassNamesWithGlobalAppearance,
   generateVKUIConfigProviderTokensClassNamesCodeExamples,
   onlyVariablesLocalURL,
   getDefaultByThemesPresets,


### PR DESCRIPTION
## Описание

Хардкод токенов не позволяет точечно переопределять платформу

## Release notes

 ## Документация
 - Вернули возможность переопределять платформу через `PlatformProvider`
