### PR TITLE
test: fix build codemods

### DIFF
--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -11,5 +11,5 @@
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
   "exclude": ["**/__testfixtures__", "**/__tests__", "node_modules"],
-  "files": ["./typings.d.ts", "./vitest.d.ts"]
+  "files": ["./typings.d.ts"]
 }


### PR DESCRIPTION
## Описание

Сломалась сборка codemods так как забыл удалить глобальные типы из tsconfig в #9105

## Release notes
-
