### PR TITLE
fix: useFocusWithin ref in render

### DIFF
--- a/packages/vkui/src/hooks/useFocusWithin.test.tsx
+++ b/packages/vkui/src/hooks/useFocusWithin.test.tsx
@@ -9,7 +9,10 @@ describe(useFocusWithin, () => {
   let focusWithin: boolean | undefined = undefined;
   const Playground = (props: React.HTMLAttributes<HTMLDivElement>) => {
     const ref = React.useRef<HTMLInputElement>(null);
-    focusWithin = useFocusWithin(ref);
+    const focus = useFocusWithin(ref);
+    React.useEffect(() => {
+      focusWithin = focus;
+    });
 
     return <input data-testid="input" ref={ref} {...props} />;
   };

--- a/packages/vkui/src/hooks/useFocusWithin.ts
+++ b/packages/vkui/src/hooks/useFocusWithin.ts
@@ -7,9 +7,7 @@ const isFocusWithin = <T extends Element>(ref: T, document: Document) =>
 
 export function useFocusWithin(ref: React.RefObject<HTMLElement | null>): boolean {
   const { document } = useDOM();
-  const [focusWithin, setFocusWithin] = React.useState<boolean>(() =>
-    ref.current && document ? isFocusWithin(ref.current, document) : false,
-  );
+  const [focusWithin, setFocusWithin] = React.useState<boolean>(false);
 
   useIsomorphicLayoutEffect(function handleAutoFocus() {
     /* istanbul ignore if: невозможный кейс, т.к. в SSR эффекты не вызываются. Проверка на будущее, если вдруг эффект будет вызываться. */


### PR DESCRIPTION
- see #6919

## Описание

Читать ref во время рендера нельзя. Также во время превого рендера будет false так как компонент не должен быть вмонтирован

## Release notes
-
