### PR TITLE
ci: use local path for repo actions

### DIFF
--- a/.github/workflows/branch_test_coverage.yml
+++ b/.github/workflows/branch_test_coverage.yml
@@ -30,11 +30,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout LFS objects
-        uses: VKCOM/VKUI/.github/actions/lfs@master
+        uses: ./.github/actions/lfs
 
   test:
     name: Call reusable unit tests workflow
-    uses: VKCOM/VKUI/.github/workflows/reusable_workflow_test.yml@master
+    uses: ./.github/workflows/reusable_workflow_test.yml
     with:
       workspace: '@vkontakte/vkui'
 

--- a/.github/workflows/dedupe_deps.yml
+++ b/.github/workflows/dedupe_deps.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Dedupe deps
         run: yarn dedupe

--- a/.github/workflows/deploy_docs_on_branch_push.yml
+++ b/.github/workflows/deploy_docs_on_branch_push.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Build
         run: yarn docs:styleguide:build
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Build
         run: yarn docs:storybook:build
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Build VKUI
         run: yarn build:vkui

--- a/.github/workflows/monday.yml
+++ b/.github/workflows/monday.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - uses: VKCOM/gh-actions/shared/node/corepack-up-pr@main
         with:

--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -16,7 +16,7 @@ jobs:
     # см. https://github.com/orgs/community/discussions/26303
     if: ${{ !cancelled() }}
     name: Call reusable workflow
-    uses: VKCOM/VKUI/.github/workflows/reusable_workflow_pr_worfklow_payload.yml@master
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
     with:
       action: upload
       override_pr_number: ${{ inputs.pr_number_by_workflow_dispatch }}
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Dependabot metadata
         id: metadata
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Get vkui-floating-ui version
         id: get_version

--- a/.github/workflows/pr_close_undeploy.yml
+++ b/.github/workflows/pr_close_undeploy.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr_workflow_payload:
     name: Call reusable workflow
-    uses: VKCOM/VKUI/.github/workflows/reusable_workflow_pr_worfklow_payload.yml@master
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
     with:
       action: download
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,23 +47,23 @@ jobs:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
 
       - name: Setting up the repository environment
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-1-setup@master
+        uses: ./.github/actions/publish-workflow-1-setup
 
       - name: Bump version
         id: updated_versions_info
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-2-bump-version@master
+        uses: ./.github/actions/publish-workflow-2-bump-version
         with:
           package_name: ${{ inputs.package_name }}
           new_version: ${{ inputs.custom_version || inputs.new_version }}
 
       - name: Run pre-publish checks
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-3-validation@master
+        uses: ./.github/actions/publish-workflow-3-validation
         with:
           package_name: ${{ inputs.package_name }}
 
       - name: Complete publish
         id: complete_publish
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-4-complete@master
+        uses: ./.github/actions/publish-workflow-4-complete
         with:
           branch: ${{ github.ref }}
           prev_version: ${{ steps.updated_versions_info.outputs.prev_version }}

--- a/.github/workflows/publish_deploy.yml
+++ b/.github/workflows/publish_deploy.yml
@@ -68,7 +68,7 @@ jobs:
           ref: ${{ env.CHECKOUT_BRANCH }}
 
       - name: Setting up the repository environment
-        uses: VKCOM/VKUI/.github/actions/setup@master
+        uses: ./.github/actions/setup
 
       - name: Creating docs for pre-release
         if: ${{ fromJSON(needs.payload.outputs.is_for_prerelease) == true }}

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -49,11 +49,11 @@ jobs:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
 
       - name: Setting up the repository environment
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-1-setup@master
+        uses: ./.github/actions/publish-workflow-1-setup
 
       - name: Bump version
         id: updated_versions_info
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-2-bump-version@master
+        uses: ./.github/actions/publish-workflow-2-bump-version
         with:
           package_name: ${{ inputs.package_name }}
           new_version: ${{ inputs.custom_version || inputs.new_version }}
@@ -61,13 +61,13 @@ jobs:
           pre_id: ${{ !inputs.custom_version && inputs.npm_tag_aka_pre_id || '' }}
 
       - name: Run pre-publish checks
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-3-validation@master
+        uses: ./.github/actions/publish-workflow-3-validation
         with:
           package_name: ${{ inputs.package_name }}
 
       - name: Complete publish
         id: complete_publish
-        uses: VKCOM/VKUI/.github/actions/publish-workflow-4-complete@master
+        uses: ./.github/actions/publish-workflow-4-complete
         with:
           branch: ${{ github.ref }}
           prev_version: ${{ steps.updated_versions_info.outputs.prev_version }}

--- a/.github/workflows/pull_request_common.yml
+++ b/.github/workflows/pull_request_common.yml
@@ -21,14 +21,14 @@ jobs:
 
       - name: Patch
         if: ${{ startsWith(github.event.pull_request.title, 'fix') }}
-        uses: VKCOM/VKUI/.github/actions/add-label-to-pull-request@master
+        uses: ./.github/actions/add-label-to-pull-request
         with:
           issue_number: ${{ github.event.pull_request.number }}
           label: 'ci:cherry-pick:patch'
 
       - name: VKUI-tokens
         if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.title, '@vkontakte/vkui-tokens') }}
-        uses: VKCOM/VKUI/.github/actions/add-label-to-pull-request@master
+        uses: ./.github/actions/add-label-to-pull-request
         with:
           issue_number: ${{ github.event.pull_request.number }}
           label: 'vkui-tokens'
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Fetch Dependabot metadata
         id: metadata
@@ -117,7 +117,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
-
+        uses: ./.github/actions/node-setup
       - name: Run Prettier
         run: yarn run lint:prettier

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Run Stylelint
         run: yarn run lint:style
@@ -67,7 +67,7 @@ jobs:
 
   test:
     name: Call reusable workflow
-    uses: VKCOM/VKUI/.github/workflows/reusable_workflow_test.yml@master
+    uses: ./.github/workflows/reusable_workflow_test.yml
 
   test_report:
     if: ${{ !cancelled() && (success() || failure()) }}
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.changed_files.outputs.package_vkui == 'true' }}
     needs: changed_files
     name: Call reusable workflow
-    uses: VKCOM/VKUI/.github/workflows/reusable_workflow_test_e2e.yml@master
+    uses: ./.github/workflows/reusable_workflow_test_e2e.yml
 
   test_e2e_prepare_and_upload_report:
     if: ${{ !cancelled() && (success() || failure()) }}
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Download Playwright blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
@@ -138,7 +138,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Generate archive
         run: yarn workspace @vkontakte/vkui pack --out ../../out/_pkg.tgz
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - uses: andresz1/size-limit-action@v1.8.0
         with:
@@ -187,7 +187,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Build
         run: yarn run docs:styleguide:build
@@ -208,7 +208,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Build
         run: yarn docs:storybook:build
@@ -229,7 +229,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Build VKUI
         run: yarn build:vkui
@@ -252,7 +252,7 @@ jobs:
     # см. https://github.com/orgs/community/discussions/26303
     if: ${{ !cancelled() }}
     name: Call reusable workflow
-    uses: VKCOM/VKUI/.github/workflows/reusable_workflow_pr_worfklow_payload.yml@master
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
     with:
       action: upload
 

--- a/.github/workflows/pull_request_packages_deploy.yml
+++ b/.github/workflows/pull_request_packages_deploy.yml
@@ -17,7 +17,7 @@ jobs:
   pr_workflow_payload:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     name: Call reusable workflow
-    uses: VKCOM/VKUI/.github/workflows/reusable_workflow_pr_worfklow_payload.yml@master
+    uses: ./.github/workflows/reusable_workflow_pr_worfklow_payload.yml
     with:
       action: download
 

--- a/.github/workflows/reusable_workflow_test.yml
+++ b/.github/workflows/reusable_workflow_test.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Run tests for all workspaces
         if: ${{ !inputs.workspace }}

--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -22,9 +22,9 @@ jobs:
 
       # Создаем кэш для ветки один раз
       - name: Checkout LFS objects
-        uses: VKCOM/VKUI/.github/actions/lfs@master
+        uses: ./.github/actions/lfs
 
-      - uses: VKCOM/VKUI/.github/actions/get-playwright-docker-image@master
+      - uses: ./.github/actions/get-playwright-docker-image
         id: result
 
   test_e2e:
@@ -47,10 +47,10 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Checkout LFS objects
-        uses: VKCOM/VKUI/.github/actions/lfs@master
+        uses: ./.github/actions/lfs
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Run e2e tests for @vkontakte/vkui workspace
         # Почему HOME=/root см. https://github.com/microsoft/playwright/issues/6500

--- a/.github/workflows/update_screens.yml
+++ b/.github/workflows/update_screens.yml
@@ -20,9 +20,9 @@ jobs:
 
       # Создаем кэш для ветки один раз
       - name: Checkout LFS objects
-        uses: VKCOM/VKUI/.github/actions/lfs@master
+        uses: ./.github/actions/lfs
 
-      - uses: VKCOM/VKUI/.github/actions/get-playwright-docker-image@master
+      - uses: ./.github/actions/get-playwright-docker-image
         id: result
 
   update_screens:
@@ -43,14 +43,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout LFS objects
-        uses: VKCOM/VKUI/.github/actions/lfs@master
+        uses: ./.github/actions/lfs
 
       - name: Install rsync && zip
         run: |
           apt-get install -y rsync zip
 
       - name: Node setup
-        uses: VKCOM/VKUI/.github/actions/node-setup@master
+        uses: ./.github/actions/node-setup
 
       - name: Update screenshots
         # Почему HOME=/root см. https://github.com/microsoft/playwright/issues/6500

--- a/packages/vkui/src/components/Button/Button.module.css
+++ b/packages/vkui/src/components/Button/Button.module.css
@@ -10,8 +10,8 @@
   border: 0;
   border-radius: var(--vkui--size_border_radius--regular);
   transition:
-    background-color 0.15s ease-out,
-    color 0.15s ease-out;
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .rounded {

--- a/packages/vkui/src/components/Button/Button.module.css
+++ b/packages/vkui/src/components/Button/Button.module.css
@@ -10,8 +10,8 @@
   border: 0;
   border-radius: var(--vkui--size_border_radius--regular);
   transition:
-    background-color 0.15s ease,
-    color 0.15s ease;
+    background-color 0.15s ease-out,
+    color 0.15s ease-out;
 }
 
 .rounded {


### PR DESCRIPTION
Пробуем починить ошибки в CI:

```
Download action repository 'VKCOM/VKUI@master' (SHA:c419a9d34380aeb65b52ce3870c9ccf9ca171d1e)
Warning: Failed to download action 'https://api.github.com/repos/VKCOM/VKUI/tarball/c419a9d34380aeb65b52ce3870c9ccf9ca171d1e'. Error: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
Warning: Back off 16.528 seconds before retry.
Warning: Failed to download action 'https://api.github.com/repos/VKCOM/VKUI/tarball/c419a9d34380aeb65b52ce3870c9ccf9ca171d1e'. Error: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
Warning: Back off 16.76 seconds before retry.
Error: Action 'https://api.github.com/repos/VKCOM/VKUI/tarball/c419a9d34380aeb65b52ce3870c9ccf9ca171d1e' download has timed out. Error: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
```

При указании `VKCOM/VKUI/.github/<path>/@master`, GitHub Actions скачивает весь репозиторий. С 05.05.2025 скачивание начало падать по таймауту. Пару недель назад мы наткнулись на проблему с лимитами Git LFS, оно было связано с новой схемой выставления лимитов. Может и GitHub Actions это затронуло.

В #8264 мы перешли на получение локальных экшенов из master предупреждая уязвимости, но потенциальный риск от использования локальных путей неясен. Также никто не мешает злоумышленнику заменить в своей ветке пути на локальные, как это сделано в ветке по текущему PR.

## Скриншот

<img width="320" alt="image" src="https://github.com/user-attachments/assets/29c30bd3-4bac-4995-abd2-c3e2cbddec33" />

## Release notes
-