### PR TITLE
ci(dependabot): rm reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,9 +86,6 @@ updates:
           - '@next/*'
     versioning-strategy: increase
     open-pull-requests-limit: 20
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
 
   # GitHub Actions
 
@@ -98,6 +95,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'


### PR DESCRIPTION
GitHub удаляет поле reviewers так как оно дублируется кодовнерством

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

## Release notes
-
