### PR TITLE
fix(Button): a11y link disabled

### DIFF
--- a/packages/vkui/src/components/Button/Button.test.tsx
+++ b/packages/vkui/src/components/Button/Button.test.tsx
@@ -18,6 +18,16 @@ describe('Button', () => {
     expect(button().tagName.toLowerCase()).toMatch('a');
   });
 
+  it('Component: Button with href and disabled is handled as a native link', () => {
+    render(
+      <ButtonTest href="#" disabled>
+        Native Link
+      </ButtonTest>,
+    );
+
+    expect(button()).toEqual(screen.getByRole('link'));
+  });
+
   it('Component: Button with loading is not clickable', () => {
     const handleClick = vi.fn();
     render(

--- a/packages/vkui/src/components/Button/Button.tsx
+++ b/packages/vkui/src/components/Button/Button.tsx
@@ -113,7 +113,7 @@ export const Button = ({
     <Tappable
       hoverMode={styles.hover}
       activeMode={styles.active}
-      Component={restProps.href ? 'a' : 'button'}
+      {...(restProps.href === undefined && { Component: 'button' })}
       focusVisibleMode="outside"
       disabled={loading || disabled}
       {...restProps}


### PR DESCRIPTION
- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Исправляем `disabled` режим при передаче `href`:

- Тег a не поддерживает атрибут disabled, поэтому используем aria-disabled
- Тег a с атрибутом href все еще кликабельный, поэтому ему нужно перестать передавать href
- Тег a без href не является ссылкой, поэтому добавляем role="link".

https://w3c.github.io/html-aria/#example-communicate-a-disabled-link-with-aria

Компонент Tappable под капотом уже умеет обрабатывать href и disabled, поэтому все что нам нужно, это при href не пробрасывать свойство Component

## Release notes
## Исправления
- [Button](https://vkui.io/${version}/components/button): при передаче `href` и `disabled` в компонент скринридер не считал элемент недоступной ссылкой
