### PR TITLE
docs: add redirects from legacy routes

### DIFF
--- a/packages/vkui-docs-theme/src/components/Navbar/Navbar.tsx
+++ b/packages/vkui-docs-theme/src/components/Navbar/Navbar.tsx
@@ -63,7 +63,7 @@ export function Navbar({ logo, fakeNavbarItem }: NavbarProps): React.ReactElemen
               hoverMode="opacity"
               activeMode="opacity"
               aria-label="Лого VKUI"
-              href="/"
+              href={fakeNavbarItem ? fakeNavbarItem.href : '/'}
             >
               {logo}
             </Tappable>

--- a/website/app/[[...mdxPath]]/page.tsx
+++ b/website/app/[[...mdxPath]]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
 import { generateStaticParamsFor, importPage } from 'nextra/pages';
 import { useMDXComponents } from '../../mdx-components';
 
@@ -23,10 +22,6 @@ export default async function Page(props: PageProps) {
   const params = await props.params;
   const result = await importPage(params.mdxPath);
   const { default: MDXContent, toc, metadata, sourceCode } = result;
-
-  if (!params.mdxPath) {
-    redirect('/overview/about');
-  }
 
   return (
     <Wrapper toc={toc} metadata={metadata} sourceCode={sourceCode}>

--- a/website/app/_components/RedirectHandler.tsx
+++ b/website/app/_components/RedirectHandler.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export function RedirectHandler() {
+  const router = useRouter();
+
+  useEffect(
+    /**
+     * Примеры:
+     *
+     * 1 кейс
+     * https://vkui.io/#/SplitLayout → https://vkui.io/components/split-layout
+     * https://vkui.io/#/SplitCol → https://vkui.io/components/split-layout/#split-col-api
+     * https://vkui.io/7.5.0/#/SplitLayout → https://vkui.io/7.5.0/components/split-layout
+     * https://vkui.io/7.5.0/#/SplitCol → https://vkui.io/7.5.0/components/split-layout/#split-col-api
+     *
+     * 2 кейс
+     * https://vkui.io → https://vkui.io/overview/about
+     * https://vkui.io/7.5.0 → https://vkui.io/7.5.0/overview/about
+     * https://vkui.io/7.10.0 → https://vkui.io/7.10.0/overview/about
+     */
+    function tryToRedirect() {
+      const redirectFns = [getRedirectUrlForLegacyRoutes, getRedirectUrlForIndexPage];
+      const location = window.location;
+      for (const getRedirectUrl of redirectFns) {
+        const redirectUrl = getRedirectUrl(location);
+        if (redirectUrl !== null) {
+          router.replace(withVersion(location, redirectUrl));
+          break;
+        }
+      }
+    },
+    [router],
+  );
+
+  return null;
+}
+
+/**
+ * ✅ https://<url>.ru/<version>
+ * ❌ https://<url>.ru/<version>/
+ */
+function withVersion(location: Location, url: string) {
+  const [, version] = location.pathname.match(/^\/(\d+\.\d+\.\d+)$/) ?? [null, null];
+  return version !== null ? `${version}/${url}` : url;
+}
+
+/**
+ * ✅ https://<url>.ru
+ * ✅ https://<url>.ru/
+ * ✅ https://<url>.ru/<version>
+ * ✅ https://<url>.ru/<version>/
+ * ❌ https://<url>.ru/<page>
+ * ❌ https://<url>.ru/<version>/<page>
+ */
+function getRedirectUrlForIndexPage(location: Location) {
+  if (location.pathname === '/' || /^\/(\d+\.\d+\.\d+)\/?$/.test(location.pathname)) {
+    return 'overview/about';
+  }
+  return null;
+}
+
+function getRedirectUrlForLegacyRoutes(location: Location) {
+  const COMPONENTS_DOCS_PARENT_PAGE_MAP: Record<string, string> = {
+    Header: 'Group',
+    Footer: 'Group',
+    SplitCol: 'SplitLayout',
+    WriteBarIcon: 'WriteBar',
+    List: 'Cell',
+    Tabbar: 'Epic',
+    TabbarItem: 'Epic',
+    PanelSpinner: 'Panel',
+    PanelHeaderButton: 'PanelHeader',
+    PanelHeaderContent: 'PanelHeader',
+    SubnavigationButton: 'SubnavigationBar',
+    TabsItem: 'Tabs',
+    ActionSheetItem: 'ActionSheet',
+    HorizontalCellShowMore: 'HorizontalCell',
+    OnboardingTooltipContainer: 'OnboardingTooltip',
+    DisplayTitle: 'Typography',
+    Title: 'Typography',
+    Headline: 'Typography',
+    Text: 'Typography',
+    Paragraph: 'Typography',
+    Subhead: 'Typography',
+    Footnote: 'Typography',
+    Caption: 'Typography',
+  };
+
+  const isCamelOrPascalCase = (str: string): boolean =>
+    /^[A-Za-z][A-Za-z0-9]*$/.test(str) && /[A-Z]/.test(str.slice(1));
+
+  const getComponentUrl = (componentName: string, foundParentPage?: string): string => {
+    const toKebabCase = (componentName: string) =>
+      componentName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+    const url = foundParentPage
+      ? `${toKebabCase(foundParentPage)}#${toKebabCase(componentName)}`
+      : toKebabCase(componentName);
+
+    return `components/${url}`;
+  };
+
+  const hash = location.hash;
+  const componentNameByHash = hash.slice(2);
+
+  if (hash.startsWith('#/') && isCamelOrPascalCase(componentNameByHash)) {
+    const foundParentPage = COMPONENTS_DOCS_PARENT_PAGE_MAP[componentNameByHash];
+    const documentationUrl = getComponentUrl(componentNameByHash, foundParentPage);
+    return documentationUrl;
+  }
+
+  return null;
+}

--- a/website/app/_components/index.ts
+++ b/website/app/_components/index.ts
@@ -1,2 +1,3 @@
 export { Versions } from './Versions/Versions';
+export { RedirectHandler } from './RedirectHandler';
 export { FooterLinks } from './FooterLinks';

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -14,7 +14,7 @@ import { type PageMapItem } from 'nextra';
 import { getPageMap } from 'nextra/page-map';
 import { PlaygroundStoreProvider } from '@/providers/playgroundStoreProvider';
 import uwuCode from '../uwu.js?raw';
-import { FooterLinks, Versions } from './_components';
+import { FooterLinks, RedirectHandler, Versions } from './_components';
 import '@vkontakte/vkui-docs-theme/styles.css';
 
 export const metadata: Metadata = {
@@ -73,6 +73,7 @@ const RootLayout: React.FC<{ children: React.ReactNode }> = async ({ children })
             __html: uwuCode,
           }}
         />
+        <RedirectHandler />
         <Layout
           pageMap={pageMap}
           navbar={navbar}


### PR DESCRIPTION
## Описание

Подготовка к замене Styleguide и редиректа с https://vkcom.github.io/VKUI/ на https://vkui.io

## Изменения

- Перенёс редирект на `/overview/about` из `[[...mdxPath]]/pages.tsx` в `RedirectHandler`
- В `vkui-docs-theme` ссылка в логотипе использует `fakeNavbarItem.href`, чтобы сразу открывать `/overview/about` вместо `/`
- в `RedirectHandler` логика перенаправления из старых styleguide урлов на новые (скопировал из `packages/vkui/.storybook/addons/documentation-button/DocumentationButton.tsx`)

## Release notes
-