### PR TITLE
docs(useFloatingMiddlewaresBootstrap): fix customMiddlewares desc

### DIFF
--- a/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
+++ b/packages/vkui/src/lib/floating/useFloatingMiddlewaresBootstrap/index.ts
@@ -62,7 +62,7 @@ export interface UseFloatingMiddlewaresBootstrapOptions {
    */
   sameWidth?: boolean;
   /**
-   * Массив кастомных модификаторов для Popper (необходимо мемоизировать).
+   * Позволяет задать или переопределить модификаторы библиотеки **Floating UI** (подробнее в документации про [middleware](https://floating-ui.com/docs/middleware)).
    */
   customMiddlewares?: UseFloatingMiddleware[];
   /**


### PR DESCRIPTION
## Описание

Исправляет описание свойства `customMiddlewares`, чтобы дать пользователю понимание о каких модификаторах речь.

- caused by #6150

## Release notes
## Документация
- [Popover](https://vkui.io/${version}/components/popover), [Popper](https://vkui.io/${version}/components/Popper): Поправлена документация свойства `customMiddlewares`