### PR TITLE
fix(ChipsSelect): fix onChange with custom fields

### DIFF
--- a/packages/vkui/src/components/ChipsInput/useChipsInput.ts
+++ b/packages/vkui/src/components/ChipsInput/useChipsInput.ts
@@ -115,7 +115,7 @@ export const useChipsInput = <O extends ChipOption>({
             ? getNewOptionData(option.value, option.label)
             : getNewOptionData(option, typeof option === 'string' ? option : '');
           resolvedNextOptionsSet.add(resolvedOption.value);
-          return resolvedOption;
+          return isLikeObjectOption ? { ...option, ...resolvedOption } : resolvedOption;
         });
 
         const nextValue = prevValue.filter(

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.test.tsx
@@ -159,6 +159,48 @@ describe('ChipsSelect', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('should check custom fields when onChange', async () => {
+    const onChange = jest.fn();
+    const options = colors.map((color, index) => ({
+      ...color,
+      custom: index.toString(),
+    }));
+
+    const result = render(
+      <ChipsSelect
+        options={options}
+        defaultValue={[]}
+        onChange={onChange}
+        dropdownTestId="dropdown"
+      />,
+    );
+    const inputLocator = result.getByRole('combobox');
+    await userEvent.click(inputLocator);
+    await waitForFloatingPosition();
+
+    const dropdownOption = within(result.getByTestId('dropdown')).getByRole('option', {
+      name: withRegExp(FIRST_OPTION.label),
+    });
+    await userEvent.hover(dropdownOption); // для вызова onDropdownMouseLeave
+    await userEvent.hover(inputLocator);
+    await userEvent.click(dropdownOption);
+
+    result.rerender(
+      <ChipsSelect
+        value={[{ ...FIRST_OPTION, custom: '0' }]}
+        options={options}
+        onChange={onChange}
+        dropdownTestId="dropdown"
+      />,
+    );
+    expect(
+      result.getByRole('option', {
+        name: withRegExp(FIRST_OPTION.label),
+      }),
+    ).toBeTruthy();
+    expect(onChange).toHaveBeenCalledWith([{ ...FIRST_OPTION, custom: '0' }]);
+  });
+
   it.each(['{ArrowDown}', 'typing text'])(
     'closes dropdown on {Escape} and open when %s',
     async (type) => {


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- caused by #8435

---

- [x] Unit-тесты
- [x] Release notes

## Описание

После #8435 появился баг - в `onChange` `ChipsSelect` и `ChipsInput` в values не прокидывались кастомные поля, заданные пользователем в `options` из-за того, что потерялся spread при расчете новых значений. Вернул spread и написал тест кейса

## Изменения

<!--
Перечисли изменения и причины по которым они сделаны, если это по какой-то причине не очевидно.
В будущем это поможет ответить почему было сделано именно так.

Если всё прозрачно, то игнорируй этот заголовок.
-->

## Release notes
## Исправления
- ChipsSelect: Поправлен баг с тем, что в `onChange` не прокидывались кастомные поля `options`
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
