### PR TITLE
fix(ImageBase): add container for image to cut filter blur effect

### DIFF
--- a/packages/vkui/src/components/ImageBase/ImageBase.e2e-playground.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.e2e-playground.tsx
@@ -1,4 +1,4 @@
-import { Icon36Done } from '@vkontakte/icons';
+import { Icon24AddOutline, Icon24StarCircleFillGreen, Icon36Done } from '@vkontakte/icons';
 import { ComponentPlayground, type ComponentPlaygroundProps } from '@vkui-e2e/playground-helpers';
 import { withLabel } from '@vkui-e2e/utils';
 import { ColorSchemeProvider } from '../ColorSchemeProvider/ColorSchemeProvider';
@@ -59,5 +59,34 @@ export const ImageWithBrokenSrc = (props: ComponentPlaygroundProps) => (
     ]}
   >
     {(props: ImageBaseProps) => <ImageBase {...props} />}
+  </ComponentPlayground>
+);
+
+export const ImageWithFilter = (props: ComponentPlaygroundProps) => (
+  <ComponentPlayground
+    {...props}
+    propSets={[
+      {
+        size: [72],
+        src: [
+          withLabel(
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA1AQMAAADbKDEzAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAADUExURf8AwIKGy4cAAAAOSURBVBjTY2AYBUMBAAABqAABpqpmMQAAAABJRU5ErkJggg==',
+            'base64',
+          ),
+        ],
+        filter: ['blur(4px)'],
+      },
+    ]}
+  >
+    {(props: ImageBaseProps) => (
+      <ImageBase {...props}>
+        <ImageBase.Overlay visibility="always">
+          <Icon24AddOutline />
+        </ImageBase.Overlay>
+        <ImageBase.Badge background="stroke">
+          <Icon24StarCircleFillGreen />
+        </ImageBase.Badge>
+      </ImageBase>
+    )}
   </ComponentPlayground>
 );

--- a/packages/vkui/src/components/ImageBase/ImageBase.e2e.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.e2e.tsx
@@ -1,6 +1,10 @@
 import { test } from '@vkui-e2e/test';
 import { Platform } from '../../lib/platform';
-import { ImageWithBrokenSrc, ImageWithParentWithBorderRadius } from './ImageBase.e2e-playground';
+import {
+  ImageWithBrokenSrc,
+  ImageWithFilter,
+  ImageWithParentWithBorderRadius,
+} from './ImageBase.e2e-playground';
 
 test.describe('ImageBase', () => {
   test.use({
@@ -27,6 +31,15 @@ test.describe('ImageBase', () => {
     componentPlaygroundProps,
   }) => {
     await mount(<ImageWithBrokenSrc {...componentPlaygroundProps} />);
+    await expectScreenshotClippedToContent();
+  });
+
+  test('Image with filter', async ({
+    mount,
+    expectScreenshotClippedToContent,
+    componentPlaygroundProps,
+  }) => {
+    await mount(<ImageWithFilter {...componentPlaygroundProps} />);
     await expectScreenshotClippedToContent();
   });
 });

--- a/packages/vkui/src/components/ImageBase/ImageBase.module.css
+++ b/packages/vkui/src/components/ImageBase/ImageBase.module.css
@@ -41,10 +41,19 @@
   transform-origin: left top;
 }
 
-.img {
-  display: block;
+.imgWithFilterContainer {
+  overflow: hidden; /* Обрезает сайд-эффекты свойства `filter`. */
+}
+
+.img,
+.imgWithFilterContainer {
   inline-size: 100%;
   block-size: 100%;
+  border-radius: inherit;
+}
+
+.img {
+  display: block;
   /* Скрывает текст из атрибута alt. */
   color: transparent;
   /*
@@ -53,7 +62,6 @@
   */
   text-indent: 10000px;
   border: 0;
-  border-radius: inherit;
 }
 
 .imgKeepRatio {

--- a/packages/vkui/src/components/ImageBase/ImageBase.tsx
+++ b/packages/vkui/src/components/ImageBase/ImageBase.tsx
@@ -118,8 +118,10 @@ export interface ImageBaseProps
    */
   elementTiming?: string | undefined;
   /**
-   * Пользовательское значения стиля filter
+   * Пользовательское значения стиля filter.
    * Подробнее можно почитать в [документации](https://developer.mozilla.org/ru/docs/Web/CSS/filter).
+   *
+   * При передаче этого свойства `<img />` будет обёрнут в дополнительный контейнер.
    */
   filter?: React.CSSProperties['filter'] | undefined;
   /**
@@ -341,6 +343,10 @@ export const ImageBase: React.FC<ImageBaseProps> & {
     [mouseOutHandlers, mouseOverHandlers, size],
   );
 
+  const imgSlot = hasSrc && (
+    <img ref={imgRef} {...imgRest} {...getFetchPriorityProp(fetchPriority)} />
+  );
+
   return (
     <ImageBaseContext.Provider value={contextValue}>
       <Clickable
@@ -355,7 +361,7 @@ export const ImageBase: React.FC<ImageBaseProps> & {
         onMouseOut={onMouseOut}
         {...restProps}
       >
-        {hasSrc && <img ref={imgRef} {...imgRest} {...getFetchPriorityProp(fetchPriority)} />}
+        {filter ? <div className={styles.imgWithFilterContainer}>{imgSlot}</div> : imgSlot}
         {fallbackIcon && <div className={styles.fallback}>{fallbackIcon}</div>}
         {children && <div className={styles.children}>{children}</div>}
         {!noBorder && <div aria-hidden className={styles.border} />}

--- a/packages/vkui/src/components/ImageBase/__image_snapshots__/imagebase-image-with-filter-android-chromium-light-1-snap.png
+++ b/packages/vkui/src/components/ImageBase/__image_snapshots__/imagebase-image-with-filter-android-chromium-light-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c15a903fbb447fc6a381d31842630e7d805d750a7baa40d6a0f0dc7eee596e4e
+size 5264


### PR DESCRIPTION
- caused by #8171

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- ~[ ] Unit-тесты~
- [x] e2e-тесты
- ~[ ] Дизайн-ревью~
- ~[ ] Документация фичи~
- [x] Release notes

## Версия

\>= 7.2.0

## Проблема

Примененние `filter`, в частности со значением `blur()`, создавало сайд-эффекты, например, перекрывая border компонента.


```jsx
<ImageBase
  size={96}
src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA1AQMAAADbKDEzAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAADUExURf8AwIKGy4cAAAAOSURBVBjTY2AYBUMBAAABqAABpqpmMQAAAABJRU5ErkJggg=="
  filter="blur(8px)"
/>
```

## Решение

При прокидывании `filter` оборачиваем `<img/>` в контейнер со св-ом `overflow: hidden`.

## Release notes
## Исправления
- ImageBase: эффект от `filter: blur(<value>px)` больше не выходит за границы компонента
- Avatar: эффект от `filter: blur(<value>px)` больше не выходит за границы компонента
- Image: эффект от `filter: blur(<value>px)` больше не выходит за границы компонента