### PR TITLE
test(Gallery): fix ref

### DIFF
--- a/packages/vkui/src/components/Gallery/Gallery.test.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.test.tsx
@@ -30,13 +30,13 @@ const simulateDrag = (element: HTMLDivElement, points: number[]) => {
 const Slide = ({
   children,
   width = 200,
-  ...rest
+  getRef,
 }: {
   children: React.ReactNode;
   width?: number;
   getRef: React.Ref<HTMLDivElement>;
 }) => (
-  <div style={{ fontSize: '72px', width }} ref={rest.getRef}>
+  <div style={{ fontSize: '72px', width }} ref={getRef}>
     {children}
   </div>
 );


### PR DESCRIPTION
- see #6919

## Описание

```
React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).

/Users/d.suvorov/Documents/VKCOM/VKUI/packages/vkui/src/components/Gallery/Gallery.test.tsx:39:49
  37 |   getRef: React.Ref<HTMLDivElement>;
  38 | }) => (
> 39 |   <div style={{ fontSize: '72px', width }} ref={rest.getRef}>
     |                                                 ^^^^^^^^^^^ Cannot access ref value during render
  40 |     {children}
  41 |   </div>
  42 | );  react-hooks/refs
```

## Release notes
-