### PR TITLE
fix: export CellButtonGroup

### DIFF
--- a/packages/vkui/src/index.ts
+++ b/packages/vkui/src/index.ts
@@ -201,6 +201,8 @@ export { SimpleCell } from './components/SimpleCell/SimpleCell';
 export type { SimpleCellProps } from './components/SimpleCell/SimpleCell';
 export { CellButton } from './components/CellButton/CellButton';
 export type { CellButtonProps } from './components/CellButton/CellButton';
+export { CellButtonGroup } from './components/CellButtonGroup/CellButtonGroup';
+export type { CellButtonGroupProps } from './components/CellButtonGroup/CellButtonGroup';
 export { HorizontalCell } from './components/HorizontalCell/HorizontalCell';
 export type { HorizontalCellProps } from './components/HorizontalCell/HorizontalCell';
 export { HorizontalCellShowMore } from './components/HorizontalScroll/HorizontalCellShowMore/HorizontalCellShowMore';


### PR DESCRIPTION
## Описание

- related to #8325 

Забыла экспортнуть, возможно, компонент никому не нужен в итоге 🤣 

## Изменения

<!--
Перечисли изменения и причины по которым они сделаны, если это по какой-то причине не очевидно.
В будущем это поможет ответить почему было сделано именно так.

Если всё прозрачно, то игнорируй этот заголовок.
-->

## Release notes

 ## Исправления
 - CellButtonGroup: компонент теперь доступен для импорта

