### PR TITLE
test(useExternRef): replace void null expressions with return in test

### DIFF
--- a/packages/vkui/src/hooks/useExternRef.test.tsx
+++ b/packages/vkui/src/hooks/useExternRef.test.tsx
@@ -27,19 +27,7 @@ describe(useExternRef, () => {
         });
         return null;
       };
-      render(
-        <RefForwarder
-          getRef={() => {
-            null;
-          }}
-        />,
-      ).rerender(
-        <RefForwarder
-          getRef={() => {
-            null;
-          }}
-        />,
-      );
+      render(<RefForwarder getRef={noop} />).rerender(<RefForwarder getRef={noop} />);
       expect((firstRef as any)?.current).toBe(counter);
     });
   });


### PR DESCRIPTION
## Описание

Исправлено предупреждение линтера "Expression has no effect" в `useExternRef.test.tsx`.
Выражения `null;` внутри стрелочных функций `getRef` не имели эффекта — заменены на `() => null`,
чтобы функции корректно возвращали `null`.

## Изменения

- `useExternRef.test.tsx`: заменены `() => { null; }` на `() => null` (строки 33, 39)

## Release notes
-