### PR TITLE
feat(HorizontalScroll): add focusable state to scrollable container

### DIFF
--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.e2e-playground.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.e2e-playground.tsx
@@ -113,3 +113,13 @@ export const HorizontalScrollWithoutHasMousePlayground = ({
     </ConfigProvider>
   );
 };
+
+export const HorizontalScrollWithFocusVisible = (props: ComponentPlaygroundProps) => (
+  <ComponentPlayground {...props}>
+    {(props: HorizontalScrollProps) => (
+      <div style={{ padding: 10 }}>
+        <HorizontalScroll {...props}>{items}</HorizontalScroll>
+      </div>
+    )}
+  </ComponentPlayground>
+);

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.e2e.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.e2e.tsx
@@ -3,6 +3,7 @@ import { ViewWidth } from '../../lib/adaptivity';
 import {
   HorizontalScrollMobilePlayground,
   HorizontalScrollSmallTabletPlayground,
+  HorizontalScrollWithFocusVisible,
   HorizontalScrollWithHasMousePlayground,
   HorizontalScrollWithoutHasMousePlayground,
 } from './HorizontalScroll.e2e-playground';
@@ -85,5 +86,27 @@ test.describe('HorizontalScroll', () => {
     await expectScreenshotClippedToContent({
       cropToContentSelector: CUSTOM_ROOT_SELECTOR,
     });
+  });
+});
+
+test.describe('HorizontalScroll', () => {
+  test.use({
+    adaptivityProviderProps: {
+      viewWidth: ViewWidth.SMALL_TABLET,
+      hasPointer: true,
+    },
+    onlyForPlatforms: ['android'],
+  });
+
+  test('State: Focus Visible', async ({
+    mount,
+    page,
+    expectScreenshotClippedToContent,
+    componentPlaygroundProps,
+  }) => {
+    await mount(<HorizontalScrollWithFocusVisible {...componentPlaygroundProps} />);
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.keyboard.press('Tab');
+    await expectScreenshotClippedToContent();
   });
 });

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.module.css
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.module.css
@@ -1,11 +1,5 @@
 .host {
   position: relative;
-
-  /**
-   * ⚠️ WARNING ⚠️
-   * `overflow-y` мы не трогаем, т.к. из-за `hidden` могут обрезаться тени у потомков.
-   */
-  overflow-x: hidden;
   isolation: isolate;
 
   --vkui_internal--HorizontalScroll_shift_direction: 1;

--- a/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/vkui/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -5,6 +5,8 @@ import { classNames, noop } from '@vkontakte/vkjs';
 import { useAdaptivityHasPointer } from '../../hooks/useAdaptivityHasPointer';
 import { useConfigDirection } from '../../hooks/useConfigDirection';
 import { useExternRef } from '../../hooks/useExternRef';
+import { useFocusVisible } from '../../hooks/useFocusVisible.ts';
+import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName.ts';
 import { easeInOutSine } from '../../lib/fx';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import type { HasRef, HTMLAttributesWithRootRef } from '../../types';
@@ -216,6 +218,12 @@ export const HorizontalScroll = ({
 }: HorizontalScrollProps): React.ReactNode => {
   const [canScrollStart, setCanScrollStart] = React.useState(false);
   const [canScrollEnd, setCanScrollEnd] = React.useState(false);
+  const { focusVisible, ...focusEvents } = useFocusVisible();
+  const focusVisibleClassNames = useFocusVisibleClassName({
+    focusVisible,
+    mode: 'outside',
+  });
+
   const direction = useConfigDirection();
   const isRtl = direction === 'rtl';
 
@@ -346,7 +354,12 @@ export const HorizontalScroll = ({
           onClick={scrollToEnd}
         />
       )}
-      <div className={styles.in} ref={scrollerRef}>
+      <div
+        className={classNames(styles.in, focusVisibleClassNames)}
+        ref={scrollerRef}
+        tabIndex={0}
+        {...focusEvents}
+      >
         <ContentWrapperComponent
           className={classNames(styles.inWrapper, contentWrapperClassName)}
           ref={contentWrapperRef}

--- a/packages/vkui/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-state-focus-visible-android-chromium-dark-1-snap.png
+++ b/packages/vkui/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-state-focus-visible-android-chromium-dark-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73a358c212ca71b8e1c3cf39db82e76331c4ccdd6bdfd4c294791410ff41273b
+size 4919

--- a/packages/vkui/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-state-focus-visible-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/HorizontalScroll/__image_snapshots__/horizontalscroll-state-focus-visible-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:567d76dc3d3556b47efc15898c6d99b8b1936bd150fc5b4225dea4bf2e822383
+size 4579


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #7704

---

- [x] e2e-тесты
- [x] Release notes

## Описание

Сейчас если в HorizontalScroll внутри нет ни одного фокусируемого элемента, то пользователи клавиатуры никак не могут скролить содержимое. Чтобы исправить эту проблему доступности необходимо контейнер, который скролится сделать фокусируемым. 

[Спека по доступности](https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/)

## Изменения

### Добавление tabindex

Чтобы контейнер был фокусируемым добавил ему атрибут `tabIndex="0"`. Чтобы фокусное состояние было как у других компонентов использовал хуки `useFocusVisible` + `useFocusVisibleClassName`

### Отображение фокуса

Изначально при использовании `useFocusVisibleClassName` выбрал `mode="inside"(`чтобы outline был внутри). Но заметил, что это выглядит не очень, так как содержимое компонента отображается поверх `outline`. Поэтому решил использовать mode="outside". Но тут появилась проблема - на .host  компонента был установлен стиль `overflow-x: hidden` из-за которого outline был не виден. Убрал его - стало хорошо. 

Может ли что-то сломаться, убрав `overflow-x: hidden`? Поисследовал этот момент. Кажется, что сломаться ничего не должно, так как содержимое находится в своем контейнере с `overflow-x: 'auto'`. Единственное, что может выйти за пределы - это кнопки, но они спозиционированы правильно, так что выйти не должны. Так что придумать кейс, когда что-то может сломаться я не смог. Также прогнал скриншотные тесты - ничего не сломалось. Добавил еще скриншоты с кейсом с фокусом.

## Release notes
## Улучшения
- HorizontalScroll: Добавлено состояние фокуса для контейнера, который скролится. Теперь при фокусе его можно скролить с помощью стрелочек
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
