### PR TITLE
docs: link alternate markdown

### DIFF
--- a/website/app/_components/AlternateMdxLink.tsx
+++ b/website/app/_components/AlternateMdxLink.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useFSRoute } from 'nextra/hooks';
+import { createMdxUrl } from '@/components/mdx/Overview/OverviewHeaderLinks/helpers';
+
+export function AlternateMdxLink() {
+  const fsRoute = useFSRoute();
+  const mdxUrl = createMdxUrl(fsRoute);
+
+  return <link rel="alternate" type="text/markdown" href={mdxUrl} />;
+}

--- a/website/app/_components/index.ts
+++ b/website/app/_components/index.ts
@@ -1,3 +1,4 @@
 export { Versions } from './Versions/Versions';
 export { RedirectHandler } from './RedirectHandler';
 export { FooterLinks } from './FooterLinks';
+export { AlternateMdxLink } from './AlternateMdxLink';

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -15,7 +15,7 @@ import { getPageMap } from 'nextra/page-map';
 import { PlaygroundStoreProvider } from '@/providers/playgroundStoreProvider';
 import challengeCode from '../inline/challange.js?raw';
 import uwuCode from '../inline/uwu.js?raw';
-import { FooterLinks, RedirectHandler, Versions } from './_components';
+import { AlternateMdxLink, FooterLinks, RedirectHandler, Versions } from './_components';
 import '@vkontakte/vkui-docs-theme/styles.css';
 
 const inlineCodeArray = [challengeCode, uwuCode];
@@ -100,7 +100,9 @@ const RootLayout: React.FC<{ children: React.ReactNode }> = async ({ children })
 
   return (
     <html lang="ru" dir="ltr" suppressHydrationWarning>
-      <Head />
+      <Head>
+        <AlternateMdxLink />
+      </Head>
       <body>
         <InlineCode />
         <RedirectHandler />


### PR DESCRIPTION
## Описание

Добавляем для агентов ссылку на markdown

link для поддержки Codex CLI

## Release notes
## Документация
- Сайт документации поддерживает [`Accept: text/markdown` для агентов](https://acceptmarkdown.com/status)