### PR TITLE
docs(FixedLayout): fix typo

### DIFF
--- a/website/content/components/fixed-layout.mdx
+++ b/website/content/components/fixed-layout.mdx
@@ -8,7 +8,7 @@ description: Компонент закрепляет переданный кон
 
 > Компонент устарел начиная с `v8.0.0` и будет **удалён** в `v10.0.0`.
 >
-> Используйте вместо него [`Box`](./components/box) с `position="sticky"` и `insetBlockStart`/`insetBlockEnd`.
+> Используйте вместо него [`Box`](/components/box) с `position="sticky"` и `insetBlockStart`/`insetBlockEnd`.
 >
 > ```tsx
 > // Пример миграции с `<FixedLayout vertical="top" />`
@@ -16,7 +16,7 @@ description: Компонент закрепляет переданный кон
 >   Я стики
 > </Box>
 > // Пример миграции с `<FixedLayout vertical="bottom" filled />`
-> <Box position="sticky" insetBlockStart="0" style={{ backgroundColor: 'var(--vkui--color_background_content)' }}>
+> <Box position="sticky" insetBlockEnd="0" style={{ backgroundColor: 'var(--vkui--color_background_content)' }}>
 >   Я стики
 > </Box>
 > ```


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- caused by #9288

---

## Описание

- исправил ссылку на `Box`;
- исправил пример миграции для `<FixedLayout vertical="bottom" />`.

## Release notes
-