### PR TITLE
fix: enable rules-of-hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
   },
   "ignorePatterns": ["examples/**"],
   "parser": "@typescript-eslint/parser",
-  "plugins": ["import", "unicorn", "eslint-plugin-react-compiler"],
+  "plugins": ["import", "unicorn"],
   "parserOptions": {
     "project": "./tsconfig.json",
     "ecmaVersion": 2018, // Allows for the parsing of modern ECMAScript features
@@ -92,7 +92,6 @@
     "eqeqeq": "error", // Only type-safe equality operators
     "unicorn/expiring-todo-comments": ["error"],
     "no-console": "error",
-    "react-compiler/react-compiler": 2,
     "no-useless-computed-key": "error",
 
     "spaced-comment": ["error", "always", { "exceptions": ["#__PURE__"] }]

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsdoc": "^61.5.0",
     "eslint-plugin-react": "^7.33.2",
-    "eslint-plugin-react-compiler": "0.0.0-experimental-56229e1-20240813",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-server-components": "^1.2.0",
     "eslint-plugin-unicorn": "^55.0.0",

--- a/packages/vkui-docs-theme/src/components/Sidebar/Menu/Menu.tsx
+++ b/packages/vkui-docs-theme/src/components/Sidebar/Menu/Menu.tsx
@@ -39,7 +39,6 @@ function Folder({ item }: FolderProps) {
   const handleClick = React.useCallback(() => {
     if (isLink) {
       if (active) {
-        // eslint-disable-next-line react-compiler/react-compiler
         TreeState[item.route] = !open;
       } else {
         TreeState[item.route] = true;

--- a/packages/vkui/.eslintrc.cjs
+++ b/packages/vkui/.eslintrc.cjs
@@ -33,8 +33,8 @@ module.exports = {
     Element: true,
   },
   rules: {
-    'react-hooks/immutability': 'warn', // TODO [#6919] поменять на 'error'
-    'react-hooks/refs': 'warn', // TODO [#6919] поменять на 'error'
+    'react-hooks/immutability': 'error',
+    'react-hooks/refs': 'error',
     'no-restricted-imports': [
       'error',
       {
@@ -191,7 +191,7 @@ module.exports = {
       extends: ['plugin:@vitest/legacy-recommended'],
       plugins: ['@vitest'],
       rules: {
-        'react-hooks/globals': 'warn', // TODO [#6919] поменять на 'error' (при необходимости, точечно отключить в тестах)
+        'react-hooks/globals': 'error',
         '@vitest/valid-describe-callback': 'off',
         '@vitest/expect-expect': 'off',
         '@vitest/valid-title': 'off',

--- a/packages/vkui/src/hooks/useGlobalOnClickOutside.test.tsx
+++ b/packages/vkui/src/hooks/useGlobalOnClickOutside.test.tsx
@@ -18,7 +18,6 @@ const WrapperUseGlobalOnClickOutside = ({
   const target1Ref = React.createRef<HTMLDivElement>();
   const target2Ref = React.createRef<HTMLDivElement>();
 
-  // eslint-disable-next-line react-compiler/react-compiler
   useGlobalOnClickOutsideImpl(
     globalClickHandler,
     disableAllTarget || disableTarget === 'target-1' ? null : target1Ref,

--- a/packages/vkui/src/hooks/usePatchChildren.ts
+++ b/packages/vkui/src/hooks/usePatchChildren.ts
@@ -20,6 +20,22 @@ type ExpectedReactElement<T> = React.ReactElement<HasRootRef<T> & React.DOMAttri
 
 type ChildrenElement<T> = ExpectedReactElement<T> | React.ReactNode;
 
+function useWarn<ElementType extends HTMLElement = HTMLElement>(
+  shouldUseRef: boolean,
+  childRef: React.RefObject<ElementType | null>,
+) {
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      if (!childRef.current && !shouldUseRef) {
+        warn(
+          'Кажется, в children передан компонент, который не поддерживает свойство getRootRef. Мы не можем получить ссылку на корневой dom-элемент этого компонента',
+          'error',
+        );
+      }
+    }
+  }, [shouldUseRef, childRef]);
+}
+
 /**
  * Хук позволяет пропатчить переданный компонент так, чтобы можно было получить ссылку на его
  * DOM-элемент. Также есть возможность прокинуть дополнительные параметры.
@@ -76,16 +92,7 @@ export const usePatchChildren = <ElementType extends HTMLElement = HTMLElement>(
 
   const patchedChildren = isValidElementResult ? React.cloneElement(children, props) : children;
 
-  React.useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
-      if (!childRef.current && !shouldUseRef) {
-        warn(
-          'Кажется, в children передан компонент, который не поддерживает свойство getRootRef. Мы не можем получить ссылку на корневой dom-элемент этого компонента',
-          'error',
-        );
-      }
-    }
-  }, [shouldUseRef, childRef]);
+  useWarn(shouldUseRef, childRef);
 
   return [childRef, patchedChildren];
 };

--- a/packages/vkui/src/testing/useCustomArgs.ts
+++ b/packages/vkui/src/testing/useCustomArgs.ts
@@ -4,7 +4,6 @@ import { useArgs } from 'storybook/preview-api';
 // @ts-expect-error: TS2322 мокаем useArgs
 export const useCustomArgs: typeof useArgs = () => {
   try {
-    // eslint-disable-next-line react-compiler/react-compiler
     return useArgs();
   } catch {
     return [{}, noop, noop];

--- a/website/app/[[...mdxPath]]/page.tsx
+++ b/website/app/[[...mdxPath]]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { generateStaticParamsFor, importPage } from 'nextra/pages';
-import { useMDXComponents } from '../../mdx-components';
+import { useMDXComponents as mdxComponents } from '../../mdx-components';
 
 export const generateStaticParams = generateStaticParamsFor('mdxPath');
 
@@ -9,8 +9,8 @@ type PageProps = Readonly<{
     mdxPath: string[];
   }>;
 }>;
-// eslint-disable-next-line react-hooks/rules-of-hooks
-const Wrapper = useMDXComponents().wrapper!;
+
+const Wrapper = mdxComponents().wrapper!;
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,7 +169,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.18.6, @babel/helper-create-class-features-plugin@npm:^7.27.1":
+"@babel/helper-create-class-features-plugin@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-create-class-features-plugin@npm:7.27.1"
   dependencies:
@@ -235,7 +235,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1":
+"@babel/helper-plugin-utils@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-plugin-utils@npm:7.27.1"
   checksum: 10/96136c2428888e620e2ec493c25888f9ceb4a21099dcf3dd4508ea64b58cdedbd5a9fb6c7b352546de84d6c24edafe482318646932a22c449ebd16d16c22d864
@@ -304,18 +304,6 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10/8d9bfb437af6c97a7f6351840b9ac06b4529ba79d6d3def24d6c2996ab38ff7f1f9d301e868ca84a93a3050fadb3d09dbc5105b24634cd281671ac11eebe8df7
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-proposal-private-methods@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/plugin-proposal-private-methods@npm:7.18.6"
-  dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.18.6"
-    "@babel/helper-plugin-utils": "npm:^7.18.6"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/22d8502ee96bca99ad2c8393e8493e2b8d4507576dd054490fd8201a36824373440106f5b098b6d821b026c7e72b0424ff4aeca69ed5f42e48f029d3a156d5ad
   languageName: node
   linkType: hard
 
@@ -5305,7 +5293,6 @@ __metadata:
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jsdoc: "npm:^61.5.0"
     eslint-plugin-react: "npm:^7.33.2"
-    eslint-plugin-react-compiler: "npm:0.0.0-experimental-56229e1-20240813"
     eslint-plugin-react-hooks: "npm:^7.0.1"
     eslint-plugin-react-server-components: "npm:^1.2.0"
     eslint-plugin-unicorn: "npm:^55.0.0"
@@ -9066,22 +9053,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-compiler@npm:0.0.0-experimental-56229e1-20240813":
-  version: 0.0.0-experimental-56229e1-20240813
-  resolution: "eslint-plugin-react-compiler@npm:0.0.0-experimental-56229e1-20240813"
-  dependencies:
-    "@babel/core": "npm:^7.24.4"
-    "@babel/parser": "npm:^7.24.4"
-    "@babel/plugin-proposal-private-methods": "npm:^7.18.6"
-    hermes-parser: "npm:^0.20.1"
-    zod: "npm:^3.22.4"
-    zod-validation-error: "npm:^3.0.3"
-  peerDependencies:
-    eslint: ">=7"
-  checksum: 10/cba57ca6515d2a6c55c7f131a3c13d7905c1e65b99efd2c6b81868f7e3229897c5d9b07930ffd263b8597e4e6d63581b1debba1c9dfeb7c48bf44603d7de0ed0
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-react-hooks@npm:^7.0.1":
   version: 7.0.1
   resolution: "eslint-plugin-react-hooks@npm:7.0.1"
@@ -10733,26 +10704,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.20.1":
-  version: 0.20.1
-  resolution: "hermes-estree@npm:0.20.1"
-  checksum: 10/b98fc2943bd9fdd904c094e995f79cb7d5958393e221006af81d88f3aed52ddbf15138a6606766d5e6be7ba166576be65f577d0c72ae5eb0f3f56d4720b32baa
-  languageName: node
-  linkType: hard
-
 "hermes-estree@npm:0.25.1":
   version: 0.25.1
   resolution: "hermes-estree@npm:0.25.1"
   checksum: 10/7b1eca98b264a25632064cffa5771360d30cf452e77db1e191f9913ee45cf78c292b2dbca707e92fb71b0870abb97e94b506a5ab80abd96ba237fee169b601fe
-  languageName: node
-  linkType: hard
-
-"hermes-parser@npm:^0.20.1":
-  version: 0.20.1
-  resolution: "hermes-parser@npm:0.20.1"
-  dependencies:
-    hermes-estree: "npm:0.20.1"
-  checksum: 10/b1ae9e9f6b49234fcf2bd45eafde140a3c727b8bcb845ab398016a538f040d326291d1f8b75fd91793b8817f2c600a890e251984d55bdedea74a5143d29f0c81
   languageName: node
   linkType: hard
 
@@ -19937,28 +19892,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-validation-error@npm:^3.0.3":
-  version: 3.5.3
-  resolution: "zod-validation-error@npm:3.5.3"
-  peerDependencies:
-    zod: ^3.25.0 || ^4.0.0
-  checksum: 10/f550565ffb2a0a1733616d856302184dbe2080ec649ff9361125467065c3dfa02aeb5bf399605cdb61fe640f79ff1fe8ad0805f6e0c8144fa34764cad58f4401
-  languageName: node
-  linkType: hard
-
 "zod-validation-error@npm:^3.5.0 || ^4.0.0":
   version: 4.0.2
   resolution: "zod-validation-error@npm:4.0.2"
   peerDependencies:
     zod: ^3.25.0 || ^4.0.0
   checksum: 10/5e35ca8ebb4602dcb526e122d7e9fca695c4a479bd97535f3400a732d49160f24f7213a9ed64986fc9dc3a2e8a6c4e1241ec0c4d8a4e3e69ea91a0328ded2192
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.22.4":
-  version: 3.25.76
-  resolution: "zod@npm:3.25.76"
-  checksum: 10/f0c963ec40cd96858451d1690404d603d36507c1fc9682f2dae59ab38b578687d542708a7fdbf645f77926f78c9ed558f57c3d3aa226c285f798df0c4da16995
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- see #6919

## Описание

- включаем линтер хуков
- выносим предупреждение usePatchChildren подальше от React.cloneElement
- удаляем eslint-plugin-react-compiler (он стал частью правил хуков)

## Release notes
-