### PR TITLE
fix: remove useless conditional expressions

### DIFF
--- a/packages/codemods/src/transforms/v7/form-item.ts
+++ b/packages/codemods/src/transforms/v7/form-item.ts
@@ -132,7 +132,7 @@ export default function transformer(file: FileInfo, api: API, options: JSCodeShi
     if (topMultiline) {
       // Если у FormItem задан topMultiline -> переопределяем
       topMultiline.value = newTopMultilineValue;
-    } else if (topLabelMultiline) {
+    } else {
       // Если у FormItem не задан topMultiline
       // добавляем его в аргументы
       formItemAttributes?.push(

--- a/packages/vkui/src/components/DateInput/DateInput.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.tsx
@@ -441,7 +441,7 @@ export const DateInput = ({
     }
   }, [handleFieldEnter, openCalendar, accessible]);
 
-  const showCalendarButton = !disableCalendar && (accessible || (!accessible && !value));
+  const showCalendarButton = !disableCalendar && (accessible || !value);
   const showClearButton = value && !readOnly;
 
   useGlobalEscKeyDown(open && !disableCalendar, closeCalendar, {

--- a/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/packages/vkui/src/components/DateRangeInput/DateRangeInput.tsx
@@ -415,7 +415,7 @@ export const DateRangeInput = ({
     }
   }, [handleFieldEnter, openCalendar, accessible]);
 
-  const showCalendarButton = !disableCalendar && (accessible || (!accessible && !value));
+  const showCalendarButton = !disableCalendar && (accessible || !value);
   const showClearButton = value && !readOnly;
 
   useGlobalEscKeyDown(open && !disableCalendar, closeCalendar, {

--- a/packages/vkui/src/hooks/useMergeProps.ts
+++ b/packages/vkui/src/hooks/useMergeProps.ts
@@ -26,7 +26,7 @@ export const useMergeProps = <T extends BaseProps = BaseProps>(
     return filterProps(originalProps);
   }
 
-  const { className: rootSlotClassName, style: rootSlotStyle, ...rootSlotProps } = slotProps || {};
+  const { className: rootSlotClassName, style: rootSlotStyle, ...rootSlotProps } = slotProps;
 
   const {
     className: originalClassName,

--- a/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
+++ b/packages/vkui/src/lib/floating/useFloatingWithInteractions/useFloatingWithInteractions.ts
@@ -310,7 +310,7 @@ export const useFloatingWithInteractions = <T extends HTMLElement = HTMLElement>
       if (shownLocalState.shown) {
         setShownFinalState(true);
         onShownChanged(true, shownLocalState.reason);
-      } else if (hasCSSAnimation.current && !willBeHide) {
+      } else if (hasCSSAnimation.current) {
         setWillBeHide(true);
       } else {
         setShownFinalState(false);


### PR DESCRIPTION
## Описание

Удалены бессмысленные условные выражения, которые всегда вычисляются в `true` или `false`,
выявленные статическим анализом.

## Изменения

- **form-item.ts**: Убрана проверка `topLabelMultiline` в `else if`, так как после раннего
  возврата при `!topLabelMultiline` переменная всегда истинна — заменено на `else`
- **DateInput.tsx**: Упрощено `accessible || (!accessible && !value)` → `accessible ||
!value` (закон дистрибутивности A || (!A && B) = A || B)
- **DateRangeInput.tsx**: Аналогичное упрощение `accessible || (!accessible && !value)` →
`accessible || !value`
- **useMergeProps.ts**: Убран `|| {}` после деструктуризации `slotProps`, так как после
раннего возврата при `!slotProps` переменная всегда определена
- **useFloatingWithInteractions.ts**: Убрано `&& !willBeHide`, так как после проверки
`willBeHide` с ранним возвратом это условие всегда истинно

## Release notes
-
