### PR TITLE
feat: add autoFocus prop from FocusTrap

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -47,8 +47,8 @@ export interface AlertActionInterface
 }
 
 export interface AlertProps
-  extends Omit<React.HTMLAttributes<HTMLElement>, 'title'>,
-    Pick<UseFocusTrapProps, 'restoreFocus'>,
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'title' | 'autoFocus'>,
+    Pick<UseFocusTrapProps, 'restoreFocus' | 'autoFocus'>,
     Pick<AppRootPortalProps, 'usePortal'>,
     HasRootRef<HTMLDivElement> {
   /**


### PR DESCRIPTION
## Изменения

Свойство `autoFocus` наследовалось из стандартных свойств, но переопределяем мы его для `FocusTrap`. Изменение не ломающее, потому что  `autoFocus` у `FocusTrap` расширяет стандартное свойство.

## Release notes

 ## Улучшения
 - Alert: свойство `autoFocus` теперь принимает значение `"root"`
