### PR TITLE
ci: grant contents - write for docs deploy jobs using gh-pages push

### DIFF
--- a/.github/workflows/deploy_docs_from_branch.yml
+++ b/.github/workflows/deploy_docs_from_branch.yml
@@ -11,9 +11,13 @@ jobs:
   build_and_deploy_docs:
     runs-on: ubuntu-latest
     name: Build and deploy docs
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Node setup
         uses: ./.github/actions/node-setup

--- a/.github/workflows/publish_deploy.yml
+++ b/.github/workflows/publish_deploy.yml
@@ -113,11 +113,14 @@ jobs:
     if: ${{ success() && needs.payload.outputs.package_name == '@vkontakte/vkui' && needs.payload.outputs.next_version }}
     runs-on: ubuntu-latest
     name: Deploy @vkontakte/vkui docs
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.CHECKOUT_BRANCH }}
+          persist-credentials: false
 
       - name: Setting up the repository environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
- cause #9880

## Описание

После PR #9880 воркфлоу publish_deploy.yml и deploy_docs_from_branch.yml получили permissions: contents: read на верхнем уровне. Джоба deploy_vkui_docs, которая делает push в ветку gh-pages через JamesIves/github-pages-deploy-action, наследовала это ограничение. Из-за этого push завершается ошибкой 403: "Permission to VKCOM/VKUI.git denied to github-actions[bot]".

Хотя экшну передаётся DEVTOOLS_GITHUB_TOKEN, actions/checkout с persist-credentials: true (по умолчанию) сохраняет GITHUB_TOKEN с contents: read в git config, и push использует его.


## Изменения

Добавляем permissions: contents: write для джобы deploy_vkui_docs и build_and_deploy_docs, а также persist-credentials: false в checkout, чтобы гарантировать использование DEVTOOLS_GITHUB_TOKEN для push в gh-pages.

## Release notes
-