### PR TITLE
fix(storybook): fix inifinite list updating

### DIFF
--- a/packages/vkui/docs/components-overview/components/ComponentOverviewCard.tsx
+++ b/packages/vkui/docs/components-overview/components/ComponentOverviewCard.tsx
@@ -97,6 +97,8 @@ export const ComponentOverviewCard: React.FC<ComponentOverviewCardProps> = ({
       mode="shadow"
       className={classNames(styles.card, direction === 'rtl' && styles.rtl)}
       style={style}
+      aria-label={`${componentName} превью компонента`}
+      tabIndex={0}
     >
       {searchedQuery ? (
         <TitleWithSearch searchedQuery={searchedQuery} name={componentName} />
@@ -108,7 +110,6 @@ export const ComponentOverviewCard: React.FC<ComponentOverviewCardProps> = ({
       <div
         className={styles.componentWrapper}
         ref={containerRef}
-        aria-label={`${componentName} component preview`}
         // @ts-expect-error: TS2322 пока react нормально не поддерживает этот атрибут
         inert=""
       >

--- a/packages/vkui/docs/icons-overview/IconsOverview.tsx
+++ b/packages/vkui/docs/icons-overview/IconsOverview.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { type KeyboardEvent, type ReactNode, useCallback, useRef, useState } from 'react';
-import { Icon16Done } from '@vkontakte/icons';
+import { Icon16Done, Icon20RefreshOutline } from '@vkontakte/icons';
 import { noop } from '@vkontakte/vkjs';
 import {
   AdaptivityProvider,
   AppRoot,
   Avatar,
+  Button,
   type ChipOption,
   ChipsSelect,
   ConfigProvider,
@@ -125,13 +126,27 @@ const IconsOverview = () => {
           </Tooltip>
         )}
         additionalHeaderItem={
-          <ChipsSelect
-            value={selectedSizes}
-            onChange={setSelectedSizes}
-            options={SIZES_OPTIONS}
-            placeholder="Выберите размеры иконок"
-            allowClearButton
-          />
+          <Flex gap={10} noWrap align="center">
+            <ChipsSelect
+              value={selectedSizes}
+              onChange={setSelectedSizes}
+              options={SIZES_OPTIONS}
+              placeholder="Выберите размеры иконок"
+              allowClearButton
+            />
+            {selectedSizes.length < SIZES_OPTIONS.length && (
+              <FlexItem flex="shrink">
+                <Button
+                  size="m"
+                  mode="secondary"
+                  before={<Icon20RefreshOutline />}
+                  onClick={() => setSelectedSizes(SIZES_OPTIONS)}
+                  rounded
+                  aria-label="Сбросить фильтры"
+                />
+              </FlexItem>
+            )}
+          </Flex>
         }
       />
       {snackbar}

--- a/packages/vkui/src/lib/object.ts
+++ b/packages/vkui/src/lib/object.ts
@@ -12,3 +12,22 @@ export function mapObject<T extends Object, R extends Record<keyof T, any>>(
     {} as R,
   );
 }
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function filterObject<T extends Object, R extends Record<keyof T, any>>(
+  object: T,
+  filter: (value: T[keyof T], key: keyof T) => boolean,
+): R {
+  return Object.entries(object).reduce(
+    (acc, [key, value]) => {
+      if (filter(value, key as keyof T)) {
+        Object.assign(acc, {
+          [key]: value,
+        });
+      }
+      return acc;
+    },
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/prefer-reduce-type-parameter
+    {} as R,
+  );
+}


### PR DESCRIPTION

## Описание

Сейчас в `storybook` на странице `IconsOverview` есть баги в логике виртуализации списка секций из-за которых ломается отображения секций при изменении фильтров

## Изменения

Сделал рефакторинг хука `useInfiniteList` и поправил баги, которые нашел

## Release notes
-
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkcom.github.io/VKUI/${version}/#/CustomSelect): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
