### PR TITLE
fix(Touch): handle touchstart events by DOM API

### DIFF
--- a/packages/vkui/src/components/Touch/Touch.tsx
+++ b/packages/vkui/src/components/Touch/Touch.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import * as React from 'react';
+import { useExternRef } from '../../hooks/useExternRef';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { getWindow, isHTMLElement, isSVGElement } from '../../lib/dom';
 import { coordX, coordY, touchEnabled, type VKUITouchEvent } from '../../lib/touch';
+import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import type { HasComponent, HasRootRef } from '../../types';
 
 /**
@@ -228,6 +230,7 @@ export const Touch = ({
   stopPropagation = false,
   ...restProps
 }: TouchProps) => {
+  const hostRef = useExternRef(getRootRef);
   const [isTouchEnabled] = React.useState(touchEnabled);
   const gestureRef = React.useRef<Gesture | null>(null);
   const didSlide = React.useRef(false);
@@ -329,58 +332,58 @@ export const Touch = ({
     }
   });
 
-  const handlePointerDown = (
-    event: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>,
-  ) => {
-    const nativeEvent = event.nativeEvent;
+  const handlePointerDown = useStableCallback(
+    (event: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement> | TouchEvent) => {
+      const nativeEvent = 'nativeEvent' in event ? event.nativeEvent : event;
 
-    gestureRef.current = initGesture(coordX(nativeEvent), coordY(nativeEvent));
+      gestureRef.current = initGesture(coordX(nativeEvent), coordY(nativeEvent));
 
-    const shouldCallDirectionHandlerOnlyIsSlide = false;
-    dispatchUserHandlers(
-      event,
-      gestureRef.current,
-      [onStart, onStartX, onStartY],
-      stopPropagation,
-      shouldCallDirectionHandlerOnlyIsSlide,
-    );
+      const shouldCallDirectionHandlerOnlyIsSlide = false;
+      dispatchUserHandlers(
+        event,
+        gestureRef.current,
+        [onStart, onStartX, onStartY],
+        stopPropagation,
+        shouldCallDirectionHandlerOnlyIsSlide,
+      );
 
-    const eventOptions = { capture: useCapture, passive: false };
+      const eventOptions = { capture: useCapture, passive: false };
 
-    // FIXME: заменить touch/mouse-события ниже на pointer-события после того, как бразуеры из
-    // .browserslistrc начнут поддерживать его (см. https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#browser_compatibility).
-    if (isTouchEnabled) {
-      if (isHTMLElement(event.target) || isSVGElement(event.target)) {
-        // Тач-события не всплывают, поэтому навешиваем события на целевой элемент
-        // см. #235, #1968, https://stackoverflow.com/a/45760014
-        const target: HTMLorSVGElementWithEvents = event.target;
+      // FIXME: заменить touch/mouse-события ниже на pointer-события после того, как бразуеры из
+      // .browserslistrc начнут поддерживать его (см. https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#browser_compatibility).
+      if (isTouchEnabled) {
+        if (isHTMLElement(event.target) || isSVGElement(event.target)) {
+          // Тач-события не всплывают, поэтому навешиваем события на целевой элемент
+          // см. #235, #1968, https://stackoverflow.com/a/45760014
+          const target: HTMLorSVGElementWithEvents = event.target;
 
-        target.addEventListener('touchmove', handleNativePointerMove, eventOptions);
-        target.addEventListener('touchend', handleNativePointerUp, eventOptions);
-        target.addEventListener('touchcancel', handleNativePointerUp, eventOptions);
+          target.addEventListener('touchmove', handleNativePointerMove, eventOptions);
+          target.addEventListener('touchend', handleNativePointerUp, eventOptions);
+          target.addEventListener('touchcancel', handleNativePointerUp, eventOptions);
+
+          disposeTargetNativeGestureEvents.current = () => {
+            target.removeEventListener('touchmove', handleNativePointerMove, eventOptions);
+            target.removeEventListener('touchend', handleNativePointerUp, eventOptions);
+            target.removeEventListener('touchcancel', handleNativePointerUp, eventOptions);
+          };
+        }
+      } else {
+        // Используем события на Document, т.к. mouse-события на целевом элементе могут теряться при
+        // выходе за границы этого элемента.
+        const doc = getWindow(event.currentTarget).document;
+
+        doc.addEventListener('mousemove', handleNativePointerMove, eventOptions);
+        doc.addEventListener('mouseup', handleNativePointerUp, eventOptions);
+        doc.addEventListener('mouseleave', handleNativePointerUp, eventOptions);
 
         disposeTargetNativeGestureEvents.current = () => {
-          target.removeEventListener('touchmove', handleNativePointerMove, eventOptions);
-          target.removeEventListener('touchend', handleNativePointerUp, eventOptions);
-          target.removeEventListener('touchcancel', handleNativePointerUp, eventOptions);
+          doc.removeEventListener('mousemove', handleNativePointerMove, eventOptions);
+          doc.removeEventListener('mouseup', handleNativePointerUp, eventOptions);
+          doc.removeEventListener('mouseleave', handleNativePointerUp, eventOptions);
         };
       }
-    } else {
-      // Используем события на Document, т.к. mouse-события на целевом элементе могут теряться при
-      // выходе за границы этого элемента.
-      const doc = getWindow(event.currentTarget).document;
-
-      doc.addEventListener('mousemove', handleNativePointerMove, eventOptions);
-      doc.addEventListener('mouseup', handleNativePointerUp, eventOptions);
-      doc.addEventListener('mouseleave', handleNativePointerUp, eventOptions);
-
-      disposeTargetNativeGestureEvents.current = () => {
-        doc.removeEventListener('mousemove', handleNativePointerMove, eventOptions);
-        doc.removeEventListener('mouseup', handleNativePointerUp, eventOptions);
-        doc.removeEventListener('mouseleave', handleNativePointerUp, eventOptions);
-      };
-    }
-  };
+    },
+  );
 
   const handlePointerEnter = onEnter
     ? (event: React.MouseEvent<HTMLElement>) => onEnter(event.nativeEvent)
@@ -421,10 +424,27 @@ export const Touch = ({
     didSlide.current = false;
   };
 
+  useIsomorphicLayoutEffect(
+    function initializeNativeTouchStartEventWithPassiveFalse() {
+      const hostEl = hostRef.current;
+      if (!hostEl || !isTouchEnabled) {
+        return;
+      }
+
+      const options = { capture: useCapture, passive: false };
+      hostEl.addEventListener('touchstart', handlePointerDown, options);
+
+      return () => {
+        hostEl.removeEventListener('touchstart', handlePointerDown, options);
+      };
+    },
+    [hostRef, isTouchEnabled, useCapture, handlePointerDown],
+  );
+
   return (
     <Component
       {...restProps}
-      ref={getRootRef}
+      ref={hostRef}
       onDragStart={handleDragStart}
       onClickCapture={handleClickCapture}
       // onEnter
@@ -433,9 +453,7 @@ export const Touch = ({
       // onLeave
       onPointerLeave={usePointerHover ? handlePointerLeave : undefined}
       onMouseLeave={!usePointerHover ? handlePointerLeave : undefined}
-      // handlePointerDown
-      onTouchStartCapture={isTouchEnabled && useCapture ? handlePointerDown : undefined}
-      onTouchStart={isTouchEnabled && !useCapture ? handlePointerDown : undefined}
+      // handlePointerDown (onTouchStart устанавливается отдельно через initializeNativeTouchEventStartWithPassiveFalse)
       onMouseDownCapture={!isTouchEnabled && useCapture ? handlePointerDown : undefined}
       onMouseDown={!isTouchEnabled && !useCapture ? handlePointerDown : undefined}
     />


### PR DESCRIPTION
- caused by #7272

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Release notes

## Описание

В рамках #7272 стал навешивать `touchstart` через React, опустив момент, что есть задачи, которые требуют вызова `preventDefault()` на `touchstart`, а т.к. React использует `passive: true` под капотом, то `preventDefault()` не срабатывает.

Инцидент: из-за не работающего `preventDefault()` глючит `<Cell draggable />` на Android. На iOS не воспроизводится, есть только ошибки в консоли.

Версия: `>= 6.6.0`

## QA

После фикса также проверил на работоспособность `Gallery`, `View`/`Panel`, `PullToRefresh`, `Slider`.

- [x] Unit-тесты
- ОС: Android 14
- Браузеры:
   - Chrome 136.0.7103.87
   - Samsung Internet 28.0.0.59

<details><summary>Пример для Storybook</summary>
<p>

```tsx
import { useState } from '@storybook/preview-api';
import type { Meta, StoryObj } from '@storybook/react';
import { CanvasFullLayout, DisableCartesianParam } from '../../storybook/constants';
import { createStoryParameters } from '../../testing/storybook/createStoryParameters';
import { Avatar } from '../Avatar/Avatar';
import { Group } from '../Group/Group';
import { List } from '../List/List';
import { Cell, type CellProps } from './Cell';

const story: Meta<CellProps> = {
  title: 'Blocks/Cell',
  component: Cell,
  parameters: createStoryParameters('Cell', CanvasFullLayout, DisableCartesianParam),
};

export default story;

type Story = StoryObj<CellProps>;

export const Multiple: Story = {
  render: function Render() {
    const [draggingList, updateDraggingList] = useState([
      'Say',
      'Hello',
      'To',
      'My',
      'Little',
      '1 Friend',
      '2 Friend',
      '3 Friend',
      '4 Friend',
      '5 Friend',
      '6 Friend',
      '7 Friend',
      '8 Friend',
      '9 Friend',
      '10 Friend',
      '11 Friend',
      '12 Friend',
      '13 Friend',
      '14 Friend',
      '15 Friend',
      '16 Friend',
      '17 Friend',
    ]);

    const reorderList = ({ from, to }, list, updateListFn) => {
      const _list = [...list];
      _list.splice(from, 1);
      _list.splice(to, 0, list[from]);
      updateListFn(_list);
    };

    return (
      <Group>
        <List>
          {draggingList.map((item) => (
            <Cell
              key={item}
              before={<Avatar />}
              draggable
              onDragFinish={({ from, to }) =>
                reorderList({ from, to }, draggingList, updateDraggingList)
              }
            >
              {item}
            </Cell>
          ))}
        </List>
      </Group>
    );
  },
};
```

</p>
</details> 

## Release notes

## Исправления

- Cell: с `v6.6.0` в режиме `draggable` на **Android** наблюдались артефакты при перетаскивании, было связано с компонентом `Touch`
- Touch: с `v6.6.0` была проблема, что тач-устройствах не работал `preventDefault()` на `onStart`