### PR TITLE
perf(ActionSheetItem/Radio): scope sibling selectors to component root

### DIFF
--- a/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.module.css
+++ b/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.module.css
@@ -1,9 +1,19 @@
+/**
+ * Селекторы ниже намеренно ограничены классом `.host`.
+ *
+ * Без класса-предка `.input ~ *` проверяется движком стилей на каждом элементе
+ * документа, и для каждого приходится сканировать всех предыдущих братьев.
+ * Bloom-фильтр при этом не срабатывает (fast-reject = 0), поэтому на страницах
+ * с большими поддеревьями (например, письмо с широкой таблицей) правило
+ * становится заметной статьёй расхода в Recalculate Style при нуле совпадений.
+ */
+
 /* stylelint-disable-next-line selector-max-universal -- отключаем иконку */
-.input ~ * {
+.host > .input ~ * {
   display: none;
 }
 
 /* stylelint-disable-next-line selector-max-universal -- включаем иконку если checked */
-.input:checked ~ * {
+.host > .input:checked ~ * {
   display: block;
 }

--- a/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.tsx
+++ b/packages/vkui/src/components/ActionSheetItem/subcomponents/Radio/Radio.tsx
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 import { Icon20CheckCircleOn, Icon24CheckCircleOn } from '@vkontakte/icons';
+import { classNames } from '@vkontakte/vkjs';
 import type { HasRef, HasRootRef } from '../../../../types';
 import { AdaptiveIconRenderer } from '../../../AdaptiveIconRenderer/AdaptiveIconRenderer';
 import { RootComponent } from '../../../RootComponent/RootComponent';
@@ -29,7 +30,11 @@ export const Radio = ({
   ...restProps
 }: ActionSheetItemCheckedProps): React.ReactNode => {
   return (
-    <RootComponent getRootRef={getRootRef} className={className} style={style}>
+    <RootComponent
+      getRootRef={getRootRef}
+      className={classNames(styles.host, className)}
+      style={style}
+    >
       <VisuallyHidden
         Component="input"
         getRootRef={getRef}


### PR DESCRIPTION
- close #10216

---

- [ ] Unit-тесты
- [ ] e2e-тесты
- [ ] Дизайн-ревью
- [ ] Документация фичи
- [x] Release notes

## Описание

Селектор `.input ~ *` в `ActionSheetItem/Radio` не имеет класса-предка. Из-за этого движок стилей проверяет его на **каждом** элементе документа, и для каждого приходится сканировать всех предыдущих братьев. Bloom-фильтр в такой форме не срабатывает (`fast_reject = 0`), поэтому на страницах с большими поддеревьями правило становится заметной статьёй расхода в Recalculate Style — при нулевом числе совпадений.

Нашли при профилировании почтового клиента: на письме с широкой таблицей (~108 000 DOM-узлов) три правила с комбинатором «сосед + универсальный селектор» съедали **5.9 с из 6.0 с** всего пересчёта стилей.

Данные из Chrome DevTools → Performance → Selector stats:

| elapsed | match attempts | matches | selector |
|---|---|---|---|
| 1975 мс | 45 926 | **0** | `.vkuiActionSheetItemRadio__input ~ *` |
| 1954 мс | 45 926 | **0** | `.vkuiActionSheetItemRadio__input:checked ~ *` |
| 1955 мс | 46 026 | **0** | `.vkuiCheckbox__input[disabled] ~ *` |

Получается ~43 мкс на одну попытку сопоставления при `fast_reject = 0`.

Правило из `Checkbox` в master уже исправлено, поэтому в этом PR остаётся `ActionSheetItem/Radio`.

## Изменения

Селекторы ограничены классом корневого элемента компонента — этого достаточно, чтобы вернулся быстрый отказ по Bloom-фильтру:

```diff
-.input ~ * { display: none }
-.input:checked ~ * { display: block }
+.host > .input ~ * { display: none }
+.host > .input:checked ~ * { display: block }
```

`.host` навешивается на `RootComponent`, который и так является прямым родителем `input` и иконки, поэтому структура DOM не меняется. Класс не содержит собственных стилей — только точка привязки для селекторов.

### Замер

Headless Chrome, таблица на 2000 строк, вычисленные стили идентичны (`display: none` для unchecked, `display: block` для checked):

```
до:                        44.8 мс
после:                     13.8 мс
без этих правил вообще:    13.8 мс   ← вышли на baseline
```

### Почему не тронут FixedLayout

В `FixedLayout.module.css` есть похожий на вид селектор:

```css
:global(.vkuiInternalPanelHeader) ~ * .verticalTop:not(...)
```

Он **не** создаёт проблемы: замыкающий класс `.verticalTop` позволяет движку отбросить кандидатов быстро. Проверено отдельно — стоимость на том же стенде совпадает с baseline (13.8 мс). Поэтому изменение ограничено только `Radio`.

## Release notes
## Исправления
- [ActionSheet](https://vkui.io/${version}/components/action-sheet): селекторы иконки ограничены корнем компонента — заметно дешевле Recalculate Style на страницах с большим DOM