### PR TITLE
fix(Clickable): ignore undefined Component

### DIFF
--- a/packages/vkui/src/components/Clickable/Clickable.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.tsx
@@ -120,6 +120,7 @@ export const Clickable = <T,>(props: ClickableProps<T>): React.ReactNode => {
   const {
     baseClassName,
     disabled, // Игнорируем disabled из пропсов, т.к. он обрабатывается в commonProps
+    Component: ignore,
     ...restProps
   } = props;
 

--- a/packages/vkui/src/components/Tappable/Tappable.test.tsx
+++ b/packages/vkui/src/components/Tappable/Tappable.test.tsx
@@ -36,6 +36,15 @@ describe(Tappable, () => {
     expect(tappable().tagName.toLowerCase()).toMatch('div');
   });
 
+  it('Component: if Component is undefined it should respect component autodetect', () => {
+    render(
+      <TappableTest href="https://vk.com" Component={undefined}>
+        VK Link
+      </TappableTest>,
+    );
+    expect(tappable().tagName.toLowerCase()).toMatch('a');
+  });
+
   it('a11y(role): role gets set for custom button', () => {
     render(<TappableTest onClick={noop}>Custom Button</TappableTest>);
     expect(tappable()).toHaveAttribute('role', 'button');


### PR DESCRIPTION
- [x] Unit-тесты
- [x] Release notes

## Описание

Если передавать `undefined` в свойство `Component`, оно будет перезаписывать автоопределённые значения

## Изменения

Игнорируем проп `Component`, потому что он обрабатывается в функции `component`

## Release notes

 ## Исправления
 - Tappable: исправлена обработка свойства `Component={undefined}`

