### PR TITLE
fix: img loading order

### DIFF
--- a/packages/vkui/src/components/ContentCard/ContentCard.tsx
+++ b/packages/vkui/src/components/ContentCard/ContentCard.tsx
@@ -102,6 +102,10 @@ export const ContentCard = ({
       >
         {(src || srcSet) && (
           <img
+            // safari и firefox нужно чтобы атрибут `loading` был до `src`
+            //
+            // https://mihaly4.ru/image-loading-lazy-bug
+            loading={loading}
             ref={getRef}
             className={styles.img}
             src={src}
@@ -109,7 +113,6 @@ export const ContentCard = ({
             alt={alt}
             crossOrigin={crossOrigin}
             decoding={decoding}
-            loading={loading}
             referrerPolicy={referrerPolicy}
             sizes={sizes}
             useMap={useMap}

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -256,6 +256,10 @@ export const ImageBase: React.FC<ImageBaseProps> & {
   } = useMergeProps<React.ComponentProps<'img'> & HasRootRef<HTMLImageElement> & HasDataAttribute>(
     hasSrc
       ? {
+          // safari и firefox нужно чтобы атрибут `loading` был до `src`
+          //
+          // https://mihaly4.ru/image-loading-lazy-bug
+          loading,
           getRootRef: getRef,
           alt,
           className: classNames(
@@ -268,7 +272,6 @@ export const ImageBase: React.FC<ImageBaseProps> & {
           ),
           crossOrigin,
           decoding,
-          loading,
           referrerPolicy,
           style: mergeStyle(
             keepAspectRatio


### PR DESCRIPTION
## Описание

В Safari и в старых Firefox есть баг с тем что в теге img атрибут loading требуется писать перед src

https://mihaly4.ru/image-loading-lazy-bug

## Release notes
## Исправления
- ContentCard, Avatar, Image, ImageBase: Для тега `img` атрибут `loading` выставлялся после `src`, что сопровождается багом в **Safari** и в старых версиях **Firefox**
