### PR TITLE
fix(ChipsInput): fix field reset

### DIFF
--- a/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/Chip/Chip.tsx
@@ -84,6 +84,7 @@ export const Chip = ({
       {!readOnly && removable && (
         <div className={styles.removable}>
           <button
+            type="button"
             tabIndex={-1} // [reason]: чтобы можно было выставлять состояние фокуса только программно через `*.focus()`
             disabled={disabled}
             className={styles.remove}


### PR DESCRIPTION
- [x] Release notes

## Описание

При использовании `ChipsInput` внутри формы нажатие на Enter вызывало очищение поля, потому что внутри каждого чипа лежала кнопка с `type="submit"`.

## Изменения

Меняем дефолтовый `type="submit"` на `type="button"`

## Release notes

 ## Исправления
 - ChipsInput: исправлена ошибка компонента внутри формы, которая приводила к очищению введённого значения по нажатию на `Enter`

