### PR TITLE
fix(date): use step parameter in eachDayOfInterval

### DIFF
--- a/packages/vkui/src/lib/date.test.ts
+++ b/packages/vkui/src/lib/date.test.ts
@@ -486,14 +486,41 @@ describe('eachDayOfInterval', () => {
     expect(result).toEqual([new Date(2023, 0, 1, 0, 0, 0, 0), new Date(2023, 0, 2, 0, 0, 0, 0)]);
   });
 
-  it('step greater than one does not affect the number of days', () => {
+  it('step greater than one skips days', () => {
     const start = new Date(2023, 0, 1);
-    const end = new Date(2023, 0, 4);
+    const end = new Date(2023, 0, 5);
 
     const resultStep1 = eachDayOfInterval(start, end, { step: 1 });
     const resultStep2 = eachDayOfInterval(start, end, { step: 2 });
+    const resultStep3 = eachDayOfInterval(start, end, { step: 3 });
 
-    expect(resultStep1).toEqual(resultStep2);
+    expect(resultStep1).toEqual([
+      new Date(2023, 0, 1),
+      new Date(2023, 0, 2),
+      new Date(2023, 0, 3),
+      new Date(2023, 0, 4),
+      new Date(2023, 0, 5),
+    ]);
+    expect(resultStep2).toEqual([new Date(2023, 0, 1), new Date(2023, 0, 3), new Date(2023, 0, 5)]);
+    expect(resultStep3).toEqual([new Date(2023, 0, 1), new Date(2023, 0, 4)]);
+  });
+
+  it('step of 2 with reversed interval skips days', () => {
+    const start = new Date(2023, 0, 5);
+    const end = new Date(2023, 0, 1);
+
+    const result = eachDayOfInterval(start, end, { step: 2 });
+
+    expect(result).toEqual([new Date(2023, 0, 5), new Date(2023, 0, 3), new Date(2023, 0, 1)]);
+  });
+
+  it('negative step greater than one skips days and reverses order', () => {
+    const start = new Date(2023, 0, 1);
+    const end = new Date(2023, 0, 5);
+
+    const result = eachDayOfInterval(start, end, { step: -2 });
+
+    expect(result).toEqual([new Date(2023, 0, 5), new Date(2023, 0, 3), new Date(2023, 0, 1)]);
   });
 
   it('negative step reverses the order of dates', () => {

--- a/packages/vkui/src/lib/date.ts
+++ b/packages/vkui/src/lib/date.ts
@@ -304,7 +304,7 @@ export function eachDayOfInterval(
 
   while (+date <= endTime) {
     dates.push(new Date(date));
-    date.setDate(date.getDate() + 1);
+    date.setDate(date.getDate() + step);
     date.setHours(0, 0, 0, 0);
   }
 


### PR DESCRIPTION
## Описание

В функции `eachDayOfInterval` параметр `step` не использовался при вычислении следующей даты — цикл всегда инкрементировал дату на
1 день, игнорируя переданное значение `step`. Присваивание `step = -step` на строке 299 помечалось линтером как бесполезное,
поскольку результат не использовался далее.

## Изменения

В цикле `date.setDate(date.getDate() + step)` вместо `+1` теперь используется `step`. Также обновлены тесты — старый
тест ошибочно утверждал, что `step > 1` не влияет на результат.

## Release notes
## Исправления
- eachDayOfInterval: параметр `step` теперь корректно пропускает дни при значении > 1