### PR TITLE
feat: add transitionDisabled prop

### DIFF
--- a/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -25,6 +25,7 @@ describe(ConfigProvider, () => {
         customPanelHeaderAfterMinWidth: 90,
         tokensClassNames: DEFAULT_TOKENS_CLASS_NAMES,
         transitionMotionEnabled: false,
+        transitionDisabled: false,
         direction: 'ltr',
       });
       return null;
@@ -34,6 +35,7 @@ describe(ConfigProvider, () => {
         colorScheme="light"
         hasCustomPanelHeaderAfter={false}
         transitionMotionEnabled={false}
+        transitionDisabled={false}
       >
         <ConfigUser />
       </ConfigProvider>,
@@ -53,6 +55,7 @@ describe(ConfigProvider, () => {
       hasCustomPanelHeaderAfter: true,
       customPanelHeaderAfterMinWidth: 90,
       transitionMotionEnabled: false,
+      transitionDisabled: false,
       isWebView: true,
       tokensClassNames: { light: 'some-class-light', dark: 'some-class-dark' },
       locale: 'en',
@@ -63,6 +66,7 @@ describe(ConfigProvider, () => {
       ['hasCustomPanelHeaderAfter', false],
       ['customPanelHeaderAfterMinWidth', 100],
       ['transitionMotionEnabled', true],
+      ['transitionDisabled', true],
       ['isWebView', false],
       ['platform', 'light'],
       ['tokensClassNames', { light: 'another-class-light', dark: 'another-class-dark' }],
@@ -96,6 +100,7 @@ describe(ConfigProviderOverride, () => {
     hasCustomPanelHeaderAfter: true,
     customPanelHeaderAfterMinWidth: 90,
     transitionMotionEnabled: false,
+    transitionDisabled: false,
     isWebView: true,
     tokensClassNames: { light: 'some-class-light', dark: 'some-class-dark' },
     locale: 'en',
@@ -106,6 +111,7 @@ describe(ConfigProviderOverride, () => {
     ['hasCustomPanelHeaderAfter', false],
     ['customPanelHeaderAfterMinWidth', 100],
     ['transitionMotionEnabled', true],
+    ['transitionDisabled', true],
     ['isWebView', false],
     ['platform', 'light'],
     ['tokensClassNames', { light: 'another-class-light', dark: 'another-class-dark' }],

--- a/packages/vkui/src/components/ConfigProvider/ConfigProviderContext.tsx
+++ b/packages/vkui/src/components/ConfigProvider/ConfigProviderContext.tsx
@@ -40,9 +40,17 @@ export interface ConfigProviderContextInterface {
    */
   colorScheme: ColorSchemeType | undefined;
   /**
-   * Включена ли анимация переходов между экранами в `Root` и `View`.
+   *  @deprecated Since 7.4.0.
+   *
+   * Свойство будет удалено в `v8`. Используйте свойство `transitionDisabled`.
    */
   transitionMotionEnabled: boolean;
+  /**
+   * Позволяет отключить анимации переходов между экранами в `Root` и `View`.
+   *
+   * В `v8` значение по умолчанию будет `false` для мобильных устройств, `true` - для планшетов и десктопов и платформы `vkcom`.
+   */
+  transitionDisabled: boolean | undefined;
   /**
    * Платформа.
    */
@@ -91,6 +99,7 @@ export const ConfigProviderContext: React.Context<ConfigProviderContextInterface
     customPanelHeaderAfterMinWidth: 90,
     isWebView: false,
     transitionMotionEnabled: true,
+    transitionDisabled: undefined,
     platform: platform(),
     colorScheme: undefined, // undefined обозначает что тема должна определиться автоматически
     tokensClassNames: DEFAULT_TOKENS_CLASS_NAMES,
@@ -108,6 +117,7 @@ export function useConfigProviderContextMemo(config: ConfigProviderContextInterf
     customPanelHeaderAfterMinWidth,
     colorScheme,
     transitionMotionEnabled,
+    transitionDisabled,
     platform,
     tokensClassNames,
     locale,
@@ -121,6 +131,7 @@ export function useConfigProviderContextMemo(config: ConfigProviderContextInterf
       customPanelHeaderAfterMinWidth,
       colorScheme,
       transitionMotionEnabled,
+      transitionDisabled,
       platform,
       tokensClassNames,
       locale,
@@ -132,6 +143,7 @@ export function useConfigProviderContextMemo(config: ConfigProviderContextInterf
     customPanelHeaderAfterMinWidth,
     colorScheme,
     transitionMotionEnabled,
+    transitionDisabled,
     platform,
     tokensClassNames,
     locale,

--- a/packages/vkui/src/components/Root/Root.tsx
+++ b/packages/vkui/src/components/Root/Root.tsx
@@ -58,9 +58,9 @@ export const Root = ({
   const scrolls = React.useRef<Record<string, number>>({}).current;
   const viewNodes = React.useRef<Record<string, HTMLElement | null>>({}).current;
 
-  const { transitionMotionEnabled = true } = useConfigProvider();
+  const { transitionMotionEnabled = true, transitionDisabled } = useConfigProvider();
   const { animate } = React.useContext(SplitColContext);
-  const disableAnimation = !transitionMotionEnabled || !animate;
+  const disableAnimation = transitionDisabled ?? (!transitionMotionEnabled || !animate);
 
   const views = React.Children.toArray(children) as Array<React.ReactElement<NavIdProps>>;
 

--- a/packages/vkui/src/components/SplitCol/SplitCol.tsx
+++ b/packages/vkui/src/components/SplitCol/SplitCol.tsx
@@ -62,7 +62,9 @@ export interface SplitColProps extends HTMLAttributesWithRootRef<HTMLDivElement>
    */
   minWidth?: number | string;
   /**
-   * Если false, то переходы между Panel происходят без анимации.
+   * @deprecated Since 7.4.0.
+   *
+   * Свойство будет удалено в `v8`. Используйте свойство `transitionDisabled` компонента `ConfigProvider`.
    */
   animate?: boolean;
   /**

--- a/packages/vkui/src/components/View/View.tsx
+++ b/packages/vkui/src/components/View/View.tsx
@@ -140,7 +140,8 @@ export const View = ({
   );
 
   const disableAnimation =
-    !configProvider.transitionMotionEnabled || !splitCol.animate || platform === 'vkcom';
+    configProvider.transitionDisabled ??
+    (!configProvider.transitionMotionEnabled || !splitCol.animate || platform === 'vkcom');
   const iOSSwipeBackSimulationEnabled =
     !disableAnimation && platform === 'ios' && configProvider.isWebView && Boolean(onSwipeBack);
 

--- a/packages/vkui/src/components/View/ViewInfinite.tsx
+++ b/packages/vkui/src/components/View/ViewInfinite.tsx
@@ -298,9 +298,10 @@ class ViewInfiniteComponent extends React.Component<
 
   shouldDisableTransitionMotion(): boolean {
     return (
-      this.props.configProvider?.transitionMotionEnabled === false ||
-      !this.props.splitCol?.animate ||
-      this.props.platform === 'vkcom'
+      this.props.configProvider?.transitionDisabled ??
+      (this.props.configProvider?.transitionMotionEnabled === false ||
+        !this.props.splitCol?.animate ||
+        this.props.platform === 'vkcom')
     );
   }
 


### PR DESCRIPTION
- [x] Unit-тесты
- [x] Документация фичи
- [x] Release notes

## Изменения

Незачем иметь два пропа под отключение анимаций переходов - поэтому мы создаём третье 😄 
В `SplitCol` в будущем мажоре следует совсем удалить `animate`.
В `ConfigProvider` добавляем `transitionDisabled`, чтобы иметь возможность без breaking change внести изменения в логику отключения анимаций (в следующем мажорном релизе в новое свойство следует по умолчанию сеттить значение из автоматических расчетов в `SplitCol`).

## Release notes

 ## Улучшения
 - ConfigProvider: добавлено свойство `transitionDisabled`, позволяющее включать/отключать анимации переходов в `Root` и `View`, свойство `transitionMotionEnabled` помечено устаревшим
  - SplitCol: свойство `animate` помечено устаревшим, используйте `transitionDisabled` в компоненте `ConfigProvider`

