### PR TITLE
docs(PopoutWrapper): add Card

### DIFF
--- a/website/content/components/popout-wrapper.mdx
+++ b/website/content/components/popout-wrapper.mdx
@@ -26,10 +26,10 @@ return (
     {isOpen && (
       <PopoutWrapper onClick={() => setIsOpen(false)}>
         <Card>
-          <Div>
+          <Box padding="system">
             <Title>Всплывающее окно</Title>
             <Text>Содержимое всплывающего окна</Text>
-          </Div>
+          </Box>
         </Card>
       </PopoutWrapper>
     )}


### PR DESCRIPTION
- see #8924

## Описание

> [Docs]PopoutWrapper: либо сделать текст "Всплывающее окно" белым, либо добавить фон, т.к. сейчас он плохо читается

## Изменения

Добавляем обертку в виде карточки

<img width="439" height="233" alt="image" src="https://github.com/user-attachments/assets/52f0bd07-f22e-4dee-b111-b6eaf752b89f" />

## Release notes
-