### PR TITLE
feat(Tabs): memoize settings context

### DIFF
--- a/packages/vkui/src/components/Tabs/Tabs.tsx
+++ b/packages/vkui/src/components/Tabs/Tabs.tsx
@@ -8,9 +8,9 @@ import { useTabsNavigation } from '../../hooks/useTabsNavigation';
 import type { HTMLAttributesWithRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent';
 import { useTabsController } from './TabsController';
+import { TabsControllerContext } from './TabsControllerContext';
 import { TabsModeContext } from './TabsModeContext';
 import styles from './Tabs.module.css';
-
 export interface TabsProps extends HTMLAttributesWithRootRef<HTMLDivElement> {
   /**
    * Режим отображения компонента.
@@ -76,6 +76,17 @@ export const Tabs = ({
 
   const { tabsRef } = useTabsNavigation(isTabFlow, direction === 'rtl');
 
+  const tabsModeContext = React.useMemo(
+    () => ({
+      mode,
+      withGaps,
+      layoutFillMode,
+      withScrollToSelectedTab,
+      scrollBehaviorToSelectedTab,
+    }),
+    [mode, withGaps, layoutFillMode, withScrollToSelectedTab, scrollBehaviorToSelectedTab],
+  );
+
   return (
     <RootComponent
       {...restProps}
@@ -89,17 +100,10 @@ export const Tabs = ({
       role={role}
     >
       <div className={styles.in} ref={tabsRef}>
-        <TabsModeContext.Provider
-          value={{
-            mode,
-            withGaps,
-            layoutFillMode,
-            withScrollToSelectedTab,
-            scrollBehaviorToSelectedTab,
-            controller,
-          }}
-        >
-          {children}
+        <TabsModeContext.Provider value={tabsModeContext}>
+          <TabsControllerContext.Provider value={controller}>
+            {children}
+          </TabsControllerContext.Provider>
         </TabsModeContext.Provider>
       </div>
     </RootComponent>

--- a/packages/vkui/src/components/Tabs/TabsController.ts
+++ b/packages/vkui/src/components/Tabs/TabsController.ts
@@ -3,7 +3,7 @@ import { useStableCallback } from '../../hooks/useStableCallback';
 import { type TabsProps } from './Tabs';
 
 /* eslint-disable jsdoc/require-jsdoc */
-export type TabsController = {
+export type TabsControllerProps = {
   onChange: (id: string) => void;
   selectedTab: string;
 };
@@ -16,7 +16,7 @@ export const useTabsController = ({
 }: Pick<
   TabsProps,
   'selectedId' | 'defaultSelectedId' | 'onSelectedIdChange'
->): TabsController | null => {
+>): TabsControllerProps | null => {
   const onSelectedIdChange = useStableCallback(
     (id: string | undefined) => id && onSelectedIdChangeProp?.(id),
   );

--- a/packages/vkui/src/components/Tabs/TabsControllerContext.ts
+++ b/packages/vkui/src/components/Tabs/TabsControllerContext.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { type TabsControllerProps } from './TabsController';
+
+export type TabsControllerContextProps = TabsControllerProps | null;
+
+export const TabsControllerContext: React.Context<TabsControllerContextProps> =
+  React.createContext<TabsControllerContextProps>(null);

--- a/packages/vkui/src/components/Tabs/TabsModeContext.ts
+++ b/packages/vkui/src/components/Tabs/TabsModeContext.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { type TabsProps } from './Tabs';
-import { type TabsController } from './TabsController';
 
 /* eslint-disable jsdoc/require-jsdoc */
 export interface TabsContextProps {
@@ -9,7 +8,6 @@ export interface TabsContextProps {
   layoutFillMode: NonNullable<TabsProps['layoutFillMode']>;
   withScrollToSelectedTab: TabsProps['withScrollToSelectedTab'];
   scrollBehaviorToSelectedTab: Required<TabsProps['scrollBehaviorToSelectedTab']>;
-  controller: TabsController | null;
 }
 /* eslint-enable jsdoc/require-jsdoc */
 
@@ -20,5 +18,4 @@ export const TabsModeContext: React.Context<TabsContextProps> =
     layoutFillMode: 'auto',
     withScrollToSelectedTab: false,
     scrollBehaviorToSelectedTab: 'nearest',
-    controller: null,
   });

--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -8,7 +8,8 @@ import { usePrevious } from '../../hooks/usePrevious';
 import { useDOM } from '../../lib/dom';
 import { warnOnce } from '../../lib/warnOnce';
 import type { AnchorHTMLAttributesOnly, HTMLAttributesWithRootRef } from '../../types';
-import { type TabsContextProps, TabsModeContext } from '../Tabs/TabsModeContext';
+import { TabsControllerContext } from '../Tabs/TabsControllerContext';
+import { TabsModeContext } from '../Tabs/TabsModeContext';
 import { Tappable, type TappableOmitProps } from '../Tappable/Tappable';
 import { Headline } from '../Typography/Headline/Headline';
 import { Subhead } from '../Typography/Subhead/Subhead';
@@ -99,14 +100,9 @@ export const TabsItem = ({
   ...restProps
 }: TabsItemProps): React.ReactNode => {
   const { sizeY = 'none' } = useAdaptivity();
-  const {
-    mode,
-    withGaps,
-    layoutFillMode,
-    scrollBehaviorToSelectedTab,
-    withScrollToSelectedTab,
-    controller,
-  }: TabsContextProps = React.useContext(TabsModeContext);
+  const { mode, withGaps, layoutFillMode, scrollBehaviorToSelectedTab, withScrollToSelectedTab } =
+    React.useContext(TabsModeContext);
+  const controller = React.useContext(TabsControllerContext);
   let statusComponent = null;
 
   const isTabFlow = role === 'tab';


### PR DESCRIPTION
- [x] Unit-тесты
- [x] e2e-тесты
- [x] Документация фичи
- [x] Release notes

## Описание

Мемоизируем контекст с настройками компонента `Tabs` - чтобы предотвратить лишние ререндеры.

Контекст разделён на два - с настройками и с контролером (в котором выбранная вкладка). Оптимизация не будет работать, если задавать выбранную вкладку на компоненте `Tabs`. Для команды, которая запрашивала оптимизацию - это ок, используют старый подход к управлению вкладками (через `selected` у `TabsItem`).

## Release notes

 ## Улучшения
 - Tabs: оптимизированы ререндеры дочерних компонентов при использовании подхода с выбранной вкладкой через свойство `selected` компонента `TabsItem`

