### PR TITLE
fix(Touch): onPointerDown preventDefault

### DIFF
--- a/packages/vkui/src/components/Touch/Touch.tsx
+++ b/packages/vkui/src/components/Touch/Touch.tsx
@@ -465,6 +465,11 @@ export const Touch = ({
       // handlePointerDown(onTouchStart устанавливается отдельно через initializeNativeTouchEventStartWithPassiveFalse)
       onMouseDownCapture={useCapture ? handlePointerDown : undefined}
       onMouseDown={!useCapture ? handlePointerDown : undefined}
+      onPointerDown={(event: PointerEvent) => {
+        if (event.pointerType === 'touch' || event.pointerType === 'pen') {
+          event.preventDefault();
+        }
+      }}
     />
   );
 };


### PR DESCRIPTION
- cause #8883

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] ~Unit-тесты~ 
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

На андроиде нажатие на touch вызывает

1. touchstart
2. touchend
3. mousestart
4. mouseend

Из-за этого события onStart onEnd вызываются два раза

## Изменения

Вызываем `preventDefault` для тач событий на onPointerDown.  mousestart и mouseend не будут вызываться.

## Release notes
## Исправления
- [Touch](https://vkui.io/${version}/components/touch): события `onStart`, `onEnd` могли два раза вызываться на Android