### PR TITLE
fix(Separator): use 1.25dppx for min-resolution

### DIFF
--- a/packages/vkui/src/styles/dynamicTokens.css
+++ b/packages/vkui/src/styles/dynamicTokens.css
@@ -1,24 +1,26 @@
 /* stylelint-disable selector-pseudo-class-disallowed-list */
 
+/*
+В Windows можно менять общий масштаб интерфейса от 100 до 500%. Готовые пресеты 125%, 150% и 175%.
+В случаях, когда `--vkui--size_border--regular` используется не для свойства `border`, а для `height`,
+одна из линий становится размером больше чем остальные.
+
+Поэтому используем пограничные значения DPI, чтобы смена на субпиксельные значения срабатывала раньше:
+- 1.01dppx вместо 2dppx для 101% и до 200%;
+- 2.01dppx вместо 3dppx для 201% и больше;
+
+@see https://github.com/VKCOM/VKUI/issues/8864
+*/
 :root {
   --vkui--size_border--regular: var(--vkui--size_border1x--regular);
 }
 
-/*
-В Windows можно менять общий масштаб интерфейса на 125%, 150% или 175%. Так как `--vkui--size_border--regular`
-используется не только для свойства `border`, но и для `height`, то первая отрендеренная подобная линия
-в `1px` будет больше чем остальные.
-
-Используем 1.25dppx вместо 2dppx, чтобы смена 1px на субпиксель срабатывал уже при 125%.
-
-@see https://github.com/VKCOM/VKUI/issues/8864
-*/
-@media (min-resolution: 1.25dppx) {
+@media (min-resolution: 1.01dppx) {
   :root {
     --vkui--size_border--regular: var(--vkui--size_border2x--regular);
   }
 }
-@media (min-resolution: 3dppx) {
+@media (min-resolution: 2.01dppx) {
   :root {
     --vkui--size_border--regular: var(--vkui--size_border3x--regular);
   }


### PR DESCRIPTION
- fix #8864
- relates #5697

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~
- [x] Release notes

## Описание

В Windows можно менять общий масштаб интерфейса от 100 до 500%. Готовые пресеты 125%, 150% и 175%.
В случаях, когда `--vkui--size_border--regular` используется не для свойства `border`, а для `height`,
одна из линий становится размером больше чем остальные.

Поэтому используем пограничные значения DPI, чтобы смена на субпиксельные значения срабатывала раньше:
- 1.01dppx вместо 2dppx для 101% и до 200%;
- 2.01dppx вместо 3dppx для 201% и больше;

## Release notes
## Исправления
- Separator: в Windows, при изменении масштаба на 125%, 150% или 175%, один из разделителей визуально рисовался больше чем остальные