### PR TITLE
fix(Gallery): fix arrow label

### DIFF
--- a/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
@@ -62,6 +62,8 @@ export const CarouselBase = ({
   getRef,
   arrowSize,
   arrowAreaHeight,
+  arrowNextLabel,
+  arrowPrevLabel,
   slideTestId,
   bulletTestId,
   nextArrowTestId,
@@ -559,6 +561,8 @@ export const CarouselBase = ({
         showArrows={showArrows}
         arrowSize={arrowSize}
         arrowAreaHeight={arrowAreaHeight}
+        arrowPrevLabel={arrowPrevLabel}
+        arrowNextLabel={arrowNextLabel}
         prevArrowTestId={prevArrowTestId}
         nextArrowTestId={nextArrowTestId}
       />

--- a/packages/vkui/src/components/CarouselBase/ScrollArrows.tsx
+++ b/packages/vkui/src/components/CarouselBase/ScrollArrows.tsx
@@ -35,7 +35,10 @@ export interface ScrollArrowsTestIds {
 }
 
 interface ScrollArrowsProps
-  extends Pick<BaseGalleryProps, 'showArrows' | 'arrowSize' | 'arrowAreaHeight'>,
+  extends Pick<
+      BaseGalleryProps,
+      'showArrows' | 'arrowSize' | 'arrowAreaHeight' | 'arrowPrevLabel' | 'arrowNextLabel'
+    >,
     ScrollArrowsTestIds {
   hasPointer?: boolean;
   canSlideLeft: boolean;
@@ -53,6 +56,8 @@ export const ScrollArrows = ({
   showArrows = false,
   arrowSize = 'm',
   arrowAreaHeight = 'stretch',
+  arrowPrevLabel,
+  arrowNextLabel,
   nextArrowTestId,
   prevArrowTestId,
 }: ScrollArrowsProps) => {
@@ -65,6 +70,7 @@ export const ScrollArrows = ({
           onClick={onSlideLeft}
           size={arrowSize}
           data-testid={prevArrowTestId}
+          label={arrowPrevLabel}
         />
       )}
       {canSlideRight && (
@@ -74,6 +80,7 @@ export const ScrollArrows = ({
           onClick={onSlideRight}
           size={arrowSize}
           data-testid={nextArrowTestId}
+          label={arrowNextLabel}
         />
       )}
     </>

--- a/packages/vkui/src/components/Gallery/Gallery.test.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.test.tsx
@@ -181,6 +181,8 @@ const setup = ({
         bulletTestId={(index, active) => (active ? `bullet-${index}-active` : `bullet-${index}`)}
         prevArrowTestId="prev-arrow"
         nextArrowTestId="next-arrow"
+        arrowPrevLabel="prev-label"
+        arrowNextLabel="next-label"
       >
         {Array.from({ length: numberOfSlides }).map((_v, index) => (
           <Slide key={index} getRef={(e: HTMLDivElement) => mockSlideData(e, index)}>
@@ -326,6 +328,9 @@ describe('Gallery', () => {
 
       const [leftArrow, rightArrow] = getArrows();
       fireEvent.click(rightArrow);
+
+      expect(screen.getByText('prev-label')).toBeInTheDocument();
+      expect(screen.getByText('next-label')).toBeInTheDocument();
 
       expect(onNext).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls).toEqual([[2]]);


### PR DESCRIPTION
- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

В компоненте карусели не прокидываются свойства лейблов для стрелок

## Изменения

Возвращаем эту возможность

## Release notes
## Исправления
- [Gallery](https://vkcom.github.io/VKUI/${version}/#/Gallery): свойства `arrowPrevLabel` и `arrowNextLabel` не прокидывались к стрелкам