### PR TITLE
feat(CalendarTime): focus on minutes before hours

### DIFF
--- a/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.tsx
@@ -226,6 +226,7 @@ export const CalendarTime = ({
       <div className={styles.picker}>
         <AdaptivityProvider sizeY="compact">
           <CustomSelect
+            maxLength={2}
             value={value.getHours()}
             options={localHours}
             onChange={onHoursChange}
@@ -244,6 +245,7 @@ export const CalendarTime = ({
       <div className={styles.picker}>
         <AdaptivityProvider sizeY="compact">
           <CustomSelect
+            maxLength={2}
             value={value.getMinutes()}
             options={localMinutes}
             onChange={onMinutesChange}


### PR DESCRIPTION
- close #9066

---

- [ ] Unit-тесты
- [x] ~e2e-тесты~
- [ ] Дизайн-ревью
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Автоматически фокусируемся на минуты после ввода двух символов в поле для часов

## Release notes
## Исправления
- [Calendar](https://vkui.io/${version}/components/calendar): фокусировка на минуты после ввода часов
