### PR TITLE
feat: add visibilityDelay

### DIFF
--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.test.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.test.tsx
@@ -1,6 +1,14 @@
+import { render } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { ScreenSpinner } from './ScreenSpinner';
+import stylesDelay from '../../styles/animationVisibilityDelay.module.css';
 
 describe('ScreenSpinner', () => {
   baselineComponent(ScreenSpinner);
+
+  it('should delay visibility', () => {
+    render(<ScreenSpinner visibilityDelay={200} />);
+
+    expect(document.querySelector(`.${stylesDelay.visibilityDelay}`)).not.toBeNull();
+  });
 });

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.tsx
@@ -29,6 +29,7 @@ export const ScreenSpinner: React.FC<ScreenSpinnerProps> & {
   label,
   customIcon,
   usePortal,
+  visibilityDelay,
   ...restProps
 }: ScreenSpinnerProps): React.ReactNode => {
   useScrollLock();
@@ -36,7 +37,13 @@ export const ScreenSpinner: React.FC<ScreenSpinnerProps> & {
   return (
     <AppRootPortal usePortal={usePortal}>
       <PopoutWrapper className={className} style={style} noBackground strategy="fixed">
-        <ScreenSpinnerContainer state={state} mode={mode} label={label} customIcon={customIcon}>
+        <ScreenSpinnerContainer
+          state={state}
+          mode={mode}
+          label={label}
+          customIcon={customIcon}
+          visibilityDelay={visibilityDelay}
+        >
           <ScreenSpinnerLoader {...restProps} />
           <ScreenSpinnerSwapIcon onClick={onClick} cancelLabel={cancelLabel} />
         </ScreenSpinnerContainer>

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinnerContainer.tsx
@@ -5,6 +5,7 @@ import { Footnote } from '../Typography/Footnote/Footnote';
 import { ScreenSpinnerContext } from './context';
 import { type ScreenSpinnerProps } from './types';
 import styles from './ScreenSpinner.module.css';
+import stylesDelay from '../../styles/animationVisibilityDelay.module.css';
 
 const stateClassNames = {
   cancelable: styles.stateCancelable,
@@ -19,7 +20,7 @@ const modeClassNames = {
 };
 
 type ScreenSpinnerContainerProps = HTMLAttributesWithRootRef<HTMLSpanElement> &
-  Pick<ScreenSpinnerProps, 'state' | 'mode' | 'label' | 'customIcon'>;
+  Pick<ScreenSpinnerProps, 'state' | 'mode' | 'label' | 'customIcon' | 'visibilityDelay'>;
 
 export const ScreenSpinnerContainer = ({
   state = 'loading',
@@ -27,6 +28,7 @@ export const ScreenSpinnerContainer = ({
   customIcon,
   label,
   children,
+  visibilityDelay,
   ...restProps
 }: ScreenSpinnerContainerProps) => {
   return (
@@ -37,6 +39,7 @@ export const ScreenSpinnerContainer = ({
           modeClassNames[mode],
           state !== 'loading' && stateClassNames[state],
           hasReactNode(label) && styles.hasLabel,
+          visibilityDelay && stylesDelay.visibilityDelay,
         )}
         {...restProps}
       >

--- a/packages/vkui/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/vkui/src/components/Skeleton/Skeleton.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { Skeleton, type SkeletonProps } from './Skeleton';
 import styles from './Skeleton.module.css';
+import stylesDelay from '../../styles/animationVisibilityDelay.module.css';
 
 describe('Skeleton', () => {
   baselineComponent(Skeleton);
@@ -49,4 +50,10 @@ describe('Skeleton', () => {
       className && expect(screen.getByTestId('skeleton')).toHaveClass(className);
     },
   );
+
+  it('should delay visibility', () => {
+    render(<Skeleton visibilityDelay={200} />);
+
+    expect(document.querySelector(`.${stylesDelay.visibilityDelay}`)).not.toBeNull();
+  });
 });

--- a/packages/vkui/src/components/Skeleton/Skeleton.tsx
+++ b/packages/vkui/src/components/Skeleton/Skeleton.tsx
@@ -3,13 +3,16 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { millisecondsInSecond } from 'date-fns/constants';
+import { mergeStyle } from '../../helpers/mergeStyle';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import { useStateWithPrev } from '../../hooks/useStateWithPrev';
 import { useDOM } from '../../lib/dom';
+import { animationVisibilityDelayStyles } from '../../styles/animationVisibilityDelay';
 import type { CSSCustomProperties, HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import styles from './Skeleton.module.css';
+import stylesDelay from '../../styles/animationVisibilityDelay.module.css';
 
 const CUSTOM_PROPERTY_GRADIENT_LEFT = '--vkui_internal--skeleton_gradient_left';
 
@@ -118,6 +121,11 @@ export interface SkeletonProps
    * Длительность анимации в секундах.
    */
   duration?: number;
+
+  /**
+   * Задерживает отрисовку элемента на заданное количество миллисекунд.
+   */
+  visibilityDelay?: number;
 }
 
 /**
@@ -146,6 +154,7 @@ export const Skeleton = ({
   duration,
   margin,
   getRootRef,
+  visibilityDelay,
   ...restProps
 }: SkeletonProps): React.ReactNode => {
   const rootRef = useExternRef(getRootRef);
@@ -181,8 +190,12 @@ export const Skeleton = ({
     <RootComponent
       getRootRef={rootRef}
       Component="span"
-      baseClassName={classNames(styles.host, disableAnimation && styles.disableAnimation)}
-      baseStyle={skeletonStyle}
+      baseClassName={classNames(
+        styles.host,
+        disableAnimation && styles.disableAnimation,
+        visibilityDelay && stylesDelay.visibilityDelay,
+      )}
+      baseStyle={mergeStyle(skeletonStyle, animationVisibilityDelayStyles(visibilityDelay))}
       {...restProps}
     >
       {children || <>&zwnj;</>}

--- a/packages/vkui/src/components/Spinner/Spinner.test.tsx
+++ b/packages/vkui/src/components/Spinner/Spinner.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { REDUCE_MOTION_MEDIA_QUERY } from '../../lib/animation';
 import { baselineComponent, matchMediaMock } from '../../testing/utils';
 import { Spinner } from './Spinner';
+import stylesDelay from '../../styles/animationVisibilityDelay.module.css';
 
 describe('Spinner', () => {
   baselineComponent(Spinner);
@@ -34,6 +35,12 @@ describe('Spinner', () => {
 
       expect(svgEl.querySelector('animate')).not.toBeInTheDocument();
       expect(svgEl.querySelector('animateTransform')).not.toBeInTheDocument();
+    });
+
+    it('should delay visibility', () => {
+      render(<Spinner visibilityDelay={200} />);
+
+      expect(document.querySelector(`.${stylesDelay.visibilityDelay}`)).not.toBeNull();
     });
   });
 });

--- a/packages/vkui/src/components/Spinner/Spinner.tsx
+++ b/packages/vkui/src/components/Spinner/Spinner.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
+import { animationVisibilityDelayStyles } from '../../styles/animationVisibilityDelay';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { SpinnerAnimation } from './SpinnerAnimation';
 import { Icon16Spinner, Icon24Spinner, Icon32Spinner, Icon44Spinner } from './icons';
 import styles from './Spinner.module.css';
+import stylesDelay from '../../styles/animationVisibilityDelay.module.css';
 
 const spinnerIconMap = {
   s: Icon16Spinner,
@@ -28,6 +30,10 @@ export interface SpinnerProps extends HTMLAttributesWithRootRef<HTMLSpanElement>
    * Задать цвет можно будет через свойство color родителя.
    */
   noColor?: boolean;
+  /**
+   * Задерживает отрисовку элемента на заданное количество миллисекунд.
+   */
+  visibilityDelay?: number;
 }
 
 /**
@@ -40,6 +46,7 @@ export const Spinner = React.memo(
     children = 'Загружается...',
     disableAnimation = false,
     noColor = false,
+    visibilityDelay,
     ...restProps
   }: SpinnerProps) => {
     const SpinnerIcon = spinnerIconMap[size];
@@ -49,7 +56,12 @@ export const Spinner = React.memo(
         Component="span"
         role="status"
         {...restProps}
-        baseClassName={classNames(styles.host, noColor && styles.noColor)}
+        baseClassName={classNames(
+          styles.host,
+          noColor && styles.noColor,
+          visibilityDelay && stylesDelay.visibilityDelay,
+        )}
+        baseStyle={animationVisibilityDelayStyles(visibilityDelay)}
       >
         <SpinnerIcon>{disableAnimation ? null : <SpinnerAnimation size={size} />}</SpinnerIcon>
         {hasReactNode(children) && <VisuallyHidden>{children}</VisuallyHidden>}

--- a/packages/vkui/src/styles/animationVisibilityDelay.module.css
+++ b/packages/vkui/src/styles/animationVisibilityDelay.module.css
@@ -1,0 +1,13 @@
+.visibilityDelay {
+  --vkui_internal--animation_delay_visibility: 200ms;
+
+  visibility: hidden;
+  animation: 0ms linear var(--vkui_internal--animation_delay_visibility) forwards
+    animation-styles-delay-visibility;
+}
+
+@keyframes animation-styles-delay-visibility {
+  to {
+    visibility: visible;
+  }
+}

--- a/packages/vkui/src/styles/animationVisibilityDelay.ts
+++ b/packages/vkui/src/styles/animationVisibilityDelay.ts
@@ -1,0 +1,13 @@
+import { type CSSCustomProperties } from '../types';
+
+export function animationVisibilityDelayStyles(
+  delay: number | undefined,
+): CSSCustomProperties | undefined {
+  if (delay === undefined) {
+    return undefined;
+  }
+
+  return {
+    '--vkui_internal--animation_delay_visibility': `${delay}ms`,
+  };
+}


### PR DESCRIPTION
- [x] Unit-тесты
- [x] ~e2e-тесты~
- [ ] Дизайн-ревью
- [x] Документация фичи
- [x] Release notes

## Описание

Добавляем для компонентов загрузки свойство `visibilityDelay ` которое скрывает элемент в начале отрисовки на заданное количество миллисекунд

## Release notes
## Улучшения
- [Spinner](https://vkcom.github.io/VKUI/${version}/#/Spinner), [ScreenSpinner](https://vkcom.github.io/VKUI/${version}/#/ScreenSpinner), [PanelSpinner](https://vkcom.github.io/VKUI/${version}/#/PanelSpinner), [Skeleton](https://vkcom.github.io/VKUI/${version}/#/Skeleton): свойство `visibilityDelay ` скрывает компонент в начале отрисовки на заданное количество миллисекунд


