### PR TITLE
fix(Calendar): input time with min minDateTime

### DIFF
--- a/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTime.test.tsx
@@ -484,6 +484,78 @@ describe('CalendarTime', () => {
     });
   });
 
+  describe('Intermediate input with isDayDisabled (minDateTime)', () => {
+    fakeTimersForScope();
+    // minDateTime = 15:00 — часы ниже 15 на этой дате запрещены
+    const baseDate = new Date('2026-07-19T00:00:00.000Z');
+    const minDateTime = setHours(baseDate, 15);
+    const value = setHours(baseDate, 15);
+    const isDayDisabled = (day: Date, withTime?: boolean) => {
+      if (withTime) {
+        return day.getTime() < minDateTime.getTime();
+      }
+      return false;
+    };
+
+    it('should keep intermediate "2" (start of "20") without resetting to min "15"', async () => {
+      const onChange = vi.fn();
+      render(
+        <CalendarTime
+          onChange={onChange}
+          value={value}
+          isDayDisabled={isDayDisabled}
+          hoursTestId="hours-picker"
+        />,
+      );
+
+      const hoursInput = screen.getByTestId('hours-picker');
+      act(() => hoursInput.focus());
+
+      // Вводим первый символ "2" — промежуточное значение для "20".
+      // Баг: "2" трактовалось как 2 часа (< 15) и мгновенно сбрасывалось к "15".
+      fireEvent.input(hoursInput, { target: { value: '2' } });
+      await act(async () => vi.runOnlyPendingTimers());
+
+      expect(hoursInput).toHaveValue('2');
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Вводим второй символ "0" → финальное валидное "20"
+      fireEvent.input(hoursInput, { target: { value: '20' } });
+      await act(async () => vi.runOnlyPendingTimers());
+
+      expect(onChange).toHaveBeenLastCalledWith(setHours(value, 20));
+      expect(hoursInput).toHaveValue('20');
+    });
+
+    it('should reset to min "15" when final hour "10" is below minDateTime', async () => {
+      const onChange = vi.fn();
+      render(
+        <CalendarTime
+          onChange={onChange}
+          value={value}
+          isDayDisabled={isDayDisabled}
+          hoursTestId="hours-picker"
+        />,
+      );
+
+      const hoursInput = screen.getByTestId('hours-picker');
+      act(() => hoursInput.focus());
+
+      // Промежуточное "1"
+      fireEvent.input(hoursInput, { target: { value: '1' } });
+      await act(async () => vi.runOnlyPendingTimers());
+      expect(hoursInput).toHaveValue('1');
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Финальное "10" (< 15) — недопустимо, должно сброситься к минимальному "15"
+      fireEvent.input(hoursInput, { target: { value: '10' } });
+      await act(async () => vi.runOnlyPendingTimers());
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(hoursInput).toHaveValue('15');
+    });
+  });
+
   describe('Custom setHours and setMinutes', () => {
     fakeTimersForScope();
     it('should use custom setHours function', async () => {

--- a/packages/vkui/src/components/CalendarTime/CalendarTimePicker.tsx
+++ b/packages/vkui/src/components/CalendarTime/CalendarTimePicker.tsx
@@ -90,11 +90,40 @@ export const CalendarTimePicker = ({
 
   const [isInputFocused, onFocus, setInputBlur] = useBooleanState(false);
 
-  const [editableValue, setEditableValue] = React.useState(padStartTimeValue(value));
+  const [editableValue, setEditableValueState] = React.useState(padStartTimeValue(value));
+  // ref хранит актуальное значение editableValue синхронно (включая незакоммиченные
+  // промежуточные значения), чтобы обработчик onBlur корректно работал даже в случае
+  // batched-обновлений, когда пропсы ещё не успели обновиться.
+  const editableValueRef = React.useRef(editableValue);
 
-  const updateValue = (newValue: string) => {
+  // Обновляем ref синхронно (в момент вызова, а не во время рендера),
+  // чтобы onBlur всегда видел последнее значение, даже в batched-сценариях
+  // (например, когда onInputEnd уводит фокус и blur срабатывает в том же тике).
+  const setEditableValue = React.useCallback((next: React.SetStateAction<string>) => {
+    const resolved = typeof next === 'function' ? next(editableValueRef.current) : next;
+    editableValueRef.current = resolved;
+    setEditableValueState(resolved);
+  }, []);
+
+  const valueAsString = padStartTimeValue(value);
+
+  // Промежуточный ввод — пользователь ещё не завершил набор значения.
+  // Не валидируем против isDayDisabled и не зовём onChange, чтобы дать
+  // пользователю возможность ввести второй символ (например, "2" как начало "20"
+  // при minDateTime=15:00). Иначе одиночная цифра трактуется как 2 часа и
+  // мгновенно сбрасывается к минимальному значению.
+  const updateValue = (newValue: string, options?: { intermediate?: boolean }) => {
+    const { intermediate = false } = options ?? {};
+
+    if (intermediate) {
+      setEditableValue(newValue);
+      return;
+    }
+
     const newDate = setTime(valueDate, Number(newValue));
     if (isDayDisabled?.(newDate, true)) {
+      // Финальное значение недопустимо — откатываемся к последнему валидному значению
+      setEditableValue(valueAsString);
       return;
     }
     setEditableValue(newValue);
@@ -105,7 +134,9 @@ export const CalendarTimePicker = ({
 
   const onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     const validateValue = validateValueInput(event, maxValue);
-    updateValue(validateValue);
+    // Одиночная цифра — промежуточное значение, пользователь продолжит ввод.
+    // Пустое и двухзначное значения считаем финальными.
+    updateValue(validateValue, { intermediate: validateValue.length === 1 });
 
     if (validateValue.length > 1 && event.target.selectionStart) {
       onInputEnd?.();
@@ -115,6 +146,14 @@ export const CalendarTimePicker = ({
   // Управление числом с клавиатуры стрелками вниз/вверх.
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    // Реагируем только на стрелки. Для остальных клавиш (включая ввод цифр)
+    // значение обрабатывается в onInput — там же применяется логика
+    // промежуточного ввода. Вызов updateValue тут для цифр приводил бы к
+    // преждевременной валидации незакоммиченного промежуточного значения
+    // (например, "2" перед вводом "0" → "20") и его сбросу к min.
+    if (event.key !== Keys.ARROW_UP && event.key !== Keys.ARROW_DOWN) {
+      return;
+    }
     const validateValue = newValueOnInputKeyDown(event, maxValue);
     updateValue(validateValue);
   };
@@ -142,11 +181,25 @@ export const CalendarTimePicker = ({
 
   const onBlur = () => {
     setInputBlur();
-    setEditableValue((value) => {
-      const newValue = padStartTimeValue(value);
-
-      return newValue;
-    });
+    const currentEditable = editableValueRef.current;
+    // Двухзначное значение уже закоммичено (или откачено к валидному) на этапе ввода
+    // или выбора из списка — повторно onChange не зовём, чтобы не плодить дубли.
+    if (currentEditable.length >= 2) {
+      setEditableValue(padStartTimeValue(currentEditable));
+      return;
+    }
+    // Одиночная цифра — это незакоммиченное промежуточное значение. Коммитим его
+    // как финальное (с падом до двух знаков и валидацией против isDayDisabled).
+    const padded = padStartTimeValue(currentEditable);
+    const newDate = setTime(valueDate, Number(padded));
+    if (isDayDisabled?.(newDate, true)) {
+      setEditableValue(valueAsString);
+    } else if (padded !== valueAsString) {
+      setEditableValue(padded);
+      onChange?.(newDate);
+    } else {
+      setEditableValue(padded);
+    }
   };
 
   // Обработка значения при нажатии в барабане
@@ -154,8 +207,6 @@ export const CalendarTimePicker = ({
   const onClickOption = (newValue: string) => {
     updateValue(newValue);
   };
-
-  const valueAsString = padStartTimeValue(value);
 
   const viewValue =
     isInputFocused || padStartTimeValue(editableValue) !== valueAsString


### PR DESCRIPTION
- [x] Unit-тесты
- [x] e2e-тесты
- [x] Дизайн-ревью
- [x] Документация фичи
- [x] Release notes

## Описание

1. В календаре выставлено `minDateTime` на 19.08.2026 15:00
2. Нажми в календаре на день 19
3. В поле часы введи 20

ФР
После ввода первого символа `2` сбрасывается на минимальное `15` (календарь обрабатывает ввод первого символа `2` как 2 часа)

ОР
В поле часы будет `20`

## Изменения

1. Промежуточный ввод: updateValue теперь принимает { intermediate }. Одиночная цифра (length === 1) считается промежуточным значением — обновляем только editableValue для отображения, без валидации isDayDisabled и без onChange.
2. Сброс к min для финального значения: при двухзначном (финальном) недопустимом значении (например "10" < 15) откатываем editableValue к последнему валидному valueAsString и не зовём onChange.
3. onKeyDown: реагирует только на ARROW_UP/ARROW_DOWN — для цифр валидация идёт в onInput, что устраняет преждевременный сброс промежуточного значения на keydown второго символа.
4. onBlur: коммитит незакоммиченное однозначное промежуточное значение как финальное (с паддингом и валидацией); для двухзначных не дублирует onChange.
5. Синхронный editableValueRef (через обёрнутый setEditableValue) гарантирует, что onBlur видит актуальное значение даже в batched-сценариях, когда onInputEnd уводит фокус в том же тике.

## Release notes
## Исправления
- [Calendar](https://vkui.io/${version}/components/calendar): ввод времени не работал с `minDateTime`