### PR TITLE
fix: rm uuid

### DIFF
--- a/packages/vkui/package.json
+++ b/packages/vkui/package.json
@@ -90,8 +90,7 @@
     "@vkontakte/icons": "^3.0.0",
     "@vkontakte/vkjs": "^2.0.2",
     "@vkontakte/vkui-date-fns-tz": "^0.0.6",
-    "@vkontakte/vkui-floating-ui": "^0.2.7",
-    "uuid": "^13.0.0"
+    "@vkontakte/vkui-floating-ui": "^0.2.7"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",

--- a/packages/vkui/src/hooks/useModalManager/helpers/useModalActions.ts
+++ b/packages/vkui/src/hooks/useModalManager/helpers/useModalActions.ts
@@ -1,7 +1,7 @@
 import type { UIEvent } from 'react';
 import * as React from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { type ModalPageCloseReason } from '../../../components/ModalPage/types';
+import { randomUUID } from '../../../lib/randomUUID';
 import { ModalCardWrapper } from '../components/ModalCardWrapper';
 import { ModalPageWrapper } from '../components/ModalPageWrapper';
 import {
@@ -167,7 +167,7 @@ export const useModalActions = ({ store, saveHistory }: UseModalActionsProps) =>
     (props) => {
       const { id: idProp, component, baseProps: modalProps, additionalProps } = resolveProps(props);
 
-      const id = idProp || uuidv4();
+      const id = idProp || randomUUID();
 
       return open<CustomModalCardItem>({
         type: 'card',
@@ -186,7 +186,7 @@ export const useModalActions = ({ store, saveHistory }: UseModalActionsProps) =>
     (props) => {
       const { id: idProp, component, baseProps: modalProps, additionalProps } = resolveProps(props);
 
-      const id = idProp || uuidv4();
+      const id = idProp || randomUUID();
 
       return open({
         type: 'page',

--- a/packages/vkui/src/hooks/useSnackbarManager/helpers/useSnackbarActionsWithStore.ts
+++ b/packages/vkui/src/hooks/useSnackbarManager/helpers/useSnackbarActionsWithStore.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from '../../../lib/randomUUID';
 import { SnackbarWrapper } from '../components/SnackbarWrapper';
 import {
   type CommonOnOpenPayload,
@@ -131,7 +131,7 @@ export const useSnackbarActionsWithStore = ({
     (config) => {
       const resolvedProps = resolveProps(config);
 
-      const id = resolvedProps.id || uuidv4();
+      const id = resolvedProps.id || randomUUID();
 
       return onOpenSnackbarImpl({
         id,

--- a/packages/vkui/src/lib/randomUUID.test.ts
+++ b/packages/vkui/src/lib/randomUUID.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test, vi } from 'vitest';
+import { randomUUID } from './randomUUID';
+
+describe('generateUUID', () => {
+  test('generates a valid UUID v4 format', () => {
+    const uuid = randomUUID();
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+    expect(uuid).toMatch(uuidRegex);
+  });
+
+  test('generates unique UUIDs', () => {
+    const uuids = new Set();
+    const iterations = 1000;
+
+    for (let i = 0; i < iterations; i++) {
+      const uuid = randomUUID();
+      uuids.add(uuid);
+    }
+
+    expect(uuids.size).toBe(iterations);
+  });
+
+  test('generates UUIDs of correct length', () => {
+    const uuid = randomUUID();
+
+    expect(uuid.length).toBe(36);
+  });
+
+  test('has correct version and variant bits', () => {
+    const uuid = randomUUID();
+    const parts = uuid.split('-');
+
+    expect(parts[0].length).toBe(8);
+    expect(parts[1].length).toBe(4);
+    expect(parts[2].length).toBe(4);
+    expect(parts[3].length).toBe(4);
+    expect(parts[4].length).toBe(12);
+
+    const versionNibble = parseInt(parts[2][0], 16);
+    expect(versionNibble).toBe(4);
+
+    const variantNibble = parseInt(parts[3][0], 16);
+    expect(variantNibble).toBeGreaterThanOrEqual(8);
+    expect(variantNibble).toBeLessThanOrEqual(11);
+  });
+
+  test('crypto.randomUUID is available by default', () => {
+    expect(typeof crypto).not.toBe('undefined');
+    expect(typeof crypto.randomUUID).toBe('function');
+  });
+
+  test('uses crypto.randomUUID when available', () => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('12345678-1234-4123-8123-123456789abc');
+
+    const uuid = randomUUID();
+
+    expect(uuid).toBe('12345678-1234-4123-8123-123456789abc');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(crypto.randomUUID).toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  test('generates lowercase hexadecimal characters', () => {
+    const uuid = randomUUID();
+
+    expect(uuid).toBe(uuid.toLowerCase());
+  });
+
+  describe('fallback when crypto.randomUUID is not available', () => {
+    const originalCrypto = global.crypto;
+
+    beforeEach(() => {
+      vi.stubGlobal('crypto', {
+        ...originalCrypto,
+        randomUUID: undefined,
+        getRandomValues: (arr: Uint8Array) => {
+          for (let i = 0; i < arr.length; i++) {
+            arr[i] = Math.floor(Math.random() * 256);
+          }
+        },
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    test('uses crypto.getRandomValues when available', () => {
+      const uuid = randomUUID();
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(uuid).toMatch(uuidRegex);
+      expect(uuid.length).toBe(36);
+    });
+
+    test('generates unique UUIDs without crypto.randomUUID', () => {
+      const uuids = new Set();
+      const iterations = 100;
+
+      for (let i = 0; i < iterations; i++) {
+        const uuid = randomUUID();
+        uuids.add(uuid);
+      }
+
+      expect(uuids.size).toBe(iterations);
+    });
+
+    test('calls crypto.getRandomValues', () => {
+      const spy = vi.spyOn(crypto, 'getRandomValues');
+      randomUUID();
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  describe('fallback when crypto.randomUUID and crypto.getRandomValues are not available', () => {
+    beforeEach(() => {
+      const originalCrypto = globalThis.crypto;
+      vi.stubGlobal('crypto', {
+        ...originalCrypto,
+        randomUUID: undefined,
+        getRandomValues: undefined,
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    test('uses Math.random as fallback', () => {
+      const uuid = randomUUID();
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(uuid).toMatch(uuidRegex);
+      expect(uuid.length).toBe(36);
+    });
+
+    test('generates unique UUIDs using Math.random fallback', () => {
+      const uuids = new Set();
+      const iterations = 50;
+
+      for (let i = 0; i < iterations; i++) {
+        const uuid = randomUUID();
+        uuids.add(uuid);
+      }
+
+      expect(uuids.size).toBe(iterations);
+    });
+
+    test('has correct version and variant bits with Math.random fallback', () => {
+      const uuid = randomUUID();
+      const parts = uuid.split('-');
+
+      expect(parts[0].length).toBe(8);
+      expect(parts[1].length).toBe(4);
+      expect(parts[2].length).toBe(4);
+      expect(parts[3].length).toBe(4);
+      expect(parts[4].length).toBe(12);
+
+      const versionNibble = parseInt(parts[2][0], 16);
+      expect(versionNibble).toBe(4);
+
+      const variantNibble = parseInt(parts[3][0], 16);
+      expect(variantNibble).toBeGreaterThanOrEqual(8);
+      expect(variantNibble).toBeLessThanOrEqual(11);
+    });
+  });
+
+  describe('fallback when neither crypto.randomUUID nor crypto.getRandomValues are available', () => {
+    beforeEach(() => {
+      vi.stubGlobal('crypto', undefined);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    test('uses Math.random as fallback', () => {
+      const uuid = randomUUID();
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(uuid).toMatch(uuidRegex);
+      expect(uuid.length).toBe(36);
+    });
+
+    test('generates unique UUIDs using Math.random fallback', () => {
+      const uuids = new Set();
+      const iterations = 50;
+
+      for (let i = 0; i < iterations; i++) {
+        const uuid = randomUUID();
+        uuids.add(uuid);
+      }
+
+      expect(uuids.size).toBe(iterations);
+    });
+
+    test('has correct version and variant bits with Math.random fallback', () => {
+      const uuid = randomUUID();
+      const parts = uuid.split('-');
+
+      expect(parts[0].length).toBe(8);
+      expect(parts[1].length).toBe(4);
+      expect(parts[2].length).toBe(4);
+      expect(parts[3].length).toBe(4);
+      expect(parts[4].length).toBe(12);
+
+      const versionNibble = parseInt(parts[2][0], 16);
+      expect(versionNibble).toBe(4);
+
+      const variantNibble = parseInt(parts[3][0], 16);
+      expect(variantNibble).toBeGreaterThanOrEqual(8);
+      expect(variantNibble).toBeLessThanOrEqual(11);
+    });
+  });
+});

--- a/packages/vkui/src/lib/randomUUID.ts
+++ b/packages/vkui/src/lib/randomUUID.ts
@@ -1,0 +1,38 @@
+function hex(byte: number): string {
+  return byte.toString(16).padStart(2, '0');
+}
+
+function fallbackRandomUUID(): string {
+  const bytes = new Uint8Array(16);
+
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  let result = hex(bytes[0]) + hex(bytes[1]) + hex(bytes[2]) + hex(bytes[3]);
+  result += '-' + hex(bytes[4]) + hex(bytes[5]);
+  result += '-' + hex((bytes[6] & 0x0f) | 0x40) + hex(bytes[7]);
+  result += '-' + hex((bytes[8] & 0x3f) | 0x80) + hex(bytes[9]);
+  result +=
+    '-' +
+    hex(bytes[10]) +
+    hex(bytes[11]) +
+    hex(bytes[12]) +
+    hex(bytes[13]) +
+    hex(bytes[14]) +
+    hex(bytes[15]);
+
+  return result;
+}
+
+export function randomUUID(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  return fallbackRandomUUID();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5421,7 +5421,6 @@ __metadata:
     "@vkontakte/vkui-floating-ui": "npm:^0.2.7"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    uuid: "npm:^13.0.0"
   peerDependencies:
     react: ^18.2.0 || ^19.0.0
     react-dom: ^18.2.0 || ^19.0.0
@@ -18808,15 +18807,6 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10/2742b24d1e00257e60612572e4d28679423469998cafbaf1fe9f1482e3edf9c40754b31bfdb3d08d71b29239f227a304588f75210b3b48f2609f0673f1feccef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- caused by #8839

---

- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

uuid собирается под es2022, нам нужно поддерживать es2018

## Изменения

Удаляем uuid, делаем полифил над crypto.randomUUID

## Release notes
## Исправления
- Удалена зависимость [uuid](https://www.npmjs.com/package/uuid), т.к. не подходит по браузерной поддержке