### PR TITLE
fix(CalendarHeader): fix yearDropdownTestId with function

### DIFF
--- a/packages/vkui/src/components/CalendarHeader/CalendarHeader.test.tsx
+++ b/packages/vkui/src/components/CalendarHeader/CalendarHeader.test.tsx
@@ -138,11 +138,17 @@ describe('CalendarHeader', () => {
   it('fire onChange when click on year dropdown item', async () => {
     const onChange = vi.fn();
     vi.useFakeTimers();
+    const yearDropdownTestId = (year: number) => `year-picker-${year}`;
+
     const { container } = render(
-      <CalendarHeader viewDate={targetDate} onChange={onChange} yearDropdownTestId="year-picker" />,
+      <CalendarHeader
+        viewDate={targetDate}
+        onChange={onChange}
+        yearDropdownTestId={yearDropdownTestId}
+      />,
     );
 
-    const yearPicker = screen.getByTestId('year-picker');
+    const yearPicker = screen.getByTestId(yearDropdownTestId(2023));
     fireEvent.click(yearPicker);
     const [minYearSelectOption] = container.getElementsByClassName(customSelectOptionStyles.host);
     await userEvent.click(minYearSelectOption);

--- a/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
@@ -276,7 +276,11 @@ export const CalendarHeader = ({
               forceDropdownPortal={false}
               selectType="accent"
               aria-label={changeYearLabel}
-              data-testid={yearDropdownTestId}
+              data-testid={
+                typeof yearDropdownTestId === 'string'
+                  ? yearDropdownTestId
+                  : yearDropdownTestId?.(currentYear)
+              }
               onInputKeyDown={stopPropogationOfEscapeKeyboardEventWhenSelectIsOpen}
             />
           </div>


### PR DESCRIPTION
<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] Release notes

## Описание

В `CalendarHeader` не работает свойство `yearDropdownTestId` при прокидывании в виде функции

## Release notes
## Исправления
- Calendar: свойство `yearDropdownTestId` не работало при прокидывании в виде функции
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
