### PR TITLE
feat(ImageBase/Avatar/Image): add slotProps.img

### DIFF
--- a/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.test.tsx
@@ -128,7 +128,7 @@ describe(ImageBase, () => {
 
   it("should provide `ref` of 'img' tag", () => {
     const refCallback = vi.fn();
-    render(<ImageBaseTest src="#" getRef={refCallback} />);
+    render(<ImageBaseTest src="#" slotProps={{ img: { getRootRef: refCallback } }} />);
     expect(refCallback).toHaveBeenCalled();
   });
 
@@ -171,7 +171,13 @@ describe(ImageBase, () => {
       });
     });
 
-    render(<ImageBaseTest getRef={getRefMock} onLoad={onLoadMock} src="https://loaded.image" />);
+    render(
+      <ImageBaseTest
+        slotProps={{ img: { getRootRef: getRefMock } }}
+        onLoad={onLoadMock}
+        src="https://loaded.image"
+      />,
+    );
 
     // make sure onLoad prop is called as is if img elment has 'complete=true'
     expect(onLoadMock).toHaveBeenCalledTimes(1);

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -4,13 +4,14 @@ import * as React from 'react';
 import { classNames } from '@vkontakte/vkjs';
 import { mergeStyle } from '../../helpers/mergeStyle';
 import { useExternRef } from '../../hooks/useExternRef';
+import { useMergeProps } from '../../hooks/useMergeProps';
 import { minOr } from '../../lib/comparing';
 import { defineComponentDisplayNames } from '../../lib/react/defineComponentDisplayNames';
 import { getFetchPriorityProp } from '../../lib/utils';
+import { warnOnce } from '../../lib/warnOnce';
 import type {
   AnchorHTMLAttributesOnly,
-  CSSCustomProperties,
-  HasRef,
+  HasDataAttribute,
   HasRootRef,
   LiteralUnion,
 } from '../../types';
@@ -47,6 +48,8 @@ export {
 
 export { ImageBaseContext };
 
+const warn = warnOnce('ImageBase');
+
 /**
  * Размер по умолчанию.
  */
@@ -55,8 +58,7 @@ const defaultSize = 24;
 export interface ImageBaseProps
   extends React.ImgHTMLAttributes<HTMLElement>,
     AnchorHTMLAttributesOnly,
-    HasRootRef<HTMLDivElement>,
-    HasRef<HTMLImageElement> {
+    HasRootRef<HTMLDivElement> {
   /**
    * Задаёт размер картинки.
    *
@@ -120,6 +122,17 @@ export interface ImageBaseProps
    * Подробнее можно почитать в [документации](https://developer.mozilla.org/ru/docs/Web/CSS/filter).
    */
   filter?: React.CSSProperties['filter'];
+  /**
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `img`: свойства для прокидывания в тег `<img>`;.
+   */
+  slotProps?: {
+    img?: React.ComponentProps<'img'> & HasRootRef<HTMLImageElement> & HasDataAttribute;
+  };
+  /**
+   * @deprecated Since 7.9.0. Будет удалено в v9. Используйте `slotProps={ img: { getRootRef: ... } }`.
+   */
+  getRef?: React.Ref<HTMLImageElement>; // TODO [>=9] Удалить свойство
 }
 
 const getObjectFitClassName = (objectFit: React.CSSProperties['objectFit']) => {
@@ -167,7 +180,7 @@ export const ImageBase: React.FC<ImageBaseProps> & {
   src,
   srcSet,
   useMap,
-  fetchPriority,
+  fetchPriority: fetchPriorityProp,
   getRef,
   size: sizeProp,
   width: widthImg,
@@ -186,8 +199,18 @@ export const ImageBase: React.FC<ImageBaseProps> & {
   keepAspectRatio = false,
   getRootRef,
   elementTiming,
+  slotProps,
   ...restProps
 }: ImageBaseProps) => {
+  if (process.env.NODE_ENV === 'development') {
+    /* istanbul ignore if: не проверяем в тестах */
+    if (getRef) {
+      warn(
+        'Свойство `getRef` устаревшее и будет удалено в VKUI v9. Используйте `slotProps={ img: { getRootRef: ... } }`',
+      );
+    }
+  }
+
   const size = sizeProp ?? minOr([sizeToNumber(widthSize), sizeToNumber(heightSize)], defaultSize);
   const wrapperRef = useExternRef(getRootRef);
 
@@ -226,7 +249,58 @@ export const ImageBase: React.FC<ImageBaseProps> & {
     onError?.(event);
   };
 
-  const imgRef = useExternRef(getRef);
+  const {
+    getRootRef: getImgRef,
+    fetchPriority,
+    ...imgRest
+  } = useMergeProps<React.ComponentProps<'img'> & HasRootRef<HTMLImageElement> & HasDataAttribute>(
+    hasSrc
+      ? {
+          getRootRef: getRef,
+          alt,
+          className: classNames(
+            styles.img,
+            getObjectFitClassName(objectFit),
+            objectPosition && styles.withObjectPosition,
+            filter && styles.withFilter,
+            keepAspectRatio && styles.imgKeepRatio,
+            failed && styles.imgHiddenAlt,
+          ),
+          crossOrigin,
+          decoding,
+          loading,
+          referrerPolicy,
+          style: mergeStyle(
+            keepAspectRatio
+              ? {
+                  width: widthImg || width,
+                  height: heightImg || height,
+                }
+              : undefined,
+            objectPosition || filter
+              ? {
+                  '--vkui_internal--ImageBase_object_position': objectPosition,
+                  '--vkui_internal--ImageBase_object_filter': filter,
+                }
+              : undefined,
+          ),
+          sizes,
+          src,
+          srcSet,
+          useMap,
+          width,
+          height,
+          onLoad: handleImageLoad,
+          onError: handleImageError,
+          fetchPriority: fetchPriorityProp,
+          // @ts-expect-error: TS2322 отсутствует в @types/react
+          elementtiming: elementTiming, // eslint-disable-line react/no-unknown-property
+        }
+      : {},
+    hasSrc ? slotProps?.img : undefined,
+  );
+
+  const imgRef = useExternRef(getImgRef);
   const isOnLoadStatusCheckedRef = React.useRef(false);
   React.useEffect(
     function dispatchLoadEventForAlreadyLoadedResourceIfReactInitializedLater() {
@@ -260,23 +334,6 @@ export const ImageBase: React.FC<ImageBaseProps> & {
     [mouseOutHandlers, mouseOverHandlers, size],
   );
 
-  const imgStyles:
-    | CSSCustomProperties<React.CSSProperties['objectPosition'] | React.CSSProperties['filter']>
-    | undefined =
-    objectPosition || filter
-      ? {
-          '--vkui_internal--ImageBase_object_position': objectPosition,
-          '--vkui_internal--ImageBase_object_filter': filter,
-        }
-      : undefined;
-
-  const keepAspectRationStyles = keepAspectRatio
-    ? {
-        width: widthImg || width,
-        height: heightImg || height,
-      }
-    : undefined;
-
   return (
     <ImageBaseContext.Provider value={contextValue}>
       <Clickable
@@ -291,36 +348,7 @@ export const ImageBase: React.FC<ImageBaseProps> & {
         onMouseOut={onMouseOut}
         {...restProps}
       >
-        {hasSrc && (
-          <img
-            ref={imgRef}
-            alt={alt}
-            className={classNames(
-              styles.img,
-              getObjectFitClassName(objectFit),
-              objectPosition && styles.withObjectPosition,
-              filter && styles.withFilter,
-              keepAspectRatio && styles.imgKeepRatio,
-              failed && styles.imgHiddenAlt,
-            )}
-            crossOrigin={crossOrigin}
-            decoding={decoding}
-            loading={loading}
-            referrerPolicy={referrerPolicy}
-            style={mergeStyle(keepAspectRationStyles, imgStyles)}
-            sizes={sizes}
-            src={src}
-            srcSet={srcSet}
-            useMap={useMap}
-            width={widthImg}
-            height={heightImg}
-            onLoad={handleImageLoad}
-            onError={handleImageError}
-            // @ts-expect-error: TS2322 отсутствует в @types/react
-            elementtiming={elementTiming} // eslint-disable-line react/no-unknown-property
-            {...getFetchPriorityProp(fetchPriority)}
-          />
-        )}
+        {hasSrc && <img ref={imgRef} {...imgRest} {...getFetchPriorityProp(fetchPriority)} />}
         {fallbackIcon && <div className={styles.fallback}>{fallbackIcon}</div>}
         {children && <div className={styles.children}>{children}</div>}
         {!noBorder && <div aria-hidden className={styles.border} />}

--- a/packages/vkui/src/helpers/mergeStyle.ts
+++ b/packages/vkui/src/helpers/mergeStyle.ts
@@ -1,3 +1,10 @@
+import type { CSSCustomProperties } from '../types';
+
+type CSSPropertiesTypes =
+  | React.CSSProperties
+  | (React.CSSProperties & CSSCustomProperties<any>)
+  | undefined;
+
 /**
  * Мержит стили, пытаясь уменьшить кол-во копирований
  *
@@ -7,9 +14,6 @@
  * const style = mergeStyle(arrowStyles, styleProp)
  * ```
  */
-export function mergeStyle(
-  a: React.CSSProperties | undefined,
-  b: React.CSSProperties | undefined,
-): React.CSSProperties | undefined {
+export function mergeStyle(a: CSSPropertiesTypes, b: CSSPropertiesTypes): CSSPropertiesTypes {
   return a && b ? { ...a, ...b } : a || b;
 }


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #9280

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- [x] Документация фичи
- [x] Release notes

## Описание

Добавил `slotProps.img`. Прокидывание пропов в другие элементы оставил под очередной запрос.

## Изменения

Если `hasSrc` тег не рендерится, поэтому в хуке `useMergeProps` передаю пустой объект, чтобы уменьшить объём оперций. Также удалил переменные `imgStyles` и `keepAspectRationStyles`, перенеся условие в `useMergeProps` – это потребовало поправить типы `mergeStyles`.

## Release notes
## Улучшения
- ImageBase: Добавлено свойство `slotProps.img` для возможности прокинуть в тег `<img>` дополнительные свойства. `getRef` отмечен устаревшим. Используйте `slotProps={ img: { getRootRef: /* ... */ } }`.
- Avatar: Добавлено свойство `slotProps.img` для возможности прокинуть в тег `<img>` дополнительные свойства. `getRef` отмечен устаревшим. Используйте `slotProps={ img: { getRootRef: /* ... */ } }`.
- Image: Добавлено свойство `slotProps.img` для возможности прокинуть в тег `<img>` дополнительные свойства. `getRef` отмечен устаревшим. Используйте `slotProps={ img: { getRootRef: /* ... */ } }`.

<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
