### PR TITLE
fix(Gallery): fix slide change animation with dynamic slide content

### DIFF
--- a/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
@@ -83,7 +83,8 @@ export const CarouselBase = ({
   const shiftXCurrentRef = React.useRef<number>(0);
   const shiftXDeltaRef = React.useRef<number>(0);
   const initialized = React.useRef<boolean>(false);
-  const { addToAnimationQueue, getAnimateFunction, startAnimation } = useSlideAnimation();
+  const { animationInQueue, addToAnimationQueue, getAnimateFunction, startAnimation } =
+    useSlideAnimation();
   const isDragging = React.useRef(false);
 
   const [controlElementsState, setControlElementsState] =
@@ -195,6 +196,7 @@ export const CarouselBase = ({
         shiftXCurrentRef.current = Math.abs(shiftXDeltaRef.current) + snaps[0];
       }
       transformCssStyles(shiftX, animation);
+      animationFrameRef.current = null;
     });
   };
 
@@ -306,6 +308,12 @@ export const CarouselBase = ({
         containerWidth,
         isRtl,
       );
+    }
+
+    const isAnimationInProgress = animationInQueue() || animationFrameRef.current !== null;
+
+    if (isAnimationInProgress) {
+      return;
     }
 
     shiftXCurrentRef.current = snaps[slideIndex];

--- a/packages/vkui/src/components/CarouselBase/hooks.ts
+++ b/packages/vkui/src/components/CarouselBase/hooks.ts
@@ -9,6 +9,7 @@ export function useSlideAnimation(): {
   getAnimateFunction: (drawFunction: DrawInterface) => () => void;
   addToAnimationQueue: (func: VoidFunction) => void;
   startAnimation: () => void;
+  animationInQueue: () => boolean;
 } {
   const animationQueue = React.useRef<VoidFunction[]>([]);
 
@@ -33,7 +34,12 @@ export function useSlideAnimation(): {
     }
   }
 
+  function animationInQueue() {
+    return !!animationQueue.current.length;
+  }
+
   return {
+    animationInQueue,
     getAnimateFunction,
     addToAnimationQueue,
     startAnimation,

--- a/packages/vkui/src/components/Gallery/Gallery.test.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.test.tsx
@@ -3,21 +3,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { baselineComponent, mockTouchStartDisabled, setNodeEnv } from '../../testing/utils';
 import type { AlignType } from '../../types';
-import { ANIMATION_DURATION } from '../CarouselBase/constants';
 import { revertRtlValue } from '../CarouselBase/helpers';
 import { type BaseGalleryProps } from '../CarouselBase/types';
 import { DirectionProvider } from '../DirectionProvider/DirectionProvider';
 import { Gallery } from './Gallery';
-
-const mockRAF = () => {
-  let lastTime = 0;
-
-  jest.spyOn(window, 'requestAnimationFrame').mockImplementation((fn) => {
-    lastTime = lastTime + ANIMATION_DURATION;
-    fn(lastTime);
-    return lastTime;
-  });
-};
 
 const mockTime = () => {
   const mockDate = new Date(2024, 7, 5);
@@ -104,7 +93,6 @@ const setup = ({
   onDragEnd?: VoidFunction;
   isRtl?: boolean;
 }) => {
-  mockRAF();
   let slideDataByIndexMap: Record<number, any> = {};
   let layerTransform = '';
   let viewPort: HTMLDivElement;
@@ -223,6 +211,15 @@ const setup = ({
 describe('Gallery', () => {
   mockTouchStartDisabled();
   baselineComponent(Gallery);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('handles slide count', () => {
     it('prevents slideIndex outside slide count', () => {
       let index;
@@ -303,6 +300,7 @@ describe('Gallery', () => {
         containerWidth: 200,
         viewPortWidth: 180,
       });
+      jest.runAllTimers();
 
       expect(mockedData.layerTransform).toBe('translate3d(10px, 0, 0)');
       expect(mockedData.getSlideMockData(0).transform).toBeFalsy();
@@ -325,6 +323,8 @@ describe('Gallery', () => {
       });
       const { rerender } = mockedData;
 
+      jest.runAllTimers();
+
       checkActiveSlide(1);
 
       const [leftArrow, rightArrow] = getArrows();
@@ -337,6 +337,8 @@ describe('Gallery', () => {
       expect(onChange.mock.calls).toEqual([[2]]);
 
       rerender({ slideIndex: 2 });
+
+      jest.runAllTimers();
       checkActiveSlide(2);
       checkTransformX(mockedData.layerTransform, -400);
 
@@ -346,6 +348,8 @@ describe('Gallery', () => {
       expect(onChange.mock.calls).toEqual([[2], [1]]);
 
       rerender({ slideIndex: 1 });
+
+      jest.runAllTimers();
       checkActiveSlide(1);
       checkTransformX(mockedData.layerTransform, -200);
     });
@@ -365,10 +369,12 @@ describe('Gallery', () => {
         onDragEnd,
         onChange,
       });
+      jest.runAllTimers();
 
       checkActiveSlide(0);
 
       simulateDrag(mockedData.viewPort, [2, 0]);
+      jest.runAllTimers();
 
       expect(onDragStart).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledTimes(1);
@@ -394,6 +400,7 @@ describe('Gallery', () => {
         align: 'center',
         onChange,
       });
+      jest.runAllTimers();
 
       if (looped) {
         expect(mockedData.layerTransform).toBe('translate3d(10px, 0, 0)');
@@ -403,6 +410,7 @@ describe('Gallery', () => {
       mockedData.containerWidth = 250;
 
       fireEvent.resize(window);
+      jest.runAllTimers();
 
       if (looped) {
         expect(mockedData.layerTransform).toBe('translate3d(35px, 0, 0)');
@@ -431,26 +439,31 @@ describe('Gallery', () => {
         onDragEnd,
         onChange,
       });
+      jest.runAllTimers();
       const { rerender } = mockedData;
 
       checkActiveSlide(0);
 
       simulateDrag(mockedData.viewPort, [150, 0]);
+      jest.runAllTimers();
 
       expect(onDragStart).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(1);
       rerender({ slideIndex: 1 });
+      jest.runAllTimers();
 
       checkTransformX(mockedData.layerTransform, -170);
       checkActiveSlide(1);
 
       simulateDrag(mockedData.viewPort, [0, 150]);
+      jest.runAllTimers();
 
       expect(onDragStart).toHaveBeenCalledTimes(2);
       expect(onDragEnd).toHaveBeenCalledTimes(2);
       expect(onChange.mock.calls).toEqual([[1], [0]]);
       rerender({ slideIndex: 0 });
+      jest.runAllTimers();
 
       checkTransformX(mockedData.layerTransform, 10);
       checkActiveSlide(0);
@@ -558,26 +571,31 @@ describe('Gallery', () => {
         onNext,
         onChange,
       });
+      jest.runAllTimers();
       const { rerender } = mockedData;
 
       checkActiveSlide(0);
 
       const [leftArrow, rightArrow] = getArrows();
       fireEvent.click(leftArrow);
+      jest.runAllTimers();
 
       expect(onPrev).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls).toEqual([[4]]);
 
       rerender({ slideIndex: 4 });
+      jest.runAllTimers();
       checkActiveSlide(4);
       checkTransformX(mockedData.layerTransform, -800);
 
       fireEvent.click(rightArrow);
+      jest.runAllTimers();
 
       expect(onNext).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls).toEqual([[4], [0]]);
 
       rerender({ slideIndex: 0 });
+      jest.runAllTimers();
       checkActiveSlide(0);
       checkTransformX(mockedData.layerTransform, 0);
     });
@@ -598,27 +616,32 @@ describe('Gallery', () => {
         onDragEnd,
         onChange,
       });
+      jest.runAllTimers();
       const { rerender } = mockedData;
 
       checkActiveSlide(0);
 
       simulateDrag(mockedData.viewPort, [0, 150]);
+      jest.runAllTimers();
 
       expect(onDragStart).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(4);
       rerender({ slideIndex: 4 });
+      jest.runAllTimers();
 
       checkTransformX(mockedData.layerTransform, -710);
       checkTransformX(mockedData.getSlideMockData(0).transform, 900);
       checkActiveSlide(4);
 
       simulateDrag(mockedData.viewPort, [150, 0]);
+      jest.runAllTimers();
 
       expect(onDragStart).toHaveBeenCalledTimes(2);
       expect(onDragEnd).toHaveBeenCalledTimes(2);
       expect(onChange.mock.calls).toEqual([[4], [0]]);
       rerender({ slideIndex: 0 });
+      jest.runAllTimers();
 
       checkTransformX(mockedData.layerTransform, 10);
       checkTransformX(mockedData.getSlideMockData(0).transform, 0);
@@ -696,6 +719,7 @@ describe('Gallery', () => {
       align: 'center',
       onChange,
     });
+    jest.runAllTimers();
 
     expect(mockedData.layerTransform).toBe('translate3d(10px, 0, 0)');
     expect(mockedData.getSlideMockData(0).transform).toBe('translate3d(0px, 0, 0)');
@@ -703,6 +727,7 @@ describe('Gallery', () => {
     mockedData.containerWidth = 250;
 
     triggerResize();
+    jest.runAllTimers();
 
     expect(mockedData.layerTransform).toBe('translate3d(35px, 0, 0)');
     expect(mockedData.getSlideMockData(0).transform).toBe('translate3d(0px, 0, 0)');
@@ -729,12 +754,14 @@ describe('Gallery', () => {
       onDragEnd,
       onChange,
     });
+    jest.runAllTimers();
     const { rerender } = mockedData;
 
     checkActiveSlide(1);
     expect(getArrows()).toHaveLength(1);
 
     simulateDrag(mockedData.viewPort, [150, 0]);
+    jest.runAllTimers();
 
     expect(onDragStart).toHaveBeenCalledTimes(1);
     expect(onDragEnd).toHaveBeenCalledTimes(1);
@@ -748,10 +775,12 @@ describe('Gallery', () => {
     onDragEnd.mockClear();
 
     rerender({ slideIndex: 1 });
+    jest.runAllTimers();
 
     expect(getArrows()).toHaveLength(1);
 
     simulateDrag(mockedData.viewPort, [150, 0]);
+    jest.runAllTimers();
 
     expect(onDragStart).toHaveBeenCalledTimes(1);
     expect(onDragEnd).toHaveBeenCalledTimes(1);
@@ -764,10 +793,12 @@ describe('Gallery', () => {
     fireEvent.resize(window);
 
     rerender({ slideIndex: 1 });
+    jest.runAllTimers();
 
     expect(getArrows()).toHaveLength(0);
 
     simulateDrag(mockedData.viewPort, [150, 0]);
+    jest.runAllTimers();
 
     expect(onDragStart).not.toHaveBeenCalled();
     expect(onDragEnd).not.toHaveBeenCalled();
@@ -824,6 +855,7 @@ describe('Gallery', () => {
         onNext,
         onChange,
       });
+      jest.runAllTimers();
       const { rerender } = mockedData;
 
       checkActiveSlide(1);
@@ -831,20 +863,24 @@ describe('Gallery', () => {
 
       const [prevArrow, nextArrow] = getArrows();
       fireEvent.click(nextArrow);
+      jest.runAllTimers();
 
       expect(onNext).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls).toEqual([[2]]);
 
       rerender({ slideIndex: 2 });
+      jest.runAllTimers();
       checkActiveSlide(2);
       checkTransformX(mockedData.layerTransform, 400);
 
       fireEvent.click(prevArrow);
+      jest.runAllTimers();
 
       expect(onPrev).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls).toEqual([[2], [1]]);
 
       rerender({ slideIndex: 1 });
+      jest.runAllTimers();
       checkActiveSlide(1);
       checkTransformX(mockedData.layerTransform, 200);
     });
@@ -866,27 +902,32 @@ describe('Gallery', () => {
         onDragEnd,
         onChange,
       });
+      jest.runAllTimers();
       const { rerender } = mockedData;
 
       checkActiveSlide(0);
 
       simulateDrag(mockedData.viewPort, [150, 0]);
+      jest.runAllTimers();
 
       expect(onDragStart).toHaveBeenCalledTimes(1);
       expect(onDragEnd).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(4);
       rerender({ slideIndex: 4 });
+      jest.runAllTimers();
 
       checkTransformX(mockedData.layerTransform, 710);
       checkTransformX(mockedData.getSlideMockData(0).transform, -900);
       checkActiveSlide(4);
 
       simulateDrag(mockedData.viewPort, [0, 150]);
+      jest.runAllTimers();
 
       expect(onDragStart).toHaveBeenCalledTimes(2);
       expect(onDragEnd).toHaveBeenCalledTimes(2);
       expect(onChange.mock.calls).toEqual([[4], [0]]);
       rerender({ slideIndex: 0 });
+      jest.runAllTimers();
 
       checkTransformX(mockedData.layerTransform, 890);
       checkTransformX(mockedData.getSlideMockData(0).transform, -900);


### PR DESCRIPTION
---

- [x] Unit-тесты
- [x] Release notes

## Описание

Сейчас у компонента `Gallery` есть проблема с кейсом когда:
1. Контент внутри слайда меняется динамически
2. При контролируемом переключении слайдов.

При `looped=true`: 
На один фрейм ломается анимация переключения слайда

При `looped=false`:
Анимация переключения вообще не воспроизводится

<details><summary>Details</summary>

```typescript
const Example = () => {
  const [slideIndex, setSlideIndex] = useState(0);
  const [dragDisabled, setDragDisabled] = useState(false);
  const [showArrows, setShowArrows] = useState(true);
  const [looped, setLooped] = useState(true);

  return (
    <View activePanel="gallery">
      <Panel nav="gallery">
        <PanelHeader>Gallery</PanelHeader>
        <Group header={<Header size="s">Controlled</Header>}>
          <Gallery
            slideWidth="90%"
            align="center"
            style={{ height: 150 }}
            slideIndex={slideIndex}
            onChange={setSlideIndex}
            dragDisabled={dragDisabled}
            showArrows={true}
            looped={looped}
            timeout={slideIndex * 5000}
          >
            <div style={{ backgroundColor: 'var(--vkui--color_background_negative)' }} />
            <div style={{ backgroundColor: 'var(--vkui--color_background_positive)' }} >
            {slideIndex === 1 && <div />}
            </div>
            <div style={{ backgroundColor: 'var(--vkui--color_background_accent)' }} />
          </Gallery>

          <FormItem>
            <Checkbox checked={dragDisabled} onChange={(e) => setDragDisabled(e.target.checked)}>
              dragDisabled
            </Checkbox>
            <Checkbox checked={showArrows} onChange={(e) => setShowArrows(e.target.checked)}>
              showArrows
            </Checkbox>
            <Checkbox checked={looped} onChange={(e) => setLooped(e.target.checked)}>
              looped
            </Checkbox>
          </FormItem>
          <FormItem>
            <Button size="l" stretched onClick={() => setSlideIndex((slideIndex + 1) % 3)}>
              Next slide
            </Button>
          </FormItem>
          <FormItem>
            <Button size="l" stretched onClick={() => setSlideIndex((slideIndex + 2) % 3)}>
              Prev slide
            </Button>
          </FormItem>
        </Group>
      </Panel>
    </View>
  );
};

<Example />;
``` 
</details> 

## Изменения

В примере проблема происходит из-за того, что при изменении переключении слайда, происходит изменение контента слайда. Последовательность шагов:
1. Происходит запуск анимации переключения слайда(точнее она запускается отложено)
2. Срабатывается mutation observer, который тригерит пересчет позиций слайдов и сразу же докручивает до нужного слайда
3. Начинает работать анимация

По сути проблема в шаге 2, а именно в том, что докрутка до нужного слайда не нужна, так как уже запланирована анимация(или уже в процессе). Добавил проверку, что анимация не в процессе. 

## Release notes
## Исправления
- Gallery: Поправлена проблема с анимацией перехода к слайду, когда контент слайда динамический.
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
