### PR TITLE
fix: FormField pointer-events none and cursor

### DIFF
--- a/packages/vkui/src/components/FormField/FormField.module.css
+++ b/packages/vkui/src/components/FormField/FormField.module.css
@@ -172,9 +172,12 @@
 /* [end] */
 
 .disabled {
-  pointer-events: none;
   cursor: not-allowed;
   opacity: var(--vkui--opacity_disable);
+}
+
+.disabled > .scrollContainer {
+  pointer-events: none;
 }
 
 /**


### PR DESCRIPTION
- cause #10006

## Описание

Из-за `pointer-events: none;` не сработал `cursor: not-allowed`

## Изменения

Перенес `pointer-events: none;` ниже


## Release notes
-