### PR TITLE
feat: es2018

### DIFF
--- a/packages/vkui/package.swcrc
+++ b/packages/vkui/package.swcrc
@@ -1,6 +1,10 @@
 {
   "$schema": "https://swc.rs/schema.json",
-  "exclude": ["\\.(test|spec|e2e|e2e-playground|stories|d)\\.[jt]sx?$", "testing/", "storybook/"],
+  "exclude": [
+    "\\.(test|spec|e2e|e2e-playground|stories|d)\\.[jt]sx?$",
+    "testing/",
+    "storybook/"
+  ],
 
   "module": {
     "type": "es6",
@@ -18,7 +22,7 @@
         "runtime": "automatic"
       }
     },
-    "target": "es2017",
+    "target": "es2018",
     "baseUrl": "./",
     "paths": {
       "*": ["node_modules", "src/*"]


### PR DESCRIPTION
- caused by #9287

## Описание

Повышаем таргет компиляции до `es2018`, который добавляет поддержку спредов и рестов для объектов. Это позволяет уменьшить размер бандла

## Release notes
## BREAKING CHANGE
- Поднята целевая версия `ECMAScript` для компиляции до `es2018`
