### PR TITLE
docs(Tappable): mv `activated` to `active`

### DIFF
--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -56,7 +56,7 @@ export interface StateProps {
   unlockParentHover?: boolean;
 
   /**
-   * Длительность показа `activated`-состояния.
+   * Длительность показа `active`-состояния.
    */
   activeEffectDelay?: number;
 


### PR DESCRIPTION
## Release notes
## Документация
- Tappable: Поправлена опечатка в документации свойства `activeEffectDelay`