### PR TITLE
fix: use camelCase for css modules names

### DIFF
--- a/packages/vkui-docs-theme/src/components/Sidebar/MobileSidebar/MobileSidebar.module.css
+++ b/packages/vkui-docs-theme/src/components/Sidebar/MobileSidebar/MobileSidebar.module.css
@@ -31,28 +31,28 @@
 }
 
 .backdropShow {
-  animation: animation-sidebar-fade-in var(--vkui--animation_duration_l) ease both;
+  animation: animationSidebarFadeIn var(--vkui--animation_duration_l) ease both;
 }
 
 .backdropHide {
-  animation: animation-sidebar-fade-out var(--vkui--animation_duration_l) ease both;
+  animation: animationSidebarFadeOut var(--vkui--animation_duration_l) ease both;
 }
 
 .rootShow {
-  animation: animation-sidebar-translate-in var(--vkui--animation_duration_l) ease both;
+  animation: animationSidebarTranslateIn var(--vkui--animation_duration_l) ease both;
 }
 
 .rootHide {
-  animation: animation-sidebar-translate-out var(--vkui--animation_duration_l) ease both;
+  animation: animationSidebarTranslateOut var(--vkui--animation_duration_l) ease both;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .rootShow {
-    animation-name: animation-sidebar-fade-in;
+    animation-name: animationSidebarFadeIn;
   }
 
   .rootHide {
-    animation-name: animation-sidebar-fade-out;
+    animation-name: animationSidebarFadeOut;
   }
 }
 @media (--viewWidth-smallTabletPlus) {
@@ -76,7 +76,7 @@
   Animations
  */
 
-@keyframes animation-sidebar-translate-in {
+@keyframes animationSidebarTranslateIn {
   from {
     transform: translateX(-100%);
   }
@@ -85,7 +85,7 @@
     transform: translateX(0);
   }
 }
-@keyframes animation-sidebar-translate-out {
+@keyframes animationSidebarTranslateOut {
   from {
     transform: translateX(0);
   }
@@ -94,7 +94,7 @@
     transform: translateX(-100%);
   }
 }
-@keyframes animation-sidebar-fade-in {
+@keyframes animationSidebarFadeIn {
   from {
     opacity: 0;
   }
@@ -103,7 +103,7 @@
     opacity: 1;
   }
 }
-@keyframes animation-sidebar-fade-out {
+@keyframes animationSidebarFadeOut {
   from {
     opacity: 1;
   }

--- a/packages/vkui-docs-theme/src/mdx/HeadingLink/HeadingLink.module.css
+++ b/packages/vkui-docs-theme/src/mdx/HeadingLink/HeadingLink.module.css
@@ -42,7 +42,7 @@
 }
 
 .heading:target {
-  animation: highlight 1.2s ease;
+  animation: animationHighlight 1.2s ease;
 }
 
 .anchor:focus .anchorIcon,
@@ -50,7 +50,7 @@
   opacity: 1;
 }
 
-@keyframes highlight {
+@keyframes animationHighlight {
   0% {
     background-color: var(--vkui--color_background_accent_themed_alpha);
   }

--- a/packages/vkui-docs-theme/src/mdx/Pre/CopyToClipboard/CopyToClipboard.module.css
+++ b/packages/vkui-docs-theme/src/mdx/Pre/CopyToClipboard/CopyToClipboard.module.css
@@ -13,14 +13,14 @@
 }
 
 .copied .copyIcon {
-  animation: hide-icon 1.25s forwards;
+  animation: animationHideIcon 1.25s forwards;
 }
 
 .copied .doneIcon {
-  animation: show-icon 1.25s 0.15s forwards;
+  animation: animationShowIcon 1.25s 0.15s forwards;
 }
 
-@keyframes hide-icon {
+@keyframes animationHideIcon {
   0% {
     opacity: 1;
   }
@@ -39,7 +39,7 @@
     opacity: 1;
   }
 }
-@keyframes show-icon {
+@keyframes animationShowIcon {
   0% {
     opacity: 0;
   }

--- a/packages/vkui/src/components/Accordion/Accordion.module.css
+++ b/packages/vkui/src/components/Accordion/Accordion.module.css
@@ -22,12 +22,12 @@
 }
 
 .inEnter {
-  animation-name: animation-accordion-expand;
+  animation-name: animationAccordionExpand;
 }
 
 @media (--reduce-motion) {
   .inEnter {
-    animation-name: animation-accordion-fade-in;
+    animation-name: animationAccordionFadeIn;
   }
 }
 
@@ -36,12 +36,12 @@
 }
 
 .inExit {
-  animation-name: animation-accordion-collapse;
+  animation-name: animationAccordionCollapse;
 }
 
 @media (--reduce-motion) {
   .inExit {
-    animation-name: animation-accordion-fade-out;
+    animation-name: animationAccordionFadeOut;
   }
 }
 
@@ -49,7 +49,7 @@
   block-size: 0;
 }
 
-@keyframes animation-accordion-expand {
+@keyframes animationAccordionExpand {
   0% {
     block-size: 0;
   }
@@ -58,7 +58,7 @@
     block-size: var(--vkui_internal--AccordionContent_height);
   }
 }
-@keyframes animation-accordion-collapse {
+@keyframes animationAccordionCollapse {
   0% {
     block-size: var(--vkui_internal--AccordionContent_height);
   }
@@ -67,7 +67,7 @@
     block-size: 0;
   }
 }
-@keyframes animation-accordion-fade-in {
+@keyframes animationAccordionFadeIn {
   0% {
     block-size: var(--vkui_internal--AccordionContent_height);
     opacity: 0;
@@ -83,7 +83,7 @@
     opacity: 1;
   }
 }
-@keyframes animation-accordion-fade-out {
+@keyframes animationAccordionFadeOut {
   0% {
     block-size: var(--vkui_internal--AccordionContent_height);
     opacity: 1;

--- a/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
+++ b/packages/vkui/src/components/ActionSheet/ActionSheet.module.css
@@ -31,13 +31,13 @@
 }
 
 .opening {
-  animation: animation-actionsheet-slide-up var(--vkui--animation_duration_m)
+  animation: animationActionSheetSlideUp var(--vkui--animation_duration_m)
     var(--vkui--animation_easing_platform);
 }
 
 .closing {
   opacity: 0;
-  animation: animation-actionsheet-slide-down var(--vkui--animation_duration_m)
+  animation: animationActionSheetSlideDown var(--vkui--animation_duration_m)
     var(--vkui--animation_easing_platform);
 }
 
@@ -126,7 +126,7 @@
   }
 }
 
-@keyframes animation-actionsheet-slide-up {
+@keyframes animationActionSheetSlideUp {
   from {
     opacity: var(--vkui_internal--actionsheet_animation_opacity_initial);
     transform: translateY(var(--vkui_internal--actionsheet_animation_translateY_initial));
@@ -137,7 +137,7 @@
     transform: translateY(0);
   }
 }
-@keyframes animation-actionsheet-slide-down {
+@keyframes animationActionSheetSlideDown {
   from {
     opacity: 1;
     transform: translateY(0);

--- a/packages/vkui/src/components/Alert/Alert.module.css
+++ b/packages/vkui/src/components/Alert/Alert.module.css
@@ -17,13 +17,13 @@
 }
 
 .opening {
-  animation: animation-alert-scale-up var(--vkui--animation_duration_m)
+  animation: animationAlertScaleUp var(--vkui--animation_duration_m)
     var(--vkui--animation_easing_platform);
 }
 
 .closing {
   opacity: 0;
-  animation: animation-alert-scale-down var(--vkui--animation_duration_m)
+  animation: animationAlertScaleDown var(--vkui--animation_duration_m)
     var(--vkui--animation_easing_platform);
 }
 
@@ -293,7 +293,7 @@
   }
 }
 
-@keyframes animation-alert-scale-up {
+@keyframes animationAlertScaleUp {
   from {
     opacity: 0;
     transform: scale(var(--vkui_internal--alert_animation_scale_initial));
@@ -304,7 +304,7 @@
     transform: scale(1);
   }
 }
-@keyframes animation-alert-scale-down {
+@keyframes animationAlertScaleDown {
   from {
     opacity: 1;
     transform: scale(1);

--- a/packages/vkui/src/components/CalendarDay/CalendarDay.test.tsx
+++ b/packages/vkui/src/components/CalendarDay/CalendarDay.test.tsx
@@ -67,13 +67,11 @@ describe('CalendarDay', () => {
         </AppRootContext.Provider>,
       );
 
-      expect(screen.getByTestId('day')).not.toHaveClass(
-        stylesFocusVisible['-focus-visible--focused'],
-      );
+      expect(screen.getByTestId('day')).not.toHaveClass(stylesFocusVisible.focusVisibleFocused);
 
       await userEvent.tab();
 
-      expect(screen.getByTestId('day')).toHaveClass(stylesFocusVisible['-focus-visible--focused']);
+      expect(screen.getByTestId('day')).toHaveClass(stylesFocusVisible.focusVisibleFocused);
     }),
   );
 });

--- a/packages/vkui/src/components/Flex/Flex.test.tsx
+++ b/packages/vkui/src/components/Flex/Flex.test.tsx
@@ -72,13 +72,13 @@ describe(Flex, () => {
         props: {
           gap: ['l', 'l'],
         },
-        className: gapStyles['-column-gap--l'],
+        className: gapStyles.columnGapL,
       },
       {
         props: {
           gap: ['l', 'l'],
         },
-        className: gapStyles['-row-gap--l'],
+        className: gapStyles.rowGapL,
       },
       {
         props: {

--- a/packages/vkui/src/components/ModalCard/ModalCardInternal.tsx
+++ b/packages/vkui/src/components/ModalCard/ModalCardInternal.tsx
@@ -22,20 +22,20 @@ import type { ModalCardProps } from './types';
 import styles from './ModalCard.module.css';
 
 const sizeByPlatformClassNames = {
-  vkcom: styles['hostMaxWidthS'],
-  ios: styles['hostMaxWidthM'],
-  android: styles['hostMaxWidthL'],
+  vkcom: styles.hostMaxWidthS,
+  ios: styles.hostMaxWidthM,
+  android: styles.hostMaxWidthL,
 };
 
 const transitionStateClassNames: Partial<Record<UseCSSTransitionState, string>> = {
-  appear: styles['hostStateEnter'],
-  appearing: styles['hostStateEntering'],
+  appear: styles.hostStateEnter,
+  appearing: styles.hostStateEntering,
 
-  enter: styles['hostStateEnter'],
-  entering: styles['hostStateEntering'],
+  enter: styles.hostStateEnter,
+  entering: styles.hostStateEntering,
 
-  exiting: styles['hostStateExiting'],
-  exited: styles['hostStateExited'],
+  exiting: styles.hostStateExiting,
+  exited: styles.hostStateExited,
 };
 
 export interface ModalCardInternalProps extends Omit<ModalCardProps, 'nav' | 'keepMounted'> {

--- a/packages/vkui/src/components/ModalOverlay/ModalOverlay.tsx
+++ b/packages/vkui/src/components/ModalOverlay/ModalOverlay.tsx
@@ -14,15 +14,15 @@ const positionClassNames = {
 };
 
 const transitionStateClassNames: Partial<Record<UseCSSTransitionState, string>> = {
-  appear: styles['hostStateEnter'],
-  appearing: styles['hostStateEntering'],
-  appeared: styles['hostStateEntered'],
-  enter: styles['hostStateEnter'],
-  entering: styles['hostStateEntering'],
-  entered: styles['hostStateEntered'],
-  exit: styles['hostStateExit'],
-  exiting: styles['hostStateExiting'],
-  exited: styles['hostStateExited'],
+  appear: styles.hostStateEnter,
+  appearing: styles.hostStateEntering,
+  appeared: styles.hostStateEntered,
+  enter: styles.hostStateEnter,
+  entering: styles.hostStateEntering,
+  entered: styles.hostStateEntered,
+  exit: styles.hostStateExit,
+  exiting: styles.hostStateExiting,
+  exited: styles.hostStateExited,
 };
 
 export interface ModalOverlayProps

--- a/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
@@ -29,14 +29,14 @@ import type { ModalPageProps } from './types';
 import styles from './ModalPage.module.css';
 
 const transitionStateClassNames: Partial<Record<UseCSSTransitionState, string>> = {
-  appear: styles['documentStateEnter'],
-  appearing: styles['documentStateEntering'],
+  appear: styles.documentStateEnter,
+  appearing: styles.documentStateEntering,
 
-  enter: styles['documentStateEnter'],
-  entering: styles['documentStateEntering'],
+  enter: styles.documentStateEnter,
+  entering: styles.documentStateEntering,
 
-  exiting: styles['documentStateExiting'],
-  exited: styles['documentStateExited'],
+  exiting: styles.documentStateExiting,
+  exited: styles.documentStateExited,
 };
 
 export interface ModalPageInternalProps
@@ -226,9 +226,9 @@ export const ModalPageInternal = ({
 };
 
 const desktopMaxWidthClassNames = {
-  s: styles['hostDesktopMaxWidthS'],
-  m: styles['hostDesktopMaxWidthM'],
-  l: styles['hostDesktopMaxWidthL'],
+  s: styles.hostDesktopMaxWidthS,
+  m: styles.hostDesktopMaxWidthM,
+  l: styles.hostDesktopMaxWidthL,
 };
 
 function resolveDesktopMaxWidth(

--- a/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.module.css
+++ b/packages/vkui/src/components/PanelHeaderContext/PanelHeaderContext.module.css
@@ -41,28 +41,28 @@
 }
 
 .opened .fade {
-  animation: animation-panelheadercontext-fade-in var(--vkui--animation_duration_m) ease both;
+  animation: animationPanelHeaderContextFadeIn var(--vkui--animation_duration_m) ease both;
 }
 
 .closing .fade {
-  animation: animation-panelheadercontext-fade-out var(--vkui--animation_duration_m) ease both;
+  animation: animationPanelHeaderContextFadeOut var(--vkui--animation_duration_m) ease both;
 }
 
 .opened .in {
-  animation: animation-panelheadercontext-translate-in var(--vkui--animation_duration_m) ease both;
+  animation: animationPanelHeaderContextTranslateIn var(--vkui--animation_duration_m) ease both;
 }
 
 .closing .in {
-  animation: animation-panelheadercontext-translate-out var(--vkui--animation_duration_m) ease both;
+  animation: animationPanelHeaderContextTranslateOut var(--vkui--animation_duration_m) ease both;
 }
 
 @media (--reduce-motion) {
   .opened .in {
-    animation-name: animation-panelheadercontext-fade-in;
+    animation-name: animationPanelHeaderContextFadeIn;
   }
 
   .closing .in {
-    animation-name: animation-panelheadercontext-fade-out;
+    animation-name: animationPanelHeaderContextFadeOut;
   }
 }
 
@@ -135,7 +135,7 @@
   Animations
  */
 
-@keyframes animation-panelheadercontext-translate-in {
+@keyframes animationPanelHeaderContextTranslateIn {
   from {
     transform: translateY(-100%);
   }
@@ -144,7 +144,7 @@
     transform: translateY(0);
   }
 }
-@keyframes animation-panelheadercontext-translate-out {
+@keyframes animationPanelHeaderContextTranslateOut {
   from {
     transform: translateY(0);
   }
@@ -153,7 +153,7 @@
     transform: translateY(-100%);
   }
 }
-@keyframes animation-panelheadercontext-fade-in {
+@keyframes animationPanelHeaderContextFadeIn {
   from {
     opacity: 0;
   }
@@ -162,7 +162,7 @@
     opacity: 1;
   }
 }
-@keyframes animation-panelheadercontext-fade-out {
+@keyframes animationPanelHeaderContextFadeOut {
   from {
     opacity: 1;
   }

--- a/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.module.css
+++ b/packages/vkui/src/components/PopoutWrapper/PopoutWrapper.module.css
@@ -33,12 +33,12 @@
 }
 
 .opened .overlay {
-  animation: animation-full-fade-in var(--vkui--animation_duration_m) ease both;
+  animation: animationPopoutWrapperFullFadeIn var(--vkui--animation_duration_m) ease both;
 }
 
 .closing .overlay {
   opacity: 0;
-  animation: animation-full-fade-out var(--vkui--animation_duration_m)
+  animation: animationPopoutWrapperFullFadeOut var(--vkui--animation_duration_m)
     var(--vkui--animation_easing_default) both;
 }
 
@@ -96,7 +96,7 @@
   justify-content: flex-end;
 }
 
-@keyframes animation-full-fade-in {
+@keyframes animationPopoutWrapperFullFadeIn {
   from {
     opacity: 0;
   }
@@ -105,7 +105,7 @@
     opacity: 1;
   }
 }
-@keyframes animation-full-fade-out {
+@keyframes animationPopoutWrapperFullFadeOut {
   from {
     opacity: 1;
   }

--- a/packages/vkui/src/components/Popover/usePopover.tsx
+++ b/packages/vkui/src/components/Popover/usePopover.tsx
@@ -146,7 +146,7 @@ export const usePopover = <ElementType extends HTMLElement = HTMLElement>({
                   className={classNames(
                     styles.in,
                     noStyling ? undefined : styles.inWithStyling,
-                    willBeHide ? animationFadeClassNames.out : animationFadeClassNames.in,
+                    willBeHide ? animationFadeClassNames.fadeOut : animationFadeClassNames.fadeIn,
                     transformOriginClassNames[resolvedPlacement],
                     className,
                   )}

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.module.css
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.module.css
@@ -52,7 +52,7 @@
 }
 
 .ios.refreshing .spinnerSelf {
-  animation: pull-to-refresh-to-refreshing 380ms ease-out;
+  animation: animationPullToRefreshToRefreshing 380ms ease-out;
 }
 
 .spinnerPath {
@@ -67,7 +67,7 @@
 }
 
 .spinnerOn .spinnerPath {
-  animation: ptr-rotator var(--vkui_internal--duration) linear infinite;
+  animation: animationPullToRefreshRotator var(--vkui_internal--duration) linear infinite;
 }
 
 .content {
@@ -82,7 +82,7 @@
   transition: none;
 }
 
-@keyframes pull-to-refresh-to-refreshing {
+@keyframes animationPullToRefreshToRefreshing {
   0% {
     transform: scale(1);
   }
@@ -99,7 +99,7 @@
     transform: scale(1);
   }
 }
-@keyframes ptr-rotator {
+@keyframes animationPullToRefreshRotator {
   0% {
     transform: rotate(0deg);
   }

--- a/packages/vkui/src/components/Root/Root.module.css
+++ b/packages/vkui/src/components/Root/Root.module.css
@@ -25,12 +25,12 @@
 }
 
 .viewShowForward {
-  animation: root-animation-show-forward var(--vkui_internal--root_animation_duration)
+  animation: animationRootAnimationShowForward var(--vkui_internal--root_animation_duration)
     var(--vkui--animation_easing_platform);
 }
 
 .viewHideBack {
-  animation: root-animation-hide-back var(--vkui_internal--root_animation_duration)
+  animation: animationRootAnimationHideBack var(--vkui_internal--root_animation_duration)
     var(--vkui--animation_easing_platform) forwards;
 }
 
@@ -63,13 +63,13 @@
 }
 
 .ios .viewShowBack::after {
-  animation: root-ios-overlay-animation-show-back var(--vkui_internal--root_animation_duration)
+  animation: animationRootIosOverlayAnimationShowBack var(--vkui_internal--root_animation_duration)
     var(--vkui--animation_easing_platform) forwards;
 }
 
 .ios .viewHideForward::after {
-  animation: root-ios-overlay-animation-hide-forward var(--vkui_internal--root_animation_duration)
-    var(--vkui--animation_easing_platform);
+  animation: animationRootIosOverlayAnimationHideForward
+    var(--vkui_internal--root_animation_duration) var(--vkui--animation_easing_platform);
 }
 
 @media (--reduce-motion) {
@@ -83,7 +83,7 @@
   }
 }
 
-@keyframes root-animation-hide-back {
+@keyframes animationRootAnimationHideBack {
   from {
     opacity: 1;
     transform: none;
@@ -94,7 +94,7 @@
     transform: var(--vkui_internal--root_animation_transform_initial);
   }
 }
-@keyframes root-animation-show-forward {
+@keyframes animationRootAnimationShowForward {
   from {
     opacity: var(--vkui_internal--root_animation_opacity_initial);
     transform: var(--vkui_internal--root_animation_transform_initial);
@@ -105,7 +105,7 @@
     transform: none;
   }
 }
-@keyframes root-ios-overlay-animation-show-back {
+@keyframes animationRootIosOverlayAnimationShowBack {
   from {
     opacity: 0.3;
   }
@@ -114,7 +114,7 @@
     opacity: 0;
   }
 }
-@keyframes root-ios-overlay-animation-hide-forward {
+@keyframes animationRootIosOverlayAnimationHideForward {
   from {
     opacity: 0;
   }

--- a/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.module.css
+++ b/packages/vkui/src/components/ScreenSpinner/ScreenSpinner.module.css
@@ -6,7 +6,7 @@
   padding-block: var(--vkui--spacing_size_2xl);
   padding-inline: var(--vkui--spacing_size_2xl);
   border-radius: var(--vkui--size_border_radius--regular);
-  animation: screen-spinner-intro 0.3s ease;
+  animation: animationScreenSpinnerIntro 0.3s ease;
 }
 
 .hasLabel {
@@ -79,17 +79,18 @@
 
 /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
 .icon :global(.vkuiIcon) {
-  animation: screen-spinner-intro 0.2s ease;
+  animation: animationScreenSpinnerIntro 0.2s ease;
 }
 
 /* stylelint-disable-next-line selector-max-type, selector-pseudo-class-disallowed-list */
 .stateDone :global(.vkuiIcon) path {
   stroke-dasharray: 50;
   stroke-dashoffset: 50;
-  animation: screen-spinner-icon-done 0.6s 0.3s var(--vkui--animation_easing_platform) forwards;
+  animation: animationScreenSpinnerIconDone 0.6s 0.3s var(--vkui--animation_easing_platform)
+    forwards;
 }
 
-@keyframes screen-spinner-icon-done {
+@keyframes animationScreenSpinnerIconDone {
   from {
     stroke-dashoffset: 50;
   }
@@ -98,7 +99,7 @@
     stroke-dashoffset: 0;
   }
 }
-@keyframes screen-spinner-intro {
+@keyframes animationScreenSpinnerIntro {
   from {
     opacity: 0;
   }

--- a/packages/vkui/src/components/SimpleGrid/SimpleGrid.test.tsx
+++ b/packages/vkui/src/components/SimpleGrid/SimpleGrid.test.tsx
@@ -24,7 +24,7 @@ describe('SimpleGrid', () => {
       props: {
         gap: ['l', 'm'],
       },
-      className: classNames(gapsStyles['-column-gap--m'], gapsStyles['-row-gap--l']),
+      className: classNames(gapsStyles.columnGapM, gapsStyles.rowGapL),
     },
     {
       props: {

--- a/packages/vkui/src/components/Skeleton/Skeleton.module.css
+++ b/packages/vkui/src/components/Skeleton/Skeleton.module.css
@@ -39,14 +39,14 @@
     var(--vkui_internal--skeleton_color_from)
   );
   transform: translateX(-100vw);
-  animation-name: animation-skeleton;
+  animation-name: animationSkeleton;
   animation-duration: 1.5s;
   animation-timing-function: ease-in-out;
   animation-iteration-count: infinite;
   animation-direction: normal /*rtl:reverse*/;
 }
 
-@keyframes animation-skeleton {
+@keyframes animationSkeleton {
   100% {
     transform: translateX(100vw);
   }

--- a/packages/vkui/src/components/Snackbar/Snackbar.module.css
+++ b/packages/vkui/src/components/Snackbar/Snackbar.module.css
@@ -159,13 +159,13 @@
 
 .stateEnter .in,
 .stateEntering .in {
-  animation-name: animation-snackbar-slide-in;
+  animation-name: animationSnackbarSlideIn;
 }
 
 @media (--reduce-motion) {
   .stateEnter .in,
   .stateEntering .in {
-    animation-name: animation-snackbar-fade-in;
+    animation-name: animationSnackbarFadeIn;
   }
 }
 
@@ -181,13 +181,13 @@
 
 .stateExit .in,
 .stateExiting .in {
-  animation-name: animation-snackbar-slide-out;
+  animation-name: animationSnackbarSlideOut;
 }
 
 @media (--reduce-motion) {
   .stateExit .in,
   .stateExiting .in {
-    animation-name: animation-snackbar-fade-out;
+    animation-name: animationSnackbarFadeOut;
   }
 } /* stylelint-disable-next-line at-rule-empty-line-before */
 
@@ -199,7 +199,7 @@
   );
 }
 
-@keyframes animation-snackbar-slide-in {
+@keyframes animationSnackbarSlideIn {
   from {
     opacity: 0;
     transform: var(--vkui_internal--snackbar_animation_from);
@@ -210,7 +210,7 @@
     transform: translate3d(0, 0, 0);
   }
 }
-@keyframes animation-snackbar-slide-out {
+@keyframes animationSnackbarSlideOut {
   from {
     opacity: 1;
     transform: var(--vkui_internal--snackbar_animation_to);
@@ -223,7 +223,7 @@
 }
 
 /* Анимации при (prefers-reduced-motion: reduce) */
-@keyframes animation-snackbar-fade-in {
+@keyframes animationSnackbarFadeIn {
   from {
     opacity: 0;
   }
@@ -232,7 +232,7 @@
     opacity: 1;
   }
 }
-@keyframes animation-snackbar-fade-out {
+@keyframes animationSnackbarFadeOut {
   from {
     opacity: 1;
   }

--- a/packages/vkui/src/components/TabbarItem/TabbarItem.test.tsx
+++ b/packages/vkui/src/components/TabbarItem/TabbarItem.test.tsx
@@ -71,10 +71,10 @@ describe('TabbarItem', () => {
       const component = renderTabbarItemForFocus({ withKeyboardInput: true });
 
       await userEvent.tab();
-      expect(screen.getByRole('presentation')).toHaveClass(styles['-focus-visible--focused']);
+      expect(screen.getByRole('presentation')).toHaveClass(styles.focusVisibleFocused);
 
       await userEvent.tab();
-      expect(screen.getByRole('presentation')).not.toHaveClass(styles['-focus-visible--focused']);
+      expect(screen.getByRole('presentation')).not.toHaveClass(styles.focusVisibleFocused);
 
       expect(component.onFocusStub).toHaveBeenCalledTimes(1);
       expect(component.onBlurStub).toHaveBeenCalledTimes(1);
@@ -87,10 +87,10 @@ describe('TabbarItem', () => {
       const component = renderTabbarItemForFocus({ withKeyboardInput: false });
 
       await userEvent.click(screen.getByTestId('test'));
-      expect(screen.getByRole('presentation')).not.toHaveClass(styles['-focus-visible--focused']);
+      expect(screen.getByRole('presentation')).not.toHaveClass(styles.focusVisibleFocused);
 
       await userEvent.tab();
-      expect(screen.getByRole('presentation')).not.toHaveClass(styles['-focus-visible--focused']);
+      expect(screen.getByRole('presentation')).not.toHaveClass(styles.focusVisibleFocused);
 
       expect(component.onFocusStub).toHaveBeenCalledTimes(1);
       expect(component.onBlurStub).toHaveBeenCalledTimes(1);

--- a/packages/vkui/src/components/Tappable/Tappable.module.css
+++ b/packages/vkui/src/components/Tappable/Tappable.module.css
@@ -94,13 +94,13 @@ https://github.com/VKCOM/VKUI/pull/3641
   background: var(--vkui--color_transparent--active);
   border-radius: 50%;
   opacity: 0;
-  animation: animation-wave 0.3s var(--vkui--animation_easing_platform);
+  animation: animationWave 0.3s var(--vkui--animation_easing_platform);
 }
 
 /**
  * Animations
  */
-@keyframes animation-wave {
+@keyframes animationWave {
   0% {
     opacity: 1;
     transform: scale(1);

--- a/packages/vkui/src/components/Tooltip/useTooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/useTooltip.tsx
@@ -114,7 +114,7 @@ export const useTooltip = ({
                   }
             }
             className={classNames(
-              willBeHide ? animationFadeClassNames.out : animationFadeClassNames.in,
+              willBeHide ? animationFadeClassNames.fadeOut : animationFadeClassNames.fadeIn,
               className,
             )}
             onCloseIconClick={closable ? onClose : undefined}

--- a/packages/vkui/src/components/View/View.module.css
+++ b/packages/vkui/src/components/View/View.module.css
@@ -32,12 +32,12 @@
 
 .panelPrev .panelOverlay {
   display: block;
-  animation: animation-ios-overlay-fade-in 0.6s var(--vkui--animation_easing_platform);
+  animation: animationIosOverlayFadeIn 0.6s var(--vkui--animation_easing_platform);
 }
 
 .panelNext .panelOverlay {
   display: block;
-  animation: animation-ios-overlay-fade-out 0.6s var(--vkui--animation_easing_platform) forwards;
+  animation: animationIosOverlayFadeOut 0.6s var(--vkui--animation_easing_platform) forwards;
 }
 
 .panelActive .panelOverlay,
@@ -124,27 +124,27 @@
  */
 
 .panelNext ~ .panelPrev {
-  animation: animation-view-prev-back 0.3s var(--vkui--animation_easing_platform) forwards;
+  animation: animationViewPrevBack 0.3s var(--vkui--animation_easing_platform) forwards;
 }
 
 .panelPrev ~ .panelNext {
-  animation: animation-view-next-forward 0.3s var(--vkui--animation_easing_platform);
+  animation: animationViewNextForward 0.3s var(--vkui--animation_easing_platform);
 }
 
 .ios .panelPrev {
-  animation: animation-ios-prev-forward 0.6s var(--vkui--animation_easing_platform);
+  animation: animationIosPrevForward 0.6s var(--vkui--animation_easing_platform);
 }
 
 .ios .panelNext {
-  animation: animation-ios-next-back 0.6s var(--vkui--animation_easing_platform);
+  animation: animationIosNextBack 0.6s var(--vkui--animation_easing_platform);
 }
 
 .ios .panelPrev ~ .panelNext {
-  animation: animation-ios-next-forward 0.6s var(--vkui--animation_easing_platform);
+  animation: animationIosNextForward 0.6s var(--vkui--animation_easing_platform);
 }
 
 .ios .panelNext ~ .panelPrev {
-  animation: animation-ios-prev-back 0.6s var(--vkui--animation_easing_platform) forwards;
+  animation: animationIosPrevBack 0.6s var(--vkui--animation_easing_platform) forwards;
 }
 
 @media (--reduce-motion) {
@@ -154,13 +154,13 @@
   }
 
   .ios .panelNext ~ .panelPrev {
-    animation-name: animation-view-prev-back;
+    animation-name: animationViewPrevBack;
     animation-duration: 0.3s;
     animation-fill-mode: forwards;
   }
 
   .ios .panelPrev ~ .panelNext {
-    animation-name: animation-view-next-forward;
+    animation-name: animationViewNextForward;
     animation-duration: 0.3s;
     animation-fill-mode: none;
   }
@@ -173,7 +173,7 @@
   animation: none;
 }
 
-@keyframes animation-view-prev-back {
+@keyframes animationViewPrevBack {
   from {
     opacity: 1;
     transform: translateY(0);
@@ -184,7 +184,7 @@
     transform: translateY(var(--vkui_internal--view_animation_translateY_initial));
   }
 }
-@keyframes animation-view-next-forward {
+@keyframes animationViewNextForward {
   from {
     opacity: 0;
     transform: translateY(var(--vkui_internal--view_animation_translateY_initial));
@@ -195,7 +195,7 @@
     transform: translateY(0);
   }
 }
-@keyframes animation-ios-next-forward {
+@keyframes animationIosNextForward {
   from {
     transform: translate3d(100%, 0, 0);
   }
@@ -204,7 +204,7 @@
     transform: translate3d(0, 0, 0);
   }
 }
-@keyframes animation-ios-next-back {
+@keyframes animationIosNextBack {
   from {
     transform: translate3d(-50%, 0, 0);
   }
@@ -213,7 +213,7 @@
     transform: translate3d(0, 0, 0);
   }
 }
-@keyframes animation-ios-prev-forward {
+@keyframes animationIosPrevForward {
   from {
     transform: translate3d(0, 0, 0);
   }
@@ -222,7 +222,7 @@
     transform: translate3d(-50%, 0, 0);
   }
 }
-@keyframes animation-ios-prev-back {
+@keyframes animationIosPrevBack {
   from {
     transform: translate3d(0, 0, 0);
   }
@@ -231,7 +231,7 @@
     transform: translate3d(100%, 0, 0);
   }
 }
-@keyframes animation-ios-overlay-fade-in {
+@keyframes animationIosOverlayFadeIn {
   from {
     opacity: 0;
   }
@@ -240,7 +240,7 @@
     opacity: 0.3;
   }
 }
-@keyframes animation-ios-overlay-fade-out {
+@keyframes animationIosOverlayFadeOut {
   from {
     opacity: 0.3;
   }

--- a/packages/vkui/src/hooks/useAdaptivityConditionalRender/constants.ts
+++ b/packages/vkui/src/hooks/useAdaptivityConditionalRender/constants.ts
@@ -8,7 +8,7 @@ export const forcedProps = { className: '' };
  * TODO [>=10]: #9015 Удалить константу.
  */
 export const sizeXCompactMediaQueryProps: ElementProps = {
-  className: styles['-viewWidth--smallTabletMinus-mq'],
+  className: styles.viewWidthSmallTabletMinusMq,
 };
 
 /**
@@ -16,25 +16,25 @@ export const sizeXCompactMediaQueryProps: ElementProps = {
  * TODO [>=10]: #9015 Удалить константу.
  */
 export const sizeXRegularMediaQueryProps: ElementProps = {
-  className: styles['-viewWidth--smallTabletPlus-mq'],
+  className: styles.viewWidthSmallTabletPlusMq,
 };
 
 export const densityCompactMediaQueryProps: ElementProps = {
-  className: styles['-density--compact-mq'],
+  className: styles.densityCompactMq,
 };
 
 export const densityRegularMediaQueryProps: ElementProps = {
-  className: styles['-density--regular-mq'],
+  className: styles.densityRegularMq,
 };
 
 export const viewWidthMediaQueryMapProps: Record<ViewWidthCSSBreakpoints, ElementProps> = {
-  smallTabletMinus: { className: styles['-viewWidth--smallTabletMinus-mq'] },
-  smallTabletPlus: { className: styles['-viewWidth--smallTabletPlus-mq'] },
-  tabletMinus: { className: styles['-viewWidth--tabletMinus-mq'] },
-  tabletPlus: { className: styles['-viewWidth--tabletPlus-mq'] },
+  smallTabletMinus: { className: styles.viewWidthSmallTabletMinusMq },
+  smallTabletPlus: { className: styles.viewWidthSmallTabletPlusMq },
+  tabletMinus: { className: styles.viewWidthTabletMinusMq },
+  tabletPlus: { className: styles.viewWidthTabletPlusMq },
 };
 
 export const deviceTypeMediaQueryMapProps: Record<DeviceTypeCSSBreakpoints, ElementProps> = {
-  mobile: { className: styles['-deviceType--mobile-mq'] },
-  desktop: { className: styles['-deviceType--desktop-mq'] },
+  mobile: { className: styles.deviceTypeMobileMq },
+  desktop: { className: styles.deviceTypeDesktopMq },
 };

--- a/packages/vkui/src/hooks/useFocusVisibleClassName.test.ts
+++ b/packages/vkui/src/hooks/useFocusVisibleClassName.test.ts
@@ -8,7 +8,7 @@ import {
 } from './useFocusVisibleClassName';
 import styles from '../styles/focusVisible.module.css';
 
-const focusedClasses = classNames(styles['-focus-visible'], styles['-focus-visible--focused']);
+const focusedClasses = classNames(styles.focusVisible, styles.focusVisibleFocused);
 
 const test = (hookConfig: UseFocusVisibleClassNameProps, resultClassNameString: string) => {
   const { result } = renderHook(() => useFocusVisibleClassName(hookConfig));
@@ -20,7 +20,7 @@ const test = (hookConfig: UseFocusVisibleClassNameProps, resultClassNameString: 
 
 describe('useFocusVisibleClassName()', () => {
   it('focusVisible: false returns proper class', () => {
-    test({ focusVisible: false }, styles['-focus-visible']);
+    test({ focusVisible: false }, styles.focusVisible);
   });
 
   it('focusVisible: true (default mode) returns proper classes', () => {

--- a/packages/vkui/src/hooks/useFocusVisibleClassName.ts
+++ b/packages/vkui/src/hooks/useFocusVisibleClassName.ts
@@ -3,8 +3,8 @@ import type { LiteralUnion } from '../types';
 import styles from '../styles/focusVisible.module.css';
 
 export const focusVisiblePresetModeClassNames: Record<'inside' | 'outside', string> = {
-  inside: styles['-focus-visible--mode-inside'],
-  outside: styles['-focus-visible--mode-outside'],
+  inside: styles.focusVisibleModeInside,
+  outside: styles.focusVisibleModeOutside,
 };
 
 type FocusVisiblePresetMode = keyof typeof focusVisiblePresetModeClassNames;
@@ -39,8 +39,8 @@ export function useFocusVisibleClassName({
   const modeClassName = isPresetMode(mode) ? focusVisiblePresetModeClassNames[mode] : mode;
 
   const focusVisibleClassNames = classNames(
-    styles['-focus-visible'],
-    focusVisible && styles['-focus-visible--focused'],
+    styles.focusVisible,
+    focusVisible && styles.focusVisibleFocused,
     focusVisible && modeClassName,
   );
 

--- a/packages/vkui/src/hooks/useSnackbarManager/components/SnackbarAnimatedWrapper.module.css
+++ b/packages/vkui/src/hooks/useSnackbarManager/components/SnackbarAnimatedWrapper.module.css
@@ -19,14 +19,14 @@
 }
 
 .stateEnter {
-  animation-name: animation-snackbar-grow-in;
+  animation-name: animationSnackbarGrowIn;
 }
 
 .stateExit {
-  animation-name: animation-snackbar-grow-out;
+  animation-name: animationSnackbarGrowOut;
 }
 
-@keyframes animation-snackbar-grow-in {
+@keyframes animationSnackbarGrowIn {
   from {
     max-block-size: 0;
     margin-block-start: 0;
@@ -37,7 +37,7 @@
     margin-block-start: var(--vkui_internal--SnackbarAnimatedWrapper_margin_top);
   }
 }
-@keyframes animation-snackbar-grow-out {
+@keyframes animationSnackbarGrowOut {
   from {
     block-size: var(--vkui_internal--SnackbarAnimatedWrapper_height);
     margin-block-start: var(--vkui_internal--SnackbarAnimatedWrapper_margin_top);

--- a/packages/vkui/src/lib/animation/fades.ts
+++ b/packages/vkui/src/lib/animation/fades.ts
@@ -1,6 +1,4 @@
 import styles from '../../styles/animationFades.module.css'; // eslint-disable-line import/order
 
-export const animationFadeClassNames: Record<'in' | 'out', string> = {
-  in: styles['-anim-fade-in'],
-  out: styles['-anim-fade-out'],
-};
+export const fadeIn = styles.animFadeIn;
+export const fadeOut = styles.animFadeOut;

--- a/packages/vkui/src/lib/animation/index.ts
+++ b/packages/vkui/src/lib/animation/index.ts
@@ -1,7 +1,7 @@
 export { useCSSKeyframesAnimationController } from './useCSSKeyframesAnimationController';
 export { REDUCE_MOTION_MEDIA_QUERY, useReducedMotion } from './useReducedMotion';
 export { rubberbandIfOutOfBounds } from './rubberbandIfOutOfBounds';
-export { animationFadeClassNames } from './fades';
+export * as animationFadeClassNames from './fades';
 export { transformOriginClassNames } from './transformOrigin';
 export {
   type UseCSSTransitionState,

--- a/packages/vkui/src/lib/animation/transformOrigin.ts
+++ b/packages/vkui/src/lib/animation/transformOrigin.ts
@@ -2,16 +2,16 @@ import type { Placement } from '../floating';
 import styles from '../../styles/transformOriginByPlacement.module.css'; // eslint-disable-line import/order
 
 export const transformOriginClassNames: Record<Placement, string> = {
-  'top': styles['-anim-transform-origin-top'],
-  'top-start': styles['-anim-transform-origin-top-start'],
-  'top-end': styles['-anim-transform-origin-top-end'],
-  'right': styles['-anim-transform-origin-right'],
-  'right-start': styles['-anim-transform-origin-right-start'],
-  'right-end': styles['-anim-transform-origin-right-end'],
-  'bottom': styles['-anim-transform-origin-bottom'],
-  'bottom-start': styles['-anim-transform-origin-bottom-start'],
-  'bottom-end': styles['-anim-transform-origin-bottom-end'],
-  'left': styles['-anim-transform-origin-left'],
-  'left-start': styles['-anim-transform-origin-left-start'],
-  'left-end': styles['-anim-transform-origin-left-end'],
+  'top': styles.animTransformOriginTop,
+  'top-start': styles.animTransformOriginTopStart,
+  'top-end': styles.animTransformOriginTopEnd,
+  'right': styles.animTransformOriginRight,
+  'right-start': styles.animTransformOriginRightStart,
+  'right-end': styles.animTransformOriginRightEnd,
+  'bottom': styles.animTransformOriginBottom,
+  'bottom-start': styles.animTransformOriginBottomStart,
+  'bottom-end': styles.animTransformOriginBottomEnd,
+  'left': styles.animTransformOriginLeft,
+  'left-start': styles.animTransformOriginLeftStart,
+  'left-end': styles.animTransformOriginLeftEnd,
 };

--- a/packages/vkui/src/lib/floating/functions.ts
+++ b/packages/vkui/src/lib/floating/functions.ts
@@ -49,7 +49,7 @@ export function convertFloatingDataToReactCSSProperties({
   if (middlewareData) {
     const hide = middlewareData.hide;
     if (hide && hide.referenceHidden) {
-      styles['visibility'] = 'hidden';
+      styles.visibility = 'hidden';
     }
   }
   return styles;

--- a/packages/vkui/src/lib/layouts/gaps.ts
+++ b/packages/vkui/src/lib/layouts/gaps.ts
@@ -3,27 +3,27 @@ import type { DesignSystemSize } from './types';
 import styles from '../../styles/gaps.module.css';
 
 export const columnGapClassNames: Record<DesignSystemSize, string> = {
-  '2xs': styles['-column-gap--2xs'],
-  'xs': styles['-column-gap--xs'],
-  's': styles['-column-gap--s'],
-  'm': styles['-column-gap--m'],
-  'l': styles['-column-gap--l'],
-  'xl': styles['-column-gap--xl'],
-  '2xl': styles['-column-gap--2xl'],
-  '3xl': styles['-column-gap--3xl'],
-  '4xl': styles['-column-gap--4xl'],
+  '2xs': styles.columnGap2xs,
+  'xs': styles.columnGapXs,
+  's': styles.columnGapS,
+  'm': styles.columnGapM,
+  'l': styles.columnGapL,
+  'xl': styles.columnGapXl,
+  '2xl': styles.columnGap2xl,
+  '3xl': styles.columnGap3xl,
+  '4xl': styles.columnGap4xl,
 };
 
 export const rowGapClassNames: Record<DesignSystemSize, string> = {
-  '2xs': styles['-row-gap--2xs'],
-  'xs': styles['-row-gap--xs'],
-  's': styles['-row-gap--s'],
-  'm': styles['-row-gap--m'],
-  'l': styles['-row-gap--l'],
-  'xl': styles['-row-gap--xl'],
-  '2xl': styles['-row-gap--2xl'],
-  '3xl': styles['-row-gap--3xl'],
-  '4xl': styles['-row-gap--4xl'],
+  '2xs': styles.rowGap2xs,
+  'xs': styles.rowGapXs,
+  's': styles.rowGapS,
+  'm': styles.rowGapM,
+  'l': styles.rowGapL,
+  'xl': styles.rowGapXl,
+  '2xl': styles.rowGap2xl,
+  '3xl': styles.rowGap3xl,
+  '4xl': styles.rowGap4xl,
 };
 
 export type GapProp = LiteralUnion<DesignSystemSize, number>;

--- a/packages/vkui/src/lib/spacings/sizes.ts
+++ b/packages/vkui/src/lib/spacings/sizes.ts
@@ -4,15 +4,15 @@ import styles from '../../styles/spacings.module.css';
 export type SpacingSize = '2xs' | 'xs' | 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl';
 
 export const spacingSizeClassNames: Record<SpacingSize, string> = {
-  '2xs': styles['-spacing--2xs'],
-  'xs': styles['-spacing--xs'],
-  's': styles['-spacing--s'],
-  'm': styles['-spacing--m'],
-  'l': styles['-spacing--l'],
-  'xl': styles['-spacing--xl'],
-  '2xl': styles['-spacing--2xl'],
-  '3xl': styles['-spacing--3xl'],
-  '4xl': styles['-spacing--4xl'],
+  '2xs': styles.spacing2xs,
+  'xs': styles.spacingXs,
+  's': styles.spacingS,
+  'm': styles.spacingM,
+  'l': styles.spacingL,
+  'xl': styles.spacingXl,
+  '2xl': styles.spacing2xl,
+  '3xl': styles.spacing3xl,
+  '4xl': styles.spacing4xl,
 };
 
 export type SpacingSizeProp = LiteralUnion<SpacingSize | `--${string}`, number>;

--- a/packages/vkui/src/styles/adaptivity.module.css
+++ b/packages/vkui/src/styles/adaptivity.module.css
@@ -15,13 +15,13 @@ Note: В начале классов разделить (`-`), чтобы кра
 /* ================================================================================================================== */
 
 @media (--density-regular) {
-  .-density--compact-mq {
+  .densityCompactMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }
 }
 @media (--density-compact) {
-  .-density--regular-mq {
+  .densityRegularMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }
@@ -30,13 +30,13 @@ Note: В начале классов разделить (`-`), чтобы кра
 /* ================================================================================================================== */
 
 @media (--viewWidth-tabletPlus) {
-  .-viewWidth--tabletMinus-mq {
+  .viewWidthTabletMinusMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }
 }
 @media (--viewWidth-tabletMinus) {
-  .-viewWidth--tabletPlus-mq {
+  .viewWidthTabletPlusMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }
@@ -45,13 +45,13 @@ Note: В начале классов разделить (`-`), чтобы кра
 /* ================================================================================================================== */
 
 @media (--viewWidth-smallTabletPlus) {
-  .-viewWidth--smallTabletMinus-mq {
+  .viewWidthSmallTabletMinusMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }
 }
 @media (--viewWidth-smallTabletMinus) {
-  .-viewWidth--smallTabletPlus-mq {
+  .viewWidthSmallTabletPlusMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }
@@ -60,13 +60,13 @@ Note: В начале классов разделить (`-`), чтобы кра
 /* ================================================================================================================== */
 
 @media (--desktop) {
-  .-deviceType--mobile-mq {
+  .deviceTypeMobileMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }
 }
 @media (--mobile) {
-  .-deviceType--desktop-mq {
+  .deviceTypeDesktopMq {
     /* stylelint-disable-next-line declaration-no-important */
     display: none !important;
   }

--- a/packages/vkui/src/styles/animationFades.module.css
+++ b/packages/vkui/src/styles/animationFades.module.css
@@ -1,12 +1,12 @@
-.-anim-fade-in {
-  animation: anim-fade-in 0.1s ease-in forwards;
+.animFadeIn {
+  animation: animationFadeIn 0.1s ease-in forwards;
 }
 
-.-anim-fade-out {
-  animation: anim-fade-out 0.1s ease-out forwards;
+.animFadeOut {
+  animation: animationFadeOut 0.1s ease-out forwards;
 }
 
-@keyframes anim-fade-in {
+@keyframes animationFadeIn {
   from {
     opacity: 0;
     transform: scale(0.8);
@@ -17,7 +17,7 @@
     transform: scale(1);
   }
 }
-@keyframes anim-fade-out {
+@keyframes animationFadeOut {
   from {
     opacity: 1;
   }

--- a/packages/vkui/src/styles/animationVisibilityDelay.module.css
+++ b/packages/vkui/src/styles/animationVisibilityDelay.module.css
@@ -3,10 +3,10 @@
 
   visibility: hidden;
   animation: 0ms linear var(--vkui_internal--animation_delay_visibility) forwards
-    animation-styles-delay-visibility;
+    animationStylesDelayVisibility;
 }
 
-@keyframes animation-styles-delay-visibility {
+@keyframes animationStylesDelayVisibility {
   to {
     visibility: visible;
   }

--- a/packages/vkui/src/styles/focusVisible.module.css
+++ b/packages/vkui/src/styles/focusVisible.module.css
@@ -2,44 +2,43 @@
  * Утилитарные классы на замену отдельному компоненту для имитации
  * :focus-visible состояния.
  */
-.-focus-visible {
+.focusVisible {
   --vkui_internal--outline_width: 2px;
 }
 
 /* stylelint-disable selector-max-universal */
-.-focus-visible:focus,
-.-focus-visible:focus-visible,
-.-focus-visible *:focus,
-.-focus-visible *:focus-visible {
+.focusVisible:focus,
+.focusVisible:focus-visible,
+.focusVisible *:focus,
+.focusVisible *:focus-visible {
   outline: none;
 }
 /* stylelint-enable selector-max-universal */
-
-.-focus-visible.-focus-visible--mode-outside {
+.focusVisible.focusVisibleModeOutside {
   --vkui_internal--outline_offset_from: 0;
   --vkui_internal--outline_offset_to: var(--vkui_internal--outline_width);
 }
 
-.-focus-visible.-focus-visible--mode-inside {
+.focusVisible.focusVisibleModeInside {
   --vkui_internal--outline_offset_from: calc(-2 * var(--vkui_internal--outline_width));
   --vkui_internal--outline_offset_to: calc(-1 * var(--vkui_internal--outline_width));
 }
 
-.-focus-visible.-focus-visible--focused.-focus-visible--mode-inside,
-.-focus-visible.-focus-visible--focused.-focus-visible--mode-outside {
+.focusVisible.focusVisibleFocused.focusVisibleModeInside,
+.focusVisible.focusVisibleFocused.focusVisibleModeOutside {
   outline: var(--vkui_internal--outline);
   outline-offset: var(--vkui_internal--outline_offset_to);
-  animation: animation-outline-offset 0.1s ease-in-out 0.01s forwards;
+  animation: animationOutlineOffset 0.1s ease-in-out 0.01s forwards;
 }
 
 @media (--reduce-motion) {
-  .-focus-visible.-focus-visible--focused.-focus-visible--mode-inside,
-  .-focus-visible.-focus-visible--focused.-focus-visible--mode-outside {
+  .focusVisible.focusVisibleFocused.focusVisibleModeInside,
+  .focusVisible.focusVisibleFocused.focusVisibleModeOutside {
     animation: none;
   }
 }
 
-@keyframes animation-outline-offset {
+@keyframes animationOutlineOffset {
   0% {
     outline-offset: var(--vkui_internal--outline_offset_from);
   }

--- a/packages/vkui/src/styles/gaps.module.css
+++ b/packages/vkui/src/styles/gaps.module.css
@@ -1,75 +1,75 @@
 /* Row Gap */
 
-.-row-gap--2xs {
+.rowGap2xs {
   --vkui_internal--row_gap: var(--vkui--spacing_size_2xs);
 }
 
-.-row-gap--xs {
+.rowGapXs {
   --vkui_internal--row_gap: var(--vkui--spacing_size_xs);
 }
 
-.-row-gap--s {
+.rowGapS {
   --vkui_internal--row_gap: var(--vkui--spacing_size_s);
 }
 
-.-row-gap--m {
+.rowGapM {
   --vkui_internal--row_gap: var(--vkui--spacing_size_m);
 }
 
-.-row-gap--l {
+.rowGapL {
   --vkui_internal--row_gap: var(--vkui--spacing_size_l);
 }
 
-.-row-gap--xl {
+.rowGapXl {
   --vkui_internal--row_gap: var(--vkui--spacing_size_xl);
 }
 
-.-row-gap--2xl {
+.rowGap2xl {
   --vkui_internal--row_gap: var(--vkui--spacing_size_2xl);
 }
 
-.-row-gap--3xl {
+.rowGap3xl {
   --vkui_internal--row_gap: var(--vkui--spacing_size_3xl);
 }
 
-.-row-gap--4xl {
+.rowGap4xl {
   --vkui_internal--row_gap: var(--vkui--spacing_size_4xl);
 }
 
 /* Column Gap */
 
-.-column-gap--2xs {
+.columnGap2xs {
   --vkui_internal--column_gap: var(--vkui--spacing_size_2xs);
 }
 
-.-column-gap--xs {
+.columnGapXs {
   --vkui_internal--column_gap: var(--vkui--spacing_size_xs);
 }
 
-.-column-gap--s {
+.columnGapS {
   --vkui_internal--column_gap: var(--vkui--spacing_size_s);
 }
 
-.-column-gap--m {
+.columnGapM {
   --vkui_internal--column_gap: var(--vkui--spacing_size_m);
 }
 
-.-column-gap--l {
+.columnGapL {
   --vkui_internal--column_gap: var(--vkui--spacing_size_l);
 }
 
-.-column-gap--xl {
+.columnGapXl {
   --vkui_internal--column_gap: var(--vkui--spacing_size_xl);
 }
 
-.-column-gap--2xl {
+.columnGap2xl {
   --vkui_internal--column_gap: var(--vkui--spacing_size_2xl);
 }
 
-.-column-gap--3xl {
+.columnGap3xl {
   --vkui_internal--column_gap: var(--vkui--spacing_size_3xl);
 }
 
-.-column-gap--4xl {
+.columnGap4xl {
   --vkui_internal--column_gap: var(--vkui--spacing_size_4xl);
 }

--- a/packages/vkui/src/styles/spacings.module.css
+++ b/packages/vkui/src/styles/spacings.module.css
@@ -1,35 +1,35 @@
-.-spacing--2xs {
+.spacing2xs {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_2xs);
 }
 
-.-spacing--xs {
+.spacingXs {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_xs);
 }
 
-.-spacing--s {
+.spacingS {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_s);
 }
 
-.-spacing--m {
+.spacingM {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_m);
 }
 
-.-spacing--l {
+.spacingL {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_l);
 }
 
-.-spacing--xl {
+.spacingXl {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_xl);
 }
 
-.-spacing--2xl {
+.spacing2xl {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_2xl);
 }
 
-.-spacing--3xl {
+.spacing3xl {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_3xl);
 }
 
-.-spacing--4xl {
+.spacing4xl {
   --vkui_internal--spacing_size: var(--vkui--spacing_size_4xl);
 }

--- a/packages/vkui/src/styles/transformOriginByPlacement.module.css
+++ b/packages/vkui/src/styles/transformOriginByPlacement.module.css
@@ -1,47 +1,47 @@
-.-anim-transform-origin-top {
+.animTransformOriginTop {
   transform-origin: bottom center;
 }
 
-.-anim-transform-origin-top-start {
+.animTransformOriginTopStart {
   transform-origin: bottom left;
 }
 
-.-anim-transform-origin-top-end {
+.animTransformOriginTopEnd {
   transform-origin: bottom right;
 }
 
-.-anim-transform-origin-right {
+.animTransformOriginRight {
   transform-origin: left center;
 }
 
-.-anim-transform-origin-right-start {
+.animTransformOriginRightStart {
   transform-origin: left top;
 }
 
-.-anim-transform-origin-right-end {
+.animTransformOriginRightEnd {
   transform-origin: left bottom;
 }
 
-.-anim-transform-origin-bottom {
+.animTransformOriginBottom {
   transform-origin: top center;
 }
 
-.-anim-transform-origin-bottom-start {
+.animTransformOriginBottomStart {
   transform-origin: top left;
 }
 
-.-anim-transform-origin-bottom-end {
+.animTransformOriginBottomEnd {
   transform-origin: top right;
 }
 
-.-anim-transform-origin-left {
+.animTransformOriginLeft {
   transform-origin: right center;
 }
 
-.-anim-transform-origin-left-start {
+.animTransformOriginLeftStart {
   transform-origin: right top;
 }
 
-.-anim-transform-origin-left-end {
+.animTransformOriginLeftEnd {
   transform-origin: right bottom;
 }

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -14,6 +14,7 @@ const config = {
   ],
   rules: {
     'property-no-deprecated': [true, { ignoreProperties: ['/^-.*-box-orient$/'] }],
+    'keyframes-name-pattern': '^animation[A-Z][a-zA-Z0-9]*$',
     'block-no-empty': null,
     'declaration-block-no-redundant-longhand-properties': null,
     'comment-empty-line-before': null,

--- a/website/components/mdx/InstallTemplates/InstallTemplates.module.css
+++ b/website/components/mdx/InstallTemplates/InstallTemplates.module.css
@@ -40,10 +40,10 @@
 }
 
 .hover .externalLink {
-  animation: link-shift 0.35s ease-out;
+  animation: animationLinkShift 0.35s ease-out;
 }
 
-@keyframes link-shift {
+@keyframes animationLinkShift {
   100% {
     transform: translateX(2px) translateY(-2px);
   }


### PR DESCRIPTION
- [x] ~Unit-тесты~ (линтеры)
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] ~Release notes~

## Описание

[happy-css-modules](https://github.com/mizdra/happy-css-modules) с большой вероятностью в дальнейшем не будет поддерживаться. В место него рекомендуется использовать [css-modules-kit](https://github.com/mizdra/css-modules-kit). css-modules-kit не дает использовать названия классов которые являются невалидными в js. Также если мы будем переходить на именованные импорты(`* as styles`), то нам необходимо иметь валидные js переменные

## Изменения

Имена классов изменены в формате camelCase для 

## Release notes
## Исправления
- Из-за отказа от [happy-css-modules](https://github.com/mizdra/happy-css-modules), именование всех CSS классов переведёно в `camelCase` формат
