### PR TITLE
chore(SnackbarHolder): remove redundant undefined check for placement

### DIFF
--- a/packages/vkui/src/hooks/useSnackbarManager/components/SnackbarHolder.tsx
+++ b/packages/vkui/src/hooks/useSnackbarManager/components/SnackbarHolder.tsx
@@ -40,7 +40,7 @@ export const SnackbarHolder: React.FC<SnackbarHolderProps> = ({
         continue;
       }
 
-      if (placement !== undefined && !map[placement]) {
+      if (!map[placement]) {
         map[placement] = [];
         openedSnackbarsCountersByPlacement[placement] = 0;
         placements.push(placement);


### PR DESCRIPTION
## Описание

В `SnackbarHolder.tsx:43` сравнение `placement !== undefined` после того, как на строке 39
уже выполнена проверка `placement === undefined` с `continue`. После `continue` тип `placement` сужается до `SnackbarPlacement`, и
сравнение с `undefined` всегда даёт `true`, что делает проверку избыточной.

## Изменения

- Убрана избыточная проверка `placement !== undefined` на строке 43, так как тип уже сужен проверкой на строке 39 с `continue`.

## Release notes
-