### PR TITLE
docs(Playground): fix whiteSpace

### DIFF
--- a/website/components/mdx/Playground/editorThemes/darkTheme.ts
+++ b/website/components/mdx/Playground/editorThemes/darkTheme.ts
@@ -2,7 +2,6 @@ export const darkTheme = {
   plain: {
     color: '#e1e4e8',
     backgroundColor: 'transparent',
-    whiteSpace: 'nowrap',
     overflow: 'auto',
   },
   styles: [

--- a/website/components/mdx/Playground/editorThemes/lightTheme.ts
+++ b/website/components/mdx/Playground/editorThemes/lightTheme.ts
@@ -2,7 +2,6 @@ export const lightTheme = {
   plain: {
     color: '#24292e',
     backgroundColor: 'transparent',
-    whiteSpace: 'nowrap',
     overflow: 'auto',
   },
   styles: [


### PR DESCRIPTION
## Описание

В FireFox ломается плейграунд кода из-за `whiteSpace`

<img width="883" height="274" alt="image" src="https://github.com/user-attachments/assets/c19f75c6-b9ca-413d-8aaa-9f110a22fafb" />


## Release notes
## Документация
- В браузере **Firefox** не работал перенос строк в коде превью компонента