### PR TITLE
fix(Tooltip): rm custom size() middleware

### DIFF
--- a/packages/vkui/src/components/Tooltip/useTooltip.tsx
+++ b/packages/vkui/src/components/Tooltip/useTooltip.tsx
@@ -9,7 +9,7 @@ import {
   type UseFloatingElementProps,
 } from '../../hooks/useFloatingElement';
 import { animationFadeClassNames } from '../../lib/animation';
-import { getArrowCoordsByMiddlewareData, sizeMiddleware } from '../../lib/floating';
+import { getArrowCoordsByMiddlewareData } from '../../lib/floating';
 import { type ReferenceProps } from '../../lib/floating/useFloatingWithInteractions/types';
 import { AppRootPortal } from '../AppRoot/AppRootPortal';
 import { TooltipBase } from '../TooltipBase/TooltipBase';
@@ -171,18 +171,6 @@ export const useTooltip = ({
     renderFloatingComponent,
     externalFloatingElementRef: getRootRef,
     remapReferenceProps,
-
-    customMiddlewares: [
-      sizeMiddleware({
-        apply({ rects, elements, availableWidth }) {
-          const width = Math.min(Math.ceil(rects.floating.width), Math.floor(availableWidth));
-          Object.assign(elements.floating.style, {
-            width: `${width}px`,
-          });
-        },
-        padding: overflowPadding,
-      }),
-    ],
   });
 
   return {


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- caused by #9281
- related to #9389

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~
- ~[ ] e2e-тесты~
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~
- [x] Release notes

## Описание

В [v7.11.0](https://github.com/VKCOM/VKUI/releases/tag/v7.11.0) в `Tooltip` внесли 2 изменения:

1. Свойство `overflowPadding`, чтобы можно было добавить отступы и избавиться от прилипания к краю области видимости.

2. Пересчёт ширины, чтобы `maxWidth` не вызлезал за `viewportWidth` (в [v7.11.2](https://github.com/VKCOM/VKUI/releases/tag/v7.11.2) был фикс округления).

Но **п.2**, к сожалению, создал другая проблему, что ширина стала статичной, поэтому для решения проблемы ничего не остается как откатить **п.2**.

Как воркэраунд, проблему с `maxWidth > viewportWidth` необхоидмо решать локально – задавать `maxWidth` с вычетом `overflowPadding`, учитывая, что эти данные должны быть заведомо известны. Также стоит учитывать какой минимальной ширины устройства у пользователей приложения.

К будущей мажорной версии **v9**, должна будет появится поддержка [min()](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/min) в CSS. Начиная с поддержки `min()`, будет возможность добавить новое свойство `fitViewport`, чтобы решить проблему с **п.2** и в тоже время решить конфликт свойства с `maxWidth`.

## Release notes
## Исправления
- Tooltip: откатили изменения из [v7.11.0](https://github.com/VKCOM/VKUI/releases/tag/v7.11.0) и [v7.11.2](https://github.com/VKCOM/VKUI/releases/tag/v7.11.2), связанные с пересчётом ширины