### PR TITLE
test: localStorage is not available

### DIFF
--- a/packages/vkui/vitest.setup.ts
+++ b/packages/vkui/vitest.setup.ts
@@ -5,6 +5,37 @@ import { noop } from '@vkontakte/vkjs';
 import { afterEach, vi } from 'vitest';
 import failOnConsole from 'vitest-fail-on-console';
 
+// В этом окружении jsdom не предоставляет `localStorage`, а Node отдаёт
+// экспериментальный геттер, который при каждом доступе печатает
+// `ExperimentalWarning: localStorage is not available ...`. Подменим его
+// рабочей in-memory реализацией — это убирает предупреждение (в т.ч. когда
+// chai инспектирует `window` при форматировании сообщений утверждений) и даёт
+// тестам реальный `localStorage`.
+class MemoryStorage implements Storage {
+  private readonly store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  key(index: number): string | null {
+    return [...this.store.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+vi.stubGlobal('localStorage', new MemoryStorage());
+vi.stubGlobal('sessionStorage', new MemoryStorage());
+
 // Без `globals: true` @testing-library/react не регистрирует автоочистку DOM
 // (она рассчитывает на глобальный `afterEach`), поэтому чистим вручную.
 afterEach(cleanup);


### PR DESCRIPTION
## Описание

> ExperimentalWarning: localStorage is not available because --localstorage-file was not provided


В этом окружении jsdom не предоставляет localStorage, поэтому globalThis.localStorage оставался Node-экспериментальным ленивым геттером, который при любом доступе печатает предупреждение (в частности, когда chai инспектирует window при форматировании сообщений утверждений).

## Изменения

Добавил в vitest.setup.ts рабочую in-memory реализацию Storage и подключил её через vi.stubGlobal('localStorage'/'sessionStorage', …) — это убирает предупреждение и заодно даёт тестам реальный localStorage.

## Release notes
-