### PR TITLE
feat(Gallery): add animation customization

### DIFF
--- a/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
@@ -16,8 +16,8 @@ import { Bullets } from './Bullets';
 import { CarouselViewPort } from './CarouselViewPort';
 import { ScrollArrows } from './ScrollArrows';
 import {
-  ANIMATION_DURATION,
   CONTROL_ELEMENTS_STATE,
+  DEFAULT_ANIMATION_DURATION,
   SLIDE_THRESHOLD,
   SLIDES_MANAGER_STATE,
 } from './constants';
@@ -67,6 +67,8 @@ export const CarouselBase = ({
   nextArrowTestId,
   prevArrowTestId,
   looped = false,
+  animationDuration = DEFAULT_ANIMATION_DURATION,
+  animationEasing = 'ease',
 
   // a11y
   'aria-roledescription': ariaRoleDescription = 'Карусель',
@@ -88,8 +90,13 @@ export const CarouselBase = ({
   const shiftXCurrentRef = React.useRef<number>(0);
   const shiftXDeltaRef = React.useRef<number>(0);
   const initialized = React.useRef<boolean>(false);
-  const { animationInQueue, addToAnimationQueue, getAnimateFunction, startAnimation } =
-    useSlideAnimation();
+  const {
+    animationInQueue,
+    addToAnimationQueue,
+    getAnimateFunction,
+    startAnimation,
+    getAnimationEasing,
+  } = useSlideAnimation(animationDuration, animationEasing);
   const isDragging = React.useRef(false);
 
   const [controlElementsState, setControlElementsState] =
@@ -155,7 +162,7 @@ export const CarouselBase = ({
 
       layerRef.current.style.transform = `translate3d(${indent}px, 0, 0)`;
       layerRef.current.style.transition = animation
-        ? `transform ${ANIMATION_DURATION}ms cubic-bezier(.1, 0, .25, 1)`
+        ? `transform ${animationDuration}ms ${getAnimationEasing()}`
         : '';
     }
   };

--- a/packages/vkui/src/components/CarouselBase/constants.ts
+++ b/packages/vkui/src/components/CarouselBase/constants.ts
@@ -1,6 +1,6 @@
 import type { ControlElementsState, SlidesManagerState } from './types';
 
-export const ANIMATION_DURATION = 240;
+export const DEFAULT_ANIMATION_DURATION = 240;
 
 export const SLIDE_THRESHOLD = 0.05;
 

--- a/packages/vkui/src/components/CarouselBase/hooks.test.ts
+++ b/packages/vkui/src/components/CarouselBase/hooks.test.ts
@@ -1,12 +1,12 @@
 import { renderHook } from '@testing-library/react';
-import { ANIMATION_DURATION } from './constants';
+import { DEFAULT_ANIMATION_DURATION } from './constants';
 import { useSlideAnimation } from './hooks';
 
 const mockRAF = () => {
   let lastTime = 0;
 
   vi.spyOn(window, 'requestAnimationFrame').mockImplementation((fn) => {
-    lastTime = lastTime + ANIMATION_DURATION;
+    lastTime = lastTime + DEFAULT_ANIMATION_DURATION;
     fn(lastTime);
     return lastTime;
   });
@@ -16,7 +16,7 @@ describe(useSlideAnimation, () => {
   it('should call drawCallback when startAnimation', () => {
     mockRAF();
     const animationStub = vi.fn();
-    const hookResult = renderHook(() => useSlideAnimation());
+    const hookResult = renderHook(() => useSlideAnimation(DEFAULT_ANIMATION_DURATION, 'ease'));
     hookResult.result.current.addToAnimationQueue(
       hookResult.result.current.getAnimateFunction(animationStub),
     );

--- a/packages/vkui/src/components/CarouselBase/types.ts
+++ b/packages/vkui/src/components/CarouselBase/types.ts
@@ -80,6 +80,9 @@ export interface SlidesManagerState {
   layerWidth: number;
 }
 
+export type PredefinedEasingType = 'linear' | 'ease' | 'ease-in' | 'ease-out' | 'ease-in-out';
+export type CubicBezierEasingType = [number, number, number, number];
+
 export interface BaseGalleryProps
   extends Omit<HTMLAttributesWithRootRef<HTMLDivElement>, 'onChange' | 'onDragStart' | 'onDragEnd'>,
     HasAlign,
@@ -148,4 +151,14 @@ export interface BaseGalleryProps
    * - `element`: пересчет позиции слайдов будет происходить при изменении размеров компонента.
    */
   resizeSource?: 'window' | 'element';
+  /**
+   * Длительность анимации смены слайда в миллисекундах.
+   */
+  animationDuration?: number;
+  /**
+   * Функция для анимации.
+   *
+   * Принимает одно из предопределённых значений или параметры функции [cubic-bezier](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function/cubic-bezier).
+   */
+  animationEasing?: PredefinedEasingType | CubicBezierEasingType;
 }

--- a/packages/vkui/src/lib/fx.ts
+++ b/packages/vkui/src/lib/fx.ts
@@ -6,13 +6,68 @@ export function easeInOutSine(x: number): number {
   return 0.5 * (1 - Math.cos(Math.PI * x));
 }
 
-export function cubicBezier(x1: number, x2: number) {
-  return function (progress: number): number {
-    const t = progress;
-    const cx = 3 * x1;
-    const bx = 3 * (x2 - x1) - cx;
-    const ax = 1 - cx - bx;
-    const x = ax * Math.pow(t, 3) + bx * Math.pow(t, 2) + cx * t;
-    return x;
+/**
+ * JS-реализация cubic bezier
+ *
+ * Алгебраический метод решения взят из PRа {@link https://github.com/gre/bezier-easing/pull/57}
+ */
+export function cubicBezier(mX1: number, mY1: number, mX2: number, mY2: number) {
+  if (!(0 <= mX1 && mX1 <= 1 && 0 <= mX2 && mX2 <= 1)) {
+    throw new Error('Bezier x values must be in [0, 1] range');
+  }
+
+  if (mX1 === mY1 && mX2 === mY2) {
+    return LinearEasing;
+  }
+
+  const a = 6 * (3 * mX1 - 3 * mX2 + 1);
+  const b = 6 * (mX2 - 2 * mX1);
+  const c = 3 * mX1;
+  const a2 = a * a;
+  const b2 = b * b;
+  const d = b / a;
+  const e = (3 * b * c) / a2 - (b2 * b) / (a2 * a);
+  const w1 = (2 * c) / a - b2 / a2;
+  const w = w1 * w1 * w1;
+  const o = 3 / a;
+  const ay = 3 * mY1 - 3 * mY2 + 1;
+  const by = mY2 - 2 * mY1;
+  const cy = 3 * mY1;
+
+  const funcX2T = a ? x2t : LinearEasing;
+
+  return (x: number) => {
+    if (x === 0 || x === 1) {
+      return x;
+    }
+    return funcY(funcX2T(x, e, o, w, d), ay, by, cy);
   };
+}
+
+function LinearEasing(x: number) {
+  return x;
+}
+
+function x2t(x: number, a: number, b: number, c: number, d: number) {
+  const q = a + b * x;
+  const s = q ** 2 + c;
+  if (s > 0) {
+    const root = Math.sqrt(s);
+    return Math.cbrt(q + root) + Math.cbrt(q - root) - d;
+  }
+  const l = Math.cbrt(Math.sqrt(q * q - s));
+  const angle = q ? Math.atan(Math.sqrt(-s) / q) : -Math.PI / 2;
+  let φ;
+  if (b < 0) {
+    φ = (q > 0 ? 2 * Math.PI : Math.PI) - angle;
+  } else if (d < 0) {
+    φ = (q > 0 ? 2 * Math.PI : -3 * Math.PI) + angle;
+  } else {
+    φ = (q > 0 ? 0 : Math.PI) + angle;
+  }
+  return 2 * l * Math.cos(φ / 3) - d;
+}
+
+function funcY(t: number, ay: number, by: number, cy: number) {
+  return ((ay * t + 3 * by) * t + cy) * t;
 }

--- a/website/content/components/gallery.mdx
+++ b/website/content/components/gallery.mdx
@@ -156,6 +156,30 @@ return (
   ```
 </Playground>
 
+## Параметры анимации
+
+С помощью свойств `animationDuration` и `animationEasing` можно изменить такие параметры анимации смены слайдов, как длительность
+и функция анимации соответственно. Свойство `animationEasing` принимает одно из предопределенных значений анимации или позволяет
+задать пользовательское значение через массив, элементы которого соответствуют параметрам аналогичной CSS-функции [cubic-bezier](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function/cubic-bezier).
+
+<Playground Wrapper={BlockWrapper}>
+  ```jsx
+  <Gallery
+    slideWidth="90%"
+    bullets="dark"
+    showArrows
+    animationDuration={1000}
+    animationEasing={[0, 0, 0.2, 1]}
+  >
+    <Placeholder style={{ backgroundColor: 'var(--vkui--color_background_negative)' }} title="1" />
+    <Placeholder style={{ backgroundColor: 'var(--vkui--color_background_positive)' }} title="2" />
+    <Placeholder style={{ backgroundColor: 'var(--vkui--color_background_accent)' }} title="3" />
+    <Placeholder style={{ backgroundColor: 'var(--vkui--color_background_negative)' }} title="4" />
+    <Placeholder style={{ backgroundColor: 'var(--vkui--color_background_positive)' }} title="5" />
+  </Gallery>
+  ```
+</Playground>
+
 ## Доступность (a11y) [#a11y]
 
 ### 1. Навигация


### PR DESCRIPTION
- close #8985

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Документация фичи
- [x] Release notes

## Описание

С помощью двух новых свойств (`animationDuration` и `animationEasing`) теперь можно управлять анимацией переключения слайдов. 

Для имплементации cubic-bezier функции на JS хотела взять [gre/bezier-easing](https://github.com/gre/bezier-easing), но либа давно не обновлялась, возможно, заброшена, поэтому скопировала предложенную улучшенную версию из [PRа](https://github.com/gre/bezier-easing/pull/57) в репе - заметила, что при некоторых параметрах она даёт результаты ближе к нативной CSS-реализации. 

## Release notes

 ## Улучшения
 - Gallery: добавлены свойства `animationDuration` и `animationEasing` для изменения длительности
и функция анимации слайда соответственно.

