### PR TITLE
fix(FormField): cursor not-allowed for disabled

### DIFF
--- a/packages/vkui/src/components/FormField/FormField.module.css
+++ b/packages/vkui/src/components/FormField/FormField.module.css
@@ -173,7 +173,7 @@
 
 .disabled {
   pointer-events: none;
-  cursor: default;
+  cursor: not-allowed;
   opacity: var(--vkui--opacity_disable);
 }
 


### PR DESCRIPTION

- [x] ~Unit-тесты~
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

> Textarea, при disabled не показыывается курсор 'not-allowed'
> В Button, Radio и тд., показывается курсор 'not-allowed'

## Изменения

Меняем курсор на `not-allowed`

## Release notes
## Исправления
- В компонентах форм при `disabled` показывался обычный курсор вместо курсора с перечеркнутым кругом
