### PR TITLE
feat(Popper): add autoUpdateOnAnimationFrame prop

### DIFF
--- a/packages/vkui/src/components/Popper/Popper.tsx
+++ b/packages/vkui/src/components/Popper/Popper.tsx
@@ -84,6 +84,10 @@ export interface PopperCommonProps
    * Подписывается на изменение геометрии `targetRef`, чтобы пересчитать свою позицию.
    */
   autoUpdateOnTargetResize?: boolean;
+  /**
+   * Пытаться обновлять позицию всплывающего элемента каждый фрейм.
+   */
+  autoUpdateOnAnimationFrame?: boolean;
 }
 
 export interface PopperProps extends PopperCommonProps {
@@ -113,6 +117,7 @@ export const Popper = ({
 
   // UseFloatingProps
   autoUpdateOnTargetResize = false,
+  autoUpdateOnAnimationFrame = false,
   strategy: strategyProp,
 
   // ArrowProps
@@ -163,6 +168,7 @@ export const Popper = ({
       /* istanbul ignore next: не знаю как проверить */
       return autoUpdateFloatingElement(...args, {
         elementResize: autoUpdateOnTargetResize,
+        animationFrame: autoUpdateOnAnimationFrame,
       });
     },
   });


### PR DESCRIPTION
- close #9000

---

- [x] Документация фичи
- [x] Release notes

## Описание

Добавлен новый проп `autoUpdateOnAnimationFrame` для компонента Popper, который позволяет автоматически обновлять позицию поппера на каждом кадре анимации.

## Release notes

## Улучшения
- Popper: добавлен проп `autoUpdateOnAnimationFrame` для автоматического обновления позиции на каждом кадре анимации