### PR TITLE
fix(storybook): fix extract liter values from enum

### DIFF
--- a/packages/vkui/.storybook/main.ts
+++ b/packages/vkui/.storybook/main.ts
@@ -47,6 +47,7 @@ const config: StorybookConfig = {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       tsconfigPath: fileURLToPath(new URL('../tsconfig.storybook.json', import.meta.url)),
+      shouldExtractLiteralValuesFromEnum: true,
       shouldRemoveUndefinedFromOptional: true,
     },
   },


### PR DESCRIPTION
- [x] Release notes

## Описание

В Storybook часть пропов с literal-типами определялась некорректно в Controls.  
Из-за этого значения могли отображаться как `Set object`/

## Изменения

- В `packages/vkui/.storybook/main.ts` для `react-docgen-typescript` включена опция:
  - `shouldExtractLiteralValuesFromEnum: true`
- Это улучшает извлечение literal-значений типов для автогенерации Controls.

## Release notes
## Исправления
- Storybook: исправлено определение literal-типов пропсов в Controls через настройку `react-docgen-typescript`.