### PR TITLE
fix(CustomSelect): prop mode

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -308,7 +308,8 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     multiline,
     placeholder,
     'icon': iconProp,
-    selectType = 'default',
+    selectType,
+    mode,
     align,
     form,
 
@@ -775,7 +776,7 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
         accessible={accessible}
         before={before}
         after={afterItems}
-        selectType={selectType}
+        selectType={selectType || mode || 'default'}
         align={align}
         status={status}
         multiline={multiline}


### PR DESCRIPTION
- [x] Release notes

## Описание

В CustomSelect из-за наследования оказалось свойство `mode` которое работало, но потом сломалось

В будущем нужно оставить только свойство `selectType`, а свойство mode задепрекейтить в CustomSelect

## Release notes
## Исправления
- [CustomSelect](https://vkui.io/${version}/components/custom-select): свойство `mode` не работало
