### PR TITLE
docs(Tooltip): fix example

### DIFF
--- a/website/content/components/tooltip.mdx
+++ b/website/content/components/tooltip.mdx
@@ -108,7 +108,7 @@ return (
   aria-label="Тултип с какой-то информацией"
 >
   <Button>Якорь</Button>
-</Popover>
+</Tooltip>
 ```
 
 ## Свойства и методы [#api]


### PR DESCRIPTION
## Описание

Неверный закрывающий компонент

## Release notes
## Документация
- Tooltip: В примере был неверный закрывающий компонент
