### PR TITLE
feat(Gallery): add `showArrows="always"`

### DIFF
--- a/packages/vkui/src/components/CarouselBase/CarouselBase.module.css
+++ b/packages/vkui/src/components/CarouselBase/CarouselBase.module.css
@@ -105,6 +105,10 @@
   opacity: var(--vkui--opacity_disable);
 }
 
+.showArrows .arrow {
+  opacity: var(--vkui--opacity_disable);
+}
+
 .arrowFocusVisible,
 .host .arrow:hover {
   opacity: 1;

--- a/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
+++ b/packages/vkui/src/components/CarouselBase/CarouselBase.tsx
@@ -567,6 +567,7 @@ export const CarouselBase = ({
         styles.host,
         slideWidth === 'custom' && styles.customWidth,
         isHovered && styles.hover,
+        showArrows === 'always' && styles.showArrows,
         isDraggable && styles.draggable,
       )}
       getRootRef={rootRef}

--- a/packages/vkui/src/components/CarouselBase/ScrollArrows.tsx
+++ b/packages/vkui/src/components/CarouselBase/ScrollArrows.tsx
@@ -67,9 +67,14 @@ export const ScrollArrows = ({
   const { focusVisible: prevArrowFocusVisible, ...prevArrowFocusHandlers } = useFocusVisible();
   const { focusVisible: nextArrowFocusVisible, ...nextArrowFocusHandlers } = useFocusVisible();
 
+  const isAlwaysVisible = showArrows === 'always';
+  // При `showArrows === "always"` показываем стрелки всегда, игнорируя границы слайдов.
+  const showLeftArrow = isAlwaysVisible || canSlideLeft;
+  const showRightArrow = isAlwaysVisible || canSlideRight;
+
   return showArrows ? (
     <>
-      {canSlideLeft && (
+      {showLeftArrow && (
         <ScrollArrow
           className={getArrowClassName('start', arrowAreaHeight, prevArrowFocusVisible)}
           direction="left"
@@ -81,7 +86,7 @@ export const ScrollArrows = ({
           {...prevArrowFocusHandlers}
         />
       )}
-      {canSlideRight && (
+      {showRightArrow && (
         <ScrollArrow
           className={getArrowClassName('end', arrowAreaHeight, nextArrowFocusVisible)}
           direction="right"

--- a/packages/vkui/src/components/CarouselBase/types.ts
+++ b/packages/vkui/src/components/CarouselBase/types.ts
@@ -112,7 +112,7 @@ export interface BaseGalleryProps
    * Позволяет отключить реагирование на тач-события.
    */
   dragDisabled?: boolean | undefined;
-  showArrows?: boolean | undefined;
+  showArrows?: boolean | 'always' | undefined;
   /**
    * Размер активной зоны стрелок (в пикселях).
    * Определяет область вокруг стрелок, реагирующую на взаимодействие пользователя. В дизайне свойство называется `arrowArea`.

--- a/packages/vkui/src/components/Gallery/Gallery.test.tsx
+++ b/packages/vkui/src/components/Gallery/Gallery.test.tsx
@@ -73,6 +73,7 @@ const setup = ({
   onDragEnd,
   numberOfSlides = 5,
   isRtl = false,
+  showArrows = true,
 }: {
   defaultSlideIndex: number;
   looped: boolean;
@@ -89,6 +90,7 @@ const setup = ({
   onDragStart?: VoidFunction | undefined;
   onDragEnd?: VoidFunction | undefined;
   isRtl?: boolean | undefined;
+  showArrows?: BaseGalleryProps['showArrows'] | undefined;
 }) => {
   let slideDataByIndexMap: Record<number, any> = {};
   let layerTransform = '';
@@ -149,7 +151,7 @@ const setup = ({
     <DirectionProvider value={isRtl ? 'rtl' : 'ltr'}>
       <Gallery
         looped={looped}
-        showArrows
+        showArrows={showArrows}
         align={align}
         slideIndex={slideIndex}
         onChange={onChange}
@@ -1033,6 +1035,34 @@ describe('Gallery', () => {
         checkTransformX(mockedData.layerTransform, 890);
         checkTransformX(mockedData.getSlideMockData(0).transform, -900);
         checkActiveSlide(0);
+      }),
+    );
+  });
+
+  describe('showArrows="always"', () => {
+    fakeTimersForScope(false);
+    it(
+      'renders both arrows even when slides are fully visible',
+      withFakeTimers(() => {
+        const mockedData = setup({
+          numberOfSlides: 2,
+          defaultSlideIndex: 0,
+          slideWidth: 200,
+          containerWidth: 540,
+          viewPortWidth: 540,
+          align: 'center',
+          looped: false,
+          showArrows: 'always',
+        });
+        vi.runAllTimers();
+
+        // Слайды полностью помещаются в контейнер, но при `showArrows="always"`
+        // обе стрелки должны отображаться.
+        expect(getArrows()).toHaveLength(2);
+        expect(screen.queryByTestId('prev-arrow')).toBeTruthy();
+        expect(screen.queryByTestId('next-arrow')).toBeTruthy();
+
+        mockedData.component.unmount();
       }),
     );
   });


### PR DESCRIPTION
- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] Документация фичи
- [x] Release notes

## Описание

Добавляем `showArrows="always"` как в HorizontalScroll

## Release notes
## Улучшения
- [Gallery](https://vkui.io/${version}/components/gallery): добалено значение `showArrows="always"` для показа стрелок всегда
