### PR TITLE
fix(ModalPage): rm CSS padding prop in desktop

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPage.module.css
+++ b/packages/vkui/src/components/ModalPage/ModalPage.module.css
@@ -30,27 +30,22 @@
 
 /* Desktop */
 .hostDesktop {
-  --vkui_internal_ModalPage--desktopSafeInsetBlock: calc(var(--vkui--spacing_size_2xl) * 2);
+  --vkui_internal_ModalPage--desktopStretchedSize: calc(100% - var(--vkui--spacing_size_2xl) * 2);
   --vkui_internal_ModalPage--desktopMaxWidth: 100%;
   --vkui_internal_ModalPage--desktopMaxHeight: 640px;
   --vkui_internal_ModalPage--userHeight: auto;
 
   position: relative;
   box-sizing: content-box;
-  max-inline-size: var(--vkui_internal_ModalPage--desktopMaxWidth);
-  max-block-size: var(--vkui_internal_ModalPage--desktopMaxHeight);
-  padding-block: var(--vkui_internal_ModalPage--desktopSafeInsetBlock);
-  padding-inline: var(--vkui--spacing_size_xl);
+  max-inline-size: min(
+    var(--vkui_internal_ModalPage--desktopMaxWidth),
+    var(--vkui_internal_ModalPage--desktopStretchedSize)
+  );
+  max-block-size: min(
+    var(--vkui_internal_ModalPage--desktopMaxHeight),
+    var(--vkui_internal_ModalPage--desktopStretchedSize)
+  );
   margin-block: auto;
-}
-
-/* Неизвестный брейкпоинт */
-@media (max-height: 672px) {
-  .hostDesktop {
-    --vkui_internal_ModalPage--desktopMaxHeight: calc(
-      100% - var(--vkui_internal_ModalPage--desktopSafeInsetBlock) * 2
-    );
-  }
 }
 
 .hostDesktopMaxWidthS {


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8788

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~
- [x] Release notes

## Описание

Заменил безопасные отступы с `padding` на ограничение `max-block-size`/`max-inline-size` через `calc(<value> - 16 * 2)`.

В связи с этим удалил лишний брейкпоинт `@media (max-height: 672px)`, который до этого рассчитывал на `padding-block` если экран `> 672px`.

## Release notes
## Исправления
- ModalPage: в режиме для настольных экранов внешние отступы препятствовали закрытию окна по нажатию на маску