### PR TITLE
fix(ChipsSelect): fix close dropdown with `closeAfterSelect`

### DIFF
--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -430,7 +430,7 @@ export const ChipsSelect = <Option extends ChipOption>({
   }, [setOpened]);
 
   useGlobalOnEventOutside(
-    'mousedown',
+    'mousedown', // см. https://github.com/VKCOM/VKUI/pull/8582
     handleClickOutside,
     opened ? rootRef : null,
     opened ? dropdownScrollBoxRef : null,

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { type MouseEventHandler } from 'react';
 import * as React from 'react';
+import { type MouseEventHandler } from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';
-import { useGlobalOnClickOutside } from '../../hooks/useGlobalOnClickOutside';
+import { useGlobalOnMouseDownOutside } from '../../hooks/useGlobalOnClickOutside';
 import { Keys } from '../../lib/accessibility';
 import type { Placement } from '../../lib/floating';
 import { defaultFilterFn } from '../../lib/select';
@@ -251,7 +251,6 @@ export const ChipsSelect = <Option extends ChipOption>({
   // Связано с ChipsInputProps
   const rootRef = useExternRef(getRootRef);
   const inputRef = useExternRef(getRef, inputRefHook);
-  const forbidCloseByOutsideClick = React.useRef(false);
 
   // Связано с CustomSelectDropdownProps
   const [dropdownVerticalPlacement, setDropdownVerticalPlacement] = React.useState<
@@ -427,13 +426,10 @@ export const ChipsSelect = <Option extends ChipOption>({
   }, [setFocusedOptionIndex]);
 
   const handleClickOutside = React.useCallback(() => {
-    if (!forbidCloseByOutsideClick.current) {
-      setOpened(false);
-    }
-    forbidCloseByOutsideClick.current = false;
+    setOpened(false);
   }, [setOpened]);
 
-  useGlobalOnClickOutside(
+  useGlobalOnMouseDownOutside(
     handleClickOutside,
     opened ? rootRef : null,
     opened ? dropdownScrollBoxRef : null,
@@ -503,7 +499,6 @@ export const ChipsSelect = <Option extends ChipOption>({
                 if (!event.defaultPrevented) {
                   closeAfterSelect && setOpened(false);
                   addOption(option);
-                  forbidCloseByOutsideClick.current = true;
                   clearInput();
                 }
               },

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { type MouseEventHandler } from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useExternRef } from '../../hooks/useExternRef';
-import { useGlobalOnMouseDownOutside } from '../../hooks/useGlobalOnClickOutside';
+import { useGlobalOnEventOutside } from '../../hooks/useGlobalOnClickOutside';
 import { Keys } from '../../lib/accessibility';
 import type { Placement } from '../../lib/floating';
 import { defaultFilterFn } from '../../lib/select';
@@ -429,7 +429,8 @@ export const ChipsSelect = <Option extends ChipOption>({
     setOpened(false);
   }, [setOpened]);
 
-  useGlobalOnMouseDownOutside(
+  useGlobalOnEventOutside(
+    'mousedown',
     handleClickOutside,
     opened ? rootRef : null,
     opened ? dropdownScrollBoxRef : null,

--- a/packages/vkui/src/hooks/useGlobalOnClickOutside.test.tsx
+++ b/packages/vkui/src/hooks/useGlobalOnClickOutside.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { useGlobalOnClickOutside, useGlobalOnMouseDownOutside } from './useGlobalOnClickOutside';
+import { useGlobalOnClickOutside, useGlobalOnEventOutside } from './useGlobalOnClickOutside';
 
 interface WrapperUseGlobalOnClickOutsideProps {
   disableTarget?: 'target-1' | 'target-2';
@@ -34,6 +34,16 @@ const WrapperUseGlobalOnClickOutside = ({
       </div>
     </div>
   );
+};
+
+const useGlobalOnMouseDownOutside = <
+  T extends React.RefObject<ElementType | null> | undefined | null,
+  ElementType extends Element = Element,
+>(
+  callback: (event: MouseEvent) => void,
+  ...refs: T[]
+): void => {
+  useGlobalOnEventOutside('mousedown', callback, ...refs);
 };
 
 describe.each([

--- a/packages/vkui/src/hooks/useGlobalOnClickOutside.ts
+++ b/packages/vkui/src/hooks/useGlobalOnClickOutside.ts
@@ -2,7 +2,7 @@ import type * as React from 'react';
 import { isElement, useDOM } from '../lib/dom';
 import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
 
-const useCommonGlobalClickOutside = <
+export const useGlobalOnEventOutside = <
   T extends React.RefObject<ElementType | null> | undefined | null,
   ElementType extends Element = Element,
 >(
@@ -47,20 +47,5 @@ export const useGlobalOnClickOutside = <
   callback: (event: MouseEvent) => void,
   ...refs: T[]
 ): void => {
-  useCommonGlobalClickOutside('click', callback, ...refs);
-};
-
-/**
- * Завязывается на document.
- *
- * @private
- */
-export const useGlobalOnMouseDownOutside = <
-  T extends React.RefObject<ElementType | null> | undefined | null,
-  ElementType extends Element = Element,
->(
-  callback: (event: MouseEvent) => void,
-  ...refs: T[]
-): void => {
-  useCommonGlobalClickOutside('mousedown', callback, ...refs);
+  useGlobalOnEventOutside('click', callback, ...refs);
 };

--- a/packages/vkui/src/hooks/useGlobalOnClickOutside.ts
+++ b/packages/vkui/src/hooks/useGlobalOnClickOutside.ts
@@ -2,15 +2,11 @@ import type * as React from 'react';
 import { isElement, useDOM } from '../lib/dom';
 import { useIsomorphicLayoutEffect } from '../lib/useIsomorphicLayoutEffect';
 
-/**
- * Завязывается на document.
- *
- * @private
- */
-export const useGlobalOnClickOutside = <
+const useCommonGlobalClickOutside = <
   T extends React.RefObject<ElementType | null> | undefined | null,
   ElementType extends Element = Element,
 >(
+  event: Extract<keyof DocumentEventMap, 'click' | 'mousedown'>,
   callback: (event: MouseEvent) => void,
   ...refs: T[]
 ): void => {
@@ -29,12 +25,42 @@ export const useGlobalOnClickOutside = <
         callback(event);
       }
     };
-    document.addEventListener('click', handleClick, {
+    document.addEventListener(event, handleClick, {
       passive: true,
       capture: true,
     });
     return () => {
-      document.removeEventListener('click', handleClick, true);
+      document.removeEventListener(event, handleClick, true);
     };
   }, [document, callback, ...refs]);
+};
+
+/**
+ * Завязывается на document.
+ *
+ * @private
+ */
+export const useGlobalOnClickOutside = <
+  T extends React.RefObject<ElementType | null> | undefined | null,
+  ElementType extends Element = Element,
+>(
+  callback: (event: MouseEvent) => void,
+  ...refs: T[]
+): void => {
+  useCommonGlobalClickOutside('click', callback, ...refs);
+};
+
+/**
+ * Завязывается на document.
+ *
+ * @private
+ */
+export const useGlobalOnMouseDownOutside = <
+  T extends React.RefObject<ElementType | null> | undefined | null,
+  ElementType extends Element = Element,
+>(
+  callback: (event: MouseEvent) => void,
+  ...refs: T[]
+): void => {
+  useCommonGlobalClickOutside('mousedown', callback, ...refs);
 };


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- caused by #8454

---

- [x] Unit-тесты
- [x] Release notes

## Описание

В pr #8454 был поправлен баг, но был допущен другой - при `closeAfterSelect={false}` после выбора одной из опций дропдаун не закрывается после первого нажатия за пределами дропдауна. 

## Изменения

Поисследовав, пришел к решению, что изменения #8454 нужно откатить, а также необходимо доработать хук `useGlobalClickOutside`, точнее добавить другой хук `useGlobalOnMouseDownOutside`, который бы слушал событие `mouseDown`. Такое решени починит текущий баг и не сломает баг из #8454.

Как альтернатива, можно было бы у `option` слушать не `onMouseDown`, а `onClick`, но ,поисследовав историю изменений, я так и не понял почему был выбран именно этот обработчик, возможно он был использован специально.


## Release notes
## Исправления
- ChipsSelect: Поправлен баг, с тем, что дропдаун не закрывался после первого нажатия за пределами его, если флаг `closeAfterSelect={false}`
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
