### PR TITLE
fix(Calendar): nowrap for select

### DIFF
--- a/packages/vkui/src/components/CalendarTime/CalendarTimePicker.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTimePicker.tsx
@@ -4,6 +4,7 @@ import { type ChangeEvent, useState } from 'react';
 import * as React from 'react';
 import { AdaptivityProvider } from '../AdaptivityProvider/AdaptivityProvider';
 import { CustomSelect, type SelectProps } from '../CustomSelect/CustomSelect';
+import { CustomSelectOption } from '../CustomSelectOption/CustomSelectOption';
 import styles from './CalendarTime.module.css';
 
 const selectFilterFn = () => true;
@@ -78,6 +79,11 @@ export const CalendarTimePicker = ({
           filterFn={selectFilterFn}
           onInputChange={onPickerValueChange}
           onInputKeyDown={onInputKeyDown}
+          renderOption={({ children: optionChildren, ...optionProps }) => (
+            <CustomSelectOption {...optionProps} textNoWrap>
+              {optionChildren}
+            </CustomSelectOption>
+          )}
           slotProps={{
             input: {
               'aria-label': inputLabel,

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.module.css
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.module.css
@@ -55,6 +55,10 @@
   word-break: break-word;
 }
 
+.textNoWrap {
+  white-space: nowrap;
+}
+
 .after {
   display: flex;
   flex-shrink: 0;

--- a/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
+++ b/packages/vkui/src/components/CustomSelectOption/CustomSelectOption.tsx
@@ -55,6 +55,10 @@ export interface CustomSelectOptionProps extends HTMLAttributesWithRootRef<HTMLD
    * опции.
    */
   disabled?: boolean;
+  /**
+   * Предотвращает перенос текста внутри опции.
+   */
+  textNoWrap?: boolean;
 }
 
 /**
@@ -69,6 +73,7 @@ export const CustomSelectOption = ({
   after,
   description,
   disabled,
+  textNoWrap,
   style: styleProp,
   className,
   onClick,
@@ -107,7 +112,9 @@ export const CustomSelectOption = ({
     >
       {hasReactNode(before) && <div className={styles.before}>{before}</div>}
       <div className={styles.main}>
-        <div className={styles.children}>{children}</div>
+        <div className={classNames(styles.children, textNoWrap && styles.textNoWrap)}>
+          {children}
+        </div>
         {hasReactNode(description) && (
           <Footnote className={styles.description}>
             <VisuallyHidden>&nbsp;</VisuallyHidden>


### PR DESCRIPTION
- close #9380                                                                                                                                        
                                                                                                                                                      
---                                                                                                                                                  
                                                                                                                                                      
## Описание                                                                                                                                          
                                                                                                                                                      
Исправлен баг с некорректным отображением цифр в выпадающем меню выбора времени в `Calendar`.                                                        
                                                                                                                                                      
При включенном `enableTime`, при наличии видимого скролл-бара и выбранном времени, текст переносился (например, "14" → "1 \n 4"). Решение реализовано
  вторым способом из предложенных в issue: добавлен параметр `textNoWrap` в `CustomSelectOption`, который включается через `renderOption` в           
`CalendarTimePicker`.                                                                                                                                
                                                                                                                                                      
## Изменения                                                                                                                                         
                                                                                                                                                      
- `CustomSelectOption`: добавлен новый проп `textNoWrap` для предотвращения переноса текста внутри опции                                             
- `CustomSelectOption.module.css`: добавлен класс `.textNoWrap` со стилем `white-space: nowrap`                                                      
- `CalendarTimePicker`: добавлен `renderOption` с пропом `textNoWrap` для `CustomSelect`                                                             
                                                                                                                                                      
## Release notes                                                                                                                                     
                                                                                                                                                      
## Исправления                                                                                                                                       
- [CustomSelectOption](https://vkui.io/${version}/components/custom-select): добавлено свойство `textNoWrap` для предотвращения переноса текста                                                                  
- [Calendar](https://vkui.io/${version}/components/calendar): исправлен баг с некорректным отображением цифр в меню времени при наличии скролл-бара  

