### PR TITLE
fix(CustomSelect): fix onInputChange callback when reset input value

### DIFF
--- a/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
@@ -134,9 +134,13 @@ export const CalendarTime = ({
 
   const onPickerValueChange = (
     e: ChangeEvent<HTMLInputElement>,
+    reason: Parameters<Exclude<SelectProps['onInputChange'], undefined>>[1],
     validate: (numericValue: string) => boolean,
     setter: (value: Date, numericValue: number) => Date,
   ) => {
+    if (reason !== 'input') {
+      return;
+    }
     const numericValue = e.target.value.replace(/\D/g, '');
     e.target.value = numericValue;
     if (validate(numericValue)) {
@@ -144,12 +148,12 @@ export const CalendarTime = ({
     }
   };
 
-  const onHoursInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onPickerValueChange(e, (numValue) => validateValue(numValue, localHours), setHours);
+  const onHoursInputChange: SelectProps['onInputChange'] = (e, reason) => {
+    onPickerValueChange(e, reason, (numValue) => validateValue(numValue, localHours), setHours);
   };
 
-  const onMinutesInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onPickerValueChange(e, (numValue) => validateValue(numValue, localMinutes), setMinutes);
+  const onMinutesInputChange: SelectProps['onInputChange'] = (e, reason) => {
+    onPickerValueChange(e, reason, (numValue) => validateValue(numValue, localMinutes), setMinutes);
   };
 
   const onHoursChange = React.useCallback(

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -50,11 +50,7 @@ const CustomSelectControlled = ({
 };
 
 const checkDropdownOpened = (opened = true) => {
-  if (opened) {
-    expect(screen.getByRole('listbox')).toBeInTheDocument();
-  } else {
-    expect(() => screen.getByRole('listbox')).toThrow();
-  }
+  expect(!!screen.queryByRole('listbox')).toBe(opened);
 };
 
 const triggerKeydownEvent = async (input: HTMLElement, key: string, code: string) => {
@@ -271,7 +267,7 @@ describe('CustomSelect', () => {
     fireEvent.click(screen.getByTestId('labelTextTestId'));
     await waitFor(() => expect(screen.getByTestId('inputTestId')).toHaveFocus());
 
-    fireEvent.change(screen.getByTestId('inputTestId'), { target: { value: 'Mi' } });
+    fireEvent.input(screen.getByTestId('inputTestId'), { target: { value: 'Mi' } });
     expect(screen.getByTestId<HTMLInputElement>('inputTestId').value).toBe('Mi');
     fireEvent.keyDown(screen.getByTestId('inputTestId'), {
       key: 'ArrowUp',
@@ -330,7 +326,7 @@ describe('CustomSelect', () => {
     );
 
     fireEvent.click(screen.getByTestId('inputTestId'));
-    fireEvent.change(screen.getByTestId('inputTestId'), { target: { value: 'Mi' } });
+    fireEvent.input(screen.getByTestId('inputTestId'), { target: { value: 'Mi' } });
 
     await waitForFloatingPosition();
 
@@ -1327,11 +1323,24 @@ describe('CustomSelect', () => {
         defaultValue="0"
       />,
     );
-    fireEvent.change(inputRef.current!, { target: { value: 'Ка' } });
-    expect(onInputChange).toHaveBeenCalledTimes(1);
+    const checkInputValue = (callIndex: number, value: string) => {
+      const event = onInputChange.mock.calls[callIndex][0];
+      expect(event.target.value).toBe(value);
+    };
 
-    fireEvent.change(inputRef.current!, { target: { value: 'Кат' } });
-    expect(onInputChange).toHaveBeenCalledTimes(2);
+    await triggerKeydownEvent(inputRef.current!, 'ArrowDown', 'ArrowDown');
+    checkDropdownOpened();
+
+    fireEvent.input(inputRef.current!, { target: { value: 'Ка' } });
+    checkInputValue(0, 'Ка');
+
+    fireEvent.input(inputRef.current!, { target: { value: 'Кат' } });
+    checkInputValue(1, 'Кат');
+
+    await triggerKeydownEvent(inputRef.current!, 'Escape', 'Escape');
+    checkDropdownOpened(false);
+
+    checkInputValue(2, '');
   });
 
   it('check scroll to bottom to element', async () => {

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -11,7 +11,12 @@ import {
 } from '../../testing/utils';
 import { Avatar } from '../Avatar/Avatar';
 import { CustomSelectOption } from '../CustomSelectOption/CustomSelectOption';
-import { CustomSelect, type CustomSelectRenderOption, type SelectProps } from './CustomSelect';
+import {
+  CustomSelect,
+  type CustomSelectRenderOption,
+  type InputChangeReason,
+  type SelectProps,
+} from './CustomSelect';
 import styles from './CustomSelect.module.css';
 
 let placementStub: Placement | undefined = undefined;
@@ -1323,24 +1328,31 @@ describe('CustomSelect', () => {
         defaultValue="0"
       />,
     );
-    const checkInputValue = (callIndex: number, value: string) => {
-      const event = onInputChange.mock.calls[callIndex][0];
+    const checkInputValue = (
+      callIndex: number,
+      value: string,
+      expectedReason: InputChangeReason,
+    ) => {
+      const params = onInputChange.mock.calls[callIndex];
+      const event = params[0];
+      const reason = params[1];
       expect(event.target.value).toBe(value);
+      expect(reason).toBe(expectedReason);
     };
 
     await triggerKeydownEvent(inputRef.current!, 'ArrowDown', 'ArrowDown');
     checkDropdownOpened();
 
     fireEvent.input(inputRef.current!, { target: { value: 'Ка' } });
-    checkInputValue(0, 'Ка');
+    checkInputValue(0, 'Ка', 'input');
 
     fireEvent.input(inputRef.current!, { target: { value: 'Кат' } });
-    checkInputValue(1, 'Кат');
+    checkInputValue(1, 'Кат', 'input');
 
     await triggerKeydownEvent(inputRef.current!, 'Escape', 'Escape');
     checkDropdownOpened(false);
 
-    checkInputValue(2, '');
+    checkInputValue(2, '', 'close-dropdown');
   });
 
   it('check scroll to bottom to element', async () => {

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -178,6 +178,8 @@ export interface CustomSelectRenderOption<T extends CustomSelectOptionInterface>
   option: T;
 }
 
+export type InputChangeReason = 'input' | 'close-dropdown' | 'clear-by-button';
+
 type PopupDirectionSide = Extract<Side, 'top' | 'bottom'>;
 
 type PopupDirection = PopupDirectionSide | `${PopupDirectionSide}-${Alignment}`;
@@ -206,7 +208,7 @@ export interface SelectProps<
   /**
    * Событие изменения текстового поля.
    */
-  onInputChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onInputChange?: (e: React.ChangeEvent<HTMLInputElement>, reason: InputChangeReason) => void;
   /**
    * Список опций в списке.
    */
@@ -363,6 +365,8 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const optionsWrapperRef = React.useRef<HTMLDivElement>(null);
   const scrollPerformedRef = React.useRef(false);
   const selectInputRef = useExternRef(getSelectInputRef);
+
+  const inputValueChangeReason = React.useRef<InputChangeReason>('input');
 
   const [focusedOptionIndex, setFocusedOptionIndex] = React.useState<number | undefined>(-1);
   const [isControlledOutside, setIsControlledOutside] = React.useState(props.value !== undefined);
@@ -542,28 +546,33 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     [keyboardInput, opened, resetFocusedOption],
   );
 
-  const nativeResetInputValue = React.useCallback(() => {
-    const input = selectInputRef.current;
-    if (!input) {
-      return;
-    }
+  const nativeResetInputValue = React.useCallback(
+    (reason: Extract<InputChangeReason, 'close-dropdown' | 'clear-by-button'>) => {
+      const input = selectInputRef.current;
+      if (!input || !input.value) {
+        return;
+      }
 
-    // eslint-disable-next-line react-compiler/react-compiler
-    input.value = '';
+      // eslint-disable-next-line react-compiler/react-compiler
+      input.value = '';
 
-    const event = new InputEvent('input', {
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-    });
+      inputValueChangeReason.current = reason;
 
-    input.dispatchEvent(event);
-  }, [selectInputRef]);
+      const event = new InputEvent('input', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      });
+
+      input.dispatchEvent(event);
+    },
+    [selectInputRef],
+  );
 
   const close = React.useCallback(() => {
     resetKeyboardInput();
 
-    nativeResetInputValue();
+    nativeResetInputValue('close-dropdown');
     setOpened(false);
     resetFocusedOption();
     onClose?.();
@@ -700,8 +709,9 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
 
   const onInputChange: React.ChangeEventHandler<HTMLInputElement> = React.useCallback(
     (e) => {
-      onInputChangeProp && onInputChangeProp(e);
+      onInputChangeProp && onInputChangeProp(e, inputValueChangeReason.current);
       setInputValue(e.target.value);
+      inputValueChangeReason.current = 'input';
     },
     [onInputChangeProp],
   );
@@ -874,7 +884,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         className={iconProp === undefined ? styles.clearIcon : undefined}
         onClick={function clearSelectState() {
           setNativeSelectValue(NOT_SELECTED.NATIVE);
-          nativeResetInputValue();
+          nativeResetInputValue('clear-by-button');
           selectInputRef.current && selectInputRef.current.focus();
         }}
         disabled={restProps.disabled}

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -362,6 +362,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const selectElRef = useExternRef(getRef);
   const optionsWrapperRef = React.useRef<HTMLDivElement>(null);
   const scrollPerformedRef = React.useRef(false);
+  const selectInputRef = useExternRef(getSelectInputRef);
 
   const [focusedOptionIndex, setFocusedOptionIndex] = React.useState<number | undefined>(-1);
   const [isControlledOutside, setIsControlledOutside] = React.useState(props.value !== undefined);
@@ -541,14 +542,32 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     [keyboardInput, opened, resetFocusedOption],
   );
 
+  const nativeResetInputValue = React.useCallback(() => {
+    const input = selectInputRef.current;
+    if (!input) {
+      return;
+    }
+
+    // eslint-disable-next-line react-compiler/react-compiler
+    input.value = '';
+
+    const event = new InputEvent('input', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+
+    input.dispatchEvent(event);
+  }, [selectInputRef]);
+
   const close = React.useCallback(() => {
     resetKeyboardInput();
 
-    setInputValue('');
+    nativeResetInputValue();
     setOpened(false);
     resetFocusedOption();
     onClose?.();
-  }, [onClose, resetKeyboardInput, resetFocusedOption]);
+  }, [resetKeyboardInput, nativeResetInputValue, resetFocusedOption, onClose]);
 
   const selectOption = React.useCallback(
     (index: number) => {
@@ -840,8 +859,6 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     }
   }, [emptyText, options, renderDropdown, renderOption]);
 
-  const selectInputRef = useExternRef(getSelectInputRef);
-
   const controlledValueSet = isControlledOutside && props.value !== NOT_SELECTED.CUSTOM;
   const uncontrolledValueSet = !isControlledOutside && nativeSelectValue !== NOT_SELECTED.NATIVE;
   const clearButtonShown =
@@ -857,7 +874,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         className={iconProp === undefined ? styles.clearIcon : undefined}
         onClick={function clearSelectState() {
           setNativeSelectValue(NOT_SELECTED.NATIVE);
-          setInputValue('');
+          nativeResetInputValue();
           selectInputRef.current && selectInputRef.current.focus();
         }}
         disabled={restProps.disabled}
@@ -871,6 +888,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     restProps.disabled,
     clearButtonTestId,
     setNativeSelectValue,
+    nativeResetInputValue,
     selectInputRef,
   ]);
 
@@ -1002,7 +1020,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         value={inputValue}
         onKeyUp={handleKeyUp}
         onKeyDown={!readOnly ? _onInputKeyDown : undefined}
-        onChange={onInputChange}
+        onInput={onInputChange}
         onClick={!readOnly ? onClick : undefined}
         before={before}
         after={afterIcons}


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8633 

---

- [x] Unit-тесты
- [x] Release notes

## Описание

В компоненте `CustomSelect` событие `onInputChange` корректно уведомляет об изменениях значения поискового поля ввода (`input`) при взаимодействии пользователя. Однако при закрытии селекта метод `close` принудительно сбрасывает значение `input` (через `setInputValue('')`), но событие `onInputChange` при этом не вызывается. Это создает неопределенность: значение поля ввода изменилось, но подписчики `onInputChange` не получают уведомления.

Значение поля ввода сбрасывается в методе `close` (через `setInputValue('')`), но событие `onInputChange` не вызывается, что нарушает ожидания разработчика, использующего это событие для отслеживания изменений.

## Изменения

- При сбросе значения в input сделал вызов нативного ивента 'input' на поле ввода, чтобы спровоцировать вызов `onInputChange` c переданным событием
- Также пришлось заменить обработчик `onChange` на `onInput` по причине того, что в React `onChange` работает не также как в нативном js - он работает точно также как и `onInput`, но его нельзя стригерить через `dispatchEvent`, а input событие можно. По логике ничего сломаться не должно

### UPD

Вскрылся баг в `CalendarTime`: там использовался проп `onInputChange`, в котором мутировалось значение input и выбиралось соответствующее число. И получалось, что при вводе числа, а затем при его выборе, сначала число устанавливалось корректно, а потом из-за того, что значение в инпуте сбрасывалось, то и число тоже сбрасывалось.

Придумал следующее решение: в `onChangeInput` добавил вторым параметром `reason` - причина изменения значения в `input` со следующими возможными значениями: `'input'` - ввод с клавиатуры, `'close-droppdown'` - закрылся дропдаун и значение сбросилось, `'clear-by-button'` - значение очищено нажатием на кнопку `clear`. В `CalendarTime` в обработчике `onInputChange`, если `reason !== 'iinput'` то дальше не обрабатываем

## Release notes
## Исправления
- CustomSelect: Раньше при сбросе значения в `input` не србатывал колбэк `onInputChange`
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
