### PR TITLE
fix(Button): improve a11y with loading state

### DIFF
--- a/packages/vkui/src/components/Button/Button.stories.tsx
+++ b/packages/vkui/src/components/Button/Button.stories.tsx
@@ -37,3 +37,12 @@ export const Playground: Story = {
     size: 's',
   },
 };
+
+export const WithHref: Story = {
+  args: {
+    children: 'Button',
+    size: 's',
+    href: 'https://vk.com',
+    target: '_blank'
+  },
+};

--- a/packages/vkui/src/components/Button/Button.test.tsx
+++ b/packages/vkui/src/components/Button/Button.test.tsx
@@ -1,11 +1,23 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { baselineComponent } from '../../testing/utils';
+import { a11yTest, baselineComponent } from '../../testing/utils';
 import { Button, type ButtonProps } from './Button';
 
 const ButtonTest = (props: ButtonProps) => <Button data-testid="custom-btn" {...props} />;
 const button = () => screen.getByTestId('custom-btn');
 
 describe('Button', () => {
+  a11yTest(() => (
+    <>
+      <ButtonTest loading>
+        Button
+      </ButtonTest>
+
+      <ButtonTest href="#" loading>
+        Button with href
+      </ButtonTest>
+    </>
+  ));
+
   baselineComponent((props) => <Button {...props}>Button</Button>);
 
   it('Component: Button is handled as a native button', () => {
@@ -36,9 +48,9 @@ describe('Button', () => {
         0
       </ButtonTest>,
     );
-    // TODO: как будто не хватает expect и что мы хотим видеть тут? Сейчас мы просто элементы по айди получаем и все
-    screen.getByTestId('before');
-    screen.getByTestId('children');
-    screen.getByTestId('after');
+
+    expect(screen.getByTestId('before')).toHaveTextContent('0')
+    expect(screen.getByTestId('children')).toHaveTextContent('0')
+    expect(screen.getByTestId('after')).toHaveTextContent('0')
   });
 });

--- a/packages/vkui/src/components/Button/Button.tsx
+++ b/packages/vkui/src/components/Button/Button.tsx
@@ -44,6 +44,11 @@ const sizeYClassNames = {
   regular: styles.sizeYRegular,
 };
 
+type ButtonDisabledOptions =
+  | Record<never, never>
+  | Pick<React.HTMLAttributes<HTMLAnchorElement>, 'tabIndex' | 'aria-disabled' | 'aria-busy'>
+  | { disabled: boolean }
+
 export interface VKUIButtonProps extends HasAlign {
   /**
    * Режим отображения кнопки.
@@ -83,7 +88,7 @@ export interface VKUIButtonProps extends HasAlign {
   rounded?: boolean;
 }
 
-export interface ButtonProps extends Omit<TappableOmitProps, 'size'>, VKUIButtonProps {}
+export interface ButtonProps extends Omit<TappableOmitProps, 'size'>, VKUIButtonProps { }
 
 /**
  * @see https://vkui.io/components/button
@@ -103,19 +108,39 @@ export const Button = ({
   disableSpinnerAnimation,
   rounded,
   disabled,
+  href,
   ...restProps
 }: ButtonProps): React.ReactNode => {
   const hasIconOnly = !children && Boolean(after) !== Boolean(before);
   const { sizeY = 'none' } = useAdaptivity();
   const platform = usePlatform();
 
+  const disabledOptions: ButtonDisabledOptions = React.useMemo(() => {
+    const isLink = Boolean(href);
+    const isDisabled = loading || disabled;
+
+    if (!isDisabled) {
+      return {}
+    }
+
+    if (isLink) {
+      return {
+        tabIndex: -1,
+        ...(loading && { 'aria-busy': true }),
+        ...(disabled && { 'aria-disabled': true }),
+      };
+    }
+
+    return { disabled: true };
+  }, [disabled, loading, href]);
   return (
     <Tappable
       hoverMode={styles.hover}
       activeMode={styles.active}
-      Component={restProps.href ? 'a' : 'button'}
+      Component={href ? 'a' : 'button'}
       focusVisibleMode="outside"
-      disabled={loading || disabled}
+      href={href}
+      {...disabledOptions}
       {...restProps}
       onClick={loading ? undefined : onClick}
       baseClassName={classNames(


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8750 

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Release notes

## Описание

Задаем корректные атрибуты для кнопки в состоянии `loading` для улучшения a11y.
Более явное различие между нативной кнопкой и ссылкой для скринридеров.
<!--
По возможности, напиши подробности о том, что делает PR.

Добавь ссылки на связанные задачи, если такие есть. Это позволит легче разобраться откуда росли
"ноги".

Пример:
- related to #123
-->

## Release notes

> - Button: улучшено a11y для кнопок с `href`, а также в состоянии `loading`

<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
