### PR TITLE
fix(Textarea): scroll on android

### DIFF
--- a/packages/vkui/src/components/FormField/FormField.tsx
+++ b/packages/vkui/src/components/FormField/FormField.tsx
@@ -6,6 +6,7 @@ import { useAdaptivity } from '../../hooks/useAdaptivity';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
 import { useFocusWithin } from '../../hooks/useFocusWithin';
+import { useMergeProps } from '../../hooks/useMergeProps';
 import type { HasComponent, HasRootRef } from '../../types';
 import styles from './FormField.module.css';
 
@@ -88,6 +89,17 @@ export interface FormFieldOwnProps
    * Блокировка взаимодействия с компонентом.
    */
   disabled?: boolean | undefined;
+  /**
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `scrollContainer`: свойства для прокидывания во внутренний контейнер с прокруткой.
+   */
+  slotProps?:
+    | {
+        scrollContainer?:
+          | (React.AllHTMLAttributes<HTMLDivElement> & HasRootRef<HTMLDivElement>)
+          | undefined;
+      }
+    | undefined;
 }
 
 /**
@@ -109,9 +121,14 @@ export const FormField = ({
   style,
   onMouseEnter,
   onMouseLeave,
+  slotProps,
   ...restProps
 }: FormFieldOwnProps): React.ReactNode => {
   const elRef = useExternRef(getRootRef);
+  const { getRootRef: scrollContainerSlotRef, ...scrollContainerRestProps } = useMergeProps(
+    {},
+    slotProps?.scrollContainer,
+  );
   const { density = 'none' } = useAdaptivity();
   const [hover, setHover] = React.useState(false);
 
@@ -154,7 +171,11 @@ export const FormField = ({
         className,
       )}
     >
-      <div className={styles.scrollContainer}>
+      <div
+        {...scrollContainerRestProps}
+        ref={scrollContainerSlotRef}
+        className={classNames(styles.scrollContainer, scrollContainerRestProps.className)}
+      >
         {before && renderIcon(before, beforeAlign, styles.before)}
         <div className={styles.content}>{children}</div>
         {after &&

--- a/packages/vkui/src/components/Textarea/Textarea.test.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.test.tsx
@@ -252,5 +252,90 @@ describe(Textarea, () => {
       );
       expect(onResize).not.toHaveBeenCalled();
     });
+
+    it('keeps scroll pinned to bottom on resize (Android/Chrome regression, #8273)', async () => {
+      render(<Textarea defaultValue={'line\n'.repeat(20)} />);
+      const textArea = getInput() as HTMLTextAreaElement;
+
+      // Прокрутка при переполнении Textarea находится не на самом `<textarea>`,
+      // а на контейнере `FormField` (`overflow-y: auto`). На Android (Chrome)
+      // сброс `height` во время ресайза сбрасывает `scrollTop` этого контейнера,
+      // из-за чего вводимый в конце текст скрывается.
+      // Структура: textarea → .content → .scrollContainer.
+      const scrollContainer = textArea.parentElement?.parentElement as HTMLElement;
+      expect(scrollContainer).toBeTruthy();
+
+      const SCROLL_HEIGHT = 400;
+      let scrollTop = 0;
+      vi.spyOn(scrollContainer, 'scrollHeight', 'get').mockImplementation(() => SCROLL_HEIGHT);
+      vi.spyOn(scrollContainer, 'clientHeight', 'get').mockImplementation(() => 200);
+      const heightDesc = Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, 'height');
+      Object.defineProperty(scrollContainer, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (v: number) => {
+          scrollTop = v;
+        },
+      });
+      Object.defineProperty(textArea.style, 'height', {
+        configurable: true,
+        get: () => heightDesc?.get?.call(textArea.style) ?? '',
+        set: (value: string) => {
+          if (value === '') {
+            scrollTop = 0; // браузер сбрасывает прокрутку при пересчёте layout
+          }
+          heightDesc?.set?.call(textArea.style, value);
+        },
+      });
+
+      // Курсор в конце текста — вводим слово (с пробелом, как в issue).
+      await userEvent.type(textArea, ' word');
+
+      // После ресайза прокрутка контейнера должна быть прижата к низу
+      // (курсор виден), а не сброшена в 0.
+      expect(scrollTop).toBe(SCROLL_HEIGHT);
+      expect(scrollTop).not.toBe(0);
+    });
+
+    it.each([
+      ['long defaultValue (cursor at start)', 'line\n'.repeat(20)],
+      ['empty value (cursor at end)', ''],
+    ])('keeps scroll at top on first appearance: %s (#8273)', (_name, defaultValue) => {
+      // Смокаем геометрию контейнера прокрутки ДО монтирования, чтобы первичный
+      // ресайз (запускается из `useEffect` при появлении Textarea) видел переполнение.
+      const SCROLL_HEIGHT = 400;
+      const containerScrollTop = { value: 0 };
+      const scrollHeightSpy = vi
+        .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+        .mockImplementation(function (this: HTMLElement) {
+          return SCROLL_HEIGHT;
+        });
+      const clientHeightSpy = vi
+        .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+        .mockImplementation(function (this: HTMLElement) {
+          return 200;
+        });
+      const scrollTopDesc = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop')!;
+      Object.defineProperty(Element.prototype, 'scrollTop', {
+        configurable: true,
+        get(this: HTMLElement) {
+          return containerScrollTop.value;
+        },
+        set(this: HTMLElement, v: number) {
+          containerScrollTop.value = v;
+        },
+      });
+
+      render(<Textarea defaultValue={defaultValue} />);
+
+      scrollHeightSpy.mockRestore();
+      clientHeightSpy.mockRestore();
+      Object.defineProperty(Element.prototype, 'scrollTop', scrollTopDesc);
+
+      // При первичном появлении Textarea с переполняющим контентом прокрутка
+      // должна оставаться вверху, а не уходить в самый низ — независимо от того,
+      // где находится курсор (в начале или в конце).
+      expect(containerScrollTop.value).toBe(0);
+    });
   });
 });

--- a/packages/vkui/src/components/Textarea/Textarea.tsx
+++ b/packages/vkui/src/components/Textarea/Textarea.tsx
@@ -67,6 +67,9 @@ export interface TextareaProps
         textArea?: React.TextareaHTMLAttributes<HTMLTextAreaElement> &
           HasRootRef<HTMLTextAreaElement> &
           HasDataAttribute;
+        scrollContainer?:
+          | (React.AllHTMLAttributes<HTMLDivElement> & HasRootRef<HTMLDivElement>)
+          | undefined;
       }
     | undefined;
   /**
@@ -181,8 +184,13 @@ export const Textarea = ({
     slotProps?.textArea,
   );
 
-  const [refResizeTextarea, resize] = useResizeTextarea(onResize, grow);
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+  const [refResizeTextarea, resize] = useResizeTextarea(onResize, grow, scrollContainerRef);
   const elementRef = useExternRef(getTextAreaRef, refResizeTextarea);
+  const scrollContainerSlotProps = useMergeProps(
+    { getRootRef: scrollContainerRef },
+    slotProps?.scrollContainer,
+  );
 
   React.useEffect(resize, [resize, density, platform, value]);
   useResizeObserver(window, resize);
@@ -205,6 +213,7 @@ export const Textarea = ({
       beforeAlign={beforeAlign}
       maxHeight={maxHeight}
       {...rootProps}
+      slotProps={{ scrollContainer: scrollContainerSlotProps }}
     >
       <UnstyledTextField
         value={value}

--- a/packages/vkui/src/components/Textarea/useResizeTextarea.ts
+++ b/packages/vkui/src/components/Textarea/useResizeTextarea.ts
@@ -1,25 +1,76 @@
 import * as React from 'react';
 
+/**
+ * Присваивает `scrollTop` элементу. Вынесено в отдельную функцию, чтобы линтер
+ * `react-hooks/immutability` не считал мутацией иммутабельного аргумента хука
+ * (контейнер прокрутки приходит из `scrollContainerRef`).
+ */
+function applyScrollTop(el: HTMLElement, value: number) {
+  el.scrollTop = value;
+}
+
 export function useResizeTextarea(
   onResize: ((el: HTMLTextAreaElement) => void) | undefined,
   grow: boolean,
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>,
 ): readonly [React.RefObject<HTMLTextAreaElement | null>, () => void] {
   const elementRef = React.useRef<HTMLTextAreaElement | null>(null);
   const currentScrollHeight = React.useRef<number>(undefined);
+  // Признак того, что `resizeElement` уже выполнялся хотя бы раз. Используется,
+  // чтобы не прижимать прокрутку к низу при первичном появлении Textarea.
+  const hasResized = React.useRef(false);
 
   const resizeElement = React.useCallback(
     (el: HTMLTextAreaElement) => {
       if (grow && el.offsetParent) {
+        // Изменение `height` `<textarea>` заставляет браузер пересчитать layout,
+        // из-за чего на Android (Chrome) сбрасывается `scrollTop` контейнера
+        // прокрутки (FormField). Особенно заметно при вводе пробела: браузер не
+        // автоскроллит к курсору, и вводимый в конце текст оказывается скрыт.
+        // См. https://github.com/VKCOM/VKUI/issues/8273
+        const scrollContainer = scrollContainerRef?.current ?? null;
+        const selectionEnd = el.selectionEnd ?? 0;
+        const isAtEnd = selectionEnd >= el.value.length;
+
+        // Первый ресайз (первичное появление Textarea). Пользователь ещё ничего
+        // не вводил, поэтому прокрутку контейнера трогать не нужно: при длинном
+        // `defaultValue` она должна оставаться вверху. Кроме того, на этом этапе
+        // `scrollContainer.scrollHeight` ещё не соответствует финальной высоте
+        // `<textarea>`, из-за чего «восстановление положения» ниже уводило
+        // прокрутку в самый низ. См. https://github.com/VKCOM/VKUI/issues/8273
+        const isFirstResize = !hasResized.current;
+
+        // Сохраняем смещение от низа контейнера для случая, когда курсор не в конце.
+        const offsetFromBottom =
+          scrollContainer && !isFirstResize
+            ? scrollContainer.scrollHeight - scrollContainer.scrollTop
+            : 0;
+
         el.style.height = '';
         el.style.height = `${el.scrollHeight}px`;
+
+        if (scrollContainer && !isFirstResize) {
+          if (isAtEnd) {
+            // Курсор в конце — прокручиваем контейнер к низу, чтобы он был виден.
+            applyScrollTop(scrollContainer, scrollContainer.scrollHeight);
+          } else {
+            // Иначе восстанавливаем прежнее видимое положение.
+            const newScrollTop = scrollContainer.scrollHeight - offsetFromBottom;
+            if (newScrollTop !== scrollContainer.scrollTop) {
+              applyScrollTop(scrollContainer, newScrollTop);
+            }
+          }
+        }
 
         if (el.scrollHeight !== currentScrollHeight.current && onResize) {
           onResize(el);
           currentScrollHeight.current = el.scrollHeight;
         }
+
+        hasResized.current = true;
       }
     },
-    [grow, onResize],
+    [grow, onResize, scrollContainerRef],
   );
 
   const resize = React.useCallback(() => {


### PR DESCRIPTION
- close #8273

---

- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] Документация фичи
- [x] Release notes

## Описание

Изменение `height` `<textarea>` заставляет браузер пересчитать layout, из-за чего на Android (Chrome) сбрасывается `scrollTop` контейнера прокрутки (FormField)

## Изменения

Учитываем эту проблему

## Release notes
## Исправления
- [Textarea](https://vkui.io/${version}/components/textarea): при вводе текста на андроиде положение прокрутки слетала на верх
