### PR TITLE
fix(Separator): rm global class

### DIFF
--- a/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
+++ b/packages/vkui/src/components/ModalPage/ModalPageInternal.tsx
@@ -4,11 +4,7 @@
 import { type ComponentType, type KeyboardEvent, useCallback } from 'react';
 import { classNames, noop } from '@vkontakte/vkjs';
 import { mergeStyle } from '../../helpers/mergeStyle';
-import { useAdaptivity } from '../../hooks/useAdaptivity';
-import {
-  isSizeXRegularFallback,
-  useAdaptivityWithJSMediaQueries,
-} from '../../hooks/useAdaptivityWithJSMediaQueries';
+import { useAdaptivityWithJSMediaQueries } from '../../hooks/useAdaptivityWithJSMediaQueries';
 import { useExternRef } from '../../hooks/useExternRef';
 import { useVirtualKeyboardState } from '../../hooks/useVirtualKeyboardState';
 import { Keys, pressedKey } from '../../lib/accessibility';
@@ -105,8 +101,7 @@ export const ModalPageInternal = ({
   const hidden = transitionState === 'exited';
   const closable = !preventClose && opened;
 
-  const { sizeX: legacySizeXContext } = useAdaptivity();
-  const { isDesktop, sizeX: legacySizeX, viewWidth } = useAdaptivityWithJSMediaQueries();
+  const { isDesktop } = useAdaptivityWithJSMediaQueries();
   const bottomSheetEnabled = !isDesktop && !preventClose && transitionState !== 'exited';
   const { opened: keyboardOpened } = useVirtualKeyboardState(bottomSheetEnabled);
 
@@ -190,8 +185,6 @@ export const ModalPageInternal = ({
                 ? styles.hostMobileSafeAreaInsetTopWithCustomOffset
                 : styles.hostMobileSafeAreaInsetTop),
             desktopMaxWidthClassName,
-            isSizeXRegularFallback(viewWidth, legacySizeX, legacySizeXContext) &&
-              'vkuiInternalModalPage--viewWidth-smallTabletPlus',
           )}
           style={mergeStyle(mergeStyle(desktopMaxWidthStyle, getHeightCSSVariable(height)), style)}
         >

--- a/packages/vkui/src/components/Separator/Separator.module.css
+++ b/packages/vkui/src/components/Separator/Separator.module.css
@@ -60,20 +60,3 @@
 .directionVertical.padded .in {
   margin-block: var(--vkui--size_base_padding_horizontal--regular);
 }
-
-/*
- * CMP:
- * ModalPage
- */
-/* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-:global(.vkuiInternalModalPage--viewWidth-smallTabletPlus) .padded {
-  padding-inline: 8px;
-}
-
-/* FIXME: Мертвый код */
-@media (--viewWidth-smallTabletPlus) {
-  /* stylelint-disable-next-line selector-pseudo-class-disallowed-list */
-  :global(.vkuiInternalModalPage--viewWidth-none) .padded {
-    padding-inline: 8px;
-  }
-}

--- a/packages/vkui/src/hooks/useAdaptivityWithJSMediaQueries.ts
+++ b/packages/vkui/src/hooks/useAdaptivityWithJSMediaQueries.ts
@@ -35,24 +35,6 @@ export const isSizeXCompactFallback = (
 ) =>
   legacySizeXContext === undefined ? viewWidth < ViewWidth.SMALL_TABLET : legacySizeX !== 'regular';
 
-/**
- * @private
- *
- * @param legacySizeX Значение из хука `useAdaptivityWithJSMediaQueries`
- * @param viewWidth Значение из хука `useAdaptivityWithJSMediaQueries`
- * @param legacySizeXContext Значение из хука `useAdaptivity`
- *
- * TODO [>=10]: #9015 удалить функцию и перенести проверку `viewWidth` на место вызова данной функции.
- */
-export const isSizeXRegularFallback = (
-  viewWidth: ViewWidthType,
-  legacySizeX: SizeTypeValues,
-  legacySizeXContext: SizeTypeValues | undefined,
-) =>
-  legacySizeXContext === undefined
-    ? viewWidth >= ViewWidth.SMALL_TABLET
-    : legacySizeX === 'regular';
-
 type RequiredNonNullable<T> = { [P in keyof T]-?: NonNullable<T[P]> };
 
 export interface UseAdaptivityWithJSMediaQueries extends RequiredNonNullable<BaseAdaptivityProps> {


### PR DESCRIPTION
## Описание

В модалках вертикальный сепаратор с `padding direction="vertical"` получал отступы по бокам

Также не понятно для чего код был предназначен, так как отступы выставляются неверные

## Изменения

Избавляемся от глобального класса

## Release notes
## Исправления
- [Separator](https://vkui.io/${version}/components/custom-select): в ModalPage выставлялись неверные отступы
