### PR TITLE
feat: add slotsProps

### DIFF
--- a/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
@@ -40,6 +40,7 @@ describe('Checkbox', () => {
             },
             'getRootRef': rootRef2,
             'onClick': onRootClick,
+            'Component': 'div',
           },
           input: {
             'className': 'inputClassName',
@@ -47,6 +48,7 @@ describe('Checkbox', () => {
             'data-testid': 'checkbox-2',
             'checked': false,
             'onClick': onClick2,
+            'Component': 'select',
           },
         }}
       />,
@@ -55,11 +57,13 @@ describe('Checkbox', () => {
     expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
     const input = screen.getByTestId('checkbox-2');
     expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('SELECT');
     expect(input).toHaveClass('inputClassName');
     expect(input).not.toBeChecked();
 
     const root = screen.getByTestId('root');
     expect(root).toBeInTheDocument();
+    expect(root.tagName).toBe('DIV');
     expect(root).toHaveClass('rootClassName');
     expect(root).toHaveClass('rootClassName-2');
     expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
@@ -76,7 +80,7 @@ describe('Checkbox', () => {
     expect(onClick2).toHaveBeenCalledTimes(1);
 
     fireEvent.click(root);
-    expect(onRootClick).toHaveBeenCalledTimes(3);
+    expect(onRootClick).toHaveBeenCalledTimes(2);
   });
 
   it('should work with slotsProps with CheckboxComponent', () => {
@@ -109,6 +113,7 @@ describe('Checkbox', () => {
             },
             'getRootRef': rootRef2,
             'onClick': onRootClick,
+            'Component': 'div',
           },
           input: {
             'className': 'inputClassName',
@@ -116,6 +121,7 @@ describe('Checkbox', () => {
             'data-testid': 'checkbox-2',
             'checked': false,
             'onClick': onClick2,
+            'Component': 'select',
           },
         }}
       >
@@ -126,11 +132,13 @@ describe('Checkbox', () => {
     expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
     const input = screen.getByTestId('checkbox-2');
     expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('SELECT');
     expect(input).toHaveClass('inputClassName');
     expect(input).not.toBeChecked();
 
     const root = screen.getByTestId('root');
     expect(root).toBeInTheDocument();
+    expect(root.tagName).toBe('DIV');
     expect(root).toHaveClass('rootClassName');
     expect(root).toHaveClass('rootClassName-2');
     expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
@@ -147,7 +155,7 @@ describe('Checkbox', () => {
     expect(onClick2).toHaveBeenCalledTimes(1);
 
     fireEvent.click(root);
-    expect(onRootClick).toHaveBeenCalledTimes(3);
+    expect(onRootClick).toHaveBeenCalledTimes(2);
   });
 
   it(

--- a/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import { act, useState } from 'react';
+import { act, createRef, useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import { getDocumentBody } from '../../lib/dom';
@@ -9,6 +9,147 @@ import { Checkbox } from './Checkbox';
 
 describe('Checkbox', () => {
   baselineComponent((props) => <Checkbox {...props}>Checkbox</Checkbox>);
+
+  it('should work with slotsProps with SimpleCheckbox', () => {
+    const rootRef1 = createRef<HTMLLabelElement>();
+    const rootRef2 = createRef<HTMLLabelElement>();
+    const inputRef1 = createRef<HTMLInputElement>();
+    const inputRef2 = createRef<HTMLInputElement>();
+    const onClick1 = vi.fn();
+    const onClick2 = vi.fn();
+    const onRootClick = vi.fn();
+
+    render(
+      <Checkbox
+        data-testid="checkbox"
+        className="rootClassName"
+        getRootRef={rootRef1}
+        getRef={inputRef1}
+        checked
+        onChange={noop}
+        onClick={onClick1}
+        style={{
+          backgroundColor: 'rgb(255, 0, 0)',
+        }}
+        slotsProps={{
+          root: {
+            'data-testid': 'root',
+            'className': 'rootClassName-2',
+            'style': {
+              color: 'rgb(255, 0, 0)',
+            },
+            'getRootRef': rootRef2,
+            'onClick': onRootClick,
+          },
+          input: {
+            'className': 'inputClassName',
+            'getRootRef': inputRef2,
+            'data-testid': 'checkbox-2',
+            'checked': false,
+            'onClick': onClick2,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
+    const input = screen.getByTestId('checkbox-2');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveClass('inputClassName');
+    expect(input).not.toBeChecked();
+
+    const root = screen.getByTestId('root');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('rootClassName');
+    expect(root).toHaveClass('rootClassName-2');
+    expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
+    expect(root).toHaveStyle('color: rgb(255, 0, 0)');
+
+    expect(rootRef1.current).toBe(rootRef2.current);
+    expect(rootRef1.current).toBe(root);
+
+    expect(inputRef1.current).toBe(inputRef2.current);
+    expect(inputRef1.current).toBe(input);
+
+    fireEvent.click(input);
+    expect(onClick1).toHaveBeenCalledTimes(1);
+    expect(onClick2).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(root);
+    expect(onRootClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('should work with slotsProps with CheckboxComponent', () => {
+    const rootRef1 = createRef<HTMLLabelElement>();
+    const rootRef2 = createRef<HTMLLabelElement>();
+    const inputRef1 = createRef<HTMLInputElement>();
+    const inputRef2 = createRef<HTMLInputElement>();
+    const onClick1 = vi.fn();
+    const onClick2 = vi.fn();
+    const onRootClick = vi.fn();
+
+    render(
+      <Checkbox
+        data-testid="checkbox"
+        className="rootClassName"
+        getRootRef={rootRef1}
+        getRef={inputRef1}
+        checked
+        onChange={noop}
+        onClick={onClick1}
+        style={{
+          backgroundColor: 'rgb(255, 0, 0)',
+        }}
+        slotsProps={{
+          root: {
+            'data-testid': 'root',
+            'className': 'rootClassName-2',
+            'style': {
+              color: 'rgb(255, 0, 0)',
+            },
+            'getRootRef': rootRef2,
+            'onClick': onRootClick,
+          },
+          input: {
+            'className': 'inputClassName',
+            'getRootRef': inputRef2,
+            'data-testid': 'checkbox-2',
+            'checked': false,
+            'onClick': onClick2,
+          },
+        }}
+      >
+        Checkbox
+      </Checkbox>,
+    );
+
+    expect(screen.queryByTestId('checkbox')).not.toBeInTheDocument();
+    const input = screen.getByTestId('checkbox-2');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveClass('inputClassName');
+    expect(input).not.toBeChecked();
+
+    const root = screen.getByTestId('root');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('rootClassName');
+    expect(root).toHaveClass('rootClassName-2');
+    expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
+    expect(root).toHaveStyle('color: rgb(255, 0, 0)');
+
+    expect(rootRef1.current).toBe(rootRef2.current);
+    expect(rootRef1.current).toBe(root);
+
+    expect(inputRef1.current).toBe(inputRef2.current);
+    expect(inputRef1.current).toBe(input);
+
+    fireEvent.click(input);
+    expect(onClick1).toHaveBeenCalledTimes(1);
+    expect(onClick2).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(root);
+    expect(onRootClick).toHaveBeenCalledTimes(3);
+  });
+
   it(
     'handles change',
     withFakeTimers(async () => {

--- a/packages/vkui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { hasReactNode } from '@vkontakte/vkjs';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
-import type { HasDataAttribute, HasRootRef } from '../../types';
+import type { HasComponent, HasDataAttribute, HasRootRef } from '../../types';
 import { SelectionControl } from '../SelectionControl/SelectionControl';
 import { SelectionControlLabel } from '../SelectionControl/SelectionControlLabel/SelectionControlLabel';
 import type { TappableOmitProps } from '../Tappable/Tappable';
@@ -23,8 +23,12 @@ export interface CheckboxProps
   slotsProps?: {
     root?: React.LabelHTMLAttributes<HTMLLabelElement> &
       HasRootRef<HTMLLabelElement> &
+      HasComponent &
       HasDataAttribute;
-    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
+    input?: React.ComponentProps<'input'> &
+      HasRootRef<HTMLInputElement> &
+      HasComponent &
+      HasDataAttribute;
   };
   /**
    * Подпись под основным текстом.
@@ -42,9 +46,9 @@ export interface CheckboxProps
 
 const CheckboxComponent = ({
   children,
-  className: rootClassName,
-  style: rootStyle,
-  getRootRef: rootGetRootRef,
+  className,
+  style,
+  getRootRef,
   getRef,
   description,
   hoverMode,
@@ -55,14 +59,20 @@ const CheckboxComponent = ({
   titleAfter,
   noPadding,
 
+  IconOnCompact,
+  IconOnRegular,
+  IconOffCompact,
+  IconOffRegular,
+  IconIndeterminate,
+
   slotsProps,
   ...restProps
 }: CheckboxProps): React.ReactNode => {
-  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+  const rootRest = useMergeProps(
     {
-      className: rootClassName,
-      style: rootStyle,
-      getRootRef: rootGetRootRef,
+      className,
+      style,
+      getRootRef,
     },
     slotsProps?.root,
   );
@@ -71,9 +81,6 @@ const CheckboxComponent = ({
 
   return (
     <SelectionControl
-      className={className}
-      style={style}
-      getRootRef={getRootRef}
       disabled={inputRest.disabled}
       hoverMode={hoverMode}
       activeMode={activeMode}
@@ -83,7 +90,14 @@ const CheckboxComponent = ({
       noPadding={noPadding}
       {...rootRest}
     >
-      <CheckboxInput slotsProps={{ input: inputRest }} />
+      <CheckboxInput
+        IconIndeterminate={IconIndeterminate}
+        IconOnCompact={IconOnCompact}
+        IconOnRegular={IconOnRegular}
+        IconOffCompact={IconOffCompact}
+        IconOffRegular={IconOffRegular}
+        slotsProps={{ input: inputRest }}
+      />
       <SelectionControlLabel titleAfter={titleAfter} description={description}>
         {children}
       </SelectionControlLabel>

--- a/packages/vkui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { hasReactNode } from '@vkontakte/vkjs';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
-import type { HasComponent, HasDataAttribute, HasRootRef } from '../../types';
+import type { HasDataAttribute, HasRootRef } from '../../types';
 import { SelectionControl } from '../SelectionControl/SelectionControl';
 import { SelectionControlLabel } from '../SelectionControl/SelectionControlLabel/SelectionControlLabel';
 import type { TappableOmitProps } from '../Tappable/Tappable';
@@ -18,17 +18,15 @@ export interface CheckboxProps
       'hoverMode' | 'activeMode' | 'hasHover' | 'hasActive' | 'focusVisibleMode'
     > {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `input`: свойства для прокидывания в скрытый `input`.
    */
   slotsProps?: {
-    root?: React.LabelHTMLAttributes<HTMLLabelElement> &
+    root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
-      HasComponent &
       HasDataAttribute;
-    input?: React.ComponentProps<'input'> &
-      HasRootRef<HTMLInputElement> &
-      HasComponent &
-      HasDataAttribute;
+    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
   };
   /**
    * Подпись под основным текстом.

--- a/packages/vkui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import * as React from 'react';
 import { hasReactNode } from '@vkontakte/vkjs';
-import type { HasRootRef } from '../../types';
+import { useMergeProps } from '../../hooks/useMergeProps.ts';
+import type { HasDataAttribute, HasRootRef } from '../../types';
 import { SelectionControl } from '../SelectionControl/SelectionControl';
 import { SelectionControlLabel } from '../SelectionControl/SelectionControlLabel/SelectionControlLabel';
 import type { TappableOmitProps } from '../Tappable/Tappable';
@@ -14,6 +17,15 @@ export interface CheckboxProps
       TappableOmitProps,
       'hoverMode' | 'activeMode' | 'hasHover' | 'hasActive' | 'focusVisibleMode'
     > {
+  /**
+   *
+   */
+  slotsProps?: {
+    root?: React.LabelHTMLAttributes<HTMLLabelElement> &
+      HasRootRef<HTMLLabelElement> &
+      HasDataAttribute;
+    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
+  };
   /**
    * Подпись под основным текстом.
    */
@@ -30,9 +42,10 @@ export interface CheckboxProps
 
 const CheckboxComponent = ({
   children,
-  className,
-  style,
-  getRootRef,
+  className: rootClassName,
+  style: rootStyle,
+  getRootRef: rootGetRootRef,
+  getRef,
   description,
   hoverMode,
   activeMode,
@@ -41,22 +54,36 @@ const CheckboxComponent = ({
   focusVisibleMode,
   titleAfter,
   noPadding,
+
+  slotsProps,
   ...restProps
 }: CheckboxProps): React.ReactNode => {
+  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+    {
+      className: rootClassName,
+      style: rootStyle,
+      getRootRef: rootGetRootRef,
+    },
+    slotsProps?.root,
+  );
+
+  const inputRest = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
+
   return (
     <SelectionControl
       className={className}
       style={style}
-      disabled={restProps.disabled}
       getRootRef={getRootRef}
+      disabled={inputRest.disabled}
       hoverMode={hoverMode}
       activeMode={activeMode}
       hasHover={hasHover}
       hasActive={hasActive}
       focusVisibleMode={focusVisibleMode}
       noPadding={noPadding}
+      {...rootRest}
     >
-      <CheckboxInput {...restProps} />
+      <CheckboxInput slotsProps={{ input: inputRest }} />
       <SelectionControlLabel titleAfter={titleAfter} description={description}>
         {children}
       </SelectionControlLabel>

--- a/packages/vkui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.tsx
@@ -59,6 +59,8 @@ const CheckboxComponent = ({
   titleAfter,
   noPadding,
 
+  indeterminate,
+  defaultIndeterminate,
   IconOnCompact,
   IconOnRegular,
   IconOffCompact,
@@ -91,6 +93,8 @@ const CheckboxComponent = ({
       {...rootRest}
     >
       <CheckboxInput
+        indeterminate={indeterminate}
+        defaultIndeterminate={defaultIndeterminate}
         IconIndeterminate={IconIndeterminate}
         IconOnCompact={IconOnCompact}
         IconOnRegular={IconOnRegular}

--- a/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
@@ -164,11 +164,11 @@ export function CheckboxInput({
       {...rootRest}
     >
       <VisuallyHidden
-        {...inputRest}
         Component="input"
         type="checkbox"
         onChange={handleChange}
         getRootRef={inputRef}
+        {...inputRest}
       />
       {platform === 'vkcom' ? (
         <IconOnCompact className={styles.iconOn} />

--- a/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
@@ -83,6 +83,9 @@ export function CheckboxInput({
   style,
   getRootRef,
   getRef,
+
+  indeterminate,
+  defaultIndeterminate,
   IconOnCompact = Icon20CheckBoxOn,
   IconOnRegular = Icon24CheckBoxOn,
   IconOffCompact = Icon20CheckBoxOff,
@@ -102,18 +105,10 @@ export function CheckboxInput({
   );
 
   const {
-    indeterminate,
-    defaultIndeterminate,
     onChange,
     getRootRef: getInputRef,
     ...inputRest
-  } = useMergeProps(
-    {
-      getRootRef: getRef,
-      ...restProps,
-    },
-    slotsProps?.input,
-  );
+  } = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
 
   const inputRef = useExternRef<HTMLInputElement>(getInputRef);
 

--- a/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
@@ -14,7 +14,7 @@ import { useExternRef } from '../../../hooks/useExternRef.ts';
 import { useMergeProps } from '../../../hooks/useMergeProps.ts';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { warnOnce } from '../../../lib/warnOnce';
-import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
+import type { HasDataAttribute, HasRef, HasRootRef } from '../../../types';
 import { RootComponent } from '../../RootComponent/RootComponent';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import styles from './CheckboxInput.module.css';
@@ -34,17 +34,15 @@ export interface CheckboxInputProps
     HasRootRef<HTMLDivElement>,
     HasRef<HTMLInputElement> {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `input`: свойства для прокидывания в скрытый `input`.
    */
   slotsProps?: {
-    root?: React.HTMLAttributes<HTMLElement> &
+    root?: Omit<React.HTMLAttributes<HTMLElement>, 'children'> &
       HasRootRef<HTMLElement> &
-      HasComponent &
       HasDataAttribute;
-    input?: React.ComponentProps<'input'> &
-      HasRootRef<HTMLInputElement> &
-      HasComponent &
-      HasDataAttribute;
+    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
   };
   /**
    * Неопределенное состояние чекбокса.

--- a/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxInput/CheckboxInput.tsx
@@ -14,7 +14,7 @@ import { useExternRef } from '../../../hooks/useExternRef.ts';
 import { useMergeProps } from '../../../hooks/useMergeProps.ts';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { warnOnce } from '../../../lib/warnOnce';
-import type { HasDataAttribute, HasRef, HasRootRef } from '../../../types';
+import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
 import { RootComponent } from '../../RootComponent/RootComponent';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import styles from './CheckboxInput.module.css';
@@ -37,8 +37,14 @@ export interface CheckboxInputProps
    *
    */
   slotsProps?: {
-    root?: React.HTMLAttributes<HTMLElement> & HasRootRef<HTMLElement> & HasDataAttribute;
-    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
+    root?: React.HTMLAttributes<HTMLElement> &
+      HasRootRef<HTMLElement> &
+      HasComponent &
+      HasDataAttribute;
+    input?: React.ComponentProps<'input'> &
+      HasRootRef<HTMLInputElement> &
+      HasComponent &
+      HasDataAttribute;
   };
   /**
    * Неопределенное состояние чекбокса.
@@ -73,9 +79,9 @@ export interface CheckboxInputProps
 const warn = warnOnce('Checkbox');
 
 export function CheckboxInput({
-  className: rootClassName,
-  style: rootStyle,
-  getRootRef: rootGetRootRef,
+  className,
+  style,
+  getRootRef,
   getRef,
   IconOnCompact = Icon20CheckBoxOn,
   IconOnRegular = Icon24CheckBoxOn,
@@ -86,11 +92,11 @@ export function CheckboxInput({
   slotsProps,
   ...restProps
 }: CheckboxInputProps) {
-  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+  const rootRest = useMergeProps(
     {
-      className: rootClassName,
-      style: rootStyle,
-      getRootRef: rootGetRootRef,
+      className,
+      style,
+      getRootRef,
     },
     slotsProps?.root,
   );
@@ -104,7 +110,6 @@ export function CheckboxInput({
   } = useMergeProps(
     {
       getRootRef: getRef,
-      className: styles.input,
       ...restProps,
     },
     slotsProps?.input,
@@ -156,18 +161,13 @@ export function CheckboxInput({
   }
 
   return (
-    <RootComponent
-      baseClassName={styles.host}
-      className={className}
-      style={style}
-      getRootRef={getRootRef}
-      {...rootRest}
-    >
+    <RootComponent baseClassName={styles.host} {...rootRest}>
       <VisuallyHidden
         Component="input"
         type="checkbox"
         onChange={handleChange}
         getRootRef={inputRef}
+        baseClassName={styles.input}
         {...inputRest}
       />
       {platform === 'vkcom' ? (

--- a/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
@@ -2,6 +2,7 @@
 
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../../hooks/useAdaptivity';
+import { useMergeProps } from '../../../hooks/useMergeProps.ts';
 import { Tappable } from '../../Tappable/Tappable';
 import type { CheckboxProps } from '../Checkbox';
 import { CheckboxInput } from '../CheckboxInput/CheckboxInput';
@@ -14,9 +15,10 @@ const sizeYClassNames = {
 
 export function CheckboxSimple({
   children,
-  className,
-  style,
-  getRootRef,
+  className: rootClassName,
+  style: rootStyle,
+  getRootRef: rootGetRootRef,
+  getRef,
   description,
   hoverMode: hoverModeProp,
   activeMode: activeModeProp,
@@ -25,8 +27,21 @@ export function CheckboxSimple({
   focusVisibleMode,
   titleAfter,
   noPadding,
+
+  slotsProps,
   ...restProps
 }: CheckboxProps) {
+  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+    {
+      className: rootClassName,
+      style: rootStyle,
+      getRootRef: rootGetRootRef,
+    },
+    slotsProps?.root,
+  );
+
+  const inputRest = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
+
   const { sizeY = 'none' } = useAdaptivity();
 
   const hoverMode = hoverModeProp || (noPadding ? 'opacity' : 'background');
@@ -41,7 +56,7 @@ export function CheckboxSimple({
         sizeY !== 'regular' && sizeYClassNames[sizeY],
       )}
       style={style}
-      disabled={restProps.disabled}
+      disabled={inputRest.disabled}
       getRootRef={getRootRef}
       hoverMode={hoverMode}
       activeMode={activeMode}
@@ -49,8 +64,9 @@ export function CheckboxSimple({
       hasActive={hasActive}
       focusVisibleMode={focusVisibleMode}
       Component="label"
+      {...rootRest}
     >
-      <CheckboxInput {...restProps} />
+      <CheckboxInput slotsProps={{ input: inputRest }} />
     </Tappable>
   );
 }

--- a/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
@@ -15,9 +15,9 @@ const sizeYClassNames = {
 
 export function CheckboxSimple({
   children,
-  className: rootClassName,
-  style: rootStyle,
-  getRootRef: rootGetRootRef,
+  className,
+  style,
+  getRootRef,
   getRef,
   description,
   hoverMode: hoverModeProp,
@@ -28,14 +28,20 @@ export function CheckboxSimple({
   titleAfter,
   noPadding,
 
+  IconOnCompact,
+  IconOnRegular,
+  IconOffCompact,
+  IconOffRegular,
+  IconIndeterminate,
+
   slotsProps,
   ...restProps
 }: CheckboxProps) {
-  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+  const rootRest = useMergeProps(
     {
-      className: rootClassName,
-      style: rootStyle,
-      getRootRef: rootGetRootRef,
+      className,
+      style,
+      getRootRef,
     },
     slotsProps?.root,
   );
@@ -49,15 +55,12 @@ export function CheckboxSimple({
 
   return (
     <Tappable
-      className={classNames(
-        className,
+      baseClassName={classNames(
         styles.host,
         !noPadding && styles.withPadding,
         sizeY !== 'regular' && sizeYClassNames[sizeY],
       )}
-      style={style}
       disabled={inputRest.disabled}
-      getRootRef={getRootRef}
       hoverMode={hoverMode}
       activeMode={activeMode}
       hasHover={hasHover}
@@ -66,7 +69,14 @@ export function CheckboxSimple({
       Component="label"
       {...rootRest}
     >
-      <CheckboxInput slotsProps={{ input: inputRest }} />
+      <CheckboxInput
+        IconIndeterminate={IconIndeterminate}
+        IconOnCompact={IconOnCompact}
+        IconOnRegular={IconOnRegular}
+        IconOffCompact={IconOffCompact}
+        IconOffRegular={IconOffRegular}
+        slotsProps={{ input: inputRest }}
+      />
     </Tappable>
   );
 }

--- a/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
+++ b/packages/vkui/src/components/Checkbox/CheckboxSimple/CheckboxSimple.tsx
@@ -28,6 +28,8 @@ export function CheckboxSimple({
   titleAfter,
   noPadding,
 
+  indeterminate,
+  defaultIndeterminate,
   IconOnCompact,
   IconOnRegular,
   IconOffCompact,
@@ -70,6 +72,8 @@ export function CheckboxSimple({
       {...rootRest}
     >
       <CheckboxInput
+        indeterminate={indeterminate}
+        defaultIndeterminate={defaultIndeterminate}
         IconIndeterminate={IconIndeterminate}
         IconOnCompact={IconOnCompact}
         IconOnRegular={IconOnRegular}

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -1,4 +1,5 @@
-import { act, useState } from 'react';
+import * as React from 'react';
+import { act, createRef, useState } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
 import type { Placement, useFloating } from '../../lib/floating';
@@ -92,6 +93,95 @@ describe('CustomSelect', () => {
   baselineComponent((props) => (
     <CustomSelect aria-label="Choose your user" {...props} options={[]} />
   ));
+
+  it(
+    'should work with slotsProps',
+    withFakeTimers(() => {
+      const rootRef1 = createRef<HTMLDivElement>();
+      const rootRef2 = createRef<HTMLDivElement>();
+      const selectRef1 = createRef<HTMLSelectElement>();
+      const selectRef2 = createRef<HTMLSelectElement>();
+      const inputRef1 = createRef<HTMLInputElement>();
+      const inputRef2 = createRef<HTMLInputElement>();
+
+      render(
+        <CustomSelect
+          options={[
+            { value: 0, label: 'Mike' },
+            { value: 1, label: 'Josh' },
+          ]}
+          defaultValue={0}
+          data-testid="input"
+          required
+          className="rootClassName"
+          getRootRef={rootRef1}
+          getRef={selectRef1}
+          getSelectInputRef={inputRef1}
+          style={{
+            backgroundColor: 'rgb(255, 0, 0)',
+          }}
+          slotsProps={{
+            root: {
+              'data-testid': 'root',
+              'className': 'rootClassName-2',
+              'style': {
+                color: 'rgb(255, 0, 0)',
+              },
+              'getRootRef': rootRef2,
+            },
+            select: {
+              'className': 'selectClassName',
+              'getRootRef': selectRef2,
+              'data-testid': 'select-2',
+              'required': false,
+              'style': {
+                color: 'rgb(255, 0, 0)',
+              },
+            },
+            input: {
+              'getRootRef': inputRef2,
+              'data-testid': 'input-2',
+              'className': 'inputClassName',
+              'style': {
+                color: 'rgb(255, 0, 0)',
+              },
+            },
+          }}
+        />,
+      );
+
+      const select = screen.getByTestId('select-2');
+      expect(select).toBeInTheDocument();
+      expect(select.tagName).toBe('SELECT');
+      expect(select).toHaveClass('selectClassName');
+      expect(select).toHaveStyle('color: rgb(255, 0, 0)');
+      expect(select).not.toHaveAttribute('required');
+
+      const root = screen.getByTestId('root');
+      expect(root.tagName).toBe('DIV');
+      expect(root).toBeInTheDocument();
+      expect(root).toHaveClass('rootClassName');
+      expect(root).toHaveClass('rootClassName-2');
+      expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
+      expect(root).toHaveStyle('color: rgb(255, 0, 0)');
+
+      expect(screen.queryByTestId('input')).not.toBeInTheDocument();
+      const input = screen.getByTestId('input-2');
+      expect(input.tagName).toBe('INPUT');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveClass('inputClassName');
+      expect(input).toHaveStyle('color: rgb(255, 0, 0)');
+
+      expect(rootRef1.current).toBe(rootRef2.current);
+      expect(rootRef1.current).toBe(root);
+
+      expect(selectRef1.current).toBe(selectRef2.current);
+      expect(selectRef1.current).toBe(select);
+
+      expect(inputRef1.current).toBe(inputRef2.current);
+      expect(inputRef1.current).toBe(input);
+    }),
+  );
 
   it('Does not explode on NaN value', () => {
     vi.spyOn(global.console, 'error').mockImplementationOnce((message) => {

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -96,13 +96,17 @@ describe('CustomSelect', () => {
 
   it(
     'should work with slotsProps',
-    withFakeTimers(() => {
+    withFakeTimers(async () => {
       const rootRef1 = createRef<HTMLDivElement>();
       const rootRef2 = createRef<HTMLDivElement>();
       const selectRef1 = createRef<HTMLSelectElement>();
       const selectRef2 = createRef<HTMLSelectElement>();
       const inputRef1 = createRef<HTMLInputElement>();
       const inputRef2 = createRef<HTMLInputElement>();
+
+      const onRootClick = vi.fn();
+      const onInputClick = vi.fn();
+      const onSelectClick = vi.fn();
 
       render(
         <CustomSelect
@@ -128,6 +132,7 @@ describe('CustomSelect', () => {
                 color: 'rgb(255, 0, 0)',
               },
               'getRootRef': rootRef2,
+              'onClick': onRootClick,
             },
             select: {
               'className': 'selectClassName',
@@ -137,6 +142,7 @@ describe('CustomSelect', () => {
               'style': {
                 color: 'rgb(255, 0, 0)',
               },
+              'onClick': onSelectClick,
             },
             input: {
               'getRootRef': inputRef2,
@@ -145,6 +151,7 @@ describe('CustomSelect', () => {
               'style': {
                 color: 'rgb(255, 0, 0)',
               },
+              'onClick': onInputClick,
             },
           }}
         />,
@@ -180,6 +187,17 @@ describe('CustomSelect', () => {
 
       expect(inputRef1.current).toBe(inputRef2.current);
       expect(inputRef1.current).toBe(input);
+
+      fireEvent.click(input);
+      await act(async () => vi.runOnlyPendingTimers());
+      expect(onInputClick).toHaveBeenCalledOnce();
+
+      fireEvent.click(select);
+      expect(onSelectClick).toHaveBeenCalledOnce();
+
+      fireEvent.click(root);
+      await act(async () => vi.runOnlyPendingTimers());
+      expect(onRootClick).toHaveBeenCalledTimes(5);
     }),
   );
 

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -19,8 +19,12 @@ import {
 } from '../CustomSelectDropdown/CustomSelectDropdown';
 import { CustomSelectOption } from '../CustomSelectOption/CustomSelectOption';
 import type { FormFieldProps } from '../FormField/FormField';
-import type { NativeSelectProps, SelectValue } from '../NativeSelect/NativeSelect';
-import { NOT_SELECTED, remapFromNativeValueToSelectValue } from '../NativeSelect/NativeSelect';
+import {
+  type NativeSelectProps,
+  NOT_SELECTED,
+  remapFromNativeValueToSelectValue,
+  type SelectValue,
+} from '../NativeSelect/NativeSelect';
 import { RootComponent } from '../RootComponent/RootComponent.tsx';
 import type { SelectType } from '../Select/Select';
 import { Footnote } from '../Typography/Footnote/Footnote';
@@ -667,7 +671,6 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const selectRest = useMergeProps(
     {
       getRootRef: selectElRef,
-      onChange: onNativeSelectChange,
       onBlur: props.onBlur,
       onFocus: props.onFocus,
       onClick: props.onClick,
@@ -675,16 +678,26 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     slotsProps?.select,
   );
 
+  // Приводим типы так как в CustomSelect типы в rest определены как React.SelectHTMLAttributes<HTMLSelectElement>
+  // Хотя эти свойства прокидываются в input
+  const typedOnInputKeyDownProp =
+    onKeyDownProp as unknown as React.KeyboardEventHandler<HTMLInputElement>;
+  const typedOnInputClickProp = onClickProp as unknown as React.MouseEventHandler<HTMLInputElement>;
+
   const inputRest = useMergeProps(
     {
       getRootRef: selectInputRef,
       onChange: onInputChange,
       onFocus: callMultiple(onFocus, onFocusProp),
       onBlur: callMultiple(onBlur, onFocusProp),
-      onKeyDown: !readOnly ? callMultiple(onInputKeyDown, onKeyDownProp) : onKeyDownProp,
-      onClick: !readOnly ? callMultiple(toggleOpened, onClickProp) : onClickProp,
+      onKeyDown: !readOnly
+        ? callMultiple(onInputKeyDown, typedOnInputKeyDownProp)
+        : typedOnInputKeyDownProp,
+      onClick: !readOnly
+        ? callMultiple(toggleOpened, typedOnInputClickProp)
+        : typedOnInputClickProp,
       className: openedClassNames,
-      ...restProps,
+      ...(restProps as React.InputHTMLAttributes<HTMLInputElement>),
     },
     slotsProps?.input,
   );
@@ -735,6 +748,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         aria-hidden
         data-testid={nativeSelectTestId}
         required={required}
+        onChange={onNativeSelectChange}
         {...selectRest}
       >
         {(allowClearButton || nativeSelectValue === NOT_SELECTED.NATIVE) && (

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -12,7 +12,7 @@ import type { Placement } from '../../lib/floating';
 import { defaultFilterFn, type FilterFn } from '../../lib/select';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { preventDefault } from '../../lib/utils';
-import { type HasDataAttribute, type HasRootRef } from '../../types';
+import { type HasComponent, type HasDataAttribute, type HasRootRef } from '../../types';
 import {
   CustomSelectDropdown,
   type CustomSelectDropdownProps,
@@ -21,6 +21,7 @@ import { CustomSelectOption } from '../CustomSelectOption/CustomSelectOption';
 import type { FormFieldProps } from '../FormField/FormField';
 import type { NativeSelectProps, SelectValue } from '../NativeSelect/NativeSelect';
 import { NOT_SELECTED, remapFromNativeValueToSelectValue } from '../NativeSelect/NativeSelect';
+import { RootComponent } from '../RootComponent/RootComponent.tsx';
 import type { SelectType } from '../Select/Select';
 import { Footnote } from '../Typography/Footnote/Footnote';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
@@ -122,6 +123,7 @@ export interface SelectProps<
   slotsProps?: NativeSelectProps['slotsProps'] & {
     input?: React.InputHTMLAttributes<HTMLInputElement> &
       HasDataAttribute &
+      HasComponent &
       HasRootRef<HTMLInputElement>;
   };
   /**
@@ -650,7 +652,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     lastMousePositionRef.current = { x: e.clientX, y: e.clientY };
   };
 
-  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+  const rootRest = useMergeProps(
     {
       style: rootStyle,
       className: rootClassName,
@@ -662,19 +664,18 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     slotsProps?.root,
   );
 
-  const { getRootRef: getSelectRef, ...selectRest } = useMergeProps(
+  const selectRest = useMergeProps(
     {
       getRootRef: selectElRef,
       onChange: onNativeSelectChange,
       onBlur: props.onBlur,
       onFocus: props.onFocus,
       onClick: props.onClick,
-      className: styles.control,
     },
     slotsProps?.select,
   );
 
-  const { disabled, ...inputRest } = useMergeProps(
+  const inputRest = useMergeProps(
     {
       getRootRef: selectInputRef,
       onChange: onInputChange,
@@ -689,10 +690,8 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   );
 
   return (
-    <div
-      className={classNames(styles.host, sizeY !== 'regular' && sizeYClassNames[sizeY], className)}
-      style={style}
-      ref={getRootRef}
+    <RootComponent
+      baseClassName={classNames(styles.host, sizeY !== 'regular' && sizeYClassNames[sizeY])}
       {...rootRest}
     >
       <CustomSelectInput
@@ -712,7 +711,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         status={status}
         placeholder={placeholder}
         multiline={multiline}
-        disabled={disabled}
+        disabled={inputRest.disabled}
         labelTextTestId={labelTextTestId}
         slotsProps={{
           input: { ...selectInputAriaProps, ...inputRest },
@@ -727,9 +726,10 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         fetchingInProgressLabel={fetchingInProgressLabel}
         fetchingCompletedLabel={fetchingCompletedLabel}
       />
-      <select
+      <RootComponent
+        Component="select"
+        baseClassName={styles.control}
         tabIndex={-1}
-        ref={getSelectRef}
         name={name}
         value={nativeSelectValue}
         aria-hidden
@@ -743,7 +743,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         {options.map((item) => (
           <option key={`${item.value}`} value={item.value} />
         ))}
-      </select>
+      </RootComponent>
       {opened && (
         <CustomSelectDropdown
           targetRef={containerRef}
@@ -765,6 +765,6 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
           {resolvedContent}
         </CustomSelectDropdown>
       )}
-    </div>
+    </RootComponent>
   );
 }

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -12,7 +12,7 @@ import type { Placement } from '../../lib/floating';
 import { defaultFilterFn, type FilterFn } from '../../lib/select';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
 import { preventDefault } from '../../lib/utils';
-import { type HasComponent, type HasDataAttribute, type HasRootRef } from '../../types';
+import { type HasDataAttribute, type HasRootRef } from '../../types';
 import {
   CustomSelectDropdown,
   type CustomSelectDropdownProps,
@@ -122,12 +122,14 @@ export interface SelectProps<
     Pick<CustomSelectDropdownProps, 'overscrollBehavior'>,
     Pick<CustomSelectInputProps, 'minLength' | 'maxLength' | 'pattern' | 'readOnly'> {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `select`: свойства для прокидывания в нативный `select`;
+   * - `input`: свойства для прокидывания в нативный `input`.
    */
   slotsProps?: NativeSelectProps['slotsProps'] & {
     input?: React.InputHTMLAttributes<HTMLInputElement> &
       HasDataAttribute &
-      HasComponent &
       HasRootRef<HTMLInputElement>;
   };
   /**

--- a/packages/vkui/src/components/CustomSelect/CustomSelectInput/CustomSelectInput.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelectInput/CustomSelectInput.tsx
@@ -30,11 +30,11 @@ export interface CustomSelectInputProps
     Omit<FormFieldProps, 'mode' | 'type' | 'maxHeight'> {
   slotsProps?: {
     input?: React.InputHTMLAttributes<HTMLInputElement> &
-      HasRef<HTMLInputElement> &
+      HasRootRef<HTMLInputElement> &
       HasComponent &
       HasDataAttribute;
     root?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> &
-      HasRef<HTMLDivElement> &
+      HasRootRef<HTMLDivElement> &
       HasComponent &
       HasDataAttribute;
   };
@@ -94,6 +94,20 @@ export const CustomSelectInput = ({
     slotsProps?.input,
   );
 
+  const {
+    style,
+    className,
+    getRootRef: rootRef,
+    ...rootRest
+  } = useMergeProps(
+    {
+      style: rootStyle,
+      className: rootClassName,
+      getRootRef: handleRootRef,
+    },
+    slotsProps?.root,
+  );
+
   const input = (
     <Text
       type="text"
@@ -118,20 +132,6 @@ export const CustomSelectInput = ({
   }, [accessible, fetching, focusWithin, inputReadonly, searchable]);
 
   const labelHidden = showLabelOrPlaceholder ? false : !inputHidden;
-
-  const {
-    style,
-    className,
-    getRootRef: rootRef,
-    ...rootRest
-  } = useMergeProps(
-    {
-      style: rootStyle,
-      className: rootClassName,
-      getRootRef: handleRootRef,
-    },
-    slotsProps?.root,
-  );
 
   const platform = usePlatform();
   return (

--- a/packages/vkui/src/components/CustomSelect/CustomSelectInput/CustomSelectInput.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelectInput/CustomSelectInput.tsx
@@ -9,7 +9,7 @@ import { useFocusWithin } from '../../../hooks/useFocusWithin';
 import { useMergeProps } from '../../../hooks/useMergeProps';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { getFormFieldModeFromSelectType } from '../../../lib/select';
-import type { HasAlign, HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
+import type { HasAlign, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
 import { FormField, type FormFieldProps } from '../../FormField/FormField';
 import type { SelectType } from '../../Select/Select';
 import { SelectTypography } from '../../SelectTypography/SelectTypography';
@@ -31,11 +31,9 @@ export interface CustomSelectInputProps
   slotsProps?: {
     input?: React.InputHTMLAttributes<HTMLInputElement> &
       HasRootRef<HTMLInputElement> &
-      HasComponent &
       HasDataAttribute;
     root?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> &
       HasRootRef<HTMLDivElement> &
-      HasComponent &
       HasDataAttribute;
   };
   selectType?: SelectType;

--- a/packages/vkui/src/components/CustomSelect/CustomSelectInput/CustomSelectInput.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelectInput/CustomSelectInput.tsx
@@ -9,7 +9,7 @@ import { useFocusWithin } from '../../../hooks/useFocusWithin';
 import { useMergeProps } from '../../../hooks/useMergeProps';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { getFormFieldModeFromSelectType } from '../../../lib/select';
-import type { HasAlign, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
+import type { HasAlign, HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
 import { FormField, type FormFieldProps } from '../../FormField/FormField';
 import type { SelectType } from '../../Select/Select';
 import { SelectTypography } from '../../SelectTypography/SelectTypography';
@@ -31,9 +31,11 @@ export interface CustomSelectInputProps
   slotsProps?: {
     input?: React.InputHTMLAttributes<HTMLInputElement> &
       HasRef<HTMLInputElement> &
+      HasComponent &
       HasDataAttribute;
     root?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> &
       HasRef<HTMLDivElement> &
+      HasComponent &
       HasDataAttribute;
   };
   selectType?: SelectType;

--- a/packages/vkui/src/components/File/File.test.tsx
+++ b/packages/vkui/src/components/File/File.test.tsx
@@ -1,6 +1,73 @@
+import { createRef } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { baselineComponent } from '../../testing/utils';
 import { File } from './File';
 
 describe('File', () => {
   baselineComponent(File);
+
+  it('should work with slotsProps', () => {
+    const rootRef1 = createRef<HTMLLabelElement>();
+    const rootRef2 = createRef<HTMLLabelElement>();
+    const inputRef1 = createRef<HTMLInputElement>();
+    const inputRef2 = createRef<HTMLInputElement>();
+    const onClick1 = vi.fn();
+    const onClick2 = vi.fn();
+    const onRootClick = vi.fn();
+
+    render(
+      <File
+        data-testid="file"
+        className="rootClassName"
+        getRootRef={rootRef1}
+        getRef={inputRef1}
+        onClick={onClick1}
+        style={{
+          backgroundColor: 'rgb(255, 0, 0)',
+        }}
+        slotsProps={{
+          root: {
+            'data-testid': 'root',
+            'className': 'rootClassName-2',
+            'style': {
+              color: 'rgb(255, 0, 0)',
+            },
+            'getRootRef': rootRef2,
+            'onClick': onRootClick,
+          },
+          input: {
+            'className': 'inputClassName',
+            'getRootRef': inputRef2,
+            'data-testid': 'file-2',
+            'onClick': onClick2,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('file')).not.toBeInTheDocument();
+    const input = screen.getByTestId('file-2');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveClass('inputClassName');
+
+    const root = screen.getByTestId('root');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('rootClassName');
+    expect(root).toHaveClass('rootClassName-2');
+    expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
+    expect(root).toHaveStyle('color: rgb(255, 0, 0)');
+
+    expect(rootRef1.current).toBe(rootRef2.current);
+    expect(rootRef1.current).toBe(root);
+
+    expect(inputRef1.current).toBe(inputRef2.current);
+    expect(inputRef1.current).toBe(input);
+
+    fireEvent.click(input);
+    expect(onClick1).toHaveBeenCalledTimes(1);
+    expect(onClick2).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(root);
+    expect(onRootClick).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/vkui/src/components/File/File.test.tsx
+++ b/packages/vkui/src/components/File/File.test.tsx
@@ -34,12 +34,14 @@ describe('File', () => {
             },
             'getRootRef': rootRef2,
             'onClick': onRootClick,
+            'Component': 'div',
           },
           input: {
             'className': 'inputClassName',
             'getRootRef': inputRef2,
             'data-testid': 'file-2',
             'onClick': onClick2,
+            'Component': 'select',
           },
         }}
       />,
@@ -47,11 +49,13 @@ describe('File', () => {
 
     expect(screen.queryByTestId('file')).not.toBeInTheDocument();
     const input = screen.getByTestId('file-2');
+    expect(input.tagName).toBe('SELECT');
     expect(input).toBeInTheDocument();
     expect(input).toHaveClass('inputClassName');
 
     const root = screen.getByTestId('root');
     expect(root).toBeInTheDocument();
+    expect(root.tagName).toBe('DIV');
     expect(root).toHaveClass('rootClassName');
     expect(root).toHaveClass('rootClassName-2');
     expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
@@ -68,6 +72,6 @@ describe('File', () => {
     expect(onClick2).toHaveBeenCalledTimes(1);
 
     fireEvent.click(root);
-    expect(onRootClick).toHaveBeenCalledTimes(3);
+    expect(onRootClick).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/vkui/src/components/File/File.tsx
+++ b/packages/vkui/src/components/File/File.tsx
@@ -50,7 +50,7 @@ export const File = ({
     {
       className,
       style,
-      getRootRef,
+      getRootRef: getRootRef as React.Ref<HTMLLabelElement>,
     },
     slotsProps?.root,
   );

--- a/packages/vkui/src/components/File/File.tsx
+++ b/packages/vkui/src/components/File/File.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
-import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { Button, type VKUIButtonProps } from '../Button/Button';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
@@ -17,9 +17,11 @@ export interface FileProps
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
+      HasComponent &
       HasDataAttribute;
     input?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> &
       HasRootRef<HTMLInputElement> &
+      HasComponent &
       HasDataAttribute;
   };
 }
@@ -28,9 +30,9 @@ export interface FileProps
  * @see https://vkui.io/components/file
  */
 export const File = ({
-  getRootRef: rootGetRootRef,
-  className: rootClassName,
-  style: rootStyle,
+  getRootRef,
+  className,
+  style,
   children = 'Выберите файл',
   align = 'left',
   size,
@@ -44,24 +46,20 @@ export const File = ({
   slotsProps,
   ...restProps
 }: FileProps): React.ReactNode => {
-  const { className, style, getRootRef, ...rootProps } = useMergeProps(
+  const rootProps = useMergeProps(
     {
-      className: rootClassName,
-      style: rootStyle,
-      getRootRef: rootGetRootRef,
+      className,
+      style,
+      getRootRef,
     },
     slotsProps?.root,
   );
-  const { disabled, ...inputRest } = useMergeProps(
-    { getRootRef: getRef, ...restProps },
-    slotsProps?.input,
-  );
+  const inputRest = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
 
   return (
     <Button
       Component="label"
       align={align}
-      className={className}
       stretched={stretched}
       mode={mode}
       appearance={appearance}
@@ -69,12 +67,10 @@ export const File = ({
       before={before}
       after={after}
       loading={loading}
-      style={style}
-      getRootRef={getRootRef}
-      disabled={disabled}
+      disabled={inputRest.disabled}
       {...rootProps}
     >
-      <VisuallyHidden title="" {...inputRest} Component="input" type="file" disabled={disabled} />
+      <VisuallyHidden title="" Component="input" type="file" {...inputRest} />
       {children}
     </Button>
   );

--- a/packages/vkui/src/components/File/File.tsx
+++ b/packages/vkui/src/components/File/File.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
-import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { Button, type VKUIButtonProps } from '../Button/Button';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
@@ -12,16 +12,16 @@ export interface FileProps
     HasRef<HTMLInputElement>,
     HasRootRef<HTMLElement> {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `input`: свойства для прокидывания в скрытый `input`.
    */
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
-      HasComponent &
       HasDataAttribute;
     input?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> &
       HasRootRef<HTMLInputElement> &
-      HasComponent &
       HasDataAttribute;
   };
 }

--- a/packages/vkui/src/components/File/File.tsx
+++ b/packages/vkui/src/components/File/File.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import * as React from 'react';
-import type { HasRef, HasRootRef } from '../../types';
+import { useMergeProps } from '../../hooks/useMergeProps.ts';
+import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { Button, type VKUIButtonProps } from '../Button/Button';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
@@ -7,12 +10,27 @@ export interface FileProps
   extends Omit<VKUIButtonProps, 'type'>,
     Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'>,
     HasRef<HTMLInputElement>,
-    HasRootRef<HTMLElement> {}
+    HasRootRef<HTMLElement> {
+  /**
+   *
+   */
+  slotsProps?: {
+    root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
+      HasRootRef<HTMLLabelElement> &
+      HasDataAttribute;
+    input?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> &
+      HasRootRef<HTMLInputElement> &
+      HasDataAttribute;
+  };
+}
 
 /**
  * @see https://vkui.io/components/file
  */
 export const File = ({
+  getRootRef: rootGetRootRef,
+  className: rootClassName,
+  style: rootStyle,
   children = 'Выберите файл',
   align = 'left',
   size,
@@ -21,13 +39,24 @@ export const File = ({
   before,
   after,
   loading,
-  className,
-  style,
   getRef,
-  getRootRef,
   appearance,
+  slotsProps,
   ...restProps
 }: FileProps): React.ReactNode => {
+  const { className, style, getRootRef, ...rootProps } = useMergeProps(
+    {
+      className: rootClassName,
+      style: rootStyle,
+      getRootRef: rootGetRootRef,
+    },
+    slotsProps?.root,
+  );
+  const { disabled, ...inputRest } = useMergeProps(
+    { getRootRef: getRef, ...restProps },
+    slotsProps?.input,
+  );
+
   return (
     <Button
       Component="label"
@@ -42,9 +71,10 @@ export const File = ({
       loading={loading}
       style={style}
       getRootRef={getRootRef}
-      disabled={restProps.disabled}
+      disabled={disabled}
+      {...rootProps}
     >
-      <VisuallyHidden title="" {...restProps} Component="input" type="file" getRootRef={getRef} />
+      <VisuallyHidden title="" {...inputRest} Component="input" type="file" disabled={disabled} />
       {children}
     </Button>
   );

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.test.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.test.tsx
@@ -1,5 +1,7 @@
+import { createRef } from 'react';
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { noop } from '@vkontakte/vkjs';
 import {
   baselineComponent,
   fakeTimersForScope,
@@ -20,6 +22,75 @@ describe('NativeSelect', () => {
       </NativeSelect>
     </>
   ));
+
+  it('should work with slotsProps', () => {
+    const rootRef1 = createRef<HTMLDivElement>();
+    const rootRef2 = createRef<HTMLDivElement>();
+    const selectRef1 = createRef<HTMLSelectElement>();
+    const selectRef2 = createRef<HTMLSelectElement>();
+    const onClick1 = vi.fn();
+    const onClick2 = vi.fn();
+    const onRootClick = vi.fn();
+
+    render(
+      <NativeSelect
+        data-testid="select"
+        className="rootClassName"
+        getRootRef={rootRef1}
+        getRef={selectRef1}
+        required
+        onChange={noop}
+        onClick={onClick1}
+        style={{
+          backgroundColor: 'rgb(255, 0, 0)',
+        }}
+        slotsProps={{
+          root: {
+            'data-testid': 'root',
+            'className': 'rootClassName-2',
+            'style': {
+              color: 'rgb(255, 0, 0)',
+            },
+            'getRootRef': rootRef2,
+            'onClick': onRootClick,
+          },
+          select: {
+            'className': 'inputClassName',
+            'getRootRef': selectRef2,
+            'data-testid': 'select-2',
+            'required': false,
+            'onClick': onClick2,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('select')).not.toBeInTheDocument();
+    const input = screen.getByTestId('select-2');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveClass('inputClassName');
+    expect(input).not.toBeChecked();
+
+    const root = screen.getByTestId('root');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('rootClassName');
+    expect(root).toHaveClass('rootClassName-2');
+    expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
+    expect(root).toHaveStyle('color: rgb(255, 0, 0)');
+
+    expect(rootRef1.current).toBe(rootRef2.current);
+    expect(rootRef1.current).toBe(root);
+
+    expect(selectRef1.current).toBe(selectRef2.current);
+    expect(selectRef1.current).toBe(input);
+
+    fireEvent.click(input);
+    expect(onClick1).toHaveBeenCalledTimes(1);
+    expect(onClick2).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(root);
+    expect(onRootClick).toHaveBeenCalledTimes(2);
+  });
 
   it(
     'works correctly with value and onChange',

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -43,7 +43,7 @@ export const remapFromSelectValueToNativeValue = (value: SelectValue): NativeSel
 export const remapFromNativeValueToSelectValue = (value: NativeSelectValue): SelectValue =>
   value === NOT_SELECTED.NATIVE ? NOT_SELECTED.CUSTOM : value;
 
-type NativeHTMLSelectProps = Omit<
+export type NativeHTMLSelectProps = Omit<
   React.SelectHTMLAttributes<HTMLSelectElement>,
   'multiple' | 'value' | 'defaultValue' | 'onChange'
 >;
@@ -157,14 +157,7 @@ export const NativeSelect = ({
     slotsProps?.root,
   );
 
-  const selectRest = useMergeProps(
-    {
-      getRootRef: selectRef,
-      onChange: callMultiple(_onChange, checkSelectedOption, onChange),
-      ...restProps,
-    },
-    slotsProps?.select,
-  );
+  const selectRest = useMergeProps({ getRootRef: selectRef, ...restProps }, slotsProps?.select);
 
   return (
     <FormField
@@ -198,6 +191,7 @@ export const NativeSelect = ({
             ? remapFromSelectValueToNativeValue(defaultValue)
             : defaultValue
         }
+        onChange={callMultiple(_onChange, checkSelectedOption)}
         {...selectRest}
       >
         {placeholder && <option value={NOT_SELECTED.NATIVE}>{placeholder}</option>}

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -9,7 +9,7 @@ import { useMergeProps } from '../../hooks/useMergeProps';
 import { callMultiple } from '../../lib/callMultiple';
 import { getFormFieldModeFromSelectType } from '../../lib/select';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
-import type { HasAlign, HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasAlign, HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { DropdownIcon } from '../DropdownIcon/DropdownIcon';
 import { FormField, type FormFieldProps } from '../FormField/FormField';
 import { RootComponent } from '../RootComponent/RootComponent.tsx';
@@ -55,17 +55,15 @@ export interface NativeSelectProps
     HasAlign,
     Pick<FormFieldProps, 'before' | 'status'> {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `select`: свойства для прокидывания в нативный `select`.
    */
   slotsProps?: {
     root?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> &
       HasDataAttribute &
-      HasComponent &
       HasRootRef<HTMLDivElement>;
-    select?: NativeHTMLSelectProps &
-      HasRootRef<HTMLSelectElement> &
-      HasComponent &
-      HasDataAttribute;
+    select?: NativeHTMLSelectProps & HasRootRef<HTMLSelectElement> & HasDataAttribute;
   };
   /**
    * Выбранное значение.

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -9,9 +9,10 @@ import { useMergeProps } from '../../hooks/useMergeProps';
 import { callMultiple } from '../../lib/callMultiple';
 import { getFormFieldModeFromSelectType } from '../../lib/select';
 import { useIsomorphicLayoutEffect } from '../../lib/useIsomorphicLayoutEffect';
-import type { HasAlign, HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasAlign, HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { DropdownIcon } from '../DropdownIcon/DropdownIcon';
 import { FormField, type FormFieldProps } from '../FormField/FormField';
+import { RootComponent } from '../RootComponent/RootComponent.tsx';
 import type { SelectType } from '../Select/Select';
 import { SelectTypography } from '../SelectTypography/SelectTypography';
 import styles from '../Select/Select.module.css';
@@ -59,8 +60,12 @@ export interface NativeSelectProps
   slotsProps?: {
     root?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> &
       HasDataAttribute &
+      HasComponent &
       HasRootRef<HTMLDivElement>;
-    select?: NativeHTMLSelectProps & HasDataAttribute & HasRootRef<HTMLSelectElement>;
+    select?: NativeHTMLSelectProps &
+      HasRootRef<HTMLSelectElement> &
+      HasComponent &
+      HasDataAttribute;
   };
   /**
    * Выбранное значение.
@@ -118,7 +123,6 @@ export const NativeSelect = ({
   onChange,
   value,
   defaultValue,
-  onChange: onChangeProp,
 
   slotsProps,
   ...restProps
@@ -153,15 +157,10 @@ export const NativeSelect = ({
     slotsProps?.root,
   );
 
-  const {
-    disabled,
-    getRootRef: getSelectRef,
-    ...selectRest
-  } = useMergeProps(
+  const selectRest = useMergeProps(
     {
       getRootRef: selectRef,
-      className: styles.el,
-      onChange: callMultiple(_onChange, checkSelectedOption, onChangeProp),
+      onChange: callMultiple(_onChange, checkSelectedOption, onChange),
       ...restProps,
     },
     slotsProps?.select,
@@ -183,27 +182,27 @@ export const NativeSelect = ({
       )}
       style={style}
       getRootRef={getRootRef}
-      disabled={disabled}
+      disabled={selectRest.disabled}
       before={before}
       after={icon}
       status={status}
       mode={getFormFieldModeFromSelectType(selectType)}
       {...rootRest}
     >
-      <select
+      <RootComponent
+        Component="select"
+        baseClassName={styles.el}
         value={value !== undefined ? remapFromSelectValueToNativeValue(value) : value}
         defaultValue={
           defaultValue !== undefined
             ? remapFromSelectValueToNativeValue(defaultValue)
             : defaultValue
         }
-        disabled={disabled}
-        ref={getSelectRef}
         {...selectRest}
       >
         {placeholder && <option value={NOT_SELECTED.NATIVE}>{placeholder}</option>}
         {children}
-      </select>
+      </RootComponent>
       <div className={styles.container} aria-hidden>
         <SelectTypography className={styles.title} selectType={selectType}>
           {title}

--- a/packages/vkui/src/components/Radio/Radio.test.tsx
+++ b/packages/vkui/src/components/Radio/Radio.test.tsx
@@ -1,5 +1,7 @@
+import { createRef } from 'react';
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { noop } from '@vkontakte/vkjs';
 import { baselineComponent } from '../../testing/utils';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { Radio } from './Radio';
@@ -13,6 +15,75 @@ describe('Radio', () => {
       <Radio aria-labelledby="radio" {...props} />
     </>
   ));
+
+  it('should work with slotsProps', () => {
+    const rootRef1 = createRef<HTMLLabelElement>();
+    const rootRef2 = createRef<HTMLLabelElement>();
+    const inputRef1 = createRef<HTMLInputElement>();
+    const inputRef2 = createRef<HTMLInputElement>();
+    const onClick1 = vi.fn();
+    const onClick2 = vi.fn();
+    const onRootClick = vi.fn();
+
+    render(
+      <Radio
+        data-testid="radio"
+        className="rootClassName"
+        getRootRef={rootRef1}
+        getRef={inputRef1}
+        checked
+        onChange={noop}
+        onClick={onClick1}
+        style={{
+          backgroundColor: 'rgb(255, 0, 0)',
+        }}
+        slotsProps={{
+          root: {
+            'data-testid': 'root',
+            'className': 'rootClassName-2',
+            'style': {
+              color: 'rgb(255, 0, 0)',
+            },
+            'getRootRef': rootRef2,
+            'onClick': onRootClick,
+          },
+          input: {
+            'className': 'inputClassName',
+            'getRootRef': inputRef2,
+            'data-testid': 'radio-2',
+            'checked': false,
+            'onClick': onClick2,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('radio')).not.toBeInTheDocument();
+    const input = screen.getByTestId('radio-2');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveClass('inputClassName');
+    expect(input).not.toBeChecked();
+
+    const root = screen.getByTestId('root');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('rootClassName');
+    expect(root).toHaveClass('rootClassName-2');
+    expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
+    expect(root).toHaveStyle('color: rgb(255, 0, 0)');
+
+    expect(rootRef1.current).toBe(rootRef2.current);
+    expect(rootRef1.current).toBe(root);
+
+    expect(inputRef1.current).toBe(inputRef2.current);
+    expect(inputRef1.current).toBe(input);
+
+    fireEvent.click(input);
+    expect(onClick1).toHaveBeenCalledTimes(1);
+    expect(onClick2).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(root);
+    expect(onRootClick).toHaveBeenCalledTimes(3);
+  });
 
   test('label and input can receive data-testid', () => {
     render(

--- a/packages/vkui/src/components/Radio/Radio.test.tsx
+++ b/packages/vkui/src/components/Radio/Radio.test.tsx
@@ -46,6 +46,7 @@ describe('Radio', () => {
             },
             'getRootRef': rootRef2,
             'onClick': onRootClick,
+            'Component': 'div',
           },
           input: {
             'className': 'inputClassName',
@@ -53,6 +54,7 @@ describe('Radio', () => {
             'data-testid': 'radio-2',
             'checked': false,
             'onClick': onClick2,
+            'Component': 'select',
           },
         }}
       />,
@@ -60,12 +62,14 @@ describe('Radio', () => {
 
     expect(screen.queryByTestId('radio')).not.toBeInTheDocument();
     const input = screen.getByTestId('radio-2');
+    expect(input.tagName).toBe('SELECT');
     expect(input).toBeInTheDocument();
     expect(input).toHaveClass('inputClassName');
     expect(input).not.toBeChecked();
 
     const root = screen.getByTestId('root');
     expect(root).toBeInTheDocument();
+    expect(root.tagName).toBe('DIV');
     expect(root).toHaveClass('rootClassName');
     expect(root).toHaveClass('rootClassName-2');
     expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
@@ -82,7 +86,7 @@ describe('Radio', () => {
     expect(onClick2).toHaveBeenCalledTimes(1);
 
     fireEvent.click(root);
-    expect(onRootClick).toHaveBeenCalledTimes(3);
+    expect(onRootClick).toHaveBeenCalledTimes(2);
   });
 
   test('label and input can receive data-testid', () => {

--- a/packages/vkui/src/components/Radio/Radio.tsx
+++ b/packages/vkui/src/components/Radio/Radio.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
-import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { SelectionControl } from '../SelectionControl/SelectionControl';
 import { SelectionControlLabel } from '../SelectionControl/SelectionControlLabel/SelectionControlLabel';
 import type { TappableOmitProps } from '../Tappable/Tappable';
@@ -24,8 +24,12 @@ export interface RadioProps
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
+      HasComponent &
       HasDataAttribute;
-    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
+    input?: React.ComponentProps<'input'> &
+      HasRootRef<HTMLInputElement> &
+      HasComponent &
+      HasDataAttribute;
   };
   /**
    * Дополнительное описание под основным текстом.
@@ -72,10 +76,7 @@ export const Radio = ({
     slotsProps?.root,
   );
 
-  const { disabled, ...inputProps } = useMergeProps(
-    { getRootRef: getRef, ...restProps },
-    slotsProps?.input,
-  );
+  const inputRest = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
 
   return (
     <SelectionControl
@@ -84,10 +85,10 @@ export const Radio = ({
       hasHover={hasHover}
       hasActive={hasActive}
       focusVisibleMode={focusVisibleMode}
-      disabled={disabled}
+      disabled={inputRest.disabled}
       {...rootProps}
     >
-      <RadioInput slotsProps={{ input: inputProps }} />
+      <RadioInput slotsProps={{ input: inputRest }} />
       <SelectionControlLabel titleAfter={titleAfter} description={description}>
         {children}
       </SelectionControlLabel>

--- a/packages/vkui/src/components/Radio/Radio.tsx
+++ b/packages/vkui/src/components/Radio/Radio.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
+import { useMergeProps } from '../../hooks/useMergeProps.ts';
 import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { SelectionControl } from '../SelectionControl/SelectionControl';
 import { SelectionControlLabel } from '../SelectionControl/SelectionControlLabel/SelectionControlLabel';
@@ -15,6 +18,15 @@ export interface RadioProps
       TappableOmitProps,
       'hoverMode' | 'activeMode' | 'hasHover' | 'hasActive' | 'focusVisibleMode'
     > {
+  /**
+   *
+   */
+  slotsProps?: {
+    root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
+      HasRootRef<HTMLLabelElement> &
+      HasDataAttribute;
+    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
+  };
   /**
    * Дополнительное описание под основным текстом.
    */
@@ -46,22 +58,36 @@ export const Radio = ({
   hasHover,
   hasActive,
   focusVisibleMode,
+
+  slotsProps,
   ...restProps
 }: RadioProps): React.ReactNode => {
+  const rootProps = useMergeProps(
+    {
+      style,
+      className: classNames(styles.host, className),
+      getRootRef,
+      ...labelProps,
+    },
+    slotsProps?.root,
+  );
+
+  const { disabled, ...inputProps } = useMergeProps(
+    { getRootRef: getRef, ...restProps },
+    slotsProps?.input,
+  );
+
   return (
     <SelectionControl
-      style={style}
-      className={classNames(styles.host, className)}
-      disabled={restProps.disabled}
-      getRootRef={getRootRef}
       hoverMode={hoverMode}
       activeMode={activeMode}
       hasHover={hasHover}
       hasActive={hasActive}
       focusVisibleMode={focusVisibleMode}
-      {...labelProps}
+      disabled={disabled}
+      {...rootProps}
     >
-      <RadioInput {...restProps} getRef={getRef} />
+      <RadioInput slotsProps={{ input: inputProps }} />
       <SelectionControlLabel titleAfter={titleAfter} description={description}>
         {children}
       </SelectionControlLabel>

--- a/packages/vkui/src/components/Radio/Radio.tsx
+++ b/packages/vkui/src/components/Radio/Radio.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
-import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { SelectionControl } from '../SelectionControl/SelectionControl';
 import { SelectionControlLabel } from '../SelectionControl/SelectionControlLabel/SelectionControlLabel';
 import type { TappableOmitProps } from '../Tappable/Tappable';
@@ -19,17 +19,15 @@ export interface RadioProps
       'hoverMode' | 'activeMode' | 'hasHover' | 'hasActive' | 'focusVisibleMode'
     > {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `input`: свойства для прокидывания в скрытый `input`.
    */
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
-      HasComponent &
       HasDataAttribute;
-    input?: React.ComponentProps<'input'> &
-      HasRootRef<HTMLInputElement> &
-      HasComponent &
-      HasDataAttribute;
+    input?: React.ComponentProps<'input'> & HasRootRef<HTMLInputElement> & HasDataAttribute;
   };
   /**
    * Дополнительное описание под основным текстом.

--- a/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
+++ b/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useMergeProps } from '../../../hooks/useMergeProps.ts';
-import type { HasDataAttribute, HasRef, HasRootRef } from '../../../types';
+import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
 import { AdaptiveIconRenderer } from '../../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { RootComponent } from '../../RootComponent/RootComponent';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
@@ -44,31 +44,30 @@ export interface RadioInputProps
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
+      HasComponent &
       HasDataAttribute;
     input?: Omit<React.ComponentProps<'input'>, 'type'> &
       HasRootRef<HTMLInputElement> &
+      HasComponent &
       HasDataAttribute;
   };
 }
 
 export function RadioInput({
-  className: rootClassName,
-  style: rootStyle,
-  getRootRef: rootGetRootRef,
+  className,
+  style,
+  getRootRef,
   getRef,
   slotsProps,
   ...restProps
 }: RadioInputProps) {
-  const { className, style, getRootRef, ...rootRest } = useMergeProps(
-    { className: rootClassName, style: rootStyle, getRootRef: rootGetRootRef },
-    slotsProps?.root,
-  );
+  const rootRest = useMergeProps({ className, style, getRootRef }, slotsProps?.root);
 
   const inputProps = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
 
   return (
-    <RootComponent className={className} style={style} getRootRef={getRootRef} {...rootRest}>
-      <VisuallyHidden {...inputProps} Component="input" type="radio" baseClassName={styles.input} />
+    <RootComponent {...rootRest}>
+      <VisuallyHidden Component="input" type="radio" baseClassName={styles.input} {...inputProps} />
       <RadioIcon />
     </RootComponent>
   );

--- a/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
+++ b/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import * as React from 'react';
-import type { HasRef, HasRootRef } from '../../../types';
+import { useMergeProps } from '../../../hooks/useMergeProps.ts';
+import type { HasDataAttribute, HasRef, HasRootRef } from '../../../types';
 import { AdaptiveIconRenderer } from '../../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { RootComponent } from '../../RootComponent/RootComponent';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
@@ -36,24 +37,38 @@ function RadioIcon() {
 export interface RadioInputProps
   extends Omit<React.ComponentProps<'input'>, 'type'>,
     HasRootRef<HTMLLabelElement>,
-    HasRef<HTMLInputElement> {}
+    HasRef<HTMLInputElement> {
+  /**
+   *
+   */
+  slotsProps?: {
+    root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
+      HasRootRef<HTMLLabelElement> &
+      HasDataAttribute;
+    input?: Omit<React.ComponentProps<'input'>, 'type'> &
+      HasRootRef<HTMLInputElement> &
+      HasDataAttribute;
+  };
+}
 
 export function RadioInput({
-  className,
-  style,
-  getRootRef,
+  className: rootClassName,
+  style: rootStyle,
+  getRootRef: rootGetRootRef,
   getRef,
+  slotsProps,
   ...restProps
 }: RadioInputProps) {
+  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+    { className: rootClassName, style: rootStyle, getRootRef: rootGetRootRef },
+    slotsProps?.root,
+  );
+
+  const inputProps = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
+
   return (
-    <RootComponent className={className} style={style} getRootRef={getRootRef}>
-      <VisuallyHidden
-        {...restProps}
-        Component="input"
-        type="radio"
-        baseClassName={styles.input}
-        getRootRef={getRef}
-      />
+    <RootComponent className={className} style={style} getRootRef={getRootRef} {...rootRest}>
+      <VisuallyHidden {...inputProps} Component="input" type="radio" baseClassName={styles.input} />
       <RadioIcon />
     </RootComponent>
   );

--- a/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
+++ b/packages/vkui/src/components/Radio/RadioInput/RadioInput.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useMergeProps } from '../../../hooks/useMergeProps.ts';
-import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../../types';
+import type { HasDataAttribute, HasRef, HasRootRef } from '../../../types';
 import { AdaptiveIconRenderer } from '../../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { RootComponent } from '../../RootComponent/RootComponent';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
@@ -39,16 +39,16 @@ export interface RadioInputProps
     HasRootRef<HTMLLabelElement>,
     HasRef<HTMLInputElement> {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `input`: свойства для прокидывания в скрытый `input`.
    */
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
-      HasComponent &
       HasDataAttribute;
     input?: Omit<React.ComponentProps<'input'>, 'type'> &
       HasRootRef<HTMLInputElement> &
-      HasComponent &
       HasDataAttribute;
   };
 }

--- a/packages/vkui/src/components/Select/Select.tsx
+++ b/packages/vkui/src/components/Select/Select.tsx
@@ -53,6 +53,8 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
     accessible,
     fetchingCompletedLabel,
     fetchingInProgressLabel,
+
+    slotsProps,
     ...restProps
   } = props;
 
@@ -63,11 +65,19 @@ export const Select = <OptionT extends CustomSelectOptionInterface>({
   return (
     <React.Fragment>
       {deviceType.desktop && (
-        <CustomSelect className={classNames(className, deviceType.desktop.className)} {...props} />
+        <CustomSelect
+          className={classNames(className, deviceType.desktop.className)}
+          slotsProps={slotsProps}
+          {...props}
+        />
       )}
       {deviceType.mobile && (
         <NativeSelect
           className={classNames(className, deviceType.mobile.className)}
+          slotsProps={{
+            select: slotsProps?.select,
+            root: slotsProps?.root,
+          }}
           {...nativeProps}
         >
           {options.map(({ label, value, disabled }) => (

--- a/packages/vkui/src/components/SelectionControl/SelectionControl.tsx
+++ b/packages/vkui/src/components/SelectionControl/SelectionControl.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { usePlatform } from '../../hooks/usePlatform';
-import type { HasRootRef } from '../../types';
+import type { HasComponent, HasRootRef } from '../../types';
 import { DEFAULT_ACTIVE_EFFECT_DELAY } from '../Clickable/useState';
 import { Tappable, type TappableOmitProps } from '../Tappable/Tappable';
 import { SelectionControlContext } from './SelectionControlContext';
@@ -19,6 +19,7 @@ const sizeYClassNames = {
 export interface SelectionControlProps
   extends React.ComponentProps<'label'>,
     HasRootRef<HTMLLabelElement>,
+    HasComponent,
     Pick<
       TappableOmitProps,
       'hoverMode' | 'activeMode' | 'hasHover' | 'hasActive' | 'focusVisibleMode' | 'disabled'

--- a/packages/vkui/src/components/Switch/Switch.test.tsx
+++ b/packages/vkui/src/components/Switch/Switch.test.tsx
@@ -46,6 +46,7 @@ describe(Switch, () => {
             },
             'getRootRef': rootRef2,
             'onClick': onRootClick,
+            'Component': 'div',
           },
           input: {
             'className': 'inputClassName',
@@ -53,6 +54,7 @@ describe(Switch, () => {
             'data-testid': 'switch-2',
             'checked': false,
             'onClick': onClick2,
+            'Component': 'select',
           },
         }}
       />,
@@ -61,11 +63,13 @@ describe(Switch, () => {
     expect(screen.queryByTestId('switch')).not.toBeInTheDocument();
     const input = screen.getByTestId('switch-2');
     expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('SELECT');
     expect(input).toHaveClass('inputClassName');
     expect(input).not.toBeChecked();
 
     const root = screen.getByTestId('root');
     expect(root).toBeInTheDocument();
+    expect(root.tagName).toBe('DIV');
     expect(root).toHaveClass('rootClassName');
     expect(root).toHaveClass('rootClassName-2');
     expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
@@ -82,7 +86,7 @@ describe(Switch, () => {
     expect(onClick2).toHaveBeenCalledTimes(1);
 
     fireEvent.click(root);
-    expect(onRootClick).toHaveBeenCalledTimes(3);
+    expect(onRootClick).toHaveBeenCalledTimes(2);
   });
 
   it(

--- a/packages/vkui/src/components/Switch/Switch.test.tsx
+++ b/packages/vkui/src/components/Switch/Switch.test.tsx
@@ -1,5 +1,7 @@
+import { createRef } from 'react';
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { noop } from '@vkontakte/vkjs';
 import { baselineComponent, userEvent, withFakeTimers } from '../../testing/utils';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { Switch } from './Switch';
@@ -13,6 +15,75 @@ describe(Switch, () => {
       <Switch aria-labelledby="switch" {...props} />
     </>
   ));
+
+  it('should work with slotsProps', () => {
+    const rootRef1 = createRef<HTMLLabelElement>();
+    const rootRef2 = createRef<HTMLLabelElement>();
+    const inputRef1 = createRef<HTMLInputElement>();
+    const inputRef2 = createRef<HTMLInputElement>();
+    const onClick1 = vi.fn();
+    const onClick2 = vi.fn();
+    const onRootClick = vi.fn();
+
+    render(
+      <Switch
+        data-testid="switch"
+        className="rootClassName"
+        getRootRef={rootRef1}
+        getRef={inputRef1}
+        checked
+        onChange={noop}
+        onClick={onClick1}
+        style={{
+          backgroundColor: 'rgb(255, 0, 0)',
+        }}
+        slotsProps={{
+          root: {
+            'data-testid': 'root',
+            'className': 'rootClassName-2',
+            'style': {
+              color: 'rgb(255, 0, 0)',
+            },
+            'getRootRef': rootRef2,
+            'onClick': onRootClick,
+          },
+          input: {
+            'className': 'inputClassName',
+            'getRootRef': inputRef2,
+            'data-testid': 'switch-2',
+            'checked': false,
+            'onClick': onClick2,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('switch')).not.toBeInTheDocument();
+    const input = screen.getByTestId('switch-2');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveClass('inputClassName');
+    expect(input).not.toBeChecked();
+
+    const root = screen.getByTestId('root');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('rootClassName');
+    expect(root).toHaveClass('rootClassName-2');
+    expect(root).toHaveStyle('background-color: rgb(255, 0, 0)');
+    expect(root).toHaveStyle('color: rgb(255, 0, 0)');
+
+    expect(rootRef1.current).toBe(rootRef2.current);
+    expect(rootRef1.current).toBe(root);
+
+    expect(inputRef1.current).toBe(inputRef2.current);
+    expect(inputRef1.current).toBe(input);
+
+    fireEvent.click(input);
+    expect(onClick1).toHaveBeenCalledTimes(1);
+    expect(onClick2).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(root);
+    expect(onRootClick).toHaveBeenCalledTimes(3);
+  });
 
   it(
     '(Uncontrolled) shows checked state',

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -93,7 +93,6 @@ export const Switch = ({
   );
 
   const inputProps: VisuallyHiddenProps<HTMLInputElement> = {
-    ...inputRest,
     Component: 'input',
     type: 'checkbox',
     role: 'switch',
@@ -101,6 +100,7 @@ export const Switch = ({
     onBlur: handleBlur,
     onFocus: handleFocus,
     onClick: callMultiple(syncUncontrolledCheckedStateOnClick, onClick),
+    ...inputRest,
   };
 
   if (isControlled) {

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -9,7 +9,7 @@ import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
 import { usePlatform } from '../../hooks/usePlatform';
 import { callMultiple } from '../../lib/callMultiple';
-import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
 import { RootComponent } from '../RootComponent/RootComponent.tsx';
 import { VisuallyHidden, type VisuallyHiddenProps } from '../VisuallyHidden/VisuallyHidden';
 import styles from './Switch.module.css';
@@ -24,16 +24,16 @@ export interface SwitchProps
     HasRootRef<HTMLLabelElement>,
     HasRef<HTMLInputElement> {
   /**
-   *
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `root`: свойства для прокидывания в корень компонента;
+   * - `input`: свойства для прокидывания в скрытый `input`.
    */
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
-      HasComponent &
       HasDataAttribute;
     input?: React.InputHTMLAttributes<HTMLInputElement> &
       HasRootRef<HTMLInputElement> &
-      HasComponent &
       HasDataAttribute;
   };
 }

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -9,7 +9,8 @@ import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
 import { useMergeProps } from '../../hooks/useMergeProps.ts';
 import { usePlatform } from '../../hooks/usePlatform';
 import { callMultiple } from '../../lib/callMultiple';
-import type { HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import type { HasComponent, HasDataAttribute, HasRef, HasRootRef } from '../../types';
+import { RootComponent } from '../RootComponent/RootComponent.tsx';
 import { VisuallyHidden, type VisuallyHiddenProps } from '../VisuallyHidden/VisuallyHidden';
 import styles from './Switch.module.css';
 
@@ -28,9 +29,11 @@ export interface SwitchProps
   slotsProps?: {
     root?: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'children'> &
       HasRootRef<HTMLLabelElement> &
+      HasComponent &
       HasDataAttribute;
     input?: React.InputHTMLAttributes<HTMLInputElement> &
       HasRootRef<HTMLInputElement> &
+      HasComponent &
       HasDataAttribute;
   };
 }
@@ -46,7 +49,7 @@ export const Switch = ({
   slotsProps,
   ...restProps
 }: SwitchProps): React.ReactNode => {
-  const { className, style, getRootRef, ...rootRest } = useMergeProps(
+  const rootRest = useMergeProps(
     {
       style: rootStyle,
       className: rootClassName,
@@ -56,15 +59,11 @@ export const Switch = ({
   );
   const {
     checked: checkedProp,
-    disabled,
     onBlur: onBlurProp,
     onFocus: onFocusProp,
     onClick,
     ...inputRest
-  } = useMergeProps(
-    { getRootRef: getRef, className: styles.inputNative, ...restProps },
-    slotsProps?.input,
-  );
+  } = useMergeProps({ getRootRef: getRef, ...restProps }, slotsProps?.input);
 
   const direction = useConfigDirection();
   const isRtl = direction === 'rtl';
@@ -96,7 +95,6 @@ export const Switch = ({
     Component: 'input',
     type: 'checkbox',
     role: 'switch',
-    disabled,
     onBlur: handleBlur,
     onFocus: handleFocus,
     onClick: callMultiple(syncUncontrolledCheckedStateOnClick, onClick),
@@ -111,31 +109,29 @@ export const Switch = ({
   }
 
   return (
-    <label
-      className={classNames(
+    <RootComponent
+      Component="label"
+      baseClassName={classNames(
         styles.host,
         sizeY !== 'regular' && sizeYClassNames[sizeY],
         platform === 'ios' ? styles.ios : styles.default,
-        disabled && styles.disabled,
+        inputRest.disabled && styles.disabled,
         isRtl && styles.rtl,
         focusVisibleClassNames,
-        className,
       )}
-      style={style}
-      ref={getRootRef}
       {...rootRest}
     >
-      <VisuallyHidden {...inputProps} />
+      <VisuallyHidden baseClassName={styles.inputNative} {...inputProps} />
       <span aria-hidden className={styles.inputFake}>
         <span className={styles.track} />
         <span
           aria-hidden
           className={classNames(
             styles.handle,
-            platform !== 'ios' && !disabled && styles.handleWithRipple,
+            platform !== 'ios' && !inputRest.disabled && styles.handleWithRipple,
           )}
         />
       </span>
-    </label>
+    </RootComponent>
   );
 };

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -47,7 +47,11 @@ export const Switch = ({
   ...restProps
 }: SwitchProps): React.ReactNode => {
   const { className, style, getRootRef, ...rootRest } = useMergeProps(
-    { style: rootStyle, className: rootClassName, getRootRef: rootGetRootRef },
+    {
+      style: rootStyle,
+      className: rootClassName,
+      getRootRef: rootGetRootRef,
+    },
     slotsProps?.root,
   );
   const {

--- a/packages/vkui/src/hooks/useMergeProps.ts
+++ b/packages/vkui/src/hooks/useMergeProps.ts
@@ -1,0 +1,48 @@
+import { classNames } from '@vkontakte/vkjs';
+import { getMergedSameEventsByProps } from '../helpers/getMergedSameEventsByProps.ts';
+import { mergeStyle } from '../helpers/mergeStyle.ts';
+import { useExternRef } from './useExternRef.ts';
+
+export const useMergeProps = (originalProps: any, slotProps?: any): any => {
+  const {
+    className: rootSlotClassName,
+    style: rootSlotStyle,
+    getRootRef: rootSlotGetRef,
+    ...rootSlotsProps
+  } = slotProps || {};
+
+  const {
+    className: originalClassName,
+    style: originalSlotStyle,
+    getRootRef: originalSlotGetRef,
+    ...originalRestProps
+  } = originalProps || {};
+
+  const resolvedClassName =
+    originalClassName || rootSlotClassName
+      ? classNames(originalClassName, rootSlotClassName)
+      : undefined;
+  const resolvedStyle =
+    originalSlotStyle || rootSlotStyle ? mergeStyle(originalSlotStyle, rootSlotStyle) : undefined;
+  const getRootRef = useExternRef(originalSlotGetRef, rootSlotGetRef);
+
+  const mergedEventsByInjectProps = getMergedSameEventsByProps(originalRestProps, rootSlotsProps);
+
+  const resolvedProps = {
+    ...originalRestProps,
+    ...rootSlotsProps,
+    ...mergedEventsByInjectProps,
+  };
+
+  if (resolvedClassName) {
+    resolvedProps.className = resolvedClassName;
+  }
+  if (resolvedStyle) {
+    resolvedProps.style = resolvedStyle;
+  }
+  if (rootSlotGetRef || originalSlotGetRef) {
+    resolvedProps.getRootRef = getRootRef;
+  }
+
+  return resolvedProps;
+};


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- link #2342

---

- [x] Unit-тесты
- [x] Release notes

## Описание

 Необходимо добавить свойство `slotsProps` для компонентов из списка `"Компоненты со скрытым инпутом"` из [комментария](https://github.com/VKCOM/VKUI/issues/2342#issuecomment-3248498503)

## Release notes
## Улучшения
- Switch: добавлено свойство `slotsProps` для прокидывания свойств во внутренние элементы компонента
- Radio: добавлено свойство `slotsProps` для прокидывания свойств во внутренние элементы компонента
- Checkbox: добавлено свойство `slotsProps` для прокидывания свойств во внутренние элементы компонента
- File: добавлено свойство `slotsProps` для прокидывания свойств во внутренние элементы компонента
- NativeSelect: добавлено свойство `slotsProps` для прокидывания свойств во внутренние элементы компонента
- CustomSelect: добавлено свойство `slotsProps` для прокидывания свойств во внутренние элементы компонента
- Select: добавлено свойство `slotsProps` для прокидывания свойств во внутренние элементы компонента
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
