### PR TITLE
fix(TabsItem): rm usePrevious

### DIFF
--- a/packages/vkui/src/components/TabsItem/TabsItem.tsx
+++ b/packages/vkui/src/components/TabsItem/TabsItem.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { classNames, hasReactNode } from '@vkontakte/vkjs';
 import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
-import { usePrevious } from '../../hooks/usePrevious';
 import { useDOM } from '../../lib/dom';
 import { warnOnce } from '../../lib/warnOnce';
 import type { AnchorHTMLAttributesOnly, HTMLAttributesWithRootRef } from '../../types';
@@ -146,14 +145,20 @@ export const TabsItem = ({
 
   const rootRef = useExternRef(getRootRef);
 
-  const prevSelected = usePrevious(selected);
-  const isInitialRender = prevSelected === undefined;
-  const shouldScrollToSelected =
-    withScrollToSelectedTab && !isInitialRender && prevSelected !== selected && selected;
+  const prevSelectedRef = React.useRef<boolean | undefined>(undefined);
 
   const { document } = useDOM();
   React.useEffect(
     function scrollToSelectedItem() {
+      const isInitialRender = prevSelectedRef.current === undefined;
+      const shouldScrollToSelected =
+        withScrollToSelectedTab &&
+        !isInitialRender &&
+        prevSelectedRef.current !== selected &&
+        selected;
+
+      prevSelectedRef.current = selected;
+
       if (!shouldScrollToSelected || !rootRef.current || !document) {
         return;
       }
@@ -181,7 +186,7 @@ export const TabsItem = ({
          **/
       }
     },
-    [rootRef, document, shouldScrollToSelected, scrollBehaviorToSelectedTab],
+    [rootRef, document, scrollBehaviorToSelectedTab, withScrollToSelectedTab, selected],
   );
 
   const _onClick: React.MouseEventHandler<HTMLElement> = React.useCallback(


### PR DESCRIPTION
- see #6919

---

- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Избавляемся в TabsItem от usePrevious который не работает с React Compiler

## Release notes
## Улучшения
- [TabsItem](https://vkui.io/${version}/components/tabs): улучшен код для поддержки React Compiler
