### PR TITLE
fix(usePatchChildren): rm Omit from InjectProps types

### DIFF
--- a/packages/vkui/src/hooks/usePatchChildren.ts
+++ b/packages/vkui/src/hooks/usePatchChildren.ts
@@ -12,7 +12,7 @@ import { useExternRef } from './useExternRef';
 
 const warn = warnOnce('usePatchChildren');
 
-type InjectProps<T> = Omit<React.HTMLAttributes<T>, keyof React.DOMAttributes<T>> &
+type InjectProps<T> = React.HTMLAttributes<T> &
   React.Attributes & {
     ref?: React.Ref<T>;
   };


### PR DESCRIPTION
## Описание

По типам в `usePatchChildren` нельзя было передавать DOM события, хотя по факту можно. В документации также есть пример с передачей `onFocus`.

## Release notes
## Исправления
- usePatchChildren: по типам нельзя было передавать DOM-события, хотя по факту можно