### PR TITLE
fix(storybook-addons): fix babel import

### DIFF
--- a/packages/storybook-addons/src/addons/live-code-editor/preset.js
+++ b/packages/storybook-addons/src/addons/live-code-editor/preset.js
@@ -3,3 +3,13 @@ import { fileURLToPath } from 'node:url';
 export function managerEntries(entry = []) {
   return [...entry, fileURLToPath(import.meta.resolve('./register.tsx'))];
 }
+
+export function viteFinal(config) {
+  return {
+    ...config,
+    optimizeDeps: {
+      ...config.optimizeDeps,
+      include: [...(config.optimizeDeps?.include || []), '@babel/standalone'],
+    },
+  };
+}

--- a/packages/storybook-addons/src/index.ts
+++ b/packages/storybook-addons/src/index.ts
@@ -11,5 +11,5 @@ export { ADDON_ID as sourceButtonAddonId } from './addons/source-button/constant
 export type { SourceButtonConfig } from './addons/source-button/config';
 export { registerSourceButtonAddon } from './addons/source-button/register';
 
-export { withLiveCodeEditor } from './liveCodeEditor';
+export { withLiveCodeEditor, EVENTS } from './liveCodeEditor';
 export type { LiveCodeEditorParameters, ExtraLibs, NamedImports } from './liveCodeEditor';

--- a/packages/storybook-addons/src/liveCodeEditor/Preview.tsx
+++ b/packages/storybook-addons/src/liveCodeEditor/Preview.tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line spaced-comment
+/// <reference path="./declarations.d.ts" />
 import * as React from 'react';
 import { CompilingBadge } from './CompilingBadge';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -40,7 +42,7 @@ export const Preview = ({
 
     void (async () => {
       try {
-        const [{ transform }, globals] = await Promise.all([
+        const [babelModule, globals] = await Promise.all([
           import(
             /* webpackChunkName: 'babel/standalone' */
             '@babel/standalone'
@@ -53,12 +55,13 @@ export const Preview = ({
           return;
         }
 
+        const babel = babelModule.default ?? babelModule;
         const moduleGlobals = Object.assign({ React }, React, ...globals, scope);
 
         delete moduleGlobals['default'];
         delete moduleGlobals[name];
 
-        const { code: moduleCode } = transform(code, {
+        const { code: moduleCode } = babel.transform(code, {
           filename: 'index.tsx',
           presets: ['typescript', ['react', { runtime: 'automatic' }]],
           plugins: ['transform-modules-commonjs'],


### PR DESCRIPTION
- caused by #9917

---

- [ ] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [ ] Release notes

## Описание

Live Code Editor аддон не работал во внешних проектах — при динамическом импорте `@babel/standalone` функция `transform` оказывалась `undefined`.

## Изменения

**Причина:** Пакет `@babel/standalone` — это UMD-модуль, который Vite pre-bundl'ит с `needsInterop: true`, оборачивая все экспорты в `default`. В монорепозитории это работает, потому что `@vkontakte/storybook-addons` — workspace-пакет, и Vite сканирует его исходники при первичном обнаружении зависимостей, корректно pre-bundl'ит `@babel/standalone` и применяет interop-слой в рантайме.

Во внешнем проекте исходники аддона лежат в `node_modules`. Vite не сканирует `node_modules` при поиске зависимостей для pre-bundling, динамический `import('@babel/standalone')` не обнаруживается на этапе сканирования, зависимость не pre-bundl'ится, interop не применяется — и деструктуризация `const [{ transform }]` даёт `undefined`.

**Что изменено:**

1. **`Preview.tsx`** — вместо деструктуризации `transform` из результата импорта, получаем babel-объект через `babelModule.default ?? babelModule` и вызываем `babel.transform(...)`. Работает и с Vite interop, и без него.

2. **`preset.js`** — добавлен хук `viteFinal`, включающий `@babel/standalone` в `optimizeDeps.include`. Это заставляет Vite во внешних проектах гарантированно обнаруживать и pre-bundled `@babel/standalone` при старте dev-сервера.

## Release notes
-