### PR TITLE
fix(codemods): fix removeProps utility

### DIFF
--- a/packages/codemods/src/codemod-helpers.ts
+++ b/packages/codemods/src/codemod-helpers.ts
@@ -185,7 +185,7 @@ export const removeProps = (
         if (attr.type === 'JSXSpreadAttribute') {
           needToShowReport = true;
         }
-        return false;
+        return true;
       });
       path.node.openingElement.attributes = newAttributes;
     });

--- a/packages/codemods/src/transforms/v7/__testfixtures__/chips-select/basic.input.tsx
+++ b/packages/codemods/src/transforms/v7/__testfixtures__/chips-select/basic.input.tsx
@@ -24,6 +24,7 @@ const App = () => {
         placeholder="Не выбраны"
         creatable="Добавить цвет"
         allowClearButton={true}
+        {...props}
       />
     </React.Fragment>
   );

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/action-sheet.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/action-sheet.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`action-sheet transforms correctly 1`] = `
 "import { ActionSheet, ActionSheetItem } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/alert.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/alert.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`alert transforms correctly 1`] = `
 "import { Alert } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/appearance-provider.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/appearance-provider.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`appearance-provider transforms correctly 1`] = `
 "import { ColorSchemeProvider, type ColorSchemeProviderProps, Snackbar } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/appearance.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/appearance.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`appearance transforms correctly 1`] = `
 "import { ColorScheme, type ColorSchemeType, useColorScheme } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/banner.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/banner.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`banner transforms correctly 1`] = `
 "import { Avatar, Banner } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/calendar.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/calendar.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`calendar transforms correctly 1`] = `
 "import { Calendar } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/card-grid.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/card-grid.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`card-grid transforms correctly 1`] = `
 "import { Card, CardGrid } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/card-scroll.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/card-scroll.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`card-scroll transforms correctly 1`] = `
 "import { Card, CardScroll } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/cell-button.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/cell-button.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`cell-button transforms correctly 1`] = `
 "import { CellButton } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/cell.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/cell.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`cell transforms correctly 1`] = `
 "import { Cell } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/chips-select.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/chips-select.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`chips-select transforms correctly 1`] = `
 "import { ChipsSelect } from '@vkontakte/vkui';
@@ -24,7 +24,8 @@ const App = () => {
         options={colors}
         placeholder="Не выбраны"
         creatable="Добавить цвет"
-        allowClearButton={true} />
+        allowClearButton={true}
+        {...props} />
     </React.Fragment>
   );
 };"

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/config-provider.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/config-provider.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`config-provider transforms correctly 1`] = `
 "import { ConfigProvider, ConfigProviderContext } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/content-card.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/content-card.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`content-card transforms correctly 1`] = `
 "import { ContentCard } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/counter.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/counter.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`counter transforms correctly 1`] = `
 "import { Cell, Counter, VisuallyHidden } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/custom-scroll-view.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/custom-scroll-view.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`custom-scroll-view transforms correctly 1`] = `
 "import { CustomScrollView, Div, Flex } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/custom-select.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/custom-select.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`custom-select transforms correctly 1`] = `
 "import { CustomSelect } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/flex.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/flex.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`flex transforms correctly 1`] = `
 "import { Flex } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/form-item.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/form-item.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`form-item transforms correctly 1`] = `
 "import { FormItem } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/form-status.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/form-status.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`form-status transforms correctly 1`] = `
 "import { FormStatus } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/header.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/header.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`header transforms correctly 1`] = `
 "import { Header, Icon12ChevronOutline, Link } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/horizontal-cell-show-more.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/horizontal-cell-show-more.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`horizontal-cell-show-more transforms correctly 1`] = `
 "import { HorizontalCellShowMore } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/horizontal-cell.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/horizontal-cell.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`horizontal-cell transforms correctly 1`] = `
 "import { HorizontalCell, Image } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/horizontal-scroll.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/horizontal-scroll.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`horizontal-scroll transforms correctly 1`] = `
 "import { HorizontalScroll } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/image-overlay.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/image-overlay.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`image-overlay transforms correctly 1`] = `
 "import { Image } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/mini-info-cell.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/mini-info-cell.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`mini-info-cell transforms correctly 1`] = `
 "import { Icon20WorkOutline, MiniInfoCell } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/modal-card.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/modal-card.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`modal-card transforms correctly 1`] = `
 "import { Button, ModalCard, ModalCardBase } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/onboarding-tooltip.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/onboarding-tooltip.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`onboarding-tooltip transforms correctly 1`] = `
 "import { Button, OnboardingTooltip } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-back.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-back.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`panel-header-back transforms correctly 1`] = `
 "import { noop, PanelHeaderBack } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-close.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-close.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`panel-header-close transforms correctly 1`] = `
 "import { noop, PanelHeaderClose } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-content.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-content.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`panel-header-content transforms correctly 1`] = `
 "import { Avatar, PanelHeader, PanelHeaderBack, PanelHeaderButton, PanelHeaderContent } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-edit.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-edit.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`panel-header-edit transforms correctly 1`] = `
 "import { noop, PanelHeaderEdit } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-submit.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-header-submit.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`panel-header-submit transforms correctly 1`] = `
 "import { noop, PanelHeaderSubmit } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-spinner.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/panel-spinner.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`panel-spinner transforms correctly 1`] = `
 "import { PanelSpinner } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/placeholder.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/placeholder.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`placeholder transforms correctly 1`] = `
 "import { Button,ButtonGroup, Icon56UserAddOutline, Icon56UsersOutline, Placeholder } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/rich-cell.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/rich-cell.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`rich-cell transforms correctly 1`] = `
 "import { Avatar, RichCell } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/screen-spinner.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/screen-spinner.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`screen-spinner transforms correctly 1`] = `
 "import { ScreenSpinner } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/scroll-arrow.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/scroll-arrow.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`scroll-arrow transforms correctly 1`] = `
 "import { Gallery, HorizontalScroll, ScrollArrow } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/select.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/select.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`select transforms correctly 1`] = `
 "import { Select } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/separator.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/separator.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`separator transforms correctly 1`] = `
 "import { Separator } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/simple-cell.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/simple-cell.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`simple-cell transforms correctly 1`] = `
 "import { SimpleCell } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/simple-grid.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/simple-grid.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`simple-grid transforms correctly 1`] = `
 "import { SimpleGrid } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spacing.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spacing.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`spacing transforms correctly 1`] = `
 "import { Separator, Spacing } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spinner.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/spinner.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`spinner transforms correctly 1`] = `
 "import { Spinner } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/subnavigation-bar.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/subnavigation-bar.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`subnavigation-bar transforms correctly 1`] = `
 "import { SubnavigationBar } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/subnavigation-button.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/subnavigation-button.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`subnavigation-button transforms correctly 1`] = `
 "import { SubnavigationButton } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/tabbar-item.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/tabbar-item.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`tabbar-item transforms correctly 1`] = `
 "import { Icon28NewsfeedOutline, Tabbar, TabbarItem } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/tooltip.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/tooltip.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`tooltip transforms correctly 1`] = `
 "import { Button, Tooltip } from '@vkontakte/vkui';

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/typography.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/typography.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`typography transforms correctly 1`] = `
 "import {

--- a/packages/codemods/src/transforms/v7/__tests__/__snapshots__/users-stack.ts.snap
+++ b/packages/codemods/src/transforms/v7/__tests__/__snapshots__/users-stack.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`users-stack transforms correctly 1`] = `
 "import { UsersStack } from '@vkontakte/vkui';


### PR DESCRIPTION

- [x] Документация фичи
- [x] Release notes

## Описание

Утилита `removeProps` также удаляла `{...props}` и прочие конструкции (выяснилось в ходе [апдейта либы](https://github.com/VKCOM/vkui-tokens/pull/1240) у токенов)

+ гугл убил сокращатель ссылок, джест в 30 версии поменял их на прямые - пофиксила во всех остальных снепшотах и это

## Release notes

 ## Исправления

- Исправили некорректную работу codemod для компонентов `ChipsSelect`, `CustomSelect`, `Select`, `CustomScrollView`, `PanelHeaderEdit`
