### PR TITLE
fix(slotProps): add missed input types

### DIFF
--- a/packages/vkui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/vkui/src/components/Checkbox/Checkbox.tsx
@@ -34,9 +34,10 @@ export interface CheckboxProps
       | 'readOnly'
       | 'required'
       | 'autoFocus'
-      | 'onChange'
       | 'name'
       | 'value'
+      | 'form'
+      | 'onChange'
       | 'onFocus'
       | 'onBlur'
     >,
@@ -108,6 +109,7 @@ const CheckboxComponent = ({
   id,
   name,
   value,
+  form,
   onChange,
   onFocus,
   onBlur,
@@ -129,6 +131,7 @@ const CheckboxComponent = ({
       id,
       name,
       value,
+      form,
       onChange,
       onFocus,
       onBlur,

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -120,7 +120,7 @@ export interface SelectProps<
 > extends Omit<NativeSelectProps, 'slotProps'>,
     Omit<FormFieldProps, 'maxHeight'>,
     Pick<CustomSelectDropdownProps, 'overscrollBehavior'>,
-    Pick<CustomSelectInputProps, 'minLength' | 'maxLength' | 'pattern' | 'readOnly'> {
+    Pick<CustomSelectInputProps, 'minLength' | 'maxLength' | 'pattern' | 'form' | 'readOnly'> {
   /**
    * Свойства, которые можно прокинуть внутрь компонента:
    * - `root`: свойства для прокидывания в корень компонента;
@@ -306,8 +306,12 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     'icon': iconProp,
     selectType = 'default',
     align,
+    form,
 
     // Input props
+    minLength,
+    maxLength,
+    pattern,
     autoFocus,
     disabled,
     id,
@@ -351,6 +355,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
       getRootRef: getRef,
       required,
       name,
+      form,
       onClick: onSelectClick,
       onFocus: onSelectFocus,
       onBlur: onSelectBlur,
@@ -371,6 +376,9 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     {
       getRootRef: getSelectInputRef,
       onChange: onInputChangeProp,
+      minLength,
+      maxLength,
+      pattern,
       autoFocus,
       disabled,
       id,

--- a/packages/vkui/src/components/File/File.tsx
+++ b/packages/vkui/src/components/File/File.tsx
@@ -23,6 +23,7 @@ export interface FileProps
       | 'accept'
       | 'capture'
       | 'multiple'
+      | 'form'
       | 'onChange'
       | 'onFocus'
       | 'onBlur'
@@ -78,6 +79,7 @@ export const File = ({
   accept,
   capture,
   multiple,
+  form,
   onChange,
   onFocus,
   onBlur,
@@ -110,6 +112,7 @@ export const File = ({
       accept,
       capture,
       multiple,
+      form,
       onChange,
       onFocus,
       onBlur,

--- a/packages/vkui/src/components/Input/Input.tsx
+++ b/packages/vkui/src/components/Input/Input.tsx
@@ -21,9 +21,13 @@ export interface InputProps
   extends Pick<
       React.InputHTMLAttributes<HTMLInputElement>,
       | 'autoComplete'
+      | 'autoCapitalize'
+      | 'autoCorrect'
       | 'disabled'
       | 'list'
+      | 'max'
       | 'maxLength'
+      | 'min'
       | 'minLength'
       | 'multiple'
       | 'name'
@@ -31,10 +35,10 @@ export interface InputProps
       | 'placeholder'
       | 'readOnly'
       | 'required'
-      | 'size'
       | 'step'
       | 'type'
       | 'value'
+      | 'form'
       | 'onChange'
       | 'onFocus'
       | 'onBlur'
@@ -76,9 +80,13 @@ export const Input = ({
 
   // input props
   autoComplete,
+  autoCapitalize,
+  autoCorrect,
   disabled,
   list,
+  max,
   maxLength,
+  min,
   minLength,
   multiple,
   name,
@@ -86,13 +94,13 @@ export const Input = ({
   placeholder,
   readOnly,
   required,
-  size,
   step,
   type = 'text',
   value,
   onChange,
   onFocus,
   onBlur,
+  form,
   id,
   inputMode,
   defaultValue,
@@ -117,9 +125,13 @@ export const Input = ({
       className: styles.el,
       getRootRef: getRef,
       autoComplete,
+      autoCapitalize,
+      autoCorrect,
       disabled,
       list,
+      max,
       maxLength,
+      min,
       minLength,
       multiple,
       name,
@@ -127,13 +139,13 @@ export const Input = ({
       placeholder,
       readOnly,
       required,
-      size,
       step,
       type,
       value,
       onChange,
       onFocus,
       onBlur,
+      form,
       id,
       inputMode,
       defaultValue,

--- a/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/vkui/src/components/NativeSelect/NativeSelect.tsx
@@ -54,7 +54,7 @@ export type NativeHTMLSelectProps = Omit<
 export interface NativeSelectProps
   extends Pick<
       React.SelectHTMLAttributes<HTMLSelectElement>,
-      'disabled' | 'required' | 'autoFocus' | 'name' | 'onFocus' | 'onBlur' | 'onClick'
+      'disabled' | 'required' | 'autoFocus' | 'name' | 'form' | 'onFocus' | 'onBlur' | 'onClick'
     >,
     Omit<
       React.HTMLAttributes<HTMLDivElement>,
@@ -139,6 +139,7 @@ export const NativeSelect = ({
   autoFocus,
   id,
   name,
+  form,
   onClick,
   onFocus,
   onBlur,
@@ -158,7 +159,7 @@ export const NativeSelect = ({
   const { className, style, getRootRef, ...rootRest } = useMergeProps(restProps, slotProps?.root);
 
   const { getRootRef: getSelectRef, ...selectRest } = useMergeProps(
-    { getRootRef: getRef, disabled, required, autoFocus, id, name, onClick, onFocus, onBlur },
+    { getRootRef: getRef, disabled, required, autoFocus, id, name, form, onClick, onFocus, onBlur },
     slotProps?.select,
   );
 

--- a/packages/vkui/src/components/Radio/Radio.tsx
+++ b/packages/vkui/src/components/Radio/Radio.tsx
@@ -23,9 +23,10 @@ export interface RadioProps
       | 'readOnly'
       | 'required'
       | 'autoFocus'
-      | 'onChange'
       | 'name'
       | 'value'
+      | 'form'
+      | 'onChange'
       | 'onFocus'
       | 'onBlur'
     >,
@@ -95,6 +96,7 @@ export const Radio = ({
   id,
   name,
   value,
+  form,
   onChange,
   onFocus,
   onBlur,
@@ -133,6 +135,7 @@ export const Radio = ({
       id,
       name,
       value,
+      form,
       onChange,
       onFocus,
       onBlur,

--- a/packages/vkui/src/components/Search/Search.tsx
+++ b/packages/vkui/src/components/Search/Search.tsx
@@ -34,15 +34,19 @@ export interface SearchProps
   extends Pick<
       React.InputHTMLAttributes<HTMLInputElement>,
       | 'autoComplete'
+      | 'autoCapitalize'
+      | 'autoCorrect'
       | 'disabled'
       | 'list'
       | 'maxLength'
       | 'minLength'
       | 'name'
+      | 'pattern'
       | 'placeholder'
       | 'readOnly'
       | 'required'
       | 'value'
+      | 'form'
       | 'onChange'
       | 'onFocus'
       | 'onBlur'
@@ -140,14 +144,18 @@ export const Search = ({
   // input props
   placeholder: placeholderProp = 'Поиск',
   autoComplete = 'off',
+  autoCapitalize,
+  autoCorrect,
   disabled,
   list,
   maxLength,
   minLength,
   name,
+  pattern,
   readOnly,
   required,
   value,
+  form,
   id: idProp,
   inputMode,
   defaultValue,
@@ -185,14 +193,18 @@ export const Search = ({
       className: styles.nativeInput,
       placeholder: placeholderProp,
       autoComplete,
+      autoCapitalize,
+      autoCorrect,
       disabled,
       list,
       maxLength,
       minLength,
       name,
+      pattern,
       readOnly,
       required,
       value,
+      form,
       id: idProp,
       inputMode,
       defaultValue,

--- a/packages/vkui/src/components/Switch/Switch.tsx
+++ b/packages/vkui/src/components/Switch/Switch.tsx
@@ -32,9 +32,10 @@ export interface SwitchProps
       | 'readOnly'
       | 'required'
       | 'autoFocus'
-      | 'onChange'
       | 'name'
       | 'value'
+      | 'form'
+      | 'onChange'
       | 'onFocus'
       | 'onBlur'
     >,
@@ -75,6 +76,7 @@ export const Switch = ({
   id,
   name,
   value,
+  form,
   onChange,
   onFocus,
   onBlur,
@@ -108,6 +110,7 @@ export const Switch = ({
       id,
       name,
       value,
+      form,
       onChange,
       onFocus,
       onBlur,

--- a/packages/vkui/src/components/Textarea/Textarea.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.tsx
@@ -27,6 +27,8 @@ export interface TextareaProps
   extends Pick<
       React.TextareaHTMLAttributes<HTMLTextAreaElement>,
       | 'autoComplete'
+      | 'autoCapitalize'
+      | 'autoCorrect'
       | 'cols'
       | 'dirName'
       | 'disabled'
@@ -39,6 +41,7 @@ export interface TextareaProps
       | 'rows'
       | 'value'
       | 'wrap'
+      | 'form'
       | 'onChange'
       | 'onFocus'
       | 'onBlur'
@@ -97,6 +100,8 @@ export const Textarea = ({
 
   // textarea props
   autoComplete,
+  autoCapitalize,
+  autoCorrect,
   cols,
   dirName,
   disabled,
@@ -109,6 +114,7 @@ export const Textarea = ({
   value: valueProp,
   wrap,
   rows = 2,
+  form,
   onChange: onChangeProp,
   onFocus,
   onBlur,
@@ -143,6 +149,8 @@ export const Textarea = ({
       className: styles.el,
       getRootRef: getRef,
       autoComplete,
+      autoCapitalize,
+      autoCorrect,
       cols,
       dirName,
       disabled,
@@ -155,6 +163,7 @@ export const Textarea = ({
       value: valueProp,
       wrap,
       rows,
+      form,
       onChange: onChangeProp,
       onFocus,
       onBlur,

--- a/packages/vkui/src/components/WriteBar/WriteBar.tsx
+++ b/packages/vkui/src/components/WriteBar/WriteBar.tsx
@@ -21,6 +21,8 @@ export interface WriteBarProps
   extends Pick<
       React.TextareaHTMLAttributes<HTMLTextAreaElement>,
       | 'autoComplete'
+      | 'autoCapitalize'
+      | 'autoCorrect'
       | 'cols'
       | 'dirName'
       | 'disabled'
@@ -33,6 +35,7 @@ export interface WriteBarProps
       | 'rows'
       | 'value'
       | 'wrap'
+      | 'form'
       | 'onChange'
       | 'onFocus'
       | 'onBlur'
@@ -106,6 +109,8 @@ export const WriteBar = ({
 
   // textarea props
   autoComplete,
+  autoCapitalize,
+  autoCorrect,
   cols,
   dirName,
   disabled,
@@ -118,6 +123,7 @@ export const WriteBar = ({
   value: valueProp,
   wrap,
   rows,
+  form,
   onChange: onChangeProp,
   onFocus,
   onBlur,
@@ -149,6 +155,8 @@ export const WriteBar = ({
       className: styles.textarea,
       getRootRef: getRef,
       autoComplete,
+      autoCapitalize,
+      autoCorrect,
       cols,
       dirName,
       disabled,
@@ -161,6 +169,7 @@ export const WriteBar = ({
       value: valueProp,
       wrap,
       rows,
+      form,
       onChange: onChangeProp,
       onFocus,
       onBlur,


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- caused by #9180
- caused by #9181
- caused by #9183
- caused by #9184
- caused by #9185

---

## Версия

`8.0.0-rc.0`

## Описание

При тесте обнаружили, что не все свойства, которые должны прокидываться через корневой элемент, есть в типах, и что некоторые события нужно для обратной совместимости также мигрировать.

Обновил описание в задачах:
  - #9043
  - #9044
  - #9045
  - #9084
  - #9086

## Release notes
-