### PR TITLE
test: Not implemented: navigation to another Document

### DIFF
--- a/packages/vkui/src/components/Touch/Touch.test.tsx
+++ b/packages/vkui/src/components/Touch/Touch.test.tsx
@@ -480,7 +480,7 @@ describe('Touch', () => {
                 </Card>
                 <Card data-testid="card">
                   <div style={{ paddingBottom: '66%' }}>
-                    <Button data-testid="button" href="vk.com" />
+                    <Button data-testid="button" href="#" />
                   </div>
                 </Card>
                 <Card>


### PR DESCRIPTION
## Описание

Тест Touch.test.tsx → «does not prevent click of a button after slide of a parent on mobile» рендерил <Button href="vk.com"> и кликал по нему напрямую через fireEvent.click с hasDefault === true (намеренно не предотвращая default). jsdom по клику пытался навигировать на http://localhost:3000/vk.com — кросс-документная навигация не реализована → предупреждение.

## Release notes
-