### PR TITLE
ci: add APT_MIRROR

### DIFF
--- a/.github/actions/lfs/action.yml
+++ b/.github/actions/lfs/action.yml
@@ -1,6 +1,10 @@
 name: Workflow / Checkout LFS objects
 description: Get lfs from cache
 
+inputs:
+  apt_mirror:
+    description: apt mirror
+
 runs:
   using: composite
   steps:
@@ -8,6 +12,15 @@ runs:
     - name: Set safe directory
       shell: bash
       run: git config --global --add safe.directory /__w/VKUI/VKUI
+
+
+    - name: Configure apt mirror
+      if: ${{ inputs.apt_mirror }}
+      shell: bash
+      run: |
+        sed -i "s|http://archive.ubuntu.com|${{ inputs.apt_mirror }}|g" /etc/apt/sources.list
+        sed -i "s|http://security.ubuntu.com|${{ inputs.apt_mirror }}|g" /etc/apt/sources.list
+        apt-get update
 
     # см. https://github.com/microsoft/playwright/issues/21920
     - name: Install git lfs

--- a/.github/workflows/branch_test_coverage.yml
+++ b/.github/workflows/branch_test_coverage.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Checkout LFS objects
         uses: ./.github/actions/lfs
+        with:
+          apt_mirror: ${{ vars.APT_MIRROR }}
 
   test:
     name: Call reusable unit tests workflow

--- a/.github/workflows/reusable_workflow_test_e2e.yml
+++ b/.github/workflows/reusable_workflow_test_e2e.yml
@@ -23,6 +23,8 @@ jobs:
       # Создаем кэш для ветки один раз
       - name: Checkout LFS objects
         uses: ./.github/actions/lfs
+        with:
+          apt_mirror: ${{ vars.APT_MIRROR }}
 
       - uses: ./.github/actions/get-playwright-docker-image
         id: result
@@ -48,6 +50,8 @@ jobs:
 
       - name: Checkout LFS objects
         uses: ./.github/actions/lfs
+        with:
+          apt_mirror: ${{ vars.APT_MIRROR }}
 
       - name: Node setup
         uses: ./.github/actions/node-setup

--- a/.github/workflows/update_screens.yml
+++ b/.github/workflows/update_screens.yml
@@ -22,6 +22,8 @@ jobs:
       # Создаем кэш для ветки один раз
       - name: Checkout LFS objects
         uses: ./.github/actions/lfs
+        with:
+          apt_mirror: ${{ vars.APT_MIRROR }}
 
       - uses: ./.github/actions/get-playwright-docker-image
         id: result
@@ -45,6 +47,8 @@ jobs:
 
       - name: Checkout LFS objects
         uses: ./.github/actions/lfs
+        with:
+          apt_mirror: ${{ vars.APT_MIRROR }}
 
       - name: Install rsync && zip
         run: |


### PR DESCRIPTION
## Описание

Добавляем возможность указать apt зеркало, так как archive.ubuntu.com может быть [не доступен из-за ddos-а](https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQFYMUQt3d_F-gn4VhVipql9UvmgQxcHUsErlGgGoE-wIQ==)

## Release notes
-