### PR TITLE
fix(Clickable): disabled hover state

### DIFF
--- a/packages/vkui/src/components/Clickable/Clickable.test.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { noop } from '@vkontakte/vkjs';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { baselineComponent } from '../../testing/utils';
 import { Clickable } from './Clickable';
 
@@ -104,5 +104,68 @@ describe('Clickable', () => {
 
     fireEvent.click(doneButton);
     expect(clickable).not.toHaveClass(hoverClass);
+  });
+
+  // https://github.com/VKCOM/VKUI/issues — hover «залипает» после disabled
+  describe('hover state across disabled toggle', () => {
+    const hoverClass = 'test-hover-class';
+
+    function setRect(
+      el: Element,
+      rect: { left: number; top: number; right: number; bottom: number },
+    ) {
+      vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+        ...rect,
+        width: rect.right - rect.left,
+        height: rect.bottom - rect.top,
+        x: rect.left,
+        y: rect.top,
+        toJSON: () => ({}),
+      });
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('does not show hover after re-enable when cursor has left while disabled', () => {
+      const TestWrapper = () => {
+        const [disabled, setDisabled] = React.useState(false);
+        return (
+          <>
+            <Clickable
+              onClick={() => setDisabled(true)}
+              disabled={disabled}
+              hoverClassName={hoverClass}
+              data-testid="clickable"
+            >
+              Click
+            </Clickable>
+            <button data-testid="done-button" onClick={() => setDisabled(false)}>
+              Done
+            </button>
+          </>
+        );
+      };
+      render(<TestWrapper />);
+      const clickable = screen.getByTestId('clickable');
+      setRect(clickable, { left: 0, top: 0, right: 100, bottom: 40 });
+
+      fireEvent.pointerEnter(clickable, { pointerType: 'mouse', pointerId: 1 });
+      expect(clickable).toHaveClass(hoverClass);
+
+      // Клик переводит кнопку в disabled. Реальный браузер не стреляет
+      // pointerleave на нативной `<button disabled>`, поэтому намеренно
+      // не отправляем его. Вместо этого эмулируем перемещение курсора
+      // за пределы элемента (стреляет по документу, как сделал бы браузер).
+      fireEvent.click(clickable);
+      expect(clickable).not.toHaveClass(hoverClass);
+
+      fireEvent.pointerMove(document, { pointerType: 'mouse', clientX: 500, clientY: 500 });
+
+      // Возвращаем в активное состояние — курсора на кнопке уже нет, hover быть не должно.
+      fireEvent.click(screen.getByTestId('done-button'));
+      expect(clickable).not.toHaveClass(hoverClass);
+    });
   });
 });

--- a/packages/vkui/src/components/Clickable/Clickable.tsx
+++ b/packages/vkui/src/components/Clickable/Clickable.tsx
@@ -64,6 +64,7 @@ function useClickableProps<T>({
   onFocus,
   onKeyDown,
   DefaultComponent,
+  disabled,
   ...restProps
 }: ClickableProps<T>) {
   const { focusVisible, ...focusEvents } = useFocusVisible();
@@ -82,6 +83,7 @@ function useClickableProps<T>({
     hasActive,
     hovered,
     activated,
+    disabled,
     unlockParentHover,
   });
 
@@ -145,7 +147,7 @@ function useProps<T>(props: ClickableProps<T>): RootComponentProps<T> &
     ...restProps,
   };
 
-  const clickableProps = useClickableProps(nextProps);
+  const clickableProps = useClickableProps({ ...nextProps, disabled });
 
   return isClickable ? clickableProps : nonClickableProps(nextProps);
 }

--- a/packages/vkui/src/components/Clickable/useState.tsx
+++ b/packages/vkui/src/components/Clickable/useState.tsx
@@ -24,6 +24,14 @@ export interface StateProps {
   hasActive?: boolean | undefined;
 
   /**
+   * Отключает компонент. При переходе в `disabled` внутреннее `hovered`-состояние
+   * сбрасывается, чтобы оно не «залипало» после возврата в активное состояние
+   * (например, когда курсор успел покинуть отключённый элемент, не вызвав
+   * `pointerleave`, что типично для нативных `<button disabled>`).
+   */
+  disabled?: boolean | undefined;
+
+  /**
    * Позволяет родительскому компоненту
    * иметь `hovered`-cостояние при наведении
    * на любой дочерний элемент.
@@ -75,7 +83,7 @@ export const DEFAULT_ACTIVE_EFFECT_DELAY = 600;
 
 const ACTIVE_DELAY = 70;
 
-interface UseHoverProps extends Pick<StateProps, 'hovered' | 'hasHover'> {
+interface UseHoverProps extends Pick<StateProps, 'hovered' | 'hasHover' | 'disabled'> {
   /**
    * Блокирование активации состояний.
    */
@@ -89,6 +97,7 @@ interface UseHoverProps extends Pick<StateProps, 'hovered' | 'hasHover'> {
 export function useHover({
   hovered,
   hasHover = true,
+  disabled = false,
   lockState = false,
   setParentStateLock = noop,
 }: UseHoverProps = {}) {
@@ -103,6 +112,18 @@ export function useHover({
       setParentStateLock(false);
     }
   }, [hasHover, setParentStateLock]);
+
+  // Отключённый компонент не получает события указателя (например,
+  // нативная `<button disabled>`), поэтому `pointerleave` может не сработать
+  // и `hoveredStateLocal` останется `true`. Сбрасываем его при переходе
+  // в `disabled`, чтобы hover не «залипал» после возврата в активное состояние.
+  React.useEffect(() => {
+    if (disabled) {
+      setHoveredStateLocal(false);
+      prevIsHoveredRef.current = false;
+      setParentStateLock(false);
+    }
+  }, [disabled, setParentStateLock]);
 
   const handleHover = React.useCallback(
     (isHover: boolean) => {
@@ -153,7 +174,8 @@ export function useHover({
   };
 }
 
-interface UseActiveProps extends Pick<StateProps, 'activated' | 'activeEffectDelay' | 'hasActive'> {
+interface UseActiveProps
+  extends Pick<StateProps, 'activated' | 'activeEffectDelay' | 'hasActive' | 'disabled'> {
   /**
    * Блокирование активации состояний.
    */
@@ -168,6 +190,7 @@ function useActive({
   activated,
   activeEffectDelay,
   hasActive = true,
+  disabled = false,
   lockState,
   setParentStateLock,
 }: UseActiveProps) {
@@ -182,11 +205,15 @@ function useActive({
   }
 
   React.useEffect(() => {
-    if (lockState || !hasActive) {
-      // Сбрасываем setActivated если обнаруживаем lockState или !hasActive
+    if (lockState || !hasActive || disabled) {
+      // Сбрасываем setActivated если обнаруживаем lockState, !hasActive или disabled.
+      // Отключённый компонент не получает события указателя, поэтому
+      // `pointerup`/`pointercancel` могут не сработать и `activatedState`
+      // останется `true` — сбрасываем, чтобы active не «залипал» после
+      // возврата в активное состояние.
       setActivated(false);
     }
-  }, [lockState, hasActive, setActivated]);
+  }, [lockState, hasActive, disabled, setActivated]);
 
   const onPointerDown = () => {
     if (lockState) {
@@ -274,6 +301,7 @@ function useLockState(
 export function useState({
   hovered,
   hasHover,
+  disabled,
   activated,
   hasActive,
   activeEffectDelay,
@@ -296,6 +324,7 @@ export function useState({
   const { isHovered, ...hoverEvent } = useHover({
     hasHover,
     hovered,
+    disabled,
     lockState: lockHoverState,
     setParentStateLock: setParentStateLockHoverBubbling,
   });
@@ -304,6 +333,7 @@ export function useState({
     activated,
     hasActive,
     activeEffectDelay,
+    disabled,
     lockState: lockActiveState,
     setParentStateLock: setParentStateLockActiveBubbling,
   });


### PR DESCRIPTION
- [x] Unit-тесты
- [x] ~e2e-тесты~
- [x] ~Дизайн-ревью~
- [x] ~Документация фичи~
- [x] Release notes

## Описание

1. Кликаем на кнопку и переводим кнопку в состояние disabled
2. Уводим курсор
3. Переводим кнопку в состояние disabled=false

ФР: 
Наведение на кнопке осталось

ОР:
Наведение на кнопке пропало

## Изменения

Обрабатываем disabled для hover

## Release notes
## Исправления
- [Tappable](https://vkui.io/${version}/components/tappable): состояние наведение сохранялось после `disabled` состояния