### PR TITLE
fix(CustomSelect): fix check before onChange call

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -103,6 +103,39 @@ describe('CustomSelect', () => {
     expect(() => h.rerender(<CustomSelect value={NaN} options={[]} />)).not.toThrow();
   });
 
+  it('should onChange not called when value=undefined and allowClearButton', () => {
+    const selectTypes = [
+      {
+        label: 'default',
+        value: 'default',
+      },
+      {
+        label: 'plain',
+        value: 'plain',
+      },
+      {
+        label: 'accent',
+        value: 'accent',
+      },
+    ];
+
+    const onChange = jest.fn();
+
+    render(
+      <CustomSelect
+        id="select-id"
+        placeholder="Не выбран"
+        options={selectTypes}
+        // Свойства для воспроизведения
+        allowClearButton
+        value={undefined}
+        onChange={onChange}
+      />,
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('works correctly as uncontrolled component', () => {
     render(
       <CustomSelect

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -658,7 +658,14 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     const isNativeValueChanged =
       convertedNativeSelectValue !== prevNativeSelectValue && prevNativeSelectValue !== undefined;
 
-    const isTriggeredByClearButton = allowClearButton && nativeSelectValue === NOT_SELECTED.NATIVE;
+    const isTriggeredByClearButton =
+      allowClearButton &&
+      // Проверяем, что новое значение NOT_SELECTED.NATIVE
+      nativeSelectValue === NOT_SELECTED.NATIVE &&
+      // Проверяем, что предыдущее значение не undefined(кейс с первой отрисовкой, когда предыдущего значения не было)
+      prevNativeSelectValue !== undefined &&
+      // Проверяем, что предыдущее значение не NOT_SELECTED.NATIVE(если до этого было уже сброшенное значение)
+      prevNativeSelectValue !== NOT_SELECTED.NATIVE;
 
     const shouldCallOnChange =
       !isCalledWithSameControlledOptionValue && (isNativeValueChanged || isTriggeredByClearButton);


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8572 

---

- [x] Unit-тесты
- [x] Release notes

## Описание

При первой отрисовке компонента, если передать в него `value={undefined}` и `allowClearButton`, вызывается `onChange` со значением `null`. По идее ничего не изменилось и `onChange` не должен вызываться

## Изменения

Перед вызовом onChange есть ряд проверок, одна из которых проверяет, что изменение вызвано нажатием на ClearButton. Но проверяется недостаточно факторов. Добавил еще проверку.

Добавил тест кейс из описания.

## Release notes
## Исправления
- CustomSelect: Поправлена проблема вызова `onChange` при первой отрисовке при использовании `allowClearButton` и `value={undefined}`
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
