### PR TITLE
ci(vkui-date-fns-tz): tmp rm provenance

### DIFF
--- a/packages/vkui-date-fns-tz/package.json
+++ b/packages/vkui-date-fns-tz/package.json
@@ -60,9 +60,6 @@
     }
   },
   "license": "MIT",
-  "publishConfig": {
-    "provenance": true
-  },
   "scripts": {
     "node": "node --experimental-transform-types",
     "build": "yarn run node build.ts",


### PR DESCRIPTION
## Описание

Временно удаляем подпись чтобы опубликовать пакет первый раз

> Can't generate provenance for new or private package, you must set `access` to public.

## Release notes
-