### PR TITLE
feat(Snackbar): add slotProps prop

### DIFF
--- a/packages/vkui/playwright/index.css
+++ b/packages/vkui/playwright/index.css
@@ -78,6 +78,10 @@
   font-family: var(--vkui--font_family_base);
 }
 
+.vkuiTestAppRoot * {
+  box-sizing: border-box;
+}
+
 /* см. packages/vkui/testing/e2e/constants.ts */
 .vkuiTestContent {
   color: var(--playwright-text);

--- a/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.test.tsx
@@ -70,11 +70,9 @@ describe(Snackbar, () => {
   it('should work correctly with slotProps', () => {
     const rootRef1 = React.createRef<HTMLDivElement>();
     const rootRef2 = React.createRef<HTMLDivElement>();
-    const contentRef = React.createRef<HTMLDivElement>();
     const actionRef = React.createRef<HTMLElement>();
     const onActionClick1 = vi.fn();
     const onActionClick2 = vi.fn();
-    const onContentClick = vi.fn();
     const onRootClick1 = vi.fn();
     const onRootClick2 = vi.fn();
 
@@ -92,12 +90,6 @@ describe(Snackbar, () => {
             'onClick': onRootClick2,
             'className': 'rootClassName',
           },
-          content: {
-            'getRootRef': contentRef,
-            'data-testid': 'content',
-            'onClick': onContentClick,
-            'className': 'contentClassName',
-          },
           action: {
             'getRootRef': actionRef,
             'data-testid': 'action',
@@ -114,11 +106,6 @@ describe(Snackbar, () => {
     expect(rootRef1.current).toBe(root);
     expect(rootRef2.current).toBe(root);
 
-    const content = screen.getByTestId('content');
-    expect(content).toBeInTheDocument();
-    expect(content).toHaveClass('contentClassName');
-    expect(contentRef.current).toBe(content);
-
     const action = screen.getByTestId('action');
     expect(action).toBeInTheDocument();
     expect(action).toHaveClass('actionClassName');
@@ -128,12 +115,9 @@ describe(Snackbar, () => {
     expect(onActionClick1).toHaveBeenCalledTimes(1);
     expect(onActionClick2).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(content);
-    expect(onContentClick).toHaveBeenCalledTimes(2);
-
     fireEvent.click(root);
-    expect(onRootClick1).toHaveBeenCalledTimes(3);
-    expect(onRootClick2).toHaveBeenCalledTimes(3);
+    expect(onRootClick1).toHaveBeenCalledTimes(2);
+    expect(onRootClick2).toHaveBeenCalledTimes(2);
   });
 
   it.each(PLACEMENT_VITEST_EACH_TABLE)(

--- a/packages/vkui/src/components/Snackbar/Snackbar.tsx
+++ b/packages/vkui/src/components/Snackbar/Snackbar.tsx
@@ -50,14 +50,12 @@ export interface SnackbarProps
   /**
    * Свойства, которые можно прокинуть внутрь компонента:
    * - `root`: свойства для прокидывания в корень компонента;
-   * - `content`: свойства для прокидывания в сам элемент `Snackbar.Basic`;
    * - `action`: свойства для прокидывания в кнопку действия.
    */
   slotProps?: {
     root?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> &
       HasRootRef<HTMLDivElement> &
       HasDataAttribute;
-    content?: React.HTMLAttributes<HTMLDivElement> & HasRootRef<HTMLDivElement> & HasDataAttribute;
     action?: React.HTMLAttributes<HTMLElement> & HasRootRef<HTMLElement> & HasDataAttribute;
   };
   /**
@@ -339,7 +337,6 @@ export const Snackbar: React.FC<SnackbarProps> & { Basic: typeof Basic } = ({
               </Button>
             )
           }
-          {...slotProps?.content}
         >
           {children}
         </Basic>


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #9060
- link #9040

---

- [x] Unit-тесты
- [x] Release notes

## Описание

 Необходимо добавить свойство `slotProps` для компонента `Snackbar`. В `slotProps` обязательно должно быть поле `action` для прокидывания свойств в кнопку действия

## Release notes
## Улучшения
- Snackbar: добавлено свойство `slotProps.action` для прокидывания пользовательских свойств, например, `data-testid`