### PR TITLE
docs(generate-props): add hooks support

### DIFF
--- a/website/components/mdx/PropsTable/PropsTable.tsx
+++ b/website/components/mdx/PropsTable/PropsTable.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
-import { Code, Table, Td, Th, Tr } from '@vkontakte/vkui-docs-theme';
+import { Code, getMdxComponents, Table, Td, Th, Tr } from '@vkontakte/vkui-docs-theme';
 import { compileMdx } from 'nextra/compile';
 import { MDXRemote } from 'nextra/mdx-remote';
 import { type PropItem } from 'react-docgen-typescript';
 import docgen from '@/docgen.json';
 import styles from './PropsTable.module.css';
+
+const Paragraph = getMdxComponents().p!;
 
 const AllProps: Record<string, PropItem[]> = docgen;
 
@@ -41,7 +43,11 @@ export function PropsTable({ name, children }: PropsTableProps) {
   });
 }
 
-function renderProps(props: PropItem[]) {
+function renderProps(props: PropItem[] = []) {
+  if (props.length === 0) {
+    return <Paragraph>Не принимает свойств</Paragraph>;
+  }
+
   return (
     <Table className={styles.root}>
       <thead>

--- a/website/content/components/adaptivity-provider.mdx
+++ b/website/content/components/adaptivity-provider.mdx
@@ -110,4 +110,10 @@ export function App() {
 
 ## Свойства и методы [#api]
 
-<PropsTable name="AdaptivityProvider" />
+<PropsTable name="AdaptivityProvider">
+
+### AdaptivityProvider [#adaptivity-provider-api]
+
+### useAdaptivity [#use-adaptivity-api]
+
+</PropsTable>

--- a/website/content/components/color-scheme-provider.mdx
+++ b/website/content/components/color-scheme-provider.mdx
@@ -71,4 +71,10 @@ const colorScheme = useColorScheme();
 
 ## Свойства и методы [#api]
 
-<PropsTable name="ColorSchemeProvider" />
+<PropsTable name="ColorSchemeProvider">
+
+### ColorSchemeProvider [#color-scheme-provider-api]
+
+### useColorScheme [#use-color-scheme-api]
+
+</PropsTable>

--- a/website/content/components/config-provider.mdx
+++ b/website/content/components/config-provider.mdx
@@ -108,4 +108,10 @@ const { colorScheme, platform, locale, direction, ...restProps } = useConfigProv
 
 ## Свойства и методы [#api]
 
-<PropsTable name="ConfigProvider" />
+<PropsTable name="ConfigProvider">
+
+### ConfigProvider [#config-provider-api]
+
+### useConfigProvider [#use-config-provider-api]
+
+</PropsTable>

--- a/website/content/components/direction-provider.mdx
+++ b/website/content/components/direction-provider.mdx
@@ -65,4 +65,10 @@ const direction = useDirection();
 
 ## Свойства и методы [#api]
 
-<PropsTable name="DirectionProvider" />
+<PropsTable name="DirectionProvider">
+
+### DirectionProvider [#direction-provider-api]
+
+### useDirection [#use-direction-api]
+
+</PropsTable>

--- a/website/content/components/locale-provider.mdx
+++ b/website/content/components/locale-provider.mdx
@@ -34,4 +34,10 @@ const locale = useLocale();
 
 ## Свойства и методы [#api]
 
-<PropsTable name="LocaleProvider" />
+<PropsTable name="LocaleProvider">
+
+### LocaleProvider [#locale-provider-api]
+
+### useLocale [#use-locale-api]
+
+</PropsTable>

--- a/website/content/components/pagination.mdx
+++ b/website/content/components/pagination.mdx
@@ -121,4 +121,10 @@ return (
 
 ## Свойства и методы [#api]
 
-<PropsTable name="Pagination" />
+<PropsTable name="Pagination">
+
+### Pagination [#pagination-api]
+
+### usePagination [#use-pagination-api]
+
+</PropsTable>

--- a/website/content/components/platform-provider.mdx
+++ b/website/content/components/platform-provider.mdx
@@ -54,7 +54,7 @@ description: Компонент, позволяющий переопредели
 > }
 > ```
 
-## Использование платформы [#use-platform]
+## Хук usePlatform [#use-platform]
 
 Для получения текущего значения платформы используйте хук `usePlatform`:
 
@@ -68,4 +68,10 @@ const platform = usePlatform();
 
 ## Свойства и методы [#api]
 
-<PropsTable name="PlatformProvider" />
+<PropsTable name="PlatformProvider">
+
+### PlatformProvider [#platform-provider-api]
+
+### usePlatform [#use-platform-api]
+
+</PropsTable>

--- a/website/content/components/popover.mdx
+++ b/website/content/components/popover.mdx
@@ -236,4 +236,10 @@ return (
 
 ## Свойства и методы [#api]
 
-<PropsTable name="Popover" />
+<PropsTable name="Popover">
+
+### Popover [#popover-api]
+
+### usePopover [#use-popover-api]
+
+</PropsTable>

--- a/website/content/components/tooltip.mdx
+++ b/website/content/components/tooltip.mdx
@@ -113,4 +113,10 @@ return (
 
 ## Свойства и методы [#api]
 
-<PropsTable name="Tooltip" />
+<PropsTable name="Tooltip">
+
+### Tooltip [#tooltip-api]
+
+### useTooltip [#use-tooltip-api]
+
+</PropsTable>

--- a/website/scripts/generate-props/get-paths.mjs
+++ b/website/scripts/generate-props/get-paths.mjs
@@ -12,11 +12,11 @@ const EXCLUDED_EXTENSIONS = [
   '.md',
   '.mdx',
 ];
-const EXCLUDED_DIRS = ['__image_snapshots__'];
+const EXCLUDED_DIRS = ['__image_snapshots__', 'storybook', 'testing', 'styles'];
 
 function shouldIgnoreFile(filename) {
   return (
-    filename[0].toLowerCase() === filename[0] ||
+    (filename[0].toLowerCase() === filename[0] && !filename.startsWith('use')) ||
     EXCLUDED_EXTENSIONS.some((ext) => filename.endsWith(ext))
   );
 }
@@ -43,7 +43,7 @@ function scanDirectory(dirPath) {
   }, []);
 }
 
-const componentsDirectory = path.resolve('../packages/vkui/src/components');
+const componentsDirectory = path.resolve('../packages/vkui/src');
 
 export function getPaths() {
   return scanDirectory(componentsDirectory);


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
~- [ ] Unit-тесты~
~- [ ] e2e-тесты~
~- [ ] Дизайн-ревью~
~- [ ] Документация фичи~
- [x] Release notes

## Описание

Добавляем в "Свойства и методы" API связанных с компонентом хуков.

## Изменения

- поправлено условие в `shouldIgnoreFiles`, чтобы файлы начинающие на `use` не фильтровались;
- в `PropsTable` учитывается, что свойств может не быть.

## Release notes
## Документация
- Добавлен просмотр API хука связанного с компонентом, например, `usePagination` у `Pagination`