### PR TITLE
fix(storybook-addons): turn off editContext in live-code-editor

### DIFF
--- a/packages/storybook-addons/src/liveCodeEditor/Editor.tsx
+++ b/packages/storybook-addons/src/liveCodeEditor/Editor.tsx
@@ -141,6 +141,7 @@ export const Editor = ({
 
     const editor = monaco.editor.create(containerRef.current, {
       automaticLayout: true,
+      editContext: false,
       fixedOverflowWidgets: true,
       model: monaco.editor.createModel(
         value,


### PR DESCRIPTION
- caused by #9965

---

## Описание

После обновления `monaco-editor` с 0.52.2 до 0.55.1 (#9965) в Live Code Editor перестали вводиться цифры 1, 2, 3 — при нажатии фокус уходил из редактора.

### Причина

В `monaco-editor@0.55.x` опция `editContext` по умолчанию стала `true` (в Chrome/Edge). Это включает новый **EditContext API** вместо textarea-архитектуры ввода. EditContext API не поглощает `keydown` события при обычном вводе текста — они всплывают до `document`, где Storybook перехватывает их своими хоткеями:

- `1` → `focusNav`
- `2` → `focusIframe`
- `3` → `focusPanel`

В старой textarea-архитектуре (0.52.2) браузер автоматически обрабатывал ввод через `<textarea>`, и клавиатурные события не всплывали наружу, поэтому конфликта не возникало.

## Изменения

- В `Editor.tsx` добавлена опция `editContext: false` при создании Monaco-редактора — возврат к проверенной textarea-модели ввода

## Release notes
-