### PR TITLE
fix(CustomSelect): all options always visible when searchable turn on

### DIFF
--- a/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.test.tsx
@@ -508,6 +508,54 @@ describe('CustomSelect', () => {
     }
   });
 
+  it('shows all options after selection until the input value changes', async () => {
+    render(
+      <CustomSelect
+        searchable
+        options={[
+          { value: 0, label: 'Москва' },
+          { value: 1, label: 'Санкт-Петербург' },
+          { value: 2, label: 'Сан-Франциско' },
+        ]}
+        slotProps={{
+          input: {
+            'data-testid': INPUT_TEST_ID,
+          },
+        }}
+      />,
+    );
+
+    const input = screen.getByTestId(INPUT_TEST_ID);
+
+    fireEvent.click(input);
+    fireEvent.change(input, { target: { value: 'Сан' } });
+
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('option', { name: 'Санкт-Петербург' }));
+
+    expect(input).toHaveValue('Санкт-Петербург');
+
+    fireEvent.click(input);
+
+    await waitForFloatingPosition();
+
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+
+    fireEvent.change(input, { target: { value: 'Санкт-Петербур' } });
+
+    expect(screen.getAllByRole('option')).toHaveLength(1);
+    expect(screen.getByRole('option')).toHaveTextContent('Санкт-Петербург');
+
+    fireEvent.change(input, { target: { value: 'Сан' } });
+
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
   it('is custom searchable', () => {
     render(
       <CustomSelect

--- a/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
+++ b/packages/vkui/src/components/CustomSelect/CustomSelect.tsx
@@ -443,17 +443,22 @@ export function CustomSelect<OptionInterfaceT extends CustomSelectOptionInterfac
     [options, selectedOptionValue],
   );
 
-  const { inputValue, onInputChange, resetInputValue, resetInputValueBySelectedOption } =
-    useInputValueController({
-      options,
-      accessible,
-      selectedValue: selectedOptionValue,
-      onInputChange: onChangeInput,
-    });
+  const {
+    inputValue,
+    isInputValueChanged,
+    onInputChange,
+    resetInputValue,
+    resetInputValueBySelectedOption,
+  } = useInputValueController({
+    options,
+    accessible,
+    selectedValue: selectedOptionValue,
+    onInputChange: onChangeInput,
+  });
 
   const filteredOptions = React.useMemo(
-    () => filter(options, searchable ? inputValue : '', filterFn),
-    [filterFn, inputValue, options, searchable],
+    () => filter(options, searchable && isInputValueChanged ? inputValue : '', filterFn),
+    [filterFn, inputValue, isInputValueChanged, options, searchable],
   );
 
   const { scrollToElement, optionsWrapperRef, scrollBoxRef } = useScrollListController();

--- a/packages/vkui/src/components/CustomSelect/hooks/useInputValueController.ts
+++ b/packages/vkui/src/components/CustomSelect/hooks/useInputValueController.ts
@@ -21,6 +21,7 @@ export function useInputValueController<OptionInterfaceT extends CustomSelectOpt
   onInputChange: onInputChangeProp,
 }: UseInputValueControllerProps<OptionInterfaceT>) {
   const [inputValue, setInputValue] = React.useState('');
+  const [isInputValueChanged, setIsInputValueChanged] = React.useState(false);
   const optionsRef = React.useRef(options);
 
   useIsomorphicLayoutEffect(() => {
@@ -29,6 +30,7 @@ export function useInputValueController<OptionInterfaceT extends CustomSelectOpt
 
   const resetInputValueBySelectedOption = React.useCallback(() => {
     setInputValue(calculateInputValueFromOptions(optionsRef.current, selectedValue));
+    setIsInputValueChanged(false);
   }, [selectedValue]);
 
   useIsomorphicLayoutEffect(() => {
@@ -39,18 +41,21 @@ export function useInputValueController<OptionInterfaceT extends CustomSelectOpt
 
   const resetInputValue = React.useCallback(() => {
     setInputValue('');
+    setIsInputValueChanged(false);
   }, []);
 
   const onInputChange: React.ChangeEventHandler<HTMLInputElement> = React.useCallback(
     (e) => {
       onInputChangeProp && onInputChangeProp(e);
       setInputValue(e.target.value);
+      setIsInputValueChanged(true);
     },
     [onInputChangeProp, setInputValue],
   );
 
   return {
     inputValue,
+    isInputValueChanged,
     resetInputValue,
     resetInputValueBySelectedOption,
     onInputChange,


### PR DESCRIPTION
- close #10151

---

- [x] Unit-тесты
- [ ] e2e-тесты — не добавлялись; сценарий вручную проверен в Chrome через Storybook
- [ ] Дизайн-ревью — не требуется, визуальная часть не менялась
- [ ] Документация фичи — не требуется, публичный API не менялся
- [x] Release notes

## Описание

В `CustomSelect` с включённым `searchable` после выбора значения и повторного открытия выпадающего списка отображалась только выбранная опция.

Причина заключалась в том, что `inputValue` одновременно использовался для отображения label выбранной опции и как поисковый запрос. В режиме `accessible` после закрытия списка в input сохранялся label, поэтому при следующем открытии опции сразу фильтровались по полному выбранному значению.

## Изменения

- Добавлен внутренний признак пользовательского изменения значения input.
- Программная установка label выбранной опции больше не активирует фильтрацию.
- После первого пользовательского изменения поиск снова фильтрует опции по текущему значению поля.
- При полной очистке поля снова отображается весь список.
- Добавлен регрессионный unit-тест со сценариями повторного открытия, посимвольного удаления и полной очистки.

Выбранный label по-прежнему остаётся в реальном input, поэтому исправление не отменяет поведение, необходимое скринридерам.

## Проверка

- `yarn workspace @vkontakte/vkui test` — 260 файлов, 3081 тест.
- `yarn workspace @vkontakte/vkui lint:types`.
- ESLint и Biome для изменённых файлов.
- Ручная проверка в Chrome через Storybook: повторное открытие, Backspace, сокращение запроса и полная очистка.

## Release notes

## Исправления
- CustomSelect: при повторном открытии списка в режиме `searchable` отображаются все опции до пользовательского изменения значения поля.
