### PR TITLE
fix(FormLayoutGroup): add disabled to removable

### DIFF
--- a/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.tsx
+++ b/packages/vkui/src/components/FormLayoutGroup/FormLayoutGroup.tsx
@@ -45,6 +45,7 @@ export const FormLayoutGroup = ({
   removePlaceholder = 'Удалить',
   onRemove,
   getRootRef,
+  disabled,
   ...restProps
 }: FormLayoutGroupProps): React.ReactNode => {
   const { sizeY = 'none' } = useAdaptivity();
@@ -64,6 +65,7 @@ export const FormLayoutGroup = ({
         isRemovable && classNames(styles.withRemovable, 'vkuiInternalFormLayoutGroup--removable'),
         segmented && classNames(styles.segmented, 'vkuiInternalFormLayoutGroup--segmented'),
       )}
+      disabled={disabled}
       {...restProps}
     >
       {isRemovable ? (
@@ -76,6 +78,7 @@ export const FormLayoutGroup = ({
               onRemove?.(e, rootEl.current);
             }
           }}
+          disabled={disabled}
           indent={removable === 'indent'}
         >
           {children}


### PR DESCRIPTION
## Описание

`disabled` не прокидывался в `removable` компонент, позволяем это делать (по аналогии с `Cell` компонентов).

Ранее обсуждали с дизайном, что этот проп может быть не нужен, но `disabled` на компоненте `fieldset` (именно он рендерится по умолчанию) имеет значение для `a11y`.

## Release notes

 ## Исправления
 - FormLayoutGroup: свойство `disabled` теперь влияет на режим `removable`


