### PR TITLE
fix(PullToRefresh): content overflow clip

### DIFF
--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.module.css
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.module.css
@@ -75,6 +75,8 @@
   flex-grow: 1;
   flex-direction: column;
   overflow: hidden;
+  /* TODO [>=9]: использовать clip чтобы не создовать контекст контейнера прокрутки и не мешать sticky элементам */
+  overflow: clip;
   transition: transform 400ms var(--vkui--animation_easing_platform);
 }
 


### PR DESCRIPTION
- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] Дизайн-ревью
- [x] Документация фичи
- [x] Release notes

## Описание

Стики элементам мешает overflow hidden

## Изменения

Используем clip чтобы не создовать контекст контейнера прокрутки и не мешать sticky элементам

Graceful degradetion: Фикс работает только на 90 хроме, 16 сафари

## Release notes
- [PullToRefresh](https://vkui.io/${version}/components/pull-to-refresh/): исправлено поведение со sticky элементами
