### PR TITLE
fix(Touch): fix using mouse with touch device

### DIFF
--- a/packages/vkui/src/components/Touch/Touch.tsx
+++ b/packages/vkui/src/components/Touch/Touch.tsx
@@ -266,8 +266,7 @@ export const Touch = ({
   const [isTouchEnabled] = React.useState(touchEnabled);
   const gestureRef = React.useRef<Gesture | null>(null);
   const didSlide = React.useRef(false);
-  const { active: isTouchStartActive, setActive: setTouchStartActive } =
-    useTouchActiveWithAutoReset();
+  const touchStart = useTouchActiveWithAutoReset();
   const disposeTargetNativeGestureEvents = React.useRef<VoidFunction | null>(null);
 
   const cleanupTargetNativeGestureEvents = () => {
@@ -301,7 +300,7 @@ export const Touch = ({
     }
 
     if (isTouchEvent) {
-      setTouchStartActive(false);
+      touchStart.setActive(false);
       // https://github.com/VKCOM/VKUI/issues/4414
       // если тач-устройство и был зафиксирован touchmove,
       // то событие клика не вызывается
@@ -374,12 +373,12 @@ export const Touch = ({
 
   const handlePointerDown = useStableCallback((event: TouchEvent | MouseEvent) => {
     const isTouchEvent = checkTouchEvent(event);
-    if (!isTouchEvent && isTouchStartActive) {
+    if (!isTouchEvent && touchStart.active) {
       return;
     }
 
     if (isTouchEvent) {
-      setTouchStartActive(true);
+      touchStart.setActive(true);
     }
 
     gestureRef.current = initGesture(coordX(event), coordY(event));


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #8882

---

- [x] Unit-тесты
- [x] Release notes

## Описание

Сейчас есть проблема, что компонент `Touch` может обрабатывать либо touch-events(если они поддерживаются), либо mouse-events. Проблема заключается в том, что если , например на планшете попытаться воспользоваться блютуз мышью, она работать не будет. Это происходит потому что мышь тригерит mouse-events, а мы слушаем touch-events. Нужно доработать механизм подписки на события так, чтобы это работало.

### Варианты решения

#### Использовать pointer-events. 
**Плюсы**:
- Для всех устройств будет общий механизм.
  
**Минусы**:
- Браузерная поддержка не даст использовать pointer-events всегда
- Для того, чтобы отключать браузерную прокрутку на touch-устройствах, нужно навешивать `touch-action: none`, так где нужно. Это breaking-change

#### Слушать mouse-events и touch-events в зависимости от того `mousedown` или `touchstart` сработал
**Плюсы**:
- Изменение не ломающее обратную совместимость

**Минусы**:
- на некоторых устройствах `touchstart` генерирует еще и событие `mousedown` для совместимости со старыми браузерами. Поэтому нужно сделать механизм, который будет игнорировать такое событие `mousedown`, чтобы не было дублирования срабатываний

## Изменения

Было решено использовать второй вариант решения проблемы. Для этого сделал следующее:
- Теперь на `touch` устройствах подписка происходит и на `mousedown` и `touchstart`
- Создан флаг `isTouchStartActive`, который устанавливается в true при срабатывании `touchstart` события. Сбрасывается этот факт в двух случаях: при срабатывании `touchend`/`touchcancel`, а также через секунду после `touchstart`. Это сдалано только для того, чтобы проигнорировать `mousedown`, который сработает после `touchstart`

## Release notes
## Исправления
- Touch: Исправлена проблема использования компонента `Touch` на планшетах с подключенной блютуз мышью
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
