### PR TITLE
fix: renderProps ref

### DIFF
--- a/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
+++ b/packages/vkui/src/components/ChipsInputBase/ChipsInputBase.tsx
@@ -354,6 +354,13 @@ export const ChipsInputBase = <O extends ChipOption>({
             <React.Fragment key={`${typeof option.value}-${option.value}`}>
               {renderChip(
                 {
+                  /**
+                   * Компилятор сходит с ума из-за рефа внутри handleChipRemove.
+                   * Обходной путь прокидывать ref в свойства для рендер пропов.
+                   */
+                  ...(false
+                    ? { '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED': inputRef }
+                    : {}),
                   'Component': 'div',
                   'value': option.value,
                   'label': option.label,

--- a/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
+++ b/packages/vkui/src/components/ChipsSelect/ChipsSelect.tsx
@@ -329,11 +329,11 @@ export const ChipsSelect = <Option extends ChipOption>({
     }
   };
 
-  const chipsSelectOptions = React.useRef<HTMLElement[]>([]).current;
+  const chipsSelectOptions = React.useRef<HTMLElement[]>([]);
 
   const scrollToElement = (index: number, center = false) => {
     const dropdown = dropdownScrollBoxRef.current;
-    const item = chipsSelectOptions[index];
+    const item = chipsSelectOptions.current[index];
 
     /* istanbul ignore if: невозможный кейс (в SSR вызова этой функции не будет) */
     if (!item || !dropdown) {
@@ -509,6 +509,13 @@ export const ChipsSelect = <Option extends ChipOption>({
         <React.Fragment key={`${typeof option.value}-${option.value}`}>
           {renderOption(
             {
+              /**
+               * Компилятор сходит с ума из-за рефа внутри getRootRef.
+               * Обходной путь прокидывать ref в свойства для рендер пропов.
+               */
+              ...(false
+                ? { '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED': chipsSelectOptions }
+                : {}),
               id: dropdownItemId,
               disabled: option.disabled,
               hovered: focusedOption
@@ -521,7 +528,7 @@ export const ChipsSelect = <Option extends ChipOption>({
               ),
               getRootRef(node) {
                 if (node) {
-                  chipsSelectOptions[index] = node;
+                  chipsSelectOptions.current[index] = node;
                 }
               },
               onMouseDown(event: React.MouseEvent<HTMLDivElement>) {

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -576,6 +576,15 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
       return (
         <React.Fragment key={`${typeof option.value}-${option.value}`}>
           {renderOptionProp({
+            /**
+             * Компилятор сходит с ума из-за рефа внутри focusOptionOnMouseMove.
+             * Обходной путь прокидывать ref в свойства для рендер пропов.
+             */
+            ...(false
+              ? {
+                  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: lastMousePositionRef,
+                }
+              : {}),
             option,
             hovered,
             children: option.label,


### PR DESCRIPTION
- see #6919

## Описание

Реакт компилятор ругается на следующий код:

```tsx
import * as React from 'react';

export default function MyApp({ renderProp}) {
  const ref = React.useRef(false)

  const onClick = () => {
    ref.current = true
  }
  
  return <div>{renderProp({ onClick })}</div>;
}
``` 

Однако если прокинуть в `renderProp` реф, то реакт компилятор перестает ругаться

```diff
-   return <div>{renderProp({ onClick })}</div>;
+   return <div>{renderProp({ ref, onClick })}</div>;
```

## Изменения

Добавлены костыли для работы реакт компилятора

## Release notes
-