### PR TITLE
fix(codemods): migrate to commander >= 13.0.0

### DIFF
--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -34,7 +34,7 @@ Options:
   -V, --version                                 output the version number
   -l --list                                     list available codemods
   --all                                         apply all available codemods
-  -tv --transforms-version <transformsVersion>  vkui major version transforms (available versions: "6", "7")
+  --tv, --transforms-version <transformsVersion>  vkui major version transforms (available versions: "6", "7")
   -p --path [paths...]                          file paths where codemods need to apply (space separated list), default: current
                                                 directory
   --input-file <file>                           apply codemods only to file/directory listed in the file
@@ -48,9 +48,9 @@ Options:
   -h, --help                                    display help for command
 ```
 
-### `-tv (--transforms-version)`
+### `--tv (--transforms-version)`
 
-Если приложение запустить без опции `-tv (--transforms-version)`, скрипт попытается автоматически определить версию, на которую необходимо мигрировать. Если этого сделать не удалось - нужно будет выбрать версию из предложенного списка.
+Если приложение запустить без опции `--tv (--transforms-version)`, скрипт попытается автоматически определить версию, на которую необходимо мигрировать. Если этого сделать не удалось - нужно будет выбрать версию из предложенного списка.
 
 ### `--all`
 
@@ -109,5 +109,5 @@ npx @vkontakte/vkui-codemods --path src/App.tsx src/Main.tsx --all
 Следующий скрипт запустит миграции компонентов `Flex` и `Separator` при обновлении на версию VKUI v7 в текущей директории:
 
 ```shell
-npx @vkontakte/vkui-codemods flex separator -tv 7
+npx @vkontakte/vkui-codemods flex separator --tv 7
 ```

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -77,7 +77,7 @@ export const runCli = async (): Promise<Cli> => {
     .option('-l --list', 'list available codemods')
     .option('--all', 'apply all available codemods')
     .option(
-      '-tv --transforms-version <transformsVersion>',
+      '--tv, --transforms-version <transformsVersion>',
       'vkui major version transforms (available versions: "6", "7")',
     )
     .option(


### PR DESCRIPTION
- caused by #8159, #8193, #8580

## Описание

С [v13.0.0](https://github.com/tj/commander.js/releases/tag/v13.0.0) сокращения 2-х символьные сокращения с одним дефисом больше не работают, в нашем случае `-tv`. Поправил на `--tv` (такая возможность появилась с [v13.1.0](https://github.com/tj/commander.js/releases/tag/v13.1.0)).

CLI стал падать с публикацией `@vkontakte/vkui-codemods@1.0.1`, с которого новая версия `commander.js` попала в NPM.

## Release notes
## Исправления
- Сокращение `-tv` заменено на `--tv` – мигрировали на [commander.js >= 13.1.0](https://github.com/tj/commander.js/releases/tag/v13.1.0)