### PR TITLE
ci: coverage upload failed. Only default branch is allowed

### DIFF
--- a/.github/workflows/branch_test_coverage.yml
+++ b/.github/workflows/branch_test_coverage.yml
@@ -71,6 +71,10 @@ jobs:
           verbose: true
 
       - name: Upload coverage to GitHub
+        # `actions/upload-code-coverage` требует pull-request-number для не-дефолтных веток,
+        # но при прямом пуше в stable-ветку PR отсутствует, и загрузка падает с HTTP 400.
+        # Поэтому загружаем coverage в GitHub только для дефолтной ветки (master).
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
           file: .nyc_output/cobertura-coverage.xml


### PR DESCRIPTION
## Описание

Воркфлоу Branch test coverage упал на шаге "Upload coverage to GitHub" с ошибкой:                                               
                                                                                                                                  
 > Coverage upload failed (HTTP 400): Only default branch is allowed if no pull_request_number is provided.

## Release notes
-