### PR TITLE
fix(DateInput): fix month names

### DIFF
--- a/packages/vkui/src/lib/calendar.ts
+++ b/packages/vkui/src/lib/calendar.ts
@@ -61,7 +61,7 @@ export const getMonths = (
 
   for (let i = 0; i < 12; i++) {
     months.push({
-      label: formatter.format(new Date('1970-01-01').setMonth(i)),
+      label: formatter.format(new Date(2023, i, 15)),
       value: i,
     });
   }


### PR DESCRIPTION
## Изменения

![image](https://github.com/user-attachments/assets/792d0075-e7ec-4ae7-9acc-9dfd61f005f5)

В некоторых таймзонах используемый метод получения месяца давал ненужное смещение, делаем получение месяца более "безопасным"

## Release notes

 ## Исправления 
 - DateInput: исправили неверные наименования месяцев в некоторых таймзонах

