### PR TITLE
feat(browserslistrc): bump browsers versions

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,8 +1,8 @@
-ChromeAndroid >= 63
-iOS >= 12
-Chrome >= 63
-Firefox >= 55
+ChromeAndroid >= 68
+iOS >= 13
+Chrome >= 68
+Firefox >= 69
 Edge >= 79
-Opera >= 50
-Safari >= 12
-Samsung >= 8.2
+Opera >= 68
+Safari >= 13
+Samsung >= 9

--- a/website/content/overview/about.mdx
+++ b/website/content/overview/about.mdx
@@ -4,6 +4,8 @@ description:
   Основана на одноименной дизайн-системе ВКонтакте.
 ---
 
+import { Icon16CheckCircleFillGreen, Icon12ErrorCircleFillYellow, Icon12ErrorCircleFill } from '@vkontakte/icons';
+
 <Overview type="doc">
 # Обзор
 
@@ -30,9 +32,19 @@ VKUI — это библиотека адаптивных React-компонен
 Для возможности использования нативной функциональности, каждый год увеличиваются версии
 поддерживаемых браузеров на основе статистики команды Вконтакте. На данный момент версии следующие:
 
-- **Chromium based 63+** (Chrome, Edge, Chrome for Android и др.);
-- **Firefox 55+**;
-- **Safari 12+** (Safari, iOS).
+- **Chromium based 68+** (Chrome, Edge, Chrome for Android и др.);
+- **Firefox 69+**;
+- **Safari 13+** (Safari, iOS).
+
+## Используемые браузерные фичи
+
+Компоненты библиотеки используют или могут использовать следующие фичи:
+
+- <Icon16CheckCircleFillGreen width={12} height={12} display="inline" /> [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#browser_compatibility)
+- <Icon16CheckCircleFillGreen width={12} height={12} display="inline" /> [position: sticky](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position#browser_compatibility)
+- <Icon12ErrorCircleFillYellow display="inline" /> [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#browser_compatibility) – с полифилом на `<iframe>` со стороны библиотеки
+- <Icon12ErrorCircleFillYellow display="inline" /> [gap | Supported in Flex Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/gap#browser_compatibility) – с полифилом на `margin` со стороны библиотеки
+- <Icon12ErrorCircleFill display="inline" /> [CSS logical properties and values](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Logical_properties_and_values) –  в CSS-бандле `@vkontakte/vkui/dist/vkui.css` при [базовой установке](/overview/install/#base-install), трансформируются в обычные свойства; при [установке ESNext версии](/overview/install/#esnext-install) решение о полифиле можно принять самому
 
 ## Релизный цикл
 


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- close #9250

---

## Описание

Обновляем `.browserslistrc` на основе статистики ВКонтакте.

Также обновил версии на странице `/overview/about/` и добавил информацию про используемые фичи.

<img width="320" height="555" alt="image" src="https://github.com/user-attachments/assets/0b49cd73-69c5-4b87-bdb1-20fe1da279a7" />

## Release notes
- Обновлён список поддерживаемых браузеров

    ```diff
    - ChromeAndroid >= 63
    + ChromeAndroid >= 68
    - iOS >= 12
    + iOS >= 13 
    - Chrome >= 63
    + Chrome >= 68
    - Firefox >= 55
    + Firefox >= 69
    Edge >= 79
    - Opera >= 50
    + Opera >= 68
    - Safari >= 12
    + Safari >= 13
    - Samsung >= 8.2
    + Samsung >= 9
    ```