### PR TITLE
BREAKING CHANGE: changing an uncontrolled input to be controlled

### DIFF
--- a/packages/vkui/src/hooks/useEnsuredControl.ts
+++ b/packages/vkui/src/hooks/useEnsuredControl.ts
@@ -55,20 +55,6 @@ export function useCustomEnsuredControl<V = any>({
     preservedControlledValueRef.current = value;
   });
 
-  /*
-   * Для ситуации, когда nextValue это пользовательская функция,
-   * и в качестве аргумента мы должны передать prevValue.
-   * Обычно в качестве prevValue используется preservedControlledValueRef, но оно может быть undefined, если
-   * некотролируемое value вдруг стало контролируемым
-   * (value = undefined ---> value = true)
-   * Если в момент вызова onChange preservedControlledValueRef ещё не был
-   * обновлён в useEffect, то мы не можем использовать preservedControlledValueRef как prevValue
-   * В качестве запасного варианта мы храним текущее значение value в currentFallbackValueRef, чтобы
-   * использовать его вместо preservedControlledValueRef.
-   */
-  const currentFallbackValueRef = React.useRef<V | undefined>(value);
-  currentFallbackValueRef.current = value;
-
   const onChange = React.useCallback(
     (nextValue: React.SetStateAction<V>) => {
       if (disabled) {
@@ -88,20 +74,14 @@ export function useCustomEnsuredControl<V = any>({
           if (process.env.NODE_ENV === 'development') {
             if (preservedControlledValueRef.current === undefined) {
               warn(
-                `Похоже, что при вызове onChange с аргументом nextValue в виде коллбэка, состояние компонента было переведено из неконтролируемого ("undefined") в контролируемое. Пожалуйста, старайтесь сохранять либо неконтролируемое состояние, либо контролируемое на всём промежутке жизненного цикла компонента, чтобы получать предсказуемое значение prevValue в коллбэке nextValue((prevValue: V) => V)`,
+                `A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://react.dev/link/controlled-components`,
                 'error',
               );
             }
           }
 
-          const prevValue =
-            preservedControlledValueRef.current === undefined
-              ? currentFallbackValueRef.current
-              : preservedControlledValueRef.current;
-          // В теории prevValue не может быть undefined,
-          // но лучше не вызывать nextValue с таким значением
-          if (prevValue !== undefined) {
-            const resolvedValue = nextValue(prevValue);
+          if (preservedControlledValueRef.current !== undefined) {
+            const resolvedValue = nextValue(preservedControlledValueRef.current);
             onChangeProp(resolvedValue);
           }
         }


### PR DESCRIPTION
- see #6919
- see #7285

---

- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Так как мы не можем взаимодействовать с ref-ом во время рендеринга пришлось избавится от костыля при переключении контролируемого и некотролирумого состяния

## Release notes
## BREAKING CHANGE
- ChipsInput, ChipsSelect: Переключение между [управляемым и неуправляемым состоянием](https://react.dev/link/controlled-components) компонента больше не обрабатывается
