### PR TITLE
ci: use pull-requests write for comment jobs in deploy workflow

### DIFF
--- a/.github/workflows/pull_request_packages_deploy.yml
+++ b/.github/workflows/pull_request_packages_deploy.yml
@@ -82,7 +82,7 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Download artifact
         id: artifact
@@ -282,7 +282,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Find diff URL comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
@@ -330,7 +330,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Find docs URLs comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0


### PR DESCRIPTION
- caused by #9880

## Описание

После PR #9880 джобы diff_comment, docs_comment и deploy_playwright_report в pull_request_packages_deploy.yml получили pull-requests: read вместо pull-requests: write. Из-за этого создание комментариев к PR через peter-evans/create-or-update-comment и VKCOM/gh-actions/VKUI/reporter завершается ошибкой 403 "Resource not accessible by integration".

Хотя в логе токена отображается Issues: write, для endpoint POST /repos/{owner}/{repo}/issues/{number}/comments в контексте workflow_run требуется pull-requests: write. До PR #9880 у этих джоб не было явного блока permissions, и они наследовали write-all от дефолтных настроек репозитория.

## Изменения

Возвращаем pull-requests: write для трёх джоб создания комментариев.

## Release notes
-