### PR TITLE
fix(ContentBadge): IconSlot

### DIFF
--- a/packages/vkui/src/components/ContentBadge/ContentBadge.e2e-playground.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadge.e2e-playground.tsx
@@ -45,27 +45,27 @@ export const ContentBadgePlayground = (props: ComponentPlaygroundProps) => {
           </ContentBadge>
 
           <ContentBadge {...restProps} size={size} capsule={capsule}>
-            <ContentBadge.SlotIcon>
+            <ContentBadge.IconSlot>
               {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-            </ContentBadge.SlotIcon>
+            </ContentBadge.IconSlot>
             {children}
           </ContentBadge>
 
           <ContentBadge {...restProps} size={size} capsule={capsule}>
             {children}
-            <ContentBadge.SlotIcon>
+            <ContentBadge.IconSlot>
               {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-            </ContentBadge.SlotIcon>
+            </ContentBadge.IconSlot>
           </ContentBadge>
 
           <ContentBadge {...restProps} size={size} capsule={capsule}>
-            <ContentBadge.SlotIcon>
+            <ContentBadge.IconSlot>
               {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-            </ContentBadge.SlotIcon>
+            </ContentBadge.IconSlot>
             {children}
-            <ContentBadge.SlotIcon>
+            <ContentBadge.IconSlot>
               {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-            </ContentBadge.SlotIcon>
+            </ContentBadge.IconSlot>
           </ContentBadge>
 
           <ContentBadge
@@ -74,9 +74,9 @@ export const ContentBadgePlayground = (props: ComponentPlaygroundProps) => {
             // для варианта с одиночной иконкой зашиваем
             capsule
           >
-            <ContentBadge.SlotIcon>
+            <ContentBadge.IconSlot>
               {size === 'l' ? <Icon20ServicesFilled /> : <Icon16Services />}
-            </ContentBadge.SlotIcon>
+            </ContentBadge.IconSlot>
           </ContentBadge>
 
           {size === 's' ? <div style={captionStyle}>should ignore icons</div> : null}

--- a/packages/vkui/src/components/ContentBadge/ContentBadge.stories.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadge.stories.tsx
@@ -42,27 +42,27 @@ export const Playground: DefaultStory = {
         </ContentBadge>
 
         <ContentBadge {...restProps} size={size}>
-          <ContentBadge.SlotIcon>
+          <ContentBadge.IconSlot>
             {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-          </ContentBadge.SlotIcon>
+          </ContentBadge.IconSlot>
           {children}
         </ContentBadge>
 
         <ContentBadge {...restProps} size={size}>
           {children}
-          <ContentBadge.SlotIcon>
+          <ContentBadge.IconSlot>
             {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-          </ContentBadge.SlotIcon>
+          </ContentBadge.IconSlot>
         </ContentBadge>
 
         <ContentBadge {...restProps} size={size}>
-          <ContentBadge.SlotIcon>
+          <ContentBadge.IconSlot>
             {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-          </ContentBadge.SlotIcon>
+          </ContentBadge.IconSlot>
           {children}
-          <ContentBadge.SlotIcon>
+          <ContentBadge.IconSlot>
             {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-          </ContentBadge.SlotIcon>
+          </ContentBadge.IconSlot>
         </ContentBadge>
       </Flex>
     );
@@ -83,9 +83,9 @@ export const SingleIcon: SingleIconStory = {
 
     return (
       <ContentBadge {...restProps} size={size}>
-        <ContentBadge.SlotIcon>
+        <ContentBadge.IconSlot>
           {size === 'l' ? <Icon20ServicesFilled /> : <Icon16Services />}
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
       </ContentBadge>
     );
   },

--- a/packages/vkui/src/components/ContentBadge/ContentBadge.test.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadge.test.tsx
@@ -8,20 +8,20 @@ describe(ContentBadge, () => {
 
   baselineComponent(
     (props) => (
-      <ContentBadge.SlotIcon {...props}>
+      <ContentBadge.IconSlot {...props}>
         <Icon16Services />{' '}
-      </ContentBadge.SlotIcon>
+      </ContentBadge.IconSlot>
     ),
     undefined,
-    'baseline (ContentBadge.SlotIcon)',
+    'baseline (ContentBadge.IconSlot)',
   );
 
   it('should hide icon if size="s"', () => {
     const result = render(
       <ContentBadge size="m">
-        <ContentBadge.SlotIcon data-testid="icon">
+        <ContentBadge.IconSlot data-testid="icon">
           <Icon16Services />
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
         Test
       </ContentBadge>,
     );
@@ -30,9 +30,9 @@ describe(ContentBadge, () => {
 
     result.rerender(
       <ContentBadge size="s">
-        <ContentBadge.SlotIcon data-testid="icon">
+        <ContentBadge.IconSlot data-testid="icon">
           <Icon16Services />
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
         Test
       </ContentBadge>,
     );

--- a/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadge.tsx
@@ -6,7 +6,7 @@ import { Caption } from '../Typography/Caption/Caption';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import type { TypographyProps } from '../Typography/Typography';
 import { ContentBadgeContext } from './ContentBadgeContext';
-import { ContentBadgeSlotIcon } from './ContentBadgeSlotIcon';
+import { ContentBadgeIconSlot } from './ContentBadgeIconSlot';
 import type { ContentBadgeModeType, ContentBadgeSizeType } from './types';
 import styles from './ContentBadge.module.css';
 
@@ -83,7 +83,11 @@ export interface ContentBadgeProps
  * @see https://vkcom.github.io/VKUI/#/ContentBadge
  */
 export const ContentBadge: React.FC<ContentBadgeProps> & {
-  SlotIcon: typeof ContentBadgeSlotIcon;
+  IconSlot: typeof ContentBadgeIconSlot;
+  /**
+   * @deprecated Since 7.3.4. Используйте `IconSlot`.
+   */
+  SlotIcon: typeof ContentBadgeIconSlot;
 } = ({
   appearance = 'accent',
   mode = 'primary',
@@ -119,8 +123,10 @@ export const ContentBadge: React.FC<ContentBadgeProps> & {
   );
 };
 
-ContentBadge.SlotIcon = ContentBadgeSlotIcon;
+ContentBadge.IconSlot = ContentBadgeIconSlot;
+ContentBadge.SlotIcon = ContentBadgeIconSlot;
 
 if (process.env.NODE_ENV !== 'production') {
+  defineComponentDisplayNames(ContentBadge.IconSlot, 'ContentBadge.IconSlot');
   defineComponentDisplayNames(ContentBadge.SlotIcon, 'ContentBadge.SlotIcon');
 }

--- a/packages/vkui/src/components/ContentBadge/ContentBadgeIconSlot.tsx
+++ b/packages/vkui/src/components/ContentBadge/ContentBadgeIconSlot.tsx
@@ -16,14 +16,14 @@ const singleIconClassNames = {
   l: styles.singleIconSlotSizeL,
 };
 
-export type ContentBadgeSlotIconProps = HTMLAttributesWithRootRef<HTMLDivElement>;
+type ContentBadgeIconSlotProps = HTMLAttributesWithRootRef<HTMLDivElement>;
 
-export const ContentBadgeSlotIcon = ({
+export const ContentBadgeIconSlot = ({
   className,
   getRootRef,
   children,
   ...restProps
-}: ContentBadgeSlotIconProps) => {
+}: ContentBadgeIconSlotProps) => {
   const { size, isSingleChild } = React.useContext(ContentBadgeContext);
 
   if (size === 's') {

--- a/packages/vkui/src/components/ContentBadge/Readme.md
+++ b/packages/vkui/src/components/ContentBadge/Readme.md
@@ -15,33 +15,33 @@ const Stand = ({ size }) =>
       </ContentBadge>
 
       <ContentBadge size={size} appearance={appearance} mode={mode} capsule={capsule}>
-        <ContentBadge.SlotIcon>
+        <ContentBadge.IconSlot>
           {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
         Badge
       </ContentBadge>
 
       <ContentBadge size={size} appearance={appearance} mode={mode} capsule={capsule}>
         Badge
-        <ContentBadge.SlotIcon>
+        <ContentBadge.IconSlot>
           {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
       </ContentBadge>
 
       <ContentBadge size={size} appearance={appearance} mode={mode} capsule={capsule}>
-        <ContentBadge.SlotIcon>
+        <ContentBadge.IconSlot>
           {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
         Badge
-        <ContentBadge.SlotIcon>
+        <ContentBadge.IconSlot>
           {size === 'l' ? <Icon16Services /> : <Icon12Services />}
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
       </ContentBadge>
 
       <ContentBadge size={size} appearance={appearance} mode={mode} capsule>
-        <ContentBadge.SlotIcon>
+        <ContentBadge.IconSlot>
           {size === 'l' ? <Icon20ServicesFilled /> : <Icon16Services />}
-        </ContentBadge.SlotIcon>
+        </ContentBadge.IconSlot>
       </ContentBadge>
     </>
   );


### PR DESCRIPTION
- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] Документация фичи
- [x] Release notes

## Описание

Подкомпонент `ContentBadge.SlotIcon` не совсем соответствует названию - это же не SlotIcon (иконка слота), а IconSlot (слот для иконки)

## Release notes
## Исправления
- [ContentBadge](https://vkcom.github.io/VKUI/${version}/#/ContentBadge): Подкомпонент `SlotIcon` помечен устаревщим, используйте `IconSlot`
