### PR TITLE
chore(examples): ignore afterInstall

### DIFF
--- a/examples/vkui-nextjs-ts/.yarnrc.yml
+++ b/examples/vkui-nextjs-ts/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+afterInstall: ''

--- a/examples/vkui-nextjs-ts/package.json
+++ b/examples/vkui-nextjs-ts/package.json
@@ -22,5 +22,5 @@
     "eslint-config-next": "^15.0.0",
     "typescript": "latest"
   },
-  "packageManager": "yarn@4.7.0+sha512.5a0afa1d4c1d844b3447ee3319633797bcd6385d9a44be07993ae52ff4facabccafb4af5dcd1c2f9a94ac113e5e9ff56f6130431905884414229e284e37bb7c9"
+  "packageManager": "yarn@4.9.2+sha512.1fc009bc09d13cfd0e19efa44cbfc2b9cf6ca61482725eb35bbc5e257e093ebf4130db6dfe15d604ff4b79efd8e1e8e99b25fa7d0a6197c9f9826358d4d65c3c"
 }

--- a/examples/vkui-vite-ts/.yarnrc.yml
+++ b/examples/vkui-vite-ts/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+afterInstall: ''

--- a/examples/vkui-vite-ts/package.json
+++ b/examples/vkui-vite-ts/package.json
@@ -25,5 +25,6 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "typescript": "latest",
     "vite": "latest"
-  }
+  },
+  "packageManager": "yarn@4.9.2+sha512.1fc009bc09d13cfd0e19efa44cbfc2b9cf6ca61482725eb35bbc5e257e093ebf4130db6dfe15d604ff4b79efd8e1e8e99b25fa7d0a6197c9f9826358d4d65c3c"
 }


### PR DESCRIPTION
yarn запускает установку зависимостей в контексте всей монорепы, а не локально. Из-за этого запускается afterInstall, который падает

## Release notes
-
