### PR TITLE
fix(Calendar): keep time picker open on scrollbar click

### DIFF
--- a/packages/vkui/src/components/Calendar/Calendar.test.tsx
+++ b/packages/vkui/src/components/Calendar/Calendar.test.tsx
@@ -265,6 +265,24 @@ describe('Calendar', () => {
     expect(screen.queryByRole('option', { selected: true, name: '40' })).toBeInTheDocument();
   });
 
+  it('does not close time picker on scrollbar mouseDown', () => {
+    render(<Calendar value={targetDate} hoursTestId="hours" enableTime />);
+
+    fireEvent.click(screen.getByTestId('hours'));
+
+    const option = screen.getByRole('option', { name: '10' });
+    const scrollView = option.parentElement;
+    const mouseDownEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    scrollView?.dispatchEvent(mouseDownEvent);
+
+    expect(mouseDownEvent.defaultPrevented).toBe(true);
+    expect(option).toBeInTheDocument();
+  });
+
   describe('DEV errors', () => {
     beforeEach(() => setNodeEnv('development'));
     afterEach(() => setNodeEnv('test'));

--- a/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
@@ -538,25 +538,4 @@ describe('CalendarTime', () => {
       expect(customSetMinutes).toHaveBeenCalled();
     });
   });
-
-  describe('Option mouseDown behavior', () => {
-    it('should prevent default on option mouseDown', () => {
-      const onChange = vi.fn();
-      render(<CalendarTime onChange={onChange} value={dayDate} hoursTestId="hours-picker" />);
-
-      const hoursInput = screen.getByTestId('hours-picker');
-      fireEvent.click(hoursInput);
-
-      const option = screen.getByRole('option', { name: '10' });
-      const mouseDownEvent = new MouseEvent('mousedown', {
-        bubbles: true,
-        cancelable: true,
-      });
-      const preventDefaultSpy = vi.spyOn(mouseDownEvent, 'preventDefault');
-
-      option.dispatchEvent(mouseDownEvent);
-
-      expect(preventDefaultSpy).toHaveBeenCalled();
-    });
-  });
 });

--- a/packages/vkui/src/components/CalendarTime/ComboBox.tsx
+++ b/packages/vkui/src/components/CalendarTime/ComboBox.tsx
@@ -80,9 +80,6 @@ function Option({ option, onClickOption, selectedValue }: OptionProps) {
     <CustomSelectOption
       getRootRef={ref}
       key={option.value}
-      onMouseDown={(event) => {
-        event.preventDefault();
-      }}
       onClick={() => {
         onClickOption?.(option.value);
       }}
@@ -143,6 +140,10 @@ export function ComboBox({
     labelsElements?.reverse();
   }
 
+  const preventPopperCloseOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
   return (
     <>
       <Input
@@ -170,6 +171,7 @@ export function ComboBox({
           targetRef={ref}
           placement={popperPlacement}
           onPlacementChange={setPopperPlacement}
+          onMouseDown={preventPopperCloseOnClick}
           className={classNames(
             styles.popper,
             popperPlacement.includes('top') ? styles.popperTop : styles.popperBottom,


### PR DESCRIPTION
- close #10213

---

- [x] Unit-тесты
- [x] Release notes

## Описание

Исправляет закрытие `CalendarTimePicker` при нажатии на скроллбар списка выбора времени в `<Calendar enableTime />`.

## Изменения

Обработчик `mousedown`, предотвращающий потерю фокуса, перенесён с отдельных опций на корневой элемент popper. Теперь он также обрабатывает нажатия на область скроллбара.

Добавлен регрессионный тест, который вызывает `mousedown` на контейнере прокрутки и проверяет, что событие отменено, а список остаётся открытым.

## Release notes

## Исправления

- Calendar: исправлено закрытие списка выбора времени при нажатии на скроллбар.
