### PR TITLE
fix(storybook): avoid React 19 runtime in manager

### DIFF
--- a/tools/storybook-addon-cartesian/src/preset/manager.tsx
+++ b/tools/storybook-addon-cartesian/src/preset/manager.tsx
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from 'react/jsx-runtime';
+import * as React from 'react';
 import { addons, types } from 'storybook/manager-api';
 import { Tool } from '../Tool';
 import { ADDON_ID, TOOL_ID } from '../constants';
@@ -13,7 +13,7 @@ addons.register(ADDON_ID, (api) => {
       if (!api.getCurrentStoryData()) {
         return null;
       }
-      return _jsx(Tool, {});
+      return React.createElement(Tool);
     },
   });
 });


### PR DESCRIPTION
- caused by #10127 

## Кратко

- cartesian-инструмент в manager рендерится через экземпляр React, предоставляемый Storybook;
- JSX runtime React 19 из проекта больше не попадает в manager-бандл Storybook.

## Причина

Storybook 10 предоставляет React 18 для своего manager UI. Cartesian-аддон напрямую импортировал `react/jsx-runtime`, который после обновления проекта разрешался в React 19. В результате runtime пытался прочитать внутреннее поле React 19 (`recentlyCreatedOwnerStacks`) из экземпляра React 18, предоставленного Storybook, и manager падал.

## Результат

Storybook корректно запускается с React 19 в проекте, а cartesian-инструмент остаётся доступен в панели инструментов.

## Проверка

- `yarn tsc --noEmit -p tools/storybook-addon-cartesian/tsconfig.json`
- `yarn eslint tools/storybook-addon-cartesian/src/preset/manager.tsx`
- `yarn docs:storybook:build`
- свежий dev-сервер Storybook и cartesian-инструмент проверены в Chrome — ошибок manager UI нет
