### PR TITLE
fix(FormItem): add disabled to removable

### DIFF
--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -26,10 +26,10 @@ const stylesStatus = {
 };
 
 export interface FormItemProps
-  extends Omit<React.AllHTMLAttributes<HTMLElement>, 'disabled'>,
+  extends React.AllHTMLAttributes<HTMLElement>,
     HasRootRef<HTMLElement>,
     HasComponent,
-    Omit<RemovableProps, 'disabled'> {
+    RemovableProps {
   /**
    * Дополнительный элемент, отображаемый над содержимым.
    */
@@ -79,12 +79,6 @@ export interface FormItemProps
    * Помечает поле обязательным.
    */
   required?: boolean;
-  /**
-   * @deprecated Since 7.4.0.
-   *
-   * Свойство ни на что не влияет и будет удалено в `v8`.
-   */
-  disabled?: boolean;
 }
 
 /**
@@ -110,6 +104,7 @@ export const FormItem: React.FC<FormItemProps> & {
   bottomId,
   noPadding,
   required = false,
+  disabled,
   ...restProps
 }: FormItemProps) => {
   const rootEl = useExternRef(getRootRef);
@@ -167,6 +162,7 @@ export const FormItem: React.FC<FormItemProps> & {
             removePlaceholder={removePlaceholder}
             indent={removable === 'indent'}
             noPadding={noPadding}
+            disabled={disabled}
           >
             <div className={classNames(styles.removable, 'vkuiInternalFormItem__removable')}>
               {wrappedChildren}

--- a/packages/vkui/src/components/FormItem/FormItem.tsx
+++ b/packages/vkui/src/components/FormItem/FormItem.tsx
@@ -26,10 +26,10 @@ const stylesStatus = {
 };
 
 export interface FormItemProps
-  extends React.AllHTMLAttributes<HTMLElement>,
+  extends Omit<React.AllHTMLAttributes<HTMLElement>, 'disabled'>,
     HasRootRef<HTMLElement>,
     HasComponent,
-    RemovableProps {
+    Omit<RemovableProps, 'disabled'> {
   /**
    * Дополнительный элемент, отображаемый над содержимым.
    */
@@ -79,6 +79,12 @@ export interface FormItemProps
    * Помечает поле обязательным.
    */
   required?: boolean;
+  /**
+   * @deprecated Since 7.4.0.
+   *
+   * Свойство ни на что не влияет и будет удалено в `v8`.
+   */
+  disabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Описание

Свойство `disabled` прокидывалось просто на `div`, не влияя на компонент, прокидываем на `removable` компонент, чтобы дизейблить кнопку удаления.

## Release notes

 ## Исправления
 - FormItem: свойство `disabled` теперь влияет на компонент

