### PR TITLE
feat(Alert): add dismissButtonMode none option

### DIFF
--- a/packages/vkui/src/components/Alert/Alert.test.tsx
+++ b/packages/vkui/src/components/Alert/Alert.test.tsx
@@ -268,25 +268,41 @@ describe('Alert', () => {
     },
   );
 
-  it.each<AlertProps['dismissButtonMode']>(['outside', 'inside'])(
-    'passes data-testid to dismiss button in %s dismissButtonMode',
-    async (dismissButtonMode) => {
-      render(
+  describe('handles dismissButtonMode', () => {
+    it.each<AlertProps['dismissButtonMode']>(['outside', 'inside'])(
+      'passes data-testid to dismiss button in %s dismissButtonMode',
+      async (dismissButtonMode) => {
+        render(
+          <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET}>
+            <Alert
+              onClose={jest.fn()}
+              dismissLabel="Закрыть предупреждение"
+              dismissButtonTestId="dismiss-button-test-id"
+              dismissButtonMode={dismissButtonMode}
+            />
+          </AdaptivityProvider>,
+        );
+        act(jest.runAllTimers);
+        expect(screen.getByTestId('dismiss-button-test-id')).toHaveTextContent(
+          'Закрыть предупреждение',
+        );
+      },
+    );
+
+    it('should hide button in dismissButtonMode="none"', async () => {
+      const result = render(
         <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET}>
           <Alert
             onClose={jest.fn()}
-            dismissLabel="Закрыть предупреждение"
             dismissButtonTestId="dismiss-button-test-id"
-            dismissButtonMode={dismissButtonMode}
+            dismissButtonMode="none"
           />
         </AdaptivityProvider>,
       );
       act(jest.runAllTimers);
-      expect(screen.getByTestId('dismiss-button-test-id')).toHaveTextContent(
-        'Закрыть предупреждение',
-      );
-    },
-  );
+      expect(result.queryByTestId('dismiss-button-test-id')).not.toBeInTheDocument();
+    });
+  });
 
   it.each([
     {

--- a/packages/vkui/src/components/Alert/Alert.tsx
+++ b/packages/vkui/src/components/Alert/Alert.tsx
@@ -86,8 +86,10 @@ export interface AlertProps
   /**
    * Расположение кнопки закрытия (внутри и вне `popout'a`)
    * Доступно только в `compact`-режиме, не отображается на `iOS`.
+   *
+   * ⚠️ ВНИМАНИЕ: использование `none` скрывает крестик, это негативно сказывается на пользовательском опыте.
    */
-  dismissButtonMode?: 'inside' | 'outside';
+  dismissButtonMode?: 'inside' | 'outside' | 'none';
   /**
    * Передает атрибут `data-testid` для кнопки закрытия.
    */


### PR DESCRIPTION
## Изменения

Добавляем вариант "none", чтобы дать возможность скрыть крестик. Добавлены тесты на это.

## Release notes

 ## Улучшения
 - Alert: добавлено значение `"none"` для свойства `dismissButtonMode`, для возможности скрыть крестик

