### PR TITLE
docs: add latin subsets for fonts

### DIFF
--- a/packages/vkui-docs-theme/src/mdx/Code/Code.tsx
+++ b/packages/vkui-docs-theme/src/mdx/Code/Code.tsx
@@ -5,7 +5,7 @@ import styles from './Code.module.css';
 
 // eslint-disable-next-line new-cap
 const jetBrainsMono = JetBrains_Mono({
-  subsets: ['cyrillic'],
+  subsets: ['latin', 'cyrillic'],
 });
 
 export function Code({

--- a/website/components/mdx/Playground/Playground.tsx
+++ b/website/components/mdx/Playground/Playground.tsx
@@ -15,7 +15,7 @@ import styles from './Playground.module.css';
 
 // eslint-disable-next-line new-cap
 const jetBrainsMono = JetBrains_Mono({
-  subsets: ['cyrillic'],
+  subsets: ['latin', 'cyrillic'],
 });
 
 export interface PlaygroundProps extends PlaygroundPreviewProps {


### PR DESCRIPTION
## Описание

Шрифт для кода подгружался не сразу, а после загрузки css-а

<img width="984" height="323" alt="image" src="https://github.com/user-attachments/assets/02df908f-f974-4319-8a56-b14b179b0613" />



## Release notes
## Документация
- Шрифт для кода подгружался не сразу, а после загрузки CSS