### PR TITLE
feat(ActionSheet): cleanup

### DIFF
--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -57,7 +57,7 @@ export interface ActionSheetProps
   mode?: 'sheet' | 'menu';
   /**
    * @deprecated Since 7.3.0.
-   * 
+   *
    * Свойство не используется и будет удалено в `v8`.
    */
   mount?: boolean;

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.tsx
@@ -30,7 +30,7 @@ export interface ActionSheetProps
       SharedDropdownProps,
       'toggleRef' | 'popupOffsetDistance' | 'placement' | 'allowClickPropagation'
     >,
-    Omit<UseFocusTrapProps, 'onClose'>,
+    Omit<UseFocusTrapProps, 'onClose' | 'mount' | 'disabled'>,
     Omit<React.HTMLAttributes<HTMLDivElement>, 'autoFocus' | 'title'> {
   /**
    * Заголовок всплыващего окна.
@@ -55,6 +55,18 @@ export interface ActionSheetProps
    * - `menu` –  отображение в виде всплывающего элемента, относительно якорного элемента.
    */
   mode?: 'sheet' | 'menu';
+  /**
+   * @deprecated Since 7.3.0.
+   * 
+   * Свойство не используется и будет удалено в `v8`.
+   */
+  mount?: boolean;
+  /**
+   * @deprecated Since 7.3.0.
+   *
+   * Свойство не используется и будет удалено в `v8`.
+   */
+  disabled?: boolean;
 }
 
 /**

--- a/packages/vkui/src/components/ActionSheet/ActionSheetDefaultIosCloseItem.tsx
+++ b/packages/vkui/src/components/ActionSheet/ActionSheetDefaultIosCloseItem.tsx
@@ -1,9 +1,12 @@
 import { ActionSheetItem, type ActionSheetItemProps } from '../ActionSheetItem/ActionSheetItem';
 
-export const ActionSheetDefaultIosCloseItem = (props: ActionSheetItemProps): React.ReactNode => {
+export const ActionSheetDefaultIosCloseItem = ({
+  children = 'Отмена',
+  ...restProps
+}: ActionSheetItemProps): React.ReactNode => {
   return (
-    <ActionSheetItem mode="cancel" isCancelItem {...props}>
-      Отмена
+    <ActionSheetItem mode="cancel" isCancelItem {...restProps}>
+      {children}
     </ActionSheetItem>
   );
 };

--- a/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/ActionSheetItem.tsx
@@ -74,7 +74,7 @@ export interface ActionSheetItemProps
    */
   onImmediateClick?: React.MouseEventHandler<HTMLElement>;
   /**
-   * Иконка для `checked` режима.
+   * Иконка для `selectable` режима.
    */
   iconChecked?: React.ReactNode;
   /**


### PR DESCRIPTION
## Изменения

- пропы `mount` и `disabled` депрекейтим, как будто для этого компонента они не имеют смысла (ну и не работают сейчас так, как ожидается). 
- для `ActionSheetDefaultIosCloseItem` добавила возможность перебить `children`

## Release notes

 ## Улучшения
 - ActionSheet: свойства `mount` и `disabled` устарели и будут удалены в `v8`
 - [ActionSheetDefaultIosCloseItem](https://vkcom.github.io/VKUI/7.3.0/#/ActionSheet): добавлена возможность переопределять `children`

