### PR TITLE
ci: keep setup-node versions in sync

### DIFF
--- a/.github/actions/get-playwright-docker-image/action.yml
+++ b/.github/actions/get-playwright-docker-image/action.yml
@@ -12,7 +12,7 @@ runs:
       run: corepack enable
       shell: bash
     - name: Setup NodeJS
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'

--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
 
     - name: Setup NodeJS
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'

--- a/.github/actions/publish-workflow-1-setup/action.yml
+++ b/.github/actions/publish-workflow-1-setup/action.yml
@@ -8,7 +8,7 @@ runs:
       run: corepack enable
       shell: bash
     - name: Setup NodeJS
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: '.nvmrc'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
 
     - name: Setup NodeJS
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   # NPM
 
   - package-ecosystem: 'npm'
-    directory: '/'
+    directories:
+      - '/'
+      - '/.github/actions/*'
     schedule:
       interval: 'weekly'
     allow:

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -344,22 +344,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check setup-node versions
-        run: |
-          setup_node_versions="$(
-            git grep -h -o -E 'actions/setup-node@[0-9a-f]{40}' -- \
-                '.github/**/*.yml' \
-                '.github/**/*.yaml' |
-              sort -u
-          )"
-          setup_node_versions_count="$(printf '%s\n' "${setup_node_versions}" | sed '/^$/d' | wc -l | tr -d ' ')"
-
-          if (( setup_node_versions_count != 1 )); then
-            echo "All actions/setup-node usages must use the same version:"
-            printf '  %s\n' "${setup_node_versions}"
-            exit 1
-          fi
-
       - name: Pin actions
         uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
         with:

--- a/.github/workflows/pull_request_packages.yml
+++ b/.github/workflows/pull_request_packages.yml
@@ -344,6 +344,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check setup-node versions
+        run: |
+          setup_node_versions="$(
+            git grep -h -o -E 'actions/setup-node@[0-9a-f]{40}' -- \
+                '.github/**/*.yml' \
+                '.github/**/*.yaml' |
+              sort -u
+          )"
+          setup_node_versions_count="$(printf '%s\n' "${setup_node_versions}" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+          if (( setup_node_versions_count != 1 )); then
+            echo "All actions/setup-node usages must use the same version:"
+            printf '  %s\n' "${setup_node_versions}"
+            exit 1
+          fi
+
       - name: Pin actions
         uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
         with:


### PR DESCRIPTION
## Что изменено

Обновил `actions/setup-node` до v7.0.0 во всех локальных composite actions из `.github/actions/*`, чтобы они использовали ту же версию, что и workflow-файлы.

В `dependabot.yml` через `directories` вручную задаем `/.github/actions/*`, чтобы в ней тоже обновлялись экшены (https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--)

## Почему

После Dependabot PR [#10065](https://github.com/VKCOM/VKUI/pull/10065) прямые вызовы `actions/setup-node` во workflow-файлах обновились с v6.4.0 до v7.0.0, но вызовы внутри `.github/actions/*/action.yml` остались на v6.4.0, потому что Dependabot их не отслеживает.

В результате разные jobs создавали Yarn-кеши с одинаковыми ключами, но разными внутренними версиями. Такие кеши не переиспользовались между jobs и занимали примерно вдвое больше места, из-за чего лимит GitHub Actions cache стал быстро исчерпываться.

После этого изменения все jobs используют одну версию `setup-node`, поэтому новые Yarn-кеши снова смогут переиспользоваться без дублирования между v6 и v7.

## Проверки

- `actionlint .github/workflows/pull_request_packages.yml`
- проверка единственного SHA `actions/setup-node` во всех YAML-файлах `.github`
- YAML parsing для изменённых workflow и composite actions
- `git diff --check`
