### PR TITLE
fix(SimpleGrid): gap default 0

### DIFF
--- a/packages/vkui/src/components/Flex/Flex.tsx
+++ b/packages/vkui/src/components/Flex/Flex.tsx
@@ -140,14 +140,14 @@ export const Flex: React.FC<FlexProps> & {
   );
 };
 
-function getGapsPresets(rowGap?: GapProp, columnGap?: GapProp) {
+function getGapsPresets(rowGap: GapProp, columnGap: GapProp) {
   return classNames(
     typeof rowGap === 'string' && rowGapClassNames[rowGap],
     typeof columnGap === 'string' && columnGapClassNames[columnGap],
   );
 }
 
-function getGapsByUser(rowGap?: GapProp, columnGap?: GapProp) {
+function getGapsByUser(rowGap: GapProp, columnGap: GapProp) {
   const style: CSSCustomProperties = {};
 
   if (typeof rowGap === 'number') {

--- a/packages/vkui/src/components/SimpleGrid/SimpleGrid.tsx
+++ b/packages/vkui/src/components/SimpleGrid/SimpleGrid.tsx
@@ -69,7 +69,7 @@ export interface SimpleGridProps extends RootComponentProps<HTMLElement>, Layout
  */
 export const SimpleGrid = ({
   columns = 1,
-  gap,
+  gap = 0,
   margin = 'none',
   minColWidth,
   align = 'stretch',

--- a/packages/vkui/src/lib/layouts/gaps.test.ts
+++ b/packages/vkui/src/lib/layouts/gaps.test.ts
@@ -2,7 +2,6 @@ import { calculateGap } from './gaps';
 
 describe(calculateGap, () => {
   it('Returns correct values', () => {
-    expect(calculateGap(undefined)).toEqual([undefined, undefined]);
     expect(calculateGap('s')).toEqual(['s', 's']);
     expect(calculateGap([8, 16])).toEqual([8, 16]);
   });

--- a/packages/vkui/src/lib/layouts/gaps.ts
+++ b/packages/vkui/src/lib/layouts/gaps.ts
@@ -33,12 +33,7 @@ export type GapsProp = GapProp | [GapProp, GapProp];
 /**
  * Возвращает массив отступов [rowGap, columnGap]
  */
-export function calculateGap(
-  gap: GapsProp | undefined,
-): [GapProp, GapProp] | [undefined, undefined] {
-  if (gap === undefined) {
-    return [undefined, undefined];
-  }
+export function calculateGap(gap: GapsProp): [GapProp, GapProp] {
   if (typeof gap === 'number' || typeof gap === 'string') {
     return [gap, gap];
   }


### PR DESCRIPTION
## Описание

Flex может влиять на gap внутри компонента SimpleGrid
<img width="862" height="402" alt="image" src="https://github.com/user-attachments/assets/f345192c-1eb6-4196-bad4-5d6d88334e2e" />

```tsx
<Flex direction="column" gap={100}>
<SimpleGrid columns={3}>
  <Avatar size={48} initials="ДС" gradientColor="orange" />
  <Avatar size={48} initials="ИМ" gradientColor="yellow" />
  <Avatar size={48} initials="ВЖ" gradientColor="violet" />
</SimpleGrid>
```

## Изменения

Делаем gap=0 по умолчанию

## Release notes
## Исправления
- [SimpleGrid](https://vkui.io/${version}/components/simple-grid): `gap` по умолчанию `0`