### PR TITLE
fix(@vkontakte/vkui-codemods): extend codemods for migration to slotProps

### DIFF
--- a/packages/codemods/src/transforms/v8/__testfixtures__/input/basic.input.tsx
+++ b/packages/codemods/src/transforms/v8/__testfixtures__/input/basic.input.tsx
@@ -17,7 +17,16 @@ const App = () => {
         placeholder="value"
         onChange={() => {}}
         onFocus={() => {}}
+        onInput={() => {}}
+        onInputCapture={() => {}}
         onClick={() => {}}
+        onClickCapture={() => {}}
+        onPaste={() => {}}
+        onPasteCapture={() => {}}
+        onKeyDown={() => {}}
+        onKeyDownCapture={() => {}}
+        onKeyUp={() => {}}
+        onKeyUpCapture={() => {}}
       />
     </React.Fragment>
   );

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/checkbox.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/checkbox.ts.snap
@@ -19,7 +19,6 @@ const App = () => {
         description="description"
         indeterminate
         hasHover={false}
-        onClick={() => {}}
         onChange={() => {}}
         onFocus={() => {}}
         slotProps={{
@@ -27,6 +26,7 @@ const App = () => {
             getRootRef: inputRef,
             "data-testid": "checkbox",
             "aria-label": "checkbox",
+            onClick: () => {},
             placeholder: "checkbox"
           }
         }} />
@@ -41,13 +41,13 @@ const App = () => {
         indeterminate
         hasHover={false}
         onChange={() => {}}
-        onClick={() => {}}
         onFocus={() => {}}
         slotProps={{
           input: {
             getRootRef: inputRef,
             "data-testid": "checkbox",
             "aria-label": "checkbox",
+            onClick: () => {},
             placeholder: "checkbox"
           }
         }}>
@@ -60,7 +60,6 @@ const App = () => {
         autoFocus
         checked
         required
-        onClick={() => {}}
         onChange={() => {}}
         onFocus={() => {}}
         slotProps={{
@@ -68,6 +67,7 @@ const App = () => {
             getRootRef: inputRef,
             "data-testid": "checkbox",
             "aria-label": "checkbox",
+            onClick: () => {},
             placeholder: "checkbox"
           }
         }} />

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/chips-input.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/chips-input.ts.snap
@@ -22,14 +22,14 @@ const App = () => {
         readOnly={true}
         onFocus={() => {}}
         onBlur={() => {}}
-        onKeyDown={() => {}}
         onChange={() => {}}
-        onClick={() => {}}
         onMouseDown={() => {}}
         slotProps={{
           input: {
             getRootRef: inputRef,
             "data-testid": "input",
+            onClick: () => {},
+            onKeyDown: () => {},
             required: true
           }
         }} />

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/chips-select.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/chips-select.ts.snap
@@ -22,9 +22,7 @@ const App = () => {
         readOnly={true}
         onFocus={() => {}}
         onBlur={() => {}}
-        onKeyDown={() => {}}
         onChange={() => {}}
-        onClick={() => {}}
         onMouseDown={() => {}}
         onChangeStart={() => {}}
         onClose={() => {}}
@@ -33,6 +31,8 @@ const App = () => {
           input: {
             getRootRef: inputRef,
             "data-testid": "input",
+            onClick: () => {},
+            onKeyDown: () => {},
             required: true
           }
         }} />

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/file.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/file.ts.snap
@@ -20,13 +20,13 @@ const App = () => {
         stretched
         accept=".txt"
         multiple
-        onClick={() => {}}
         onChange={() => {}}
         slotProps={{
           input: {
             getRootRef: inputRef,
             "data-testid": "input",
             "aria-label": "input",
+            onClick: () => {},
             placeholder: "file"
           }
         }} />

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/input.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/input.ts.snap
@@ -17,12 +17,21 @@ const App = () => {
         placeholder="value"
         onChange={() => {}}
         onFocus={() => {}}
-        onClick={() => {}}
         slotProps={{
           input: {
             getRootRef: inputRef,
             "data-testid": "input",
-            "aria-label": "input"
+            "aria-label": "input",
+            onKeyUpCapture: () => {},
+            onKeyUp: () => {},
+            onKeyDownCapture: () => {},
+            onKeyDown: () => {},
+            onPasteCapture: () => {},
+            onPaste: () => {},
+            onClickCapture: () => {},
+            onClick: () => {},
+            onInputCapture: () => {},
+            onInput: () => {}
           }
         }} />
     </React.Fragment>

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/native-select.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/native-select.ts.snap
@@ -16,7 +16,6 @@ const App = () => {
         onChange={() => {}}
         disabled={false}
         required
-        onClick={() => {}}
         onBlur={() => {}}
         onFocus={() => {}}
         onMouseDown={() => {}}
@@ -25,6 +24,7 @@ const App = () => {
             getRootRef: selectRef,
             "data-testid": "select",
             "aria-label": "select",
+            onClick: () => {},
             size: 100
           }
         }}>

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/radio.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/radio.ts.snap
@@ -16,7 +16,6 @@ const App = () => {
         autoFocus
         required
         checked
-        onClick={() => {}}
         onChange={() => {}}
         description="description"
         slotProps={{
@@ -29,6 +28,7 @@ const App = () => {
             getRootRef: inputRef,
             "data-testid": "radio",
             "aria-label": "radio",
+            onClick: () => {},
             placeholder: "radio"
           }
         }} />
@@ -39,13 +39,13 @@ const App = () => {
         autoFocus
         required
         checked
-        onClick={() => {}}
         onChange={() => {}}
         slotProps={{
           input: {
             getRootRef: inputRef,
             "data-testid": "radio",
             "aria-label": "radio",
+            onClick: () => {},
             placeholder: "radio"
           }
         }} />

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/search.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/search.ts.snap
@@ -22,12 +22,12 @@ const App = () => {
         onFindButtonClick={() => {}}
         onFocus={() => {}}
         onBlur={() => {}}
-        onClick={() => {}}
         slotProps={{
           input: {
             getRootRef: inputRef,
             "data-testid": "input",
-            "aria-label": "input"
+            "aria-label": "input",
+            onClick: () => {}
           }
         }} />
     </React.Fragment>

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/select.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/select.ts.snap
@@ -19,7 +19,6 @@ const App = () => {
         disabled={false}
         required
         onInputChange={() => {}}
-        onClick={() => {}}
         onBlur={() => {}}
         onFocus={() => {}}
         onClose={() => {}}
@@ -36,6 +35,7 @@ const App = () => {
             getRootRef: inputRef,
             "data-testid": "input",
             "aria-label": "input",
+            onClick: () => {},
             size: 100
           }
         }} />

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/switch.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/switch.ts.snap
@@ -16,7 +16,6 @@ const App = () => {
         autoFocus
         checked
         onChange={() => {}}
-        onClick={() => {}}
         slotProps={{
           input: {
             getRootRef: inputRef,
@@ -24,6 +23,7 @@ const App = () => {
             "data-testid": "switch",
             "aria-checked": "checked",
             "aria-label": "switch",
+            onClick: () => {},
             placeholder: "switch"
           }
         }} />

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/text-area.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/text-area.ts.snap
@@ -17,7 +17,6 @@ const App = () => {
         onResize={() => {}}
         onFocus={() => {}}
         onBlur={() => {}}
-        onClick={() => {}}
         rows={4}
         cols={10}
         maxLength={100}
@@ -28,7 +27,8 @@ const App = () => {
           textArea: {
             getRootRef: textAreaRef,
             "data-testid": "text-area",
-            "aria-label": "text-area"
+            "aria-label": "text-area",
+            onClick: () => {}
           }
         }} />
     </React.Fragment>

--- a/packages/codemods/src/transforms/v8/__tests__/__snapshots__/write-bar.ts.snap
+++ b/packages/codemods/src/transforms/v8/__tests__/__snapshots__/write-bar.ts.snap
@@ -15,7 +15,6 @@ const App = () => {
         onHeightChange={() => {}}
         onFocus={() => {}}
         onBlur={() => {}}
-        onClick={() => {}}
         rows={4}
         cols={10}
         maxLength={100}
@@ -26,7 +25,8 @@ const App = () => {
           textArea: {
             getRootRef: textAreaRef,
             "data-testid": "text-area",
-            "aria-label": "text-area"
+            "aria-label": "text-area",
+            onClick: () => {}
           }
         }} />
     </React.Fragment>

--- a/packages/codemods/src/transforms/v8/checkbox.ts
+++ b/packages/codemods/src/transforms/v8/checkbox.ts
@@ -41,7 +41,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       moveInputPropsIntoSlotProps(j, {
         root: source,
         componentName,
-        excludedProps: ['checked', 'disabled', 'readOnly', 'required', 'name', 'value'],
+        excludedProps: ['checked', 'disabled', 'readOnly', 'required', 'name', 'value', 'form'],
       });
     });
   }

--- a/packages/codemods/src/transforms/v8/common/moveInputPropsIntoSlotProps.ts
+++ b/packages/codemods/src/transforms/v8/common/moveInputPropsIntoSlotProps.ts
@@ -32,6 +32,16 @@ const INPUT_SPECIFIC_PROPS = [
   'type',
   'value',
   'width',
+  'onInput',
+  'onInputCapture',
+  'onClick',
+  'onClickCapture',
+  'onPaste',
+  'onPasteCapture',
+  'onKeyDown',
+  'onKeyDownCapture',
+  'onKeyUp',
+  'onKeyUpCapture',
 ] as const;
 
 type InputSpecificProp = (typeof INPUT_SPECIFIC_PROPS)[number];

--- a/packages/codemods/src/transforms/v8/custom-select.ts
+++ b/packages/codemods/src/transforms/v8/custom-select.ts
@@ -56,7 +56,19 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
     moveInputPropsIntoSlotProps(j, {
       root: source,
       componentName: localName,
-      excludedProps: ['disabled', 'readOnly', 'required', 'name', 'value', 'placeholder'],
+      excludedProps: [
+        'disabled',
+        'readOnly',
+        'required',
+        'name',
+        'value',
+        'placeholder',
+        'minLength',
+        'maxLength',
+        'pattern',
+        'form',
+        'onClick',
+      ],
     });
   }
 

--- a/packages/codemods/src/transforms/v8/file.ts
+++ b/packages/codemods/src/transforms/v8/file.ts
@@ -50,6 +50,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
         'capture',
         'multiple',
         'size',
+        'form',
       ],
     });
   }

--- a/packages/codemods/src/transforms/v8/input.ts
+++ b/packages/codemods/src/transforms/v8/input.ts
@@ -1,6 +1,7 @@
 import { API, FileInfo } from 'jscodeshift';
 import { getImportInfo } from '../../codemod-helpers';
 import { JSCodeShiftOptions } from '../../types';
+import { moveInputPropsIntoSlotProps } from './common/moveInputPropsIntoSlotProps';
 import {
   moveAriaAttrsIntoSlotProps,
   moveDataAttrsIntoSlotProps,
@@ -34,6 +35,30 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       root: source,
       componentName: localName,
       slotName: 'input',
+    });
+
+    moveInputPropsIntoSlotProps(j, {
+      root: source,
+      componentName: localName,
+      excludedProps: [
+        'autoComplete',
+        'disabled',
+        'list',
+        'max',
+        'maxLength',
+        'min',
+        'minLength',
+        'multiple',
+        'name',
+        'pattern',
+        'placeholder',
+        'readOnly',
+        'required',
+        'step',
+        'type',
+        'value',
+        'form',
+      ],
     });
   }
 

--- a/packages/codemods/src/transforms/v8/radio.ts
+++ b/packages/codemods/src/transforms/v8/radio.ts
@@ -48,7 +48,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       moveInputPropsIntoSlotProps(j, {
         root: source,
         componentName,
-        excludedProps: ['checked', 'disabled', 'readOnly', 'required', 'name', 'value'],
+        excludedProps: ['checked', 'disabled', 'readOnly', 'required', 'name', 'value', 'form'],
       });
     });
   }

--- a/packages/codemods/src/transforms/v8/search.ts
+++ b/packages/codemods/src/transforms/v8/search.ts
@@ -42,14 +42,10 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       componentName: localName,
       slotName: 'input',
       excludedProps: [
-        'alt',
         'autoComplete',
-        'capture',
         'disabled',
         'list',
-        'max',
         'maxLength',
-        'min',
         'minLength',
         'name',
         'pattern',
@@ -57,6 +53,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
         'readOnly',
         'required',
         'value',
+        'form',
       ],
     });
   }

--- a/packages/codemods/src/transforms/v8/switch.ts
+++ b/packages/codemods/src/transforms/v8/switch.ts
@@ -40,7 +40,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
     moveInputPropsIntoSlotProps(j, {
       root: source,
       componentName: localName,
-      excludedProps: ['checked', 'disabled', 'readOnly', 'required', 'name', 'value'],
+      excludedProps: ['checked', 'disabled', 'readOnly', 'required', 'name', 'value', 'form'],
     });
   }
 

--- a/packages/codemods/src/transforms/v8/text-area.ts
+++ b/packages/codemods/src/transforms/v8/text-area.ts
@@ -1,6 +1,7 @@
 import { API, FileInfo } from 'jscodeshift';
 import { getImportInfo } from '../../codemod-helpers';
 import { JSCodeShiftOptions } from '../../types';
+import { moveInputPropsIntoSlotProps } from './common/moveInputPropsIntoSlotProps';
 import {
   moveAriaAttrsIntoSlotProps,
   moveDataAttrsIntoSlotProps,
@@ -34,6 +35,24 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       root: source,
       componentName: localName,
       slotName: 'textArea',
+    });
+
+    moveInputPropsIntoSlotProps(j, {
+      root: source,
+      componentName: localName,
+      slotName: 'textArea',
+      excludedProps: [
+        'autoComplete',
+        'disabled',
+        'maxLength',
+        'minLength',
+        'name',
+        'placeholder',
+        'readOnly',
+        'required',
+        'value',
+        'form',
+      ],
     });
   }
 

--- a/packages/codemods/src/transforms/v8/write-bar.ts
+++ b/packages/codemods/src/transforms/v8/write-bar.ts
@@ -1,6 +1,7 @@
 import { API, FileInfo } from 'jscodeshift';
 import { getImportInfo } from '../../codemod-helpers';
 import { JSCodeShiftOptions } from '../../types';
+import { moveInputPropsIntoSlotProps } from './common/moveInputPropsIntoSlotProps';
 import {
   moveAriaAttrsIntoSlotProps,
   moveDataAttrsIntoSlotProps,
@@ -34,6 +35,24 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
       root: source,
       componentName: localName,
       slotName: 'textArea',
+    });
+
+    moveInputPropsIntoSlotProps(j, {
+      root: source,
+      componentName: localName,
+      slotName: 'textArea',
+      excludedProps: [
+        'autoComplete',
+        'disabled',
+        'maxLength',
+        'minLength',
+        'name',
+        'placeholder',
+        'readOnly',
+        'required',
+        'value',
+        'form',
+      ],
     });
   }
 


### PR DESCRIPTION
<!-- Если этот PR закрывает Issue, то укажи ссылку на него. Используй доступные ключевые слова (см. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests). -->
- related to #2342
- caused by #9087

---

## Описание

Обновляем кодмод для VKUI v8 по мотивам #9444.

Пополняем `moveInputPropsIntoSlotProps` событиями:
- `onInput`
- `onInputCapture`
- `onClick`
- `onClickCapture`
- `onPaste`
- `onPasteCapture`
- `onKeyDown`
- `onKeyDownCapture`
- `onKeyUp`
- `onKeyUpCapture`

пользователи могут завязываться на `event.currentTarget`, а это теперь корневой элемент, зачастую `<div>`. Если даже не завязываются, то могу упасть типы – например, `<Input onPaste={(event: React.SyntheticEvent<HTMLInputElement>) => void 0} />` выдаст ошибку типов (см. скрин ниже):

<img width="320" height="367" alt="image" src="https://github.com/user-attachments/assets/cb7b142a-dfc8-4027-8b1f-de011a00adc1" />


## Release notes
## Исправления
Поправлены трансформации под `slotProps` в компонентах: `Switch`, `Checkbox`, `Radio`, `File`, `CustomSelect`, `NativeSelect`, `Select`, `Textarea`, `WriteBar`, `Input`, `Search` – теперь для обратной совместимости также переносятся события, т.к. может быть завязка на `event.currentTarget` и/или может упасть проверка типов.