### PR TITLE
fix(storybook): fix controls generation

### DIFF
--- a/packages/vkui/.storybook/main.ts
+++ b/packages/vkui/.storybook/main.ts
@@ -45,6 +45,10 @@ const config: StorybookConfig = {
   },
   typescript: {
     reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      tsconfigPath: fileURLToPath(new URL('../tsconfig.storybook.json', import.meta.url)),
+      shouldRemoveUndefinedFromOptional: true,
+    },
   },
 };
 

--- a/packages/vkui/tsconfig.storybook.json
+++ b/packages/vkui/tsconfig.storybook.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.web.json",
+  "include": ["types/env.d.ts", "types/css.d.ts", "src", "docs"],
+  "exclude": ["src/**/*.test.ts*", "src/**/*.e2e*.ts*"]
+}


### PR DESCRIPTION
- caused by #9673

---

## Описание

После обновления Storybook с `10.3.3` до `10.3.4` перестала корректно работать автогенерация Controls:
- в `Controls` отображались только явно заданные `argTypes`;
- у части пропсов пропал корректный тип контролов (например, для `boolean` не показывался toggle).

Причина: в `10.3.4` через `@storybook/react-vite` был обновлен `@joshwooding/vite-plugin-react-docgen-typescript` до `0.7.0` 
После обновления docgen стал строже к "active TypeScript project" и начал пропускать файлы, не входящие в используемый TS-конфиг (`Skipping docgen ... not included in the active TypeScript project`), что ломало корректную инференцию `argTypes` и отображение контролов.

## Изменения

- Добавлен отдельный TS-конфиг для Storybook/docgen: `packages/vkui/tsconfig.storybook.json`.
- Обновлен `packages/vkui/.storybook/main.ts`:
  - для `react-docgen-typescript` явно указан `tsconfigPath` на `tsconfig.storybook.json`;
  - добавлена опция `shouldRemoveUndefinedFromOptional: true`, чтобы optional boolean-пропсы не приходили как `boolean | undefined` и корректно отображались в Controls (toggle).

## Release notes
-