### PR TITLE
fix(DateInput): disable usePortal

### DIFF
--- a/packages/vkui/src/components/CalendarTime/ComboBox.tsx
+++ b/packages/vkui/src/components/CalendarTime/ComboBox.tsx
@@ -178,6 +178,7 @@ export function ComboBox({
           autoUpdateOnTargetResize
           flipMiddlewareFallbackAxisSideDirection="none"
           offsetByMainAxis={0}
+          usePortal={false}
         >
           <CustomScrollView tabIndex={-1} className={styles.customScroll}>
             {labelsElements}

--- a/packages/vkui/src/components/DateInput/DateInput.test.tsx
+++ b/packages/vkui/src/components/DateInput/DateInput.test.tsx
@@ -294,6 +294,40 @@ describe('DateInput', () => {
   });
 
   it(
+    'should keep calendar open when selecting time in dropdown',
+    withFakeTimers(async () => {
+      const onCalendarOpenChanged = vi.fn();
+      render(
+        <DateInput
+          value={date}
+          enableTime={true}
+          onCalendarOpenChanged={onCalendarOpenChanged}
+          {...testIds}
+          calendarTestsProps={{
+            dayTestId,
+            hoursTestId: 'hours-picker',
+            minutesTestId: 'minutes-picker',
+          }}
+        />,
+      );
+
+      const [dates] = getInputsLike();
+      await userEvent.click(dates);
+      expect(onCalendarOpenChanged).toHaveBeenCalledExactlyOnceWith(true);
+      expect(screen.queryByRole('dialog', { name: 'Календарь' })).toBeTruthy();
+
+      const hoursInput = screen.getByTestId('hours-picker');
+      fireEvent.click(hoursInput);
+
+      const hoursOption = screen.getByRole('option', { selected: false, name: '15' });
+      fireEvent.click(hoursOption);
+
+      expect(screen.queryByRole('dialog', { name: 'Календарь' })).toBeTruthy();
+      expect(onCalendarOpenChanged).toHaveBeenCalledTimes(1);
+    }),
+  );
+
+  it(
     'should not call onChange when selecting date in calendar with enableTime',
     withFakeTimers(async () => {
       const onChange = vi.fn();


### PR DESCRIPTION
- Fixes #10014

---

<!-- Чеклист. Лишние пункты можно удалить если изменения не подразумевают их наличие. Иначе, необходимо обоснование по каждому пункту. -->
- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

Из-за того что всплывашка в портале, при нажатии на нее закрывается календарь

## Изменения

Отключаем портал

## Release notes
## Исправления
- [DateInput](https://vkui.io/${version}/components/date-input): нельзя было выбрать время из выпадающего списка в календаре 
