### PR TITLE
feat(PullToRefresh): support controls z-index

### DIFF
--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.test.tsx
@@ -211,6 +211,16 @@ describe(PullToRefresh, () => {
     });
   });
 
+  it('allows to set controls z-index through slotProps', () => {
+    const { container } = render(
+      <PullToRefresh onRefresh={noop} slotProps={{ controls: { zIndex: 15 } }} />,
+    );
+
+    expect(container.getElementsByClassName(pullToRefreshStyles.controls)[0]).toHaveStyle({
+      zIndex: '15',
+    });
+  });
+
   it('disables native pull-to-refresh while pulling', async () => {
     const component = render(
       <ConfigProvider platform="ios">

--- a/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/vkui/src/components/PullToRefresh/PullToRefresh.tsx
@@ -53,6 +53,15 @@ export interface PullToRefreshProps extends DOMProps, TouchProps, HasChildren {
    * Текст скрытой кнопки, запускающей обновление для пользователей ассистивных технологий.
    */
   refreshLabel?: string | undefined;
+  /**
+   * Свойства, которые можно прокинуть внутрь компонента:
+   * - `controls`: свойства контейнера спиннера.
+   */
+  slotProps?:
+    | {
+        controls?: Pick<React.CSSProperties, 'zIndex'> | undefined;
+      }
+    | undefined;
   /** @ignore */
   scroll?: ScrollContextInterface | undefined;
 }
@@ -67,6 +76,7 @@ export const PullToRefresh = ({
   accessibilityLabel = 'Обновление контента',
   refreshLabel = 'Обновить',
   className,
+  slotProps,
   ...restProps
 }: PullToRefreshProps): React.ReactNode => {
   const platform = usePlatform();
@@ -282,6 +292,7 @@ export const PullToRefresh = ({
           className={styles.controls}
           inlineSize="100%"
           position="fixed"
+          style={{ zIndex: slotProps?.controls?.zIndex }}
         >
           <PullToRefreshSpinner
             style={{


### PR DESCRIPTION
- close #10044

---

- [x] Unit-тесты
- [x] Release notes

## Описание

Добавляет возможность настроить `z-index` контейнера спиннера в `PullToRefresh` через `slotProps.controls.zIndex`.

Ранее контейнер использовал только платформенное значение из CSS: `3` на iOS и `9` на Android/VKCOM. Из-за этого порядок наложения нельзя было изменить со стороны пользователя компонента.

## Изменения

- добавлено типизированное свойство `slotProps.controls.zIndex`;
- значение применяется как inline-стиль и переопределяет платформенный `z-index`;
- добавлен unit-тест нового свойства.

## Release notes

## Улучшения

- PullToRefresh: добавлена возможность настраивать `z-index` контейнера спиннера через `slotProps.controls.zIndex`.
