### PR TITLE
docs(FixedLayout): scrollable-region-focusable

### DIFF
--- a/website/content/components/fixed-layout.mdx
+++ b/website/content/components/fixed-layout.mdx
@@ -25,7 +25,7 @@ import { FixedLayoutWrapper } from '@/components/wrappers';
   <Group mode="plain">
     {/** Компенсируем место, занятое поиском **/}
     <Spacing size={40} />
-    <Div style={{ maxHeight: 170, overflow: 'auto' }}>
+    <Div style={{ maxHeight: 170, overflow: 'auto' }} tabIndex={0}>
       <Paragraph>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a sollicitudin lectus, a
         commodo sapien. Vivamus a urna leo. Integer iaculis dignissim urna, sit amet vestibulum diam


### PR DESCRIPTION
## Описание

Правим проблему [scrollable-region-focusable](https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/) в примере документации

<details>
<summary>Детали</summary>

Title: WCAG 2.1.1: Ensure elements that have scrollable content are accessible by keyboard (.Div_host__hpJdV)
Tags: Accessibility, WCAG 2.1.1, scrollable-region-focusable

Issue: Ensure elements that have scrollable content are accessible by keyboard (scrollable-region-focusable - https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable)

Target application: FixedLayout | VKUI - https://vkui.io/components/fixed-layout/

Element path: .Div_host__hpJdV

Snippet: `<div class="Div_host__hpJdV RootComponent_host__N681x" style="max-height: 170px; overflow: auto;">`

How to fix: 
Fix any of the following:
  Element should have focusable content
  Element should be focusable

Environment: Chrome version 143.0.0.0
</details>

## Release notes
-
