### PR TITLE
tech: remove postcssGapProperties plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "postcss": "^8.5.10",
     "postcss-cli": "^11.0.1",
     "postcss-custom-media": "^12.0.1",
-    "postcss-gap-properties": "^7.0.0",
     "postcss-import": "^16.1.1",
     "postcss-loader": "^8.2.1",
     "postcss-logical": "^9.0.0",

--- a/packages/vkui/scripts/postcss.ts
+++ b/packages/vkui/scripts/postcss.ts
@@ -6,7 +6,6 @@ import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
 import type { AcceptedPlugin } from 'postcss';
 import postcssCustomMedia from 'postcss-custom-media';
-import postcssGapProperties from 'postcss-gap-properties';
 import cssImport from 'postcss-import';
 import postcssLogical from 'postcss-logical';
 import cssModules from 'postcss-modules';
@@ -111,13 +110,6 @@ function makePostcssPlugins({
         getJSON: () => void 0,
       }),
     );
-  }
-
-  // TODO [>=9]: Проверить браузерную поддержку
-  //
-  // https://caniuse.com/mdn-css_properties_gap_grid_context
-  if (!isESNext) {
-    plugins.push(postcssGapProperties());
   }
 
   // Уменьшение размера для продакшен сборки

--- a/packages/vkui/vite.config.ts
+++ b/packages/vkui/vite.config.ts
@@ -4,7 +4,6 @@ import layoutClasses from '@project-tools/postcss-layout-classes';
 import restructureVariable from '@project-tools/postcss-restructure-variable';
 import autoprefixer from 'autoprefixer';
 import postcssCustomMedia from 'postcss-custom-media';
-import postcssGapProperties from 'postcss-gap-properties';
 import cssImport from 'postcss-import';
 import type { InlineConfig } from 'vite';
 import tsconfig from './tsconfig.test.json' with { type: 'json' };
@@ -59,11 +58,6 @@ export default {
 
         // Обработка CustomMedia
         postcssCustomMedia(),
-
-        // TODO [>=9]: Проверить браузерную поддержку
-        //
-        // https://caniuse.com/mdn-css_properties_gap_grid_context
-        postcssGapProperties(),
       ],
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,7 +5244,6 @@ __metadata:
     postcss: "npm:^8.5.10"
     postcss-cli: "npm:^11.0.1"
     postcss-custom-media: "npm:^12.0.1"
-    postcss-gap-properties: "npm:^7.0.0"
     postcss-import: "npm:^16.1.1"
     postcss-loader: "npm:^8.2.1"
     postcss-logical: "npm:^9.0.0"
@@ -14208,15 +14207,6 @@ __metadata:
   peerDependencies:
     postcss: ^8.5.10
   checksum: 10/4b15dc21b35372cfb15c3375cffd81c370713869ccd1884c00d4f5094e50b556cf287f028122178ff7acf2e175d4b90b228cc079480a9286e8e6db31922edadf
-  languageName: node
-  linkType: hard
-
-"postcss-gap-properties@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "postcss-gap-properties@npm:7.0.0"
-  peerDependencies:
-    postcss: ^8.4
-  checksum: 10/b16633237beafc6e9561f9b7e14cdc02ea80ed37608e1d1bea1149c15ecd1dc8f00fcdc679b3c69d1f3b1cca0c198a1d645580c3933ec90c2c9d7953771802a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- caused by #9250

## Описание

Выпилил плагин `postcss-gap-properties`, так как по браузерной поддержке он уже не нужен
<img width="1388" height="449" alt="image" src="https://github.com/user-attachments/assets/d238f257-4141-4f07-a8c9-535cfee66c48" />

## Release notes
-
