### PR TITLE
chore: vkcom is not web

### DIFF
--- a/packages/vkui/src/lib/platform.ts
+++ b/packages/vkui/src/lib/platform.ts
@@ -1,3 +1,9 @@
+/**
+ * android - базовая платформа
+ * ios - платформа которая подстраивается под ios
+ * vkcom - платформа предназначенная для миниприложений которые встраиваются в vk.com
+ */
+
 import { type BrowserInfo, computeBrowserInfo } from './browser';
 
 export const Platform = {
@@ -6,9 +12,6 @@ export const Platform = {
   VKCOM: 'vkcom',
 } as const;
 
-/**
- * TODO [>=8]: Переименовать 'vkcom' в 'web' и заменить в DEFAULT_TOKENS_CLASS_NAMES тему по умолчанию
- */
 export type PlatformType = 'android' | 'ios' | 'vkcom';
 
 export function platform(browserInfo?: BrowserInfo): PlatformType {


### PR DESCRIPTION
## Описание

`vkcom` это платформа предназначенная для миниприложений которые встраиваются в vk.com. Ее не требуется переименовывать в `web`

## Release notes
-