### PR TITLE
feat(ModalPage): extend size prop with any other CSS properties

### DIFF
--- a/packages/vkui/src/components/ModalCard/ModalCard.module.css
+++ b/packages/vkui/src/components/ModalCard/ModalCard.module.css
@@ -61,7 +61,6 @@
 .hostDesktop {
   box-sizing: content-box;
   inline-size: 100%;
-  padding: var(--vkui--spacing_size_m);
   margin-block: auto;
   opacity: 1;
   transition: opacity 340ms var(--vkui--animation_easing_platform);

--- a/packages/vkui/src/components/ModalOutlet/ModalOutlet.module.css
+++ b/packages/vkui/src/components/ModalOutlet/ModalOutlet.module.css
@@ -15,4 +15,5 @@
   display: flex;
   align-items: flex-start;
   justify-content: flex-start;
+  padding: var(--vkui--spacing_size_2xl);
 }

--- a/packages/vkui/src/components/ModalPage/ModalPage.module.css
+++ b/packages/vkui/src/components/ModalPage/ModalPage.module.css
@@ -31,21 +31,14 @@
 
 /* Desktop */
 .hostDesktop {
-  --vkui_internal_ModalPage--desktopStretchedSize: calc(100% - var(--vkui--spacing_size_2xl) * 2);
   --vkui_internal_ModalPage--desktopMaxWidth: 100%;
   --vkui_internal_ModalPage--desktopMaxHeight: 640px;
   --vkui_internal_ModalPage--userHeight: auto;
 
   position: relative;
   box-sizing: content-box;
-  max-inline-size: min(
-    var(--vkui_internal_ModalPage--desktopMaxWidth),
-    var(--vkui_internal_ModalPage--desktopStretchedSize)
-  );
-  max-block-size: min(
-    var(--vkui_internal_ModalPage--desktopMaxHeight),
-    var(--vkui_internal_ModalPage--desktopStretchedSize)
-  );
+  max-inline-size: var(--vkui_internal_ModalPage--desktopMaxWidth);
+  max-block-size: min(var(--vkui_internal_ModalPage--desktopMaxHeight), 100%);
   margin-block: auto;
 }
 

--- a/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPage.test.tsx
@@ -9,6 +9,7 @@ import { ConfigProvider } from '../ConfigProvider/ConfigProvider';
 import { type ModalCardProps } from '../ModalCard/types';
 import { ModalPageHeader } from '../ModalPageHeader/ModalPageHeader';
 import { ModalPage } from './ModalPage';
+import styles from './ModalPage.module.css';
 
 export const waitModalPageCSSTransitionEnd = async (el: HTMLElement) =>
   await waitCSSTransitionEnd(
@@ -245,6 +246,69 @@ describe(ModalPage, () => {
       } else {
         expect(openButton).not.toHaveFocus();
       }
+    });
+  });
+
+  describe('size prop', () => {
+    it.each([
+      ['s' as const, styles.hostDesktopMaxWidthS],
+      ['m' as const, styles.hostDesktopMaxWidthM],
+      ['l' as const, styles.hostDesktopMaxWidthL],
+    ])('applies preset class on desktop for size=%s', async (size, expectedClass) => {
+      const h = render(
+        <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET} hasPointer>
+          <ModalPage key="host" id="host" open size={size} noFocusToDialog data-testid="host" />
+        </AdaptivityProvider>,
+      );
+
+      await waitModalPageCSSTransitionEnd(h.getByTestId('host'));
+      expect(h.getByTestId('host')).toHaveClass(expectedClass);
+    });
+
+    it('sets CSS variable for custom numeric size on desktop', async () => {
+      const h = render(
+        <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET} hasPointer>
+          <ModalPage key="host" id="host" open size={500} noFocusToDialog data-testid="host" />
+        </AdaptivityProvider>,
+      );
+
+      await waitModalPageCSSTransitionEnd(h.getByTestId('host'));
+      expect(h.getByTestId('host')).toHaveStyle(
+        '--vkui_internal_ModalPage--desktopMaxWidth: 500px',
+      );
+    });
+
+    it('sets CSS variable for custom string size on desktop', async () => {
+      const h = render(
+        <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET} hasPointer>
+          <ModalPage
+            key="host"
+            id="host"
+            open
+            size="fit-content"
+            noFocusToDialog
+            data-testid="host"
+          />
+        </AdaptivityProvider>,
+      );
+
+      await waitModalPageCSSTransitionEnd(h.getByTestId('host'));
+      expect(h.getByTestId('host')).toHaveStyle(
+        '--vkui_internal_ModalPage--desktopMaxWidth: fit-content',
+      );
+    });
+
+    it('ignores size on mobile', async () => {
+      const h = render(
+        <AdaptivityProvider viewWidth={ViewWidth.SMALL_MOBILE}>
+          <ModalPage key="host" id="host" open size="l" noFocusToDialog data-testid="host" />
+        </AdaptivityProvider>,
+      );
+
+      await waitModalPageCSSTransitionEnd(h.getByTestId('host'));
+      const el = h.getByTestId('host');
+      expect(el).toHaveClass(styles.hostMobile);
+      expect(el).not.toHaveClass(styles.hostDesktopMaxWidthS);
     });
   });
 });

--- a/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
@@ -118,9 +118,9 @@ export const ModalPageInternal = ({
   const handleSheetRef = useExternRef<HTMLDivElement>(setSheetEl, ref);
   const handleSheetScrollRef = useExternRef<HTMLDivElement>(setSheetScrollEl, getModalContentRef);
 
-  const [desktopMaxWidthClassName, desktopMaxWidthStyle] = resolveDesktopMaxWidth(
-    isDesktop ? desktopMaxWidth : 's',
-  );
+  const [desktopMaxWidthClassName, desktopMaxWidthStyle] = isDesktop
+    ? resolveDesktopMaxWidth(desktopMaxWidth)
+    : [undefined, undefined];
 
   const modalOverlay = !disableModalOverlay && (
     <ModalOverlay
@@ -213,16 +213,13 @@ const desktopMaxWidthClassNames = {
 function resolveDesktopMaxWidth(
   desktopMaxWidth: ModalPageInternalProps['size'] = 's',
 ): [string | undefined, CSSCustomProperties | undefined] {
-  if (typeof desktopMaxWidth === 'string') {
-    return [desktopMaxWidthClassNames[desktopMaxWidth], undefined];
+  if (typeof desktopMaxWidth === 'number') {
+    return [undefined, { '--vkui_internal_ModalPage--desktopMaxWidth': `${desktopMaxWidth}px` }];
   }
 
-  return [
-    undefined,
-    typeof desktopMaxWidth === 'number'
-      ? { '--vkui_internal_ModalPage--desktopMaxWidth': `${desktopMaxWidth}px` }
-      : undefined,
-  ];
+  return desktopMaxWidthClassNames.hasOwnProperty(desktopMaxWidth)
+    ? [desktopMaxWidthClassNames[desktopMaxWidth], undefined]
+    : [undefined, { '--vkui_internal_ModalPage--desktopMaxWidth': desktopMaxWidth }];
 }
 
 function getHeightCSSVariable(height?: number | string): CSSCustomProperties | undefined {

--- a/packages/vkui/src/components/ModalPage/types.ts
+++ b/packages/vkui/src/components/ModalPage/types.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties, ReactNode, Ref, UIEvent } from 'react';
 import { type UseFocusTrapProps } from '../../hooks/useFocusTrap';
 import type { NavIdProps } from '../../lib/getNavId';
-import type { HTMLAttributesWithRootRef } from '../../types';
+import type { HTMLAttributesWithRootRef, LiteralUnion } from '../../types';
 
 export type ModalPageCloseReason =
   | 'click-overlay'
@@ -44,7 +44,10 @@ export interface ModalPageProps
   /**
    * Задаёт контенту максимальную ширину на десктопе.
    */
-  size?: 's' | 'm' | 'l' | number;
+  size?: LiteralUnion<
+    's' | 'm' | 'l' | 'auto' | 'fit-content' | 'max-content' | 'min-content',
+    string | number
+  >;
   /**
    * Задаёт модальному окну фиксированную высоту.
    * Можно передать числовое значение в пикселях, а можно строкой, в том числе и в процентах "50%".


### PR DESCRIPTION
- close #8817

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~
- [x] Release notes

## Описание

- Добавляем для `size` поддержку  всех свойств, которые поддерживаются CSS свойством `width`.
- Переносим "безопасные" отступы, которые добавляются для desktop версии, с `ModalPage` и `ModalCard` в `ModalOutlet` (для `ModalCard` ).

## Release notes
## Улучшения
- ModalPage: `size` теперь принимает все другие допустимые для CSS свойства `width` значения