### PR TITLE
fix(Link): not interactive

### DIFF
--- a/packages/vkui/src/components/Link/Link.module.css
+++ b/packages/vkui/src/components/Link/Link.module.css
@@ -13,10 +13,8 @@
   border-radius: 0;
 }
 
-@media (--hover-has) {
-  .withUnderline:hover {
-    text-decoration: underline;
-  }
+.withUnderline.hover {
+  text-decoration: underline;
 }
 
 .hasVisited:visited {

--- a/packages/vkui/src/components/Link/Link.test.tsx
+++ b/packages/vkui/src/components/Link/Link.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { noop } from '@vkontakte/vkjs';
 import { baselineComponent } from '../../testing/utils';
 import { Link } from './Link';
 import styles from './Link.module.css';
@@ -10,14 +11,20 @@ describe(Link, () => {
     </Link>
   ));
 
-  it('should use <button> tag', () => {
-    const result = render(<Link />);
+  it('should use button role', () => {
+    const result = render(<Link onClick={noop} />);
     expect(result.getByRole('button')).toBeInTheDocument();
   });
 
-  it('should use <a> tag', () => {
+  it('should use link role', () => {
     const result = render(<Link href="https://vk.com" />);
     expect(result.getByRole('link')).toBeInTheDocument();
+  });
+
+  it('should use div role when no href is provided', () => {
+    const result = render(<Link />);
+    expect(result.queryByRole('button')).not.toBeInTheDocument();
+    expect(result.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('should render before and after elements', () => {

--- a/packages/vkui/src/components/Link/Link.tsx
+++ b/packages/vkui/src/components/Link/Link.tsx
@@ -38,16 +38,14 @@ export const Link = ({
 
   return (
     <Tappable
-      Component={restProps.href ? 'a' : 'button'}
-      hasHover={false}
       activeMode="opacity"
-      hoverMode="none"
+      hoverMode={styles.hover}
       focusVisibleMode="outside"
       {...restProps}
       baseClassName={classNames(
         styles.host,
         hasVisited && styles.hasVisited,
-        noUnderline ? undefined : styles.withUnderline,
+        !noUnderline && styles.withUnderline,
       )}
     >
       {before}


### PR DESCRIPTION
- Fixes #7609

---

- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Link без свойств превращается в button

Также наведение не отрабатывает при использовании мышки на планшете

## Изменения

Используем механизм наведения из Clickable, убираем превращение в button

## Release notes
## Исправления
- [Link](https://vkcom.github.io/VKUI/${version}/#/Link): наведение могло не отрабатываться на сенсорных экранах при использовании мышки или стилуса
- [Link](https://vkcom.github.io/VKUI/${version}/#/Link): не интерактивный компонент не превращается в button