### PR TITLE
feat(floating): add disableShiftMiddleware prop

### DIFF
--- a/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/packages/vkui/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -39,6 +39,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'children'
   | 'onPlacementChange'
   | 'disableFlipMiddleware'
+  | 'disableShiftMiddleware'
   | 'disableFocusTrap'
 >;
 
@@ -98,6 +99,7 @@ export const OnboardingTooltip = ({
   disableArrow = false,
   onPlacementChange,
   disableFlipMiddleware = false,
+  disableShiftMiddleware = false,
   overlayLabel = 'Закрыть',
   title,
   'aria-label': ariaLabel,
@@ -124,6 +126,7 @@ export const OnboardingTooltip = ({
     arrowHeight,
     arrowPadding,
     disableFlipMiddleware,
+    disableShiftMiddleware,
   });
   const {
     x: floatingDataX,

--- a/packages/vkui/src/components/Popover/Popover.tsx
+++ b/packages/vkui/src/components/Popover/Popover.tsx
@@ -63,6 +63,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'children'
   | 'zIndex'
   | 'disableFlipMiddleware'
+  | 'disableShiftMiddleware'
   | 'customMiddlewares'
   | 'strategy'
   | 'disableFocusTrap'

--- a/packages/vkui/src/components/Popover/usePopover.tsx
+++ b/packages/vkui/src/components/Popover/usePopover.tsx
@@ -43,6 +43,7 @@ export const usePopover = <ElementType extends HTMLElement = HTMLElement>({
   placement = 'bottom-start',
   onPlacementChange,
   disableFlipMiddleware = false,
+  disableShiftMiddleware = false,
   trigger = 'click',
   strategy,
   content,
@@ -184,6 +185,7 @@ export const usePopover = <ElementType extends HTMLElement = HTMLElement>({
     sameWidth,
     hideWhenReferenceHidden,
     disableFlipMiddleware,
+    disableShiftMiddleware,
     customMiddlewares,
 
     trigger,

--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -55,6 +55,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'customMiddlewares'
   | 'onPlacementChange'
   | 'disableFlipMiddleware'
+  | 'disableShiftMiddleware'
   | 'flipMiddlewareFallbackAxisSideDirection'
 >;
 
@@ -107,6 +108,7 @@ export const Popper = ({
   arrowPadding = DEFAULT_ARROW_PADDING,
   customMiddlewares,
   disableFlipMiddleware = false,
+  disableShiftMiddleware = false,
   flipMiddlewareFallbackAxisSideDirection,
 
   // UseFloatingProps
@@ -142,6 +144,7 @@ export const Popper = ({
     hideWhenReferenceHidden,
     customMiddlewares,
     disableFlipMiddleware,
+    disableShiftMiddleware,
     flipMiddlewareFallbackAxisSideDirection,
   });
 

--- a/packages/vkui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/Tooltip.tsx
@@ -24,6 +24,7 @@ type AllowedFloatingComponentProps = Pick<
   | 'usePortal'
   | 'onPlacementChange'
   | 'disableFlipMiddleware'
+  | 'disableShiftMiddleware'
   | 'strategy'
 >;
 

--- a/packages/vkui/src/components/Tooltip/useTooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/useTooltip.tsx
@@ -43,6 +43,7 @@ export const useTooltip = ({
   offsetByCrossAxis = 0,
   hideWhenReferenceHidden,
   disableFlipMiddleware = false,
+  disableShiftMiddleware = false,
   disableTriggerOnFocus = false,
   onReferenceHiddenChange,
 
@@ -151,6 +152,7 @@ export const useTooltip = ({
     offsetByCrossAxis,
     hideWhenReferenceHidden,
     disableFlipMiddleware,
+    disableShiftMiddleware,
 
     defaultShown,
     shown: shownProp,

--- a/packages/vkui/src/hooks/useFloatingElement.tsx
+++ b/packages/vkui/src/hooks/useFloatingElement.tsx
@@ -69,6 +69,7 @@ export const useFloatingElement = <
   customMiddlewares,
   hideWhenReferenceHidden,
   disableFlipMiddleware = false,
+  disableShiftMiddleware = false,
 
   // useFloatingWithInteractions
   trigger,
@@ -108,6 +109,7 @@ export const useFloatingElement = <
     arrowPadding,
     arrowHeight,
     disableFlipMiddleware,
+    disableShiftMiddleware,
   });
 
   const {


### PR DESCRIPTION
- close #8122

---

## Описание

Нужна возможность отключения смещения по главной оси (shift middleware), в случаях, когда положение тултипа
просчитывается самостоятельно и нужно гарантировать положение относительно якорного элемента

## Изменения

<!--
Перечисли изменения и причины по которым они сделаны, если это по какой-то причине не очевидно.
В будущем это поможет ответить почему было сделано именно так.

Если всё прозрачно, то игнорируй этот заголовок.
-->

## Release notes

 ## Улучшения
 
 - Все всплывающие элементы (`Tooltip`, `Popover`, `Popper`, `OnboardingTooltip`) теперь обладают свойством `disableShiftMiddleware` для возможности отключить смещение по главной оси

