### PR TITLE
tech: fix branch using when creating pull request

### DIFF
--- a/.github/actions/publish-workflow-4-complete/action.yml
+++ b/.github/actions/publish-workflow-4-complete/action.yml
@@ -80,6 +80,7 @@ runs:
         echo ${{ inputs.npm_tag }} > publish_workflow_payload/npm_tag.txt
         echo ${{ steps.git_release_tag.outputs.value }} > publish_workflow_payload/git_release_tag.txt
         echo ${{ inputs.close_milestone }} > publish_workflow_payload/close_milestone.txt
+        echo ${{ inputs.branch }} > publish_workflow_payload/branch.txt
       shell: bash
 
     - name: Upload payload data to artifact for deploy workflow

--- a/.github/workflows/publish_complete.yml
+++ b/.github/workflows/publish_complete.yml
@@ -37,6 +37,7 @@ jobs:
       npm_tag: ${{ steps.publish_workflow_payload.outputs.npm_tag || inputs.npm_tag }}
       git_release_tag: ${{ steps.publish_workflow_payload.outputs.git_release_tag || inputs.git_release_tag }}
       close_milestone: ${{ steps.publish_workflow_payload.outputs.close_milestone || github.event_name == 'workflow_dispatch' }}
+      branch: ${{ steps.publish_workflow_payload.outputs.branch || github.ref }}
     steps:
       - name: Download artifact (if it is 'workflow_run')
         if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success' }}
@@ -56,6 +57,7 @@ jobs:
           echo "npm_tag=$(cat publish_workflow_payload/npm_tag.txt)" >> $GITHUB_OUTPUT
           echo "git_release_tag=$(cat publish_workflow_payload/git_release_tag.txt)" >> $GITHUB_OUTPUT
           echo "close_milestone=$(cat publish_workflow_payload/close_milestone.txt)" >> $GITHUB_OUTPUT
+          echo "branch=$(cat publish_workflow_payload/branch.txt)" >> $GITHUB_OUTPUT
 
   package_vkui_complete:
     needs: ['payload']
@@ -89,12 +91,6 @@ jobs:
           VERSION="${TAG##*@}"
           echo "value=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Define branch name
-        id: define_branch_name
-        run: |
-          # Используем единый формат ветки, совпадающий с тем, что создаётся в pr_close.yml (release/vkui-floating-ui-{version})
-          echo "branch_name=release/vkui-floating-ui-${{ steps.vkui_floating_ui_version.outputs.value }}" >> $GITHUB_OUTPUT
-
       # Обновляем версию vkui-floating-ui в vkui
       - name: update vkui-floating-ui version in vkui
         run: |
@@ -107,7 +103,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: master
-          branch: ${{ steps.define_branch_name.outputs.branch_name }}
+          branch: ${{ needs.payload.outputs.branch }}
           commit-message: 'build(deps): Bump @vkontakte/vkui-floating-ui to ${{ steps.vkui_floating_ui_version.outputs.value }}'
           delete-branch: true
           title: 'build(deps): Bump @vkontakte/vkui-floating-ui to ${{ steps.vkui_floating_ui_version.outputs.value }}'


### PR DESCRIPTION
- link #7404
- caused by #9422
- caused by #9468

## Описание

Очередная правка автопубликации `@vkontakte/vkui-floating-ui`. Конкретно здесь, при создании pr-а некорректно указывался бранч, так как между workflow не передаются env переменные. Заменил на ручное составление названия бранча

## Release notes
-
<!-- 
Необходимо описать основные изменения, которые будут отображены в release notes релиза, в который попадет задача
Формат следующий:
- Если вы не хотите, чтобы в Release notes попала информация о вашем PR, то оставьте просто "-"
- Изменения нужно сгруппировать в секции. Можно указать несколько секций, порядок не важен. Секция должна быть заголовом второго уровня (`## ${заголовок}`). Ниже список секций
  - Новые компоненты
  - Улучшения
  - Исправления
  - Документация
  - Зависимости
  - BREAKING CHANGE
- В каждой секции нужно указать список изменений
- Каждый пункт изменений должен начинаться с '-'
- Если изменение касается какого-то конкретного компонента, то его название должно быть указано и отделено от описания через ':'
Пример:
> - CustomSelect: поправлен баг с неправильным позиционированием

или

> - [CustomSelect](https://vkui.io/${version}/components/custom-select): поправил баг с неправильным позиционированием 

- Если изменений по одному компоненту несколько, их нужно указать в следующем формате
> - CustomSelect:
>   - Поправлен баг с позиционированием
>   - Добавлен новый props

- Если изменение не касается конкретного компонента, то его нужно также указать через '-' и далее в свободной форме
Пример:
> - Переделан механизм отображения всех модальных окон

- Для каждого пункта можно добавить дополнительную информацию. Ее можно указать на следующей строке после описания изменения

Пример:
> ## Новые компоненты
> - Button: компонент, для отображения кнопок
> Более подробное описание
> {Картинка нового компонента}

-->
