### PR TITLE
fix(Tooltip): use ceil for width

### DIFF
--- a/packages/vkui/src/components/Tooltip/useTooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/useTooltip.tsx
@@ -175,7 +175,7 @@ export const useTooltip = ({
     customMiddlewares: [
       sizeMiddleware({
         apply({ rects, elements, availableWidth }) {
-          const width = Math.min(Math.round(rects.floating.width), Math.floor(availableWidth));
+          const width = Math.min(Math.ceil(rects.floating.width), Math.floor(availableWidth));
           Object.assign(elements.floating.style, {
             width: `${width}px`,
           });


### PR DESCRIPTION
- caused by #9281

## Описание

С версии `v7.11.0` в некоторых случаях ширина тултипа была не целая и округлялась в нижнюю сторону, из-за чего текст переходил на новую строку

<img width="450" height="217" alt="image" src="https://github.com/user-attachments/assets/8ecabcc2-baf5-4b1b-89c4-296f9b15912f" />


## Release notes
## Исправления
- [Tooltip](https://vkui.io/${version}/components/tooltip): текст мог переходить на новую строку
