### PR TITLE
docs: add trailingSlash

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -27,6 +27,7 @@ const withNextra = nextra({
 
 export default withBundleAnalyzer(
   withNextra({
+    trailingSlash: true,
     // ... your Next.js config
     transpilePackages: ['@vkontakte/vkui-docs-theme', '@vkontakte/vkui'],
     modularizeImports: {


### PR DESCRIPTION
## Описание
Включаем [trailingSlash](https://nextjs.org/docs/pages/api-reference/config/next-config-js/trailingSlash) для генерации `/about/index.html` вместо `/about.html`

## Release notes
-