### PR TITLE
feat: add useLocale hook

### DIFF
--- a/packages/vkui/src/hooks/useLocale.test.tsx
+++ b/packages/vkui/src/hooks/useLocale.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import { ConfigProvider } from '../components/ConfigProvider/ConfigProvider';
+import type { HasChildren } from '../types';
+import { useLocale } from './useLocale';
+
+describe(useLocale, () => {
+  it("returns ConfigProvider's locale", () => {
+    const wrapper = ({ children }: HasChildren) => (
+      <ConfigProvider locale="en">{children}</ConfigProvider>
+    );
+
+    const { result } = renderHook(() => useLocale(), { wrapper });
+
+    expect(result.current).toEqual('en');
+  });
+
+  it("handles ConfigProvider's without locale", () => {
+    const wrapper = ({ children }: HasChildren) => <ConfigProvider>{children}</ConfigProvider>;
+
+    const { result } = renderHook(() => useLocale(), { wrapper });
+
+    expect(result.current).toEqual('ru');
+  });
+
+  it('handles no ConfigProvider', () => {
+    const { result } = renderHook(() => useLocale());
+
+    expect(result.current).toEqual('ru');
+  });
+});

--- a/packages/vkui/src/hooks/useLocale.ts
+++ b/packages/vkui/src/hooks/useLocale.ts
@@ -1,0 +1,7 @@
+import { useConfigProvider } from '../components/ConfigProvider/ConfigProviderContext';
+
+export function useLocale(): string {
+  const { locale } = useConfigProvider();
+
+  return locale;
+}

--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -437,6 +437,7 @@ export { withPlatform } from './hoc/withPlatform';
  */
 export { usePlatform } from './hooks/usePlatform';
 export { useConfigDirection as useDirection } from './hooks/useConfigDirection';
+export { useLocale } from './hooks/useLocale';
 export { useAdaptivity } from './hooks/useAdaptivity';
 export {
   type UseAdaptivityConditionalRender,


### PR DESCRIPTION
- [x] Unit-тесты
- [x] Release notes

## Описание

Добавляем хук `useLocale`, как для остальных параметров конфига

## Release notes

 ## Улучшения
 - Добавлен хук `useLocale` для получения текущей локали

