### PR TITLE
docs: remove duplicate mode prop in Cell removable example

### DIFF
--- a/website/content/components/cell.mdx
+++ b/website/content/components/cell.mdx
@@ -31,9 +31,8 @@ tags: list
 <Playground>
   ```jsx
   <Cell
-    mode="selectable"
-    before={<Avatar />}
     mode="removable"
+    before={<Avatar />}
     onRemove={() => alert('Обработчик удаления')}
   >
     Пётр Кузнецов


### PR DESCRIPTION
## Описание

Убран дублирующийся `mode="selectable"`, оставлен только `mode="removable"`

## Release notes
## Документация
- [Cell](https://vkui.io/${version}/components/cell): Убран дублирующийся `mode="selectable"`, оставлен только `mode="removable"`
