### PR TITLE
fix(CustomSelect): fix fetching status by default

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -1560,6 +1560,27 @@ describe('CustomSelect', () => {
     expect(screen.queryByText('Список категорий загружен.')).toBeFalsy();
   });
 
+  it('check no status label by default', async () => {
+    jest.useFakeTimers();
+    const Fixture = () => (
+      <CustomSelect
+        data-testid="select"
+        fetching={false}
+        fetchingCompletedLabel="Список категорий загружен."
+        options={[
+          { value: '0', label: 'Не выбрано' },
+          { value: '1', label: 'Категория 1' },
+          { value: '2', label: 'Категория 2' },
+          { value: '3', label: 'Категория 3' },
+        ]}
+      />
+    );
+
+    render(<Fixture />);
+
+    expect(screen.queryByText('Список категорий загружен.')).toBeFalsy();
+  });
+
   it('should not call select option when not focus to option', async () => {
     const inputRef: React.RefObject<HTMLInputElement | null> = {
       current: null,

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -94,8 +94,10 @@ const FetchingStatus = ({
       if (fetching) {
         setStatus('fetching');
       } else {
-        setStatus('loaded');
-        setTimeout(() => setStatus('none'), FETCH_STATUS_RESET_DELAY);
+        if (status === 'fetching') {
+          setStatus('loaded');
+          setTimeout(() => setStatus('none'), FETCH_STATUS_RESET_DELAY);
+        }
       }
     },
     [fetching],


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- cased by #8663

---

- [x] Unit-тесты
- [x] Release notes

## Описание

В #8663 был добавлен лейбел с состояние подгрузки опций. Проблема в том, что по умолчанию при первой отрисовке выставляется лейбел с окончание загрузки опций. По идее изначально этого не должно быть

## Release notes
## Исправления
- CustomSelect: При первой отрисовке компонента озвучивался текст о том, что опции были загружены
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
