### PR TITLE
fix(CustomSelect): fix native select handlers call

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -106,7 +106,11 @@ describe('CustomSelect', () => {
 
       const onRootClick = vi.fn();
       const onInputClick = vi.fn();
-      const onSelectClick = vi.fn();
+      const onSelectClick1 = vi.fn();
+      const onSelectClick2 = vi.fn();
+
+      const onSelectFocus = vi.fn();
+      const onInputFocus = vi.fn();
 
       render(
         <CustomSelect
@@ -119,6 +123,8 @@ describe('CustomSelect', () => {
           required
           className="rootClassName"
           getRootRef={rootRef1}
+          onClick={onSelectClick1}
+          onFocus={onSelectFocus}
           getRef={selectRef1}
           getSelectInputRef={inputRef1}
           nativeSelectTestId="select"
@@ -143,7 +149,7 @@ describe('CustomSelect', () => {
               'style': {
                 color: 'rgb(255, 0, 0)',
               },
-              'onClick': onSelectClick,
+              'onClick': onSelectClick2,
             },
             input: {
               'getRootRef': inputRef2,
@@ -153,6 +159,7 @@ describe('CustomSelect', () => {
                 color: 'rgb(255, 0, 0)',
               },
               'onClick': onInputClick,
+              'onFocus': onInputFocus,
             },
           }}
         />,
@@ -195,11 +202,22 @@ describe('CustomSelect', () => {
       expect(onInputClick).toHaveBeenCalledTimes(1);
 
       fireEvent.click(select);
-      expect(onSelectClick).toHaveBeenCalledTimes(1);
+      expect(onSelectClick1).toHaveBeenCalledTimes(1);
+      expect(onSelectClick2).toHaveBeenCalledTimes(1);
+      expect(onInputFocus).toHaveBeenCalledTimes(1);
+      expect(onSelectFocus).toHaveBeenCalledTimes(1);
 
       fireEvent.click(root);
       await act(async () => vi.runOnlyPendingTimers());
       expect(onRootClick).toHaveBeenCalledTimes(5);
+
+      fireEvent.focus(input);
+      expect(onInputFocus).toHaveBeenCalledTimes(2);
+      expect(onSelectFocus).toHaveBeenCalledTimes(2);
+
+      fireEvent.focus(select);
+      expect(onInputFocus).toHaveBeenCalledTimes(2);
+      expect(onSelectFocus).toHaveBeenCalledTimes(3);
     }),
   );
 

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -312,6 +312,9 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     fetchingInProgressLabel,
     fetchingCompletedLabel,
     'value': selectValue,
+    'onBlur': onSelectBlur,
+    'onFocus': onSelectFocus,
+    'onClick': onSelectClick,
 
     slotProps,
     ...restProps
@@ -342,9 +345,9 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
   const { getRootRef: getSelectRef, ...selectRest } = useMergeProps(
     {
       getRootRef: getRef,
-      onBlur: props.onBlur,
-      onFocus: props.onFocus,
-      onClick: props.onClick,
+      onBlur: onSelectBlur,
+      onFocus: onSelectFocus,
+      onClick: onSelectClick,
     },
     slotProps?.select,
   );


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- causes by #9036

---

- [x] Unit-тесты
- [x] Release notes

## Описание

В #9036 был допущен баг. При прокидывании в компонент `CustomSelect` колбэка `onClick` и затем при click на нативный `select` колбэк срабатывает дважды, хотя раньше срабатывал один раз.

Пример:

```typescript
const onClickFn = vi.fn();

...

<CustomSelect
  ...
  onClick={onClickFn}
  nativeSelectTestId="select"
/>

fireEvent.click(screen.getById('select'));
expect(onClickFn).toHaveBeenCalledTimes(1) // тут будет ошибка, что функция вызвана 2 раза
```

То же самое происходит с обработчиками `onFocus`, `onBlur`.

## Release notes
## Исправления
- CustomSelect: Поправлена проблема, что при клике на нативный `select` обработчик `onClick`, переданный в компонент, срабатывал дважды. То же самое было с обработчиками `onFocus`, `onBlur`
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
