### PR TITLE
fix(CalendarHeader): fix breakpoint for adaptivity

### DIFF
--- a/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/vkui/src/components/CalendarHeader/CalendarHeader.tsx
@@ -233,7 +233,7 @@ export const CalendarHeader = ({
   return (
     <RootComponent baseClassName={styles.host} {...restProps}>
       {!prevMonthHidden && (
-        <AdaptivityProvider viewWidth={ViewWidth.MOBILE}>
+        <AdaptivityProvider viewWidth={ViewWidth.SMALL_TABLET}>
           <Tappable
             baseClassName={classNames(styles.navIcon, styles.navIconPrev, prevMonthClassName)}
             onClick={onPrevMonth}


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- caused by #9334

---

## Описание

При миграции в PR #9334 заменил `sizeX="regular"` не на тот брейкпоинт – нужен `viewWidth={ViewWidth.SMALL_TABLET}`.

## Release notes
-